### PR TITLE
Update high ResponseCode in EDNS Section if required

### DIFF
--- a/crates/proto/src/op/header.rs
+++ b/crates/proto/src/op/header.rs
@@ -285,6 +285,9 @@ impl Header {
     }
 
     /// The low response code (original response codes before EDNS extensions)
+    ///
+    /// Warning: This method can only used for basic ResponseCodes.
+    /// Some ResponseCode require the use of the EDNS record to represent the high bits.
     pub fn set_response_code(&mut self, response_code: ResponseCode) -> &mut Self {
         self.response_code = response_code;
         self

--- a/crates/server/src/authority/message_response.rs
+++ b/crates/server/src/authority/message_response.rs
@@ -207,6 +207,8 @@ impl<'q> MessageResponseBuilder<'q> {
 
     /// Constructs a new error MessageResponse with associated settings
     ///
+    /// If the `response_code` requires an EDNS section, this function creates one if not already present.
+    ///
     /// # Arguments
     ///
     /// * `id` - request id to which this is a response
@@ -226,6 +228,11 @@ impl<'q> MessageResponseBuilder<'q> {
     > {
         let mut header = Header::response_from_request(request_header);
         header.set_response_code(response_code);
+        let mut edns = self.edns;
+        if response_code.high() != 0 {
+            edns.get_or_insert_with(Edns::new)
+                .set_rcode_high(response_code.high());
+        }
 
         MessageResponse {
             header,
@@ -235,7 +242,7 @@ impl<'q> MessageResponseBuilder<'q> {
             soa: Box::new(None.into_iter()),
             additionals: Box::new(None.into_iter()),
             sig0: self.sig0.unwrap_or_default(),
-            edns: self.edns,
+            edns,
         }
     }
 }
@@ -321,5 +328,27 @@ mod tests {
         assert!(response.header().truncated());
         assert_eq!(response.answer_count(), 0);
         assert!(response.name_server_count() > 1);
+    }
+
+    #[test]
+    fn test_extended_response_codes() {
+        let mut buf = Vec::with_capacity(512);
+        {
+            let mut encoder = BinEncoder::new(&mut buf);
+            encoder.set_max_size(512);
+
+            let message = MessageResponseBuilder {
+                query: None,
+                sig0: None,
+                edns: None,
+            };
+            message
+                .error_msg(&Header::new(), ResponseCode::BADCOOKIE)
+                .destructive_emit(&mut encoder)
+                .expect("failed to encode");
+        }
+
+        let response = Message::from_vec(&buf).expect("failed to decode");
+        assert_eq!(response.response_code(), ResponseCode::BADCOOKIE);
     }
 }


### PR DESCRIPTION

Some ResponseCodes have high bits which require EDNS to encode them.
This commit updates Message::set_response_code and
MessageResponseBuiler::error_msg to silently create a EDNS section if
required and sets the high bits there.

This also adds a warning to Header::set_response_code that this function
cannot set the high bits.

Closes #1203
Closes #1207