### PR TITLE
Saethlin fix rdata zero

### DIFF
--- a/bin/benches/comparison_benches.rs
+++ b/bin/benches/comparison_benches.rs
@@ -132,7 +132,7 @@ where
     assert_eq!(response.response_code(), ResponseCode::NoError);
 
     let record = &response.answers()[0];
-    if let RData::A(ref address) = *record.rdata() {
+    if let Some(RData::A(ref address)) = record.data() {
         assert_eq!(address, &Ipv4Addr::new(127, 0, 0, 1));
     } else {
         unreachable!();

--- a/bin/tests/named_tests.rs
+++ b/bin/tests/named_tests.rs
@@ -306,7 +306,7 @@ fn test_forward() {
             RecordType::A,
         );
         assert_eq!(
-            *response.answers()[0].rdata().as_a().unwrap(),
+            *response.answers()[0].data().and_then(RData::as_a).unwrap(),
             Ipv4Addr::new(93, 184, 216, 34)
         );
 
@@ -328,7 +328,7 @@ fn test_forward() {
             RecordType::A,
         );
         assert_eq!(
-            *response.answers()[0].rdata().as_a().unwrap(),
+            *response.answers()[0].data().and_then(RData::as_a).unwrap(),
             Ipv4Addr::new(93, 184, 216, 34)
         );
         assert!(!response.header().authoritative());

--- a/bin/tests/server_harness/mod.rs
+++ b/bin/tests/server_harness/mod.rs
@@ -229,7 +229,7 @@ pub fn query_a<C: ClientHandle>(io_loop: &mut Runtime, client: &mut C) {
     let response = query_message(io_loop, client, name, RecordType::A);
     let record = &response.answers()[0];
 
-    if let RData::A(ref address) = *record.rdata() {
+    if let Some(RData::A(ref address)) = record.data() {
         assert_eq!(address, &Ipv4Addr::new(127, 0, 0, 1))
     } else {
         panic!("wrong RDATA")
@@ -262,7 +262,7 @@ pub fn query_all_dnssec(
         .iter()
         .filter(|r| r.rr_type() == RecordType::DNSKEY)
         .map(|r| {
-            if let RData::DNSSEC(DNSSECRData::DNSKEY(ref dnskey)) = *r.rdata() {
+            if let Some(RData::DNSSEC(DNSSECRData::DNSKEY(ref dnskey))) = r.data() {
                 dnskey.clone()
             } else {
                 panic!("wrong RDATA")
@@ -278,7 +278,7 @@ pub fn query_all_dnssec(
         .iter()
         .filter(|r| r.rr_type() == RecordType::RRSIG)
         .map(|r| {
-            if let RData::DNSSEC(DNSSECRData::SIG(ref rrsig)) = *r.rdata() {
+            if let Some(RData::DNSSEC(DNSSECRData::SIG(ref rrsig))) = r.data() {
                 rrsig.clone()
             } else {
                 panic!("wrong RDATA")

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -47,7 +47,7 @@ let answers: &[Record] = response.answers();
 // Records are generic objects which can contain any data.
 //  In order to access it we need to first check what type of record it is
 //  In this case we are interested in A, IPv4 address
-if let &RData::A(ref ip) = answers[0].rdata() {
+if let Some(RData::A(ref ip)) = answers[0].data() {
     assert_eq!(*ip, Ipv4Addr::new(93, 184, 216, 34))
 } else {
     assert!(false, "unexpected result")

--- a/crates/client/src/client/async_client.rs
+++ b/crates/client/src/client/async_client.rs
@@ -709,16 +709,11 @@ impl<R> ClientStreamXfrState<R> {
     }
 
     /// Helper to ingest answer Records
-    // TODO this is complexe enough it should get its own tests
+    // TODO: this is complex enough it should get its own tests
     fn process(&mut self, answers: &[Record]) -> Result<(), ClientError> {
         use ClientStreamXfrState::*;
         fn get_serial(r: &Record) -> Option<u32> {
-            let rdata = r.rdata();
-            if let RData::SOA(soa) = rdata {
-                Some(soa.serial())
-            } else {
-                None
-            }
+            r.data().and_then(RData::as_soa).map(SOA::serial)
         }
 
         if answers.is_empty() {

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -124,7 +124,7 @@
 //! // Records are generic objects which can contain any data.
 //! //  In order to access it we need to first check what type of record it is
 //! //  In this case we are interested in A, IPv4 address
-//! if let &RData::A(ref ip) = answers[0].rdata() {
+//! if let Some(RData::A(ref ip)) = answers[0].data() {
 //!     assert_eq!(*ip, Ipv4Addr::new(93, 184, 216, 34))
 //! } else {
 //!     assert!(false, "unexpected result")
@@ -199,7 +199,7 @@
 //! let mut record = Record::with(Name::from_str("new.example.com").unwrap(),
 //!                               RecordType::A,
 //!                               Duration::minutes(5).whole_seconds() as u32);
-//! record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+//! record.set_data(Some(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
 //!
 //! // the server must be authoritative for this zone
 //! let origin = Name::from_str("example.com.").unwrap();
@@ -260,7 +260,7 @@
 //!     let response = query.await.unwrap();
 //!
 //!     // validate it's what we expected
-//!     if let RData::A(addr) = response.answers()[0].rdata() {
+//!     if let Some(RData::A(addr)) = response.answers()[0].data() {
 //!         assert_eq!(*addr, Ipv4Addr::new(93, 184, 216, 34));
 //!     }
 //! }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -199,7 +199,7 @@
 //! let mut record = Record::with(Name::from_str("new.example.com").unwrap(),
 //!                               RecordType::A,
 //!                               Duration::minutes(5).whole_seconds() as u32);
-//! record.set_data(Some(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+//! record.set_data(Some(RData::A(Ipv4Addr::new(100, 10, 100, 10))));
 //!
 //! // the server must be authoritative for this zone
 //! let origin = Name::from_str("example.com.").unwrap();

--- a/crates/client/src/op/update_message.rs
+++ b/crates/client/src/op/update_message.rs
@@ -481,7 +481,7 @@ pub fn delete_rrset(mut record: Record, zone_origin: Name, use_edns: bool) -> Me
     // the TTL should be 0
     record.set_ttl(0);
     // the rdata must be null to delete all rrsets
-    record.set_rdata(RData::NULL(NULL::new()));
+    record.set_data(Some(RData::NULL(NULL::new())));
     message.add_update(record);
 
     // Extended dns

--- a/crates/client/src/rr/dnssec/signer.rs
+++ b/crates/client/src/rr/dnssec/signer.rs
@@ -557,7 +557,9 @@ impl MessageFinalizer for SigSigner {
             Vec::new(),
         );
         let signature: Vec<u8> = self.sign_message(message, &pre_sig0)?;
-        sig0.set_rdata(RData::DNSSEC(DNSSECRData::SIG(pre_sig0.set_sig(signature))));
+        sig0.set_data(Some(RData::DNSSEC(DNSSECRData::SIG(
+            pre_sig0.set_sig(signature),
+        ))));
 
         Ok((vec![sig0], None))
     }
@@ -648,7 +650,7 @@ mod tests {
         let sig = signer.sign_message(&question, &pre_sig0);
         println!("sig after sign: {:?}", sig);
 
-        if let RData::DNSSEC(DNSSECRData::SIG(ref sig)) = *question.sig0()[0].rdata() {
+        if let Some(RData::DNSSEC(DNSSECRData::SIG(ref sig))) = question.sig0()[0].data() {
             assert!(sig0key.verify_message(&question, sig.sig(), sig).is_ok());
         }
     }
@@ -669,7 +671,7 @@ mod tests {
             .set_ttl(86400)
             .set_rr_type(RecordType::NS)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::DNSSEC(DNSSECRData::SIG(SIG::new(
+            .set_data(Some(RData::DNSSEC(DNSSECRData::SIG(SIG::new(
                 RecordType::NS,
                 Algorithm::RSASHA256,
                 origin.num_labels(),
@@ -679,7 +681,7 @@ mod tests {
                 signer.calculate_key_tag().unwrap(),
                 origin.clone(),
                 vec![],
-            ))))
+            )))))
             .clone();
         let rrset = vec![
             Record::new()
@@ -687,14 +689,18 @@ mod tests {
                 .set_ttl(86400)
                 .set_rr_type(RecordType::NS)
                 .set_dns_class(DNSClass::IN)
-                .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
+                .set_data(Some(RData::NS(
+                    Name::parse("a.iana-servers.net.", None).unwrap(),
+                )))
                 .clone(),
             Record::new()
                 .set_name(origin)
                 .set_ttl(86400)
                 .set_rr_type(RecordType::NS)
                 .set_dns_class(DNSClass::IN)
-                .set_rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
+                .set_data(Some(RData::NS(
+                    Name::parse("b.iana-servers.net.", None).unwrap(),
+                )))
                 .clone(),
         ];
 
@@ -799,7 +805,7 @@ MC0CAQACBQC+L6pNAgMBAAECBQCYj0ZNAgMA9CsCAwDHZwICeEUCAnE/AgMA3u0=
                 .set_ttl(86400)
                 .set_rr_type(RecordType::NS)
                 .set_dns_class(DNSClass::IN)
-                .set_rdata(RData::DNSSEC(DNSSECRData::SIG(SIG::new(
+                .set_data(Some(RData::DNSSEC(DNSSECRData::SIG(SIG::new(
                     RecordType::NS,
                     Algorithm::RSASHA256,
                     origin.num_labels(),
@@ -809,7 +815,7 @@ MC0CAQACBQC+L6pNAgMBAAECBQCYj0ZNAgMA9CsCAwDHZwICeEUCAnE/AgMA3u0=
                     signer.calculate_key_tag().unwrap(),
                     origin.clone(),
                     vec![],
-                ))))
+                )))))
                 .clone();
             let rrset = vec![
                 Record::new()
@@ -817,14 +823,18 @@ MC0CAQACBQC+L6pNAgMBAAECBQCYj0ZNAgMA9CsCAwDHZwICeEUCAnE/AgMA3u0=
                     .set_ttl(86400)
                     .set_rr_type(RecordType::NS)
                     .set_dns_class(DNSClass::IN)
-                    .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
+                    .set_data(Some(RData::NS(
+                        Name::parse("a.iana-servers.net.", None).unwrap(),
+                    )))
                     .clone(),
                 Record::new()
                     .set_name(origin.clone())
                     .set_ttl(86400)
                     .set_rr_type(RecordType::NS)
                     .set_dns_class(DNSClass::IN)
-                    .set_rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
+                    .set_data(Some(RData::NS(
+                        Name::parse("b.iana-servers.net.", None).unwrap(),
+                    )))
                     .clone(),
             ];
 
@@ -837,37 +847,45 @@ MC0CAQACBQC+L6pNAgMBAAECBQCYj0ZNAgMA9CsCAwDHZwICeEUCAnE/AgMA3u0=
                     .set_ttl(86400)
                     .set_rr_type(RecordType::CNAME)
                     .set_dns_class(DNSClass::IN)
-                    .set_rdata(RData::CNAME(
+                    .set_data(Some(RData::CNAME(
                         Name::parse("a.iana-servers.net.", None).unwrap(),
-                    ))
+                    )))
                     .clone(), // different type
                 Record::new()
                     .set_name(Name::parse("www.example.com.", None).unwrap())
                     .set_ttl(86400)
                     .set_rr_type(RecordType::NS)
                     .set_dns_class(DNSClass::IN)
-                    .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
+                    .set_data(Some(RData::NS(
+                        Name::parse("a.iana-servers.net.", None).unwrap(),
+                    )))
                     .clone(), // different name
                 Record::new()
                     .set_name(origin.clone())
                     .set_ttl(86400)
                     .set_rr_type(RecordType::NS)
                     .set_dns_class(DNSClass::CH)
-                    .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
+                    .set_data(Some(RData::NS(
+                        Name::parse("a.iana-servers.net.", None).unwrap(),
+                    )))
                     .clone(), // different class
                 Record::new()
                     .set_name(origin.clone())
                     .set_ttl(86400)
                     .set_rr_type(RecordType::NS)
                     .set_dns_class(DNSClass::IN)
-                    .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
+                    .set_data(Some(RData::NS(
+                        Name::parse("a.iana-servers.net.", None).unwrap(),
+                    )))
                     .clone(),
                 Record::new()
                     .set_name(origin)
                     .set_ttl(86400)
                     .set_rr_type(RecordType::NS)
                     .set_dns_class(DNSClass::IN)
-                    .set_rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
+                    .set_data(Some(RData::NS(
+                        Name::parse("b.iana-servers.net.", None).unwrap(),
+                    )))
                     .clone(),
             ];
 

--- a/crates/client/src/rr/dnssec/tsig.rs
+++ b/crates/client/src/rr/dnssec/tsig.rs
@@ -117,7 +117,7 @@ impl TSigner {
         first_message: bool,
     ) -> ProtoResult<(Vec<u8>, Range<u64>, u64)> {
         let (tbv, record) = signed_bitmessage_to_buf(previous_hash, message, first_message)?;
-        let tsig = if let RData::DNSSEC(DNSSECRData::TSIG(tsig)) = record.rdata() {
+        let tsig = if let Some(RData::DNSSEC(DNSSECRData::TSIG(tsig))) = record.data() {
             tsig
         } else {
             unreachable!("tsig::signed_message_to_buff always returns a TSIG record")

--- a/crates/client/src/serialize/txt/parse_rdata.rs
+++ b/crates/client/src/serialize/txt/parse_rdata.rs
@@ -86,6 +86,7 @@ impl RDataParser for RData {
                 return Err(ParseError::from("RRSIG should be dynamically generated"))
             }
             RecordType::TSIG => return Err(ParseError::from("TSIG is only used during AXFR")),
+            #[allow(deprecated)]
             RecordType::ZERO => RData::ZERO,
             r @ RecordType::Unknown(..) | r => {
                 // TODO: add a way to associate generic record types to the zone

--- a/crates/client/src/serialize/txt/rdata_parsers/svcb.rs
+++ b/crates/client/src/serialize/txt/rdata_parsers/svcb.rs
@@ -322,6 +322,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use trust_dns_proto::rr::RData;
+
     use crate::rr::DNSClass;
     use crate::serialize::txt::{Lexer, Parser};
 
@@ -342,8 +344,8 @@ mod tests {
             .into_iter()
             .next()
             .unwrap()
-            .rdata()
-            .as_svcb()
+            .data()
+            .and_then(RData::as_svcb)
             .expect("Not an SVCB record")
             .clone()
     }

--- a/crates/client/src/serialize/txt/zone.rs
+++ b/crates/client/src/serialize/txt/zone.rs
@@ -344,10 +344,10 @@ impl Parser {
             }
         }
 
-        // TODO validate record, e.g. the name of SRV record allows _ but others do not.
+        // TODO: validate record, e.g. the name of SRV record allows _ but others do not.
 
         // move the rdata into record...
-        record.set_rdata(rdata);
+        record.set_data(Some(rdata));
 
         // add to the map
         let key = RrKey::new(LowerName::new(record.name()), record.rr_type());

--- a/crates/proto/src/https/https_client_stream.rs
+++ b/crates/proto/src/https/https_client_stream.rs
@@ -541,11 +541,10 @@ mod tests {
             .expect("send_message failed");
 
         let record = &response.answers()[0];
-        let addr = if let RData::A(addr) = record.rdata() {
-            addr
-        } else {
-            panic!("invalid response, expected A record");
-        };
+        let addr = record
+            .data()
+            .and_then(RData::as_a)
+            .expect("Expected A record");
 
         assert_eq!(addr, &Ipv4Addr::new(93, 184, 216, 34));
 
@@ -568,11 +567,10 @@ mod tests {
             }
 
             let record = &response.answers()[0];
-            let addr = if let RData::AAAA(addr) = record.rdata() {
-                addr
-            } else {
-                panic!("invalid response, expected A record");
-            };
+            let addr = record
+                .data()
+                .and_then(RData::as_aaaa)
+                .expect("invalid response, expected A record");
 
             assert_eq!(
                 addr,
@@ -609,11 +607,10 @@ mod tests {
             .expect("send_message failed");
 
         let record = &response.answers()[0];
-        let addr = if let RData::A(addr) = record.rdata() {
-            addr
-        } else {
-            panic!("invalid response, expected A record");
-        };
+        let addr = record
+            .data()
+            .and_then(RData::as_a)
+            .expect("invalid response, expected A record");
 
         assert_eq!(addr, &Ipv4Addr::new(93, 184, 216, 34));
 
@@ -632,11 +629,10 @@ mod tests {
             .expect("send_message failed");
 
         let record = &response.answers()[0];
-        let addr = if let RData::AAAA(addr) = record.rdata() {
-            addr
-        } else {
-            panic!("invalid response, expected A record");
-        };
+        let addr = record
+            .data()
+            .and_then(RData::as_aaaa)
+            .expect("invalid response, expected A record");
 
         assert_eq!(
             addr,

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -1106,3 +1106,13 @@ fn test_legit_message() {
 
     assert_eq!(message.id(), 4096);
 }
+
+#[test]
+fn rdata_zero_roundtrip() {
+    let buf = &[
+        160, 160, 0, 13, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0,
+    ];
+    let msg = Message::from_bytes(buf).unwrap();
+    let encoded = msg.to_bytes().unwrap();
+    assert_eq!(Message::from_bytes(&encoded).unwrap(), msg);
+}

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -1114,5 +1114,7 @@ fn rdata_zero_roundtrip() {
     ];
     let msg = Message::from_bytes(buf).unwrap();
     let encoded = msg.to_bytes().unwrap();
+
+    assert_eq!(encoded.len(), buf.len());
     assert_eq!(Message::from_bytes(&encoded).unwrap(), msg);
 }

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -1112,9 +1112,6 @@ fn rdata_zero_roundtrip() {
     let buf = &[
         160, 160, 0, 13, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0,
     ];
-    let msg = Message::from_bytes(buf).unwrap();
-    let encoded = msg.to_bytes().unwrap();
 
-    assert_eq!(encoded.len(), buf.len());
-    assert_eq!(Message::from_bytes(&encoded).unwrap(), msg);
+    assert!(Message::from_bytes(buf).is_err());
 }

--- a/crates/proto/src/rr/dnssec/rdata/tsig.rs
+++ b/crates/proto/src/rr/dnssec/rdata/tsig.rs
@@ -725,8 +725,8 @@ pub fn signed_bitmessage_to_buf(
 
     // parse a tsig record
     let sig = Record::read(&mut decoder)?;
-    let tsig = if let (RecordType::TSIG, RData::DNSSEC(DNSSECRData::TSIG(tsig_data))) =
-        (sig.rr_type(), sig.rdata())
+    let tsig = if let (RecordType::TSIG, Some(RData::DNSSEC(DNSSECRData::TSIG(tsig_data)))) =
+        (sig.rr_type(), sig.data())
     {
         tsig_data
     } else {
@@ -774,7 +774,7 @@ pub fn make_tsig_record(name: Name, rdata: TSIG) -> Record {
         .set_dns_class(DNSClass::ANY)
         //   TTL:  This MUST be 0.
         .set_ttl(0)
-        .set_rdata(DNSSECRData::TSIG(rdata).into());
+        .set_data(Some(DNSSECRData::TSIG(rdata).into()));
     tsig
 }
 

--- a/crates/proto/src/rr/rdata/null.rs
+++ b/crates/proto/src/rr/rdata/null.rs
@@ -81,10 +81,8 @@ pub fn read(decoder: &mut BinDecoder<'_>, rdata_length: Restrict<u16>) -> ProtoR
 
 /// Write the RData from the given Decoder
 pub fn emit(encoder: &mut BinEncoder<'_>, nil: &NULL) -> ProtoResult<()> {
-    if let anything = nil.anything() {
-        for b in anything.iter() {
-            encoder.emit(*b)?;
-        }
+    for b in nil.anything() {
+        encoder.emit(*b)?;
     }
 
     Ok(())

--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -687,6 +687,7 @@ pub enum RData {
     },
 
     /// This corresponds to a record type of 0, unspecified
+    #[deprecated(note = "Use None for the RData in the resource record instead")]
     ZERO,
 }
 

--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -7,6 +7,8 @@
 
 //! record data enum variants
 
+#![allow(deprecated)] // allows us to deprecate RData types
+
 use std::cmp::Ordering;
 #[cfg(test)]
 use std::convert::From;
@@ -749,6 +751,9 @@ impl RData {
             }
             RecordType::ZERO => {
                 trace!("reading EMPTY");
+                // we should never get here, since ZERO should be 0 length, and None in the Record.
+                //   this invariant is verified below, and the decoding will fail with an err.
+                #[allow(deprecated)]
                 Ok(RData::ZERO)
             }
             RecordType::MX => {

--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -749,7 +749,7 @@ impl RData {
             }
             RecordType::ZERO => {
                 trace!("reading EMPTY");
-                return Ok(RData::ZERO);
+                Ok(RData::ZERO)
             }
             RecordType::MX => {
                 trace!("reading MX");

--- a/crates/proto/src/rr/record_type.rs
+++ b/crates/proto/src/rr/record_type.rs
@@ -176,6 +176,12 @@ impl RecordType {
                 | RecordType::TSIG
         )
     }
+
+    /// Returns true if this is a Zero (unspecified) RecordType
+    #[inline]
+    pub fn is_zero(self) -> bool {
+        self == RecordType::ZERO
+    }
 }
 
 impl FromStr for RecordType {

--- a/crates/proto/src/rr/resource.rs
+++ b/crates/proto/src/rr/resource.rs
@@ -441,18 +441,12 @@ impl<'r> BinDecodable<'r> for Record {
                 ))
             })?;
 
-        // this is to handle updates, RFC 2136, which uses 0 to indicate certain aspects of
-        //  pre-requisites
-        let rdata: RData = if rd_length == 0 {
-            RData::NULL(NULL::new())
-        } else {
-            // RDATA           a variable length string of octets that describes the
-            //                resource.  The format of this information varies
-            //                according to the TYPE and CLASS of the resource record.
-            // Adding restrict to the rdata length because it's used for many calculations later
-            //  and must be validated before hand
-            RData::read(decoder, record_type, Restrict::new(rd_length))?
-        };
+        // RDATA          a variable length string of octets that describes the
+        //                resource.  The format of this information varies
+        //                according to the TYPE and CLASS of the resource record.
+        // Adding restrict to the rdata length because it's used for many calculations later
+        //  and must be validated before hand
+        let rdata = RData::read(decoder, record_type, Restrict::new(rd_length))?;
 
         Ok(Record {
             name_labels,

--- a/crates/proto/src/rr/resource.rs
+++ b/crates/proto/src/rr/resource.rs
@@ -441,12 +441,17 @@ impl<'r> BinDecodable<'r> for Record {
                 ))
             })?;
 
-        // RDATA          a variable length string of octets that describes the
-        //                resource.  The format of this information varies
-        //                according to the TYPE and CLASS of the resource record.
-        // Adding restrict to the rdata length because it's used for many calculations later
-        //  and must be validated before hand
-        let rdata = RData::read(decoder, record_type, Restrict::new(rd_length))?;
+        //  pre-requisites
+        let rdata: RData = if rd_length == 0 && !record_type.is_zero() {
+            RData::NULL(NULL::new())
+        } else {
+            // RDATA           a variable length string of octets that describes the
+            //                resource.  The format of this information varies
+            //                according to the TYPE and CLASS of the resource record.
+            // Adding restrict to the rdata length because it's used for many calculations later
+            //  and must be validated before hand
+            RData::read(decoder, record_type, Restrict::new(rd_length))?
+        };
 
         Ok(Record {
             name_labels,

--- a/crates/proto/src/rr/resource.rs
+++ b/crates/proto/src/rr/resource.rs
@@ -94,7 +94,7 @@ impl Default for Record {
         Record {
             // TODO: these really should all be Optionals, I was lazy.
             name_labels: Name::new(),
-            rr_type: RecordType::A,
+            rr_type: RecordType::NULL,
             dns_class: DNSClass::IN,
             ttl: 0,
             rdata: RData::NULL(NULL::new()),

--- a/crates/proto/src/rr/resource.rs
+++ b/crates/proto/src/rr/resource.rs
@@ -266,7 +266,7 @@ impl Record {
     #[deprecated(note = "use `Record::data` instead")]
     pub fn rdata(&self) -> &RData {
         if let Some(ref rdata) = &self.rdata {
-            return rdata;
+            rdata
         } else {
             NULL_RDATA
         }
@@ -386,7 +386,7 @@ impl BinEncodable for Record {
 
         // write the RData
         //   the None case is handled below by writing `0` for the length of the RData
-        //   this is in turn read as None during the `read` operation.
+        //   this is in turn read as `None` during the `read` operation.
         if let Some(rdata) = &self.rdata {
             rdata.emit(encoder)?;
         }
@@ -714,7 +714,7 @@ mod tests {
             .set_rr_type(RecordType::A)
             .set_dns_class(DNSClass::IN)
             .set_ttl(5)
-            .set_rdata(RData::A(Ipv4Addr::new(192, 168, 0, 1)));
+            .set_data(Some(RData::A(Ipv4Addr::new(192, 168, 0, 1))));
 
         let mut greater_name = record.clone();
         greater_name.set_name(Name::from_str("zzz.example.com").unwrap());
@@ -726,7 +726,7 @@ mod tests {
         greater_class.set_dns_class(DNSClass::NONE);
 
         let mut greater_rdata = record.clone();
-        greater_rdata.set_rdata(RData::A(Ipv4Addr::new(192, 168, 0, 255)));
+        greater_rdata.set_data(Some(RData::A(Ipv4Addr::new(192, 168, 0, 255))));
 
         let compares = vec![
             (&record, &greater_name),

--- a/crates/proto/src/rr/resource.rs
+++ b/crates/proto/src/rr/resource.rs
@@ -222,7 +222,13 @@ impl Record {
     ///                 For example, the if the TYPE is A and the CLASS is IN,
     ///                 the RDATA field is a 4 octet ARPA Internet address.
     /// ```
+    #[allow(deprecated)]
     pub fn set_data(&mut self, rdata: Option<RData>) -> &mut Self {
+        debug_assert!(
+            !(matches!(&rdata, Some(RData::ZERO))
+                && matches!(&rdata, Some(RData::NULL(null)) if null.anything().is_empty())),
+            "pass None rather than ZERO or NULL"
+        );
         self.rdata = rdata;
         self
     }

--- a/crates/proto/src/rr/rr_set.rs
+++ b/crates/proto/src/rr/rr_set.rs
@@ -8,7 +8,7 @@ use std::iter::Chain;
 use std::slice::Iter;
 use std::vec;
 
-use log::info;
+use log::{info, warn};
 
 use crate::rr::{DNSClass, Name, RData, Record, RecordType};
 
@@ -232,7 +232,7 @@ impl RecordSet {
 
         self.records
             .iter()
-            .find(|r| r.rdata() == rdata)
+            .find(|r| r.data().map(|r| r == rdata).unwrap_or(false))
             .expect("insert failed")
     }
 
@@ -241,7 +241,7 @@ impl RecordSet {
         debug_assert_eq!(self.record_type, rdata.to_record_type());
 
         let mut record = Record::with(self.name.clone(), self.record_type, self.ttl);
-        record.set_rdata(rdata);
+        record.set_data(Some(rdata));
         self.insert(record, 0)
     }
 
@@ -295,9 +295,9 @@ impl RecordSet {
                 assert!(self.records.len() <= 1);
 
                 if let Some(soa_record) = self.records.get(0) {
-                    match soa_record.rdata() {
-                        &RData::SOA(ref existing_soa) => {
-                            if let RData::SOA(ref new_soa) = *record.rdata() {
+                    match soa_record.data() {
+                        Some(RData::SOA(ref existing_soa)) => {
+                            if let Some(RData::SOA(ref new_soa)) = record.data() {
                                 if new_soa.serial() <= existing_soa.serial() {
                                     info!(
                                         "update ignored serial out of data: {:?} <= {:?}",
@@ -307,11 +307,14 @@ impl RecordSet {
                                 }
                             } else {
                                 // not panicking here, b/c this is a bad record from the client or something, ignore
-                                info!("wrong rdata for SOA update: {:?}", record.rdata());
+                                info!("wrong rdata for SOA update: {:?}", record.data());
                                 return false;
                             }
                         }
-                        rdata => panic!("wrong rdata: {:?}", rdata), // valid panic, never should happen
+                        rdata => {
+                            warn!("wrong rdata: {:?}, expected SOA", rdata);
+                            return false;
+                        }
                     }
                 }
 
@@ -354,7 +357,7 @@ impl RecordSet {
             .records
             .iter()
             .enumerate()
-            .filter(|&(_, rr)| rr.rdata() == record.rdata())
+            .filter(|&(_, rr)| rr.data() == record.data())
             .map(|(i, _)| i)
             .collect::<Vec<usize>>();
 
@@ -421,7 +424,7 @@ impl RecordSet {
             .records
             .iter()
             .enumerate()
-            .filter(|&(_, rr)| rr.rdata() == record.rdata())
+            .filter(|&(_, rr)| rr.data() == record.data())
             .map(|(i, _)| i)
             .collect::<Vec<usize>>();
 
@@ -557,14 +560,14 @@ impl<'r> Iterator for RrsigsByAlgorithms<'r> {
             self.rrsigs
                 .by_ref()
                 .filter(|record| {
-                    if let RData::DNSSEC(DNSSECRData::SIG(ref rrsig)) = *record.rdata() {
+                    if let Some(RData::DNSSEC(DNSSECRData::SIG(ref rrsig))) = record.data() {
                         supported_algorithms.has(rrsig.algorithm())
                     } else {
                         false
                     }
                 })
                 .max_by_key(|record| {
-                    if let RData::DNSSEC(DNSSECRData::SIG(ref rrsig)) = *record.rdata() {
+                    if let Some(RData::DNSSEC(DNSSECRData::SIG(ref rrsig))) = record.data() {
                         rrsig.algorithm()
                     } else {
                         Algorithm::RSASHA1
@@ -626,7 +629,7 @@ mod test {
             .set_ttl(86400)
             .set_rr_type(record_type)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+            .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 24))))
             .clone();
 
         assert!(rr_set.insert(insert.clone(), 0));
@@ -644,7 +647,7 @@ mod test {
             .set_ttl(86400)
             .set_rr_type(record_type)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 25)))
+            .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 25))))
             .clone();
         assert!(rr_set.insert(insert1.clone(), 0));
         assert_eq!(rr_set.records_without_rrsigs().count(), 2);
@@ -664,7 +667,7 @@ mod test {
             .set_ttl(3600)
             .set_rr_type(RecordType::SOA)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::SOA(SOA::new(
+            .set_data(Some(RData::SOA(SOA::new(
                 Name::from_str("sns.dns.icann.org.").unwrap(),
                 Name::from_str("noc.dns.icann.org.").unwrap(),
                 2015082403,
@@ -672,14 +675,14 @@ mod test {
                 3600,
                 1209600,
                 3600,
-            )))
+            ))))
             .clone();
         let same_serial = Record::new()
             .set_name(name.clone())
             .set_ttl(3600)
             .set_rr_type(RecordType::SOA)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::SOA(SOA::new(
+            .set_data(Some(RData::SOA(SOA::new(
                 Name::from_str("sns.dns.icann.net.").unwrap(),
                 Name::from_str("noc.dns.icann.net.").unwrap(),
                 2015082403,
@@ -687,14 +690,14 @@ mod test {
                 3600,
                 1209600,
                 3600,
-            )))
+            ))))
             .clone();
         let new_serial = Record::new()
             .set_name(name)
             .set_ttl(3600)
             .set_rr_type(RecordType::SOA)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::SOA(SOA::new(
+            .set_data(Some(RData::SOA(SOA::new(
                 Name::from_str("sns.dns.icann.net.").unwrap(),
                 Name::from_str("noc.dns.icann.net.").unwrap(),
                 2015082404,
@@ -702,7 +705,7 @@ mod test {
                 3600,
                 1209600,
                 3600,
-            )))
+            ))))
             .clone();
 
         assert!(rr_set.insert(insert.clone(), 0));
@@ -741,14 +744,14 @@ mod test {
             .set_ttl(3600)
             .set_rr_type(RecordType::CNAME)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::CNAME(cname))
+            .set_data(Some(RData::CNAME(cname)))
             .clone();
         let new_record = Record::new()
             .set_name(name)
             .set_ttl(3600)
             .set_rr_type(RecordType::CNAME)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::CNAME(new_cname))
+            .set_data(Some(RData::CNAME(new_cname)))
             .clone();
 
         assert!(rr_set.insert(insert.clone(), 0));
@@ -773,14 +776,14 @@ mod test {
             .set_ttl(86400)
             .set_rr_type(record_type)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+            .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 24))))
             .clone();
         let insert1 = Record::new()
             .set_name(name)
             .set_ttl(86400)
             .set_rr_type(record_type)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 25)))
+            .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 25))))
             .clone();
 
         assert!(rr_set.insert(insert.clone(), 0));
@@ -804,7 +807,7 @@ mod test {
             .set_ttl(3600)
             .set_rr_type(RecordType::SOA)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::SOA(SOA::new(
+            .set_data(Some(RData::SOA(SOA::new(
                 Name::from_str("sns.dns.icann.org.").unwrap(),
                 Name::from_str("noc.dns.icann.org.").unwrap(),
                 2015082403,
@@ -812,7 +815,7 @@ mod test {
                 3600,
                 1209600,
                 3600,
-            )))
+            ))))
             .clone();
 
         assert!(rr_set.insert(insert.clone(), 0));
@@ -831,14 +834,18 @@ mod test {
             .set_ttl(86400)
             .set_rr_type(RecordType::NS)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::NS(Name::from_str("a.iana-servers.net.").unwrap()))
+            .set_data(Some(RData::NS(
+                Name::from_str("a.iana-servers.net.").unwrap(),
+            )))
             .clone();
         let ns2 = Record::new()
             .set_name(name)
             .set_ttl(86400)
             .set_rr_type(RecordType::NS)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::NS(Name::from_str("b.iana-servers.net.").unwrap()))
+            .set_data(Some(RData::NS(
+                Name::from_str("b.iana-servers.net.").unwrap(),
+            )))
             .clone();
 
         assert!(rr_set.insert(ns1.clone(), 0));
@@ -914,28 +921,28 @@ mod test {
             .set_ttl(3600)
             .set_rr_type(RecordType::RRSIG)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::DNSSEC(DNSSECRData::SIG(rsasha256)))
+            .set_data(Some(RData::DNSSEC(DNSSECRData::SIG(rsasha256))))
             .clone();
         let rrsig_ecp256 = Record::new()
             .set_name(name.clone())
             .set_ttl(3600)
             .set_rr_type(RecordType::RRSIG)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::DNSSEC(DNSSECRData::SIG(ecp256)))
+            .set_data(Some(RData::DNSSEC(DNSSECRData::SIG(ecp256))))
             .clone();
         let rrsig_ecp384 = Record::new()
             .set_name(name.clone())
             .set_ttl(3600)
             .set_rr_type(RecordType::RRSIG)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::DNSSEC(DNSSECRData::SIG(ecp384)))
+            .set_data(Some(RData::DNSSEC(DNSSECRData::SIG(ecp384))))
             .clone();
         let rrsig_ed25519 = Record::new()
             .set_name(name.clone())
             .set_ttl(3600)
             .set_rr_type(RecordType::RRSIG)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::DNSSEC(DNSSECRData::SIG(ed25519)))
+            .set_data(Some(RData::DNSSEC(DNSSECRData::SIG(ed25519))))
             .clone();
 
         let a = Record::new()
@@ -943,7 +950,7 @@ mod test {
             .set_ttl(3600)
             .set_rr_type(RecordType::A)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+            .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 24))))
             .clone();
 
         let mut rrset = RecordSet::from(a);
@@ -955,7 +962,7 @@ mod test {
         assert!(rrset
             .records_with_rrsigs(SupportedAlgorithms::all(),)
             .any(
-                |r| if let RData::DNSSEC(DNSSECRData::SIG(ref sig)) = *r.rdata() {
+                |r| if let Some(RData::DNSSEC(DNSSECRData::SIG(ref sig))) = r.data() {
                     sig.algorithm() == Algorithm::ED25519
                 } else {
                     false
@@ -965,7 +972,7 @@ mod test {
         let mut supported_algorithms = SupportedAlgorithms::new();
         supported_algorithms.set(Algorithm::ECDSAP384SHA384);
         assert!(rrset.records_with_rrsigs(supported_algorithms).any(|r| {
-            if let RData::DNSSEC(DNSSECRData::SIG(ref sig)) = *r.rdata() {
+            if let Some(RData::DNSSEC(DNSSECRData::SIG(ref sig))) = r.data() {
                 sig.algorithm() == Algorithm::ECDSAP384SHA384
             } else {
                 false
@@ -975,7 +982,7 @@ mod test {
         let mut supported_algorithms = SupportedAlgorithms::new();
         supported_algorithms.set(Algorithm::ED25519);
         assert!(rrset.records_with_rrsigs(supported_algorithms).any(|r| {
-            if let RData::DNSSEC(DNSSECRData::SIG(ref sig)) = *r.rdata() {
+            if let Some(RData::DNSSEC(DNSSECRData::SIG(ref sig))) = r.data() {
                 sig.algorithm() == Algorithm::ED25519
             } else {
                 false

--- a/crates/proto/src/tests/udp.rs
+++ b/crates/proto/src/tests/udp.rs
@@ -222,8 +222,8 @@ pub fn udp_client_stream_test<S: UdpSocket + Send + 'static, E: Executor, TE: Ti
         println!("client got response {}", i);
 
         let response = Message::from(response);
-        if let RData::NULL(null) = response.answers()[0].rdata() {
-            assert_eq!(null.anything().expect("no bytes in NULL"), test_bytes);
+        if let Some(RData::NULL(null)) = response.answers()[0].data() {
+            assert_eq!(null.anything(), test_bytes);
         } else {
             panic!("not a NULL response");
         }

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -542,7 +542,7 @@ mod test {
                 .set_ttl(86400)
                 .set_rr_type(RecordType::A)
                 .set_dns_class(DNSClass::IN)
-                .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
+                .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 34))))
                 .clone(),
         );
         (DnsRequest::new(query, Default::default()), vec![msg])
@@ -571,7 +571,7 @@ mod test {
             .set_ttl(3600)
             .set_rr_type(RecordType::SOA)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::SOA(SOA::new(
+            .set_data(Some(RData::SOA(SOA::new(
                 Name::parse("sns.dns.icann.org.", None).unwrap(),
                 Name::parse("noc.dns.icann.org.", None).unwrap(),
                 2015082403,
@@ -579,7 +579,7 @@ mod test {
                 3600,
                 1209600,
                 3600,
-            )))
+            ))))
             .clone();
 
         vec![
@@ -589,30 +589,34 @@ mod test {
                 .set_ttl(86400)
                 .set_rr_type(RecordType::NS)
                 .set_dns_class(DNSClass::IN)
-                .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
+                .set_data(Some(RData::NS(
+                    Name::parse("a.iana-servers.net.", None).unwrap(),
+                )))
                 .clone(),
             Record::new()
                 .set_name(origin.clone())
                 .set_ttl(86400)
                 .set_rr_type(RecordType::NS)
                 .set_dns_class(DNSClass::IN)
-                .set_rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
+                .set_data(Some(RData::NS(
+                    Name::parse("b.iana-servers.net.", None).unwrap(),
+                )))
                 .clone(),
             Record::new()
                 .set_name(origin.clone())
                 .set_ttl(86400)
                 .set_rr_type(RecordType::A)
                 .set_dns_class(DNSClass::IN)
-                .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
+                .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 34))))
                 .clone(),
             Record::new()
                 .set_name(origin)
                 .set_ttl(86400)
                 .set_rr_type(RecordType::AAAA)
                 .set_dns_class(DNSClass::IN)
-                .set_rdata(RData::AAAA(Ipv6Addr::new(
+                .set_data(Some(RData::AAAA(Ipv6Addr::new(
                     0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
-                )))
+                ))))
                 .clone(),
             soa,
         ]

--- a/crates/proto/src/xfer/dnssec_dns_handle.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle.rs
@@ -288,7 +288,7 @@ where
             .chain(message_result.additionals())
             .filter(|rr| is_dnssec(rr, RecordType::RRSIG))
             .filter(|rr| {
-                if let RData::DNSSEC(DNSSECRData::SIG(ref rrsig)) = *rr.rdata() {
+                if let Some(RData::DNSSEC(DNSSECRData::SIG(ref rrsig))) = rr.data() {
                     rrsig.type_covered() == record_type
                 } else {
                     false
@@ -478,7 +478,7 @@ where
             .enumerate()
             .filter(|&(_, rr)| is_dnssec(rr, RecordType::DNSKEY))
             .filter_map(|(i, rr)| {
-                if let RData::DNSSEC(DNSSECRData::DNSKEY(ref rdata)) = *rr.rdata() {
+                if let Some(RData::DNSSEC(DNSSECRData::DNSKEY(ref rdata))) = rr.data() {
                     Some((i, rdata))
                 } else {
                     None
@@ -522,7 +522,7 @@ where
         .enumerate()
         .filter(|&(_, rr)| is_dnssec(rr, RecordType::DNSKEY))
         .filter_map(|(i, rr)| {
-            if let RData::DNSSEC(DNSSECRData::DNSKEY(ref rdata)) = *rr.rdata() {
+            if let Some(RData::DNSSEC(DNSSECRData::DNSKEY(ref rdata))) = rr.data() {
                 Some((i, rdata))
             } else {
                 None
@@ -534,7 +534,7 @@ where
                 .iter()
                 .filter(|ds| is_dnssec(ds, RecordType::DS))
                 .filter_map(|ds| {
-                    if let RData::DNSSEC(DNSSECRData::DS(ref ds_rdata)) = *ds.rdata() {
+                    if let Some(RData::DNSSEC(DNSSECRData::DS(ref ds_rdata))) = ds.data() {
                         Some((ds.name(), ds_rdata))
                     } else {
                         None
@@ -658,7 +658,7 @@ where
         .iter()
         .filter(|rrsig| is_dnssec(rrsig, RecordType::RRSIG))
         .any(|rrsig| {
-            if let RData::DNSSEC(DNSSECRData::SIG(ref sig)) = *rrsig.rdata() {
+            if let Some(RData::DNSSEC(DNSSECRData::SIG(ref sig))) = rrsig.data() {
                 RecordType::DNSKEY == rrset.record_type && sig.signer_name() == &rrset.name
             } else {
                 panic!("expected a SIG here");
@@ -675,7 +675,7 @@ where
                 // this filter is technically unnecessary, can probably remove it...
                 .filter(|rrsig| is_dnssec(rrsig, RecordType::RRSIG))
                 .map(|rrsig| {
-                    if let RData::DNSSEC(DNSSECRData::SIG(sig)) = rrsig.into_data() {
+                    if let Some(RData::DNSSEC(DNSSECRData::SIG(sig))) = rrsig.into_data() {
                         // setting up the context explicitly.
                         sig
                     } else {
@@ -686,11 +686,11 @@ where
                     let rrset = Arc::clone(&rrset);
 
                     if rrset.records.iter().any(|r| {
-                        if let RData::DNSSEC(DNSSECRData::DNSKEY(ref dnskey)) = *r.rdata() {
+                        if let Some(RData::DNSSEC(DNSSECRData::DNSKEY(ref dnskey))) = r.data() {
                             let dnskey_name = r.name();
                             verify_rrset_with_dnskey(dnskey_name, dnskey, &sig, &rrset).is_ok()
                         } else {
-                            panic!("expected a DNSKEY here: {:?}", r.rdata());
+                            panic!("expected a DNSKEY here: {:?}", r.data());
                         }
                     }) {
                         Some(())
@@ -722,7 +722,7 @@ where
         // this filter is technically unnecessary, can probably remove it...
         .filter(|rrsig| is_dnssec(rrsig, RecordType::RRSIG))
         .map(|rrsig|
-            if let RData::DNSSEC(DNSSECRData::SIG(sig)) = rrsig.into_data() {
+            if let Some(RData::DNSSEC(DNSSECRData::SIG(sig))) = rrsig.into_data() {
                 // setting up the context explicitly.
                 sig
             } else {
@@ -746,11 +746,11 @@ where
                         .iter()
                         .filter(|r| is_dnssec(r, RecordType::DNSKEY))
                         .find(|r|
-                            if let RData::DNSSEC(DNSSECRData::DNSKEY(ref dnskey)) = *r.rdata() {
+                            if let Some(RData::DNSSEC(DNSSECRData::DNSKEY(ref dnskey))) = r.data() {
                                 let dnskey_name = r.name();
                                 verify_rrset_with_dnskey(dnskey_name, dnskey, &sig, &rrset).is_ok()
                             } else {
-                                panic!("expected a DNSKEY here: {:?}", r.rdata());
+                                panic!("expected a DNSKEY here: {:?}", r.data());
                             }
                         )
                         .map(|_| ())

--- a/crates/proto/src/xfer/dnssec_dns_handle.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle.rs
@@ -892,8 +892,8 @@ pub fn verify_nsec(query: &Query, soa_name: &Name, nsecs: &[&Record]) -> bool {
     //    WTF? is that bad server, bad record
     if let Some(nsec) = nsecs.iter().find(|nsec| query.name() == nsec.name()) {
         return nsec
-            .rdata()
-            .as_dnssec()
+            .data()
+            .and_then(RData::as_dnssec)
             .and_then(DNSSECRData::as_nsec)
             .map_or(false, |rdata| {
                 // this should not be in the covered list
@@ -905,8 +905,8 @@ pub fn verify_nsec(query: &Query, soa_name: &Name, nsecs: &[&Record]) -> bool {
         nsecs.iter().any(|nsec| {
             // the query name must be greater than nsec's label (or equal in the case of wildcard)
             name >= nsec.name() && {
-                nsec.rdata()
-                    .as_dnssec()
+                nsec.data()
+                    .and_then(RData::as_dnssec)
                     .and_then(DNSSECRData::as_nsec)
                     .map_or(false, |rdata| {
                         // the query name is less than the next name

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -426,7 +426,7 @@ impl<C: DnsHandle<Error = ResolveError>, P: ConnectionProvider<Conn = C>> AsyncR
             self.client_cache.clone(),
             DnsRequestOptions::default(),
             hosts,
-            finally_ip_addr.map(Record::into_data),
+            finally_ip_addr.and_then(Record::into_data),
         )
         .await
     }

--- a/crates/resolver/src/caching_client.rs
+++ b/crates/resolver/src/caching_client.rs
@@ -333,8 +333,8 @@ where
                     response.answers().iter().fold(
                         (Cow::Borrowed(query.name()), INITIAL_TTL, false),
                         |(search_name, cname_ttl, was_cname), r| {
-                            match *r.rdata() {
-                                RData::CNAME(ref cname) => {
+                            match r.data() {
+                                Some(RData::CNAME(ref cname)) => {
                                     // take the minimum TTL of the cname_ttl and the next record in the chain
                                     let ttl = cname_ttl.min(r.ttl());
                                     debug_assert_eq!(r.rr_type(), RecordType::CNAME);
@@ -342,7 +342,7 @@ where
                                         return (Cow::Owned(cname.clone()), ttl, true);
                                     }
                                 }
-                                RData::SRV(ref srv) => {
+                                Some(RData::SRV(ref srv)) => {
                                     // take the minimum TTL of the cname_ttl and the next record in the chain
                                     let ttl = cname_ttl.min(r.ttl());
                                     debug_assert_eq!(r.rr_type(), RecordType::SRV);

--- a/crates/resolver/src/lookup.rs
+++ b/crates/resolver/src/lookup.rs
@@ -123,7 +123,7 @@ impl<'a> Iterator for LookupIter<'a> {
     type Item = &'a RData;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(Record::rdata)
+        self.0.next().and_then(Record::data)
     }
 }
 
@@ -166,7 +166,7 @@ impl Iterator for LookupIntoIter {
     type Item = RData;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let rdata = self.records.get(self.index).map(Record::rdata);
+        let rdata = self.records.get(self.index).and_then(Record::data);
         self.index += 1;
         rdata.cloned()
     }

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -430,6 +430,7 @@ mod tests {
     use proto::op::Query;
     use proto::rr::{Name, RecordType};
     use proto::xfer::{DnsHandle, DnsRequestOptions};
+    use trust_dns_proto::rr::RData;
 
     use super::*;
     use crate::config::NameServerConfig;
@@ -551,8 +552,8 @@ mod tests {
 
         assert_eq!(
             *response.answers()[0]
-                .rdata()
-                .as_a()
+                .data()
+                .and_then(RData::as_a)
                 .expect("no a record available"),
             Ipv4Addr::new(93, 184, 216, 34)
         );
@@ -575,8 +576,8 @@ mod tests {
 
         assert_eq!(
             *response.answers()[0]
-                .rdata()
-                .as_aaaa()
+                .data()
+                .and_then(RData::as_aaaa)
                 .expect("no aaaa record available"),
             Ipv6Addr::new(0x2606, 0x2800, 0x0220, 0x0001, 0x0248, 0x1893, 0x25c8, 0x1946)
         );

--- a/crates/server/src/authority/message_response.rs
+++ b/crates/server/src/authority/message_response.rs
@@ -250,7 +250,7 @@ mod tests {
 
             let answer = Record::new()
                 .set_name(Name::from_str("www.example.com.").unwrap())
-                .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
+                .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 34))))
                 .set_dns_class(DNSClass::NONE)
                 .clone();
 
@@ -286,7 +286,7 @@ mod tests {
 
             let answer = Record::new()
                 .set_name(Name::from_str("www.example.com.").unwrap())
-                .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
+                .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 34))))
                 .set_dns_class(DNSClass::NONE)
                 .clone();
 

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -392,9 +392,9 @@ mod tests {
             .into_iter()
             .next()
             .expect("A record not found in authity")
-            .rdata()
+            .data()
         {
-            RData::A(ip) => assert_eq!(Ipv4Addr::new(127, 0, 0, 1), *ip),
+            Some(RData::A(ip)) => assert_eq!(Ipv4Addr::new(127, 0, 0, 1), *ip),
             _ => panic!("wrong rdata type returned"),
         }
 
@@ -410,9 +410,9 @@ mod tests {
             .into_iter()
             .next()
             .expect("A record not found in authity")
-            .rdata()
+            .data()
         {
-            RData::A(ip) => assert_eq!(Ipv4Addr::new(127, 0, 0, 5), *ip),
+            Some(RData::A(ip)) => assert_eq!(Ipv4Addr::new(127, 0, 0, 5), *ip),
             _ => panic!("wrong rdata type returned"),
         }
     }

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -523,7 +523,7 @@ impl InnerInMemory {
             return 0;
         };
 
-        let serial = if let RData::SOA(ref mut soa_rdata) = *record.rdata_mut() {
+        let serial = if let Some(RData::SOA(ref mut soa_rdata)) = record.data_mut() {
             soa_rdata.increment_serial();
             soa_rdata.serial()
         } else {

--- a/crates/server/src/store/sqlite/authority.rs
+++ b/crates/server/src/store/sqlite/authority.rs
@@ -327,7 +327,7 @@ impl SqliteAuthority {
 
             match require.dns_class() {
                 DNSClass::ANY => {
-                    if let RData::NULL(..) = *require.rdata() {
+                    if require.data().is_none() {
                         match require.rr_type() {
                             // ANY      ANY      empty    Name is in use
                             RecordType::ANY => {
@@ -365,7 +365,7 @@ impl SqliteAuthority {
                     }
                 }
                 DNSClass::NONE => {
-                    if let RData::NULL(..) = *require.rdata() {
+                    if require.data().is_none() {
                         match require.rr_type() {
                             // NONE     ANY      empty    Name is not in use
                             RecordType::ANY => {
@@ -481,11 +481,9 @@ impl SqliteAuthority {
         if !sig0s.is_empty() {
             let mut found_key = false;
             for sig in sig0s.iter().filter_map(|sig0| {
-                if let RData::DNSSEC(DNSSECRData::SIG(ref sig)) = *sig0.rdata() {
-                    Some(sig)
-                } else {
-                    None
-                }
+                sig0.data()
+                    .and_then(RData::as_dnssec)
+                    .and_then(DNSSECRData::as_sig)
             }) {
                 let name = LowerName::from(sig.signer_name());
                 let keys = self
@@ -502,11 +500,10 @@ impl SqliteAuthority {
                 found_key = keys
                     .iter()
                     .filter_map(|rr_set| {
-                        if let RData::DNSSEC(DNSSECRData::KEY(ref key)) = *rr_set.rdata() {
-                            Some(key)
-                        } else {
-                            None
-                        }
+                        rr_set
+                            .data()
+                            .and_then(RData::as_dnssec)
+                            .and_then(DNSSECRData::as_key)
                     })
                     .any(|key| {
                         key.verify_message(update_message, sig.sig(), sig)
@@ -604,9 +601,7 @@ impl SqliteAuthority {
                         if rr.ttl() != 0 {
                             return Err(ResponseCode::FormErr);
                         }
-                        if let RData::NULL(..) = *rr.rdata() {
-                            ()
-                        } else {
+                        if rr.data().is_some() {
                             return Err(ResponseCode::FormErr);
                         }
                         match rr.rr_type() {
@@ -778,7 +773,7 @@ impl SqliteAuthority {
                             //   SOA or NS RRs will be deleted.
 
                             // ANY      rrset    empty    Delete an RRset
-                            if let RData::NULL(..) = *rr.rdata() {
+                            if let Some(RData::NULL(..)) = rr.data() {
                                 let deleted = self.in_memory.records_mut().await.remove(&rr_key);
                                 info!("deleted rrset: {:?}", deleted);
                                 updated = updated || deleted.is_some();

--- a/crates/server/tests/authority_battery/dynamic_update.rs
+++ b/crates/server/tests/authority_battery/dynamic_update.rs
@@ -54,9 +54,9 @@ pub fn test_create<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys: &[
             .into_iter()
             .next()
             .expect("A record not found in authity")
-            .rdata()
+            .data()
         {
-            RData::A(ip) => assert_eq!(Ipv4Addr::new(127, 0, 0, 10), *ip),
+            Some(RData::A(ip)) => assert_eq!(Ipv4Addr::new(127, 0, 0, 10), *ip),
             _ => panic!("wrong rdata type returned"),
         }
 
@@ -79,11 +79,11 @@ pub fn test_create_multi<A: Authority<Lookup = AuthLookup>>(mut authority: A, ke
             .unwrap();
         // create a record
         let mut record = Record::with(name.clone(), RecordType::A, 8);
-        record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+        record.set_data(Some(RData::A(Ipv4Addr::new(100, 10, 100, 10))));
         let record = record;
 
         let mut record2 = record.clone();
-        record2.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 11)));
+        record2.set_data(Some(RData::A(Ipv4Addr::new(100, 10, 100, 11))));
         let record2 = record2;
 
         let mut rrset = RecordSet::from(record.clone());
@@ -119,7 +119,7 @@ pub fn test_append<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys: &[
 
         // append a record
         let mut record = Record::with(name.clone(), RecordType::A, 8);
-        record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+        record.set_data(Some(RData::A(Ipv4Addr::new(100, 10, 100, 10))));
 
         // first check the must_exist option
         let mut message = update_message::append(
@@ -151,7 +151,7 @@ pub fn test_append<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys: &[
 
         // will fail if already set and not the same value.
         let mut record2 = record.clone();
-        record2.set_rdata(RData::A(Ipv4Addr::new(101, 11, 101, 11)));
+        record2.set_data(Some(RData::A(Ipv4Addr::new(101, 11, 101, 11))));
 
         let message = update_message::append(
             record2.clone().into(),
@@ -198,7 +198,7 @@ pub fn test_append_multi<A: Authority<Lookup = AuthLookup>>(mut authority: A, ke
 
         // append a record
         let mut record = Record::with(name.clone(), RecordType::A, 8);
-        record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+        record.set_data(Some(RData::A(Ipv4Addr::new(100, 10, 100, 10))));
 
         // next append to a non-existent RRset
         let message = update_message::append(
@@ -211,9 +211,9 @@ pub fn test_append_multi<A: Authority<Lookup = AuthLookup>>(mut authority: A, ke
 
         // will fail if already set and not the same value.
         let mut record2 = record.clone();
-        record2.set_rdata(RData::A(Ipv4Addr::new(101, 11, 101, 11)));
+        record2.set_data(Some(RData::A(Ipv4Addr::new(101, 11, 101, 11))));
         let mut record3 = record.clone();
-        record3.set_rdata(RData::A(Ipv4Addr::new(101, 11, 101, 12)));
+        record3.set_data(Some(RData::A(Ipv4Addr::new(101, 11, 101, 12))));
 
         // build the append set
         let mut rrset = RecordSet::from(record2.clone());
@@ -270,7 +270,7 @@ pub fn test_compare_and_swap<A: Authority<Lookup = AuthLookup>>(
 
         // create a record
         let mut record = Record::with(name.clone(), RecordType::A, 8);
-        record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+        record.set_data(Some(RData::A(Ipv4Addr::new(100, 10, 100, 10))));
         let record = record;
 
         let message = update_message::create(
@@ -282,7 +282,7 @@ pub fn test_compare_and_swap<A: Authority<Lookup = AuthLookup>>(
 
         let current = record;
         let mut new = current.clone();
-        new.set_rdata(RData::A(Ipv4Addr::new(101, 11, 101, 11)));
+        new.set_data(Some(RData::A(Ipv4Addr::new(101, 11, 101, 11))));
         let new = new;
 
         let message = update_message::compare_and_swap(
@@ -302,7 +302,7 @@ pub fn test_compare_and_swap<A: Authority<Lookup = AuthLookup>>(
 
         // check the it fails if tried again.
         let mut not = new.clone();
-        not.set_rdata(RData::A(Ipv4Addr::new(102, 12, 102, 12)));
+        not.set_data(Some(RData::A(Ipv4Addr::new(102, 12, 102, 12))));
         let not = not;
 
         let message = update_message::compare_and_swap(
@@ -383,7 +383,7 @@ pub fn test_compare_and_swap_multi<A: Authority<Lookup = AuthLookup>>(
 
         // check the it fails if tried again.
         let mut not = new1.clone();
-        not.set_rdata(RData::A(Ipv4Addr::new(102, 12, 102, 12)));
+        not.set_data(Some(RData::A(Ipv4Addr::new(102, 12, 102, 12))));
         let not = not;
 
         let message = update_message::compare_and_swap(
@@ -419,7 +419,7 @@ pub fn test_delete_by_rdata<A: Authority<Lookup = AuthLookup>>(
 
         // append a record
         let mut record1 = Record::with(name.clone(), RecordType::A, 8);
-        record1.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+        record1.set_data(Some(RData::A(Ipv4Addr::new(100, 10, 100, 10))));
 
         // first check the must_exist option
         let mut message = update_message::delete_by_rdata(
@@ -438,7 +438,7 @@ pub fn test_delete_by_rdata<A: Authority<Lookup = AuthLookup>>(
         assert!(update_authority(message, key, &mut authority).expect("delete_by_rdata failed"));
 
         let mut record2 = record1.clone();
-        record2.set_rdata(RData::A(Ipv4Addr::new(101, 11, 101, 11)));
+        record2.set_data(Some(RData::A(Ipv4Addr::new(101, 11, 101, 11))));
         let message = update_message::append(
             record2.clone().into(),
             Name::from_str("example.com.").unwrap(),
@@ -507,8 +507,8 @@ pub fn test_delete_by_rdata_multi<A: Authority<Lookup = AuthLookup>>(
         // append a record
         let mut rrset = RecordSet::with_ttl(name.clone(), RecordType::A, 8);
 
-        let record1 = rrset.new_record(record1.rdata()).clone();
-        let record3 = rrset.new_record(record3.rdata()).clone();
+        let record1 = rrset.new_record(record1.data().unwrap()).clone();
+        let record3 = rrset.new_record(record3.data().unwrap()).clone();
         let rrset = rrset;
 
         let message = update_message::append(
@@ -548,7 +548,7 @@ pub fn test_delete_rrset<A: Authority<Lookup = AuthLookup>>(mut authority: A, ke
 
         // append a record
         let mut record = Record::with(name.clone(), RecordType::A, 8);
-        record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+        record.set_data(Some(RData::A(Ipv4Addr::new(100, 10, 100, 10))));
 
         // first check the must_exist option
         let message = update_message::delete_rrset(
@@ -567,7 +567,7 @@ pub fn test_delete_rrset<A: Authority<Lookup = AuthLookup>>(mut authority: A, ke
         assert!(update_authority(message, key, &mut authority).expect("create failed"));
 
         let mut record = record.clone();
-        record.set_rdata(RData::A(Ipv4Addr::new(101, 11, 101, 11)));
+        record.set_data(Some(RData::A(Ipv4Addr::new(101, 11, 101, 11))));
         let message = update_message::append(
             record.clone().into(),
             Name::from_str("example.com.").unwrap(),
@@ -604,7 +604,7 @@ pub fn test_delete_all<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys
 
         // append a record
         let mut record = Record::with(name.clone(), RecordType::A, 8);
-        record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+        record.set_data(Some(RData::A(Ipv4Addr::new(100, 10, 100, 10))));
 
         // first check the must_exist option
         let message = update_message::delete_all(
@@ -625,7 +625,7 @@ pub fn test_delete_all<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys
 
         let mut record = record.clone();
         record.set_rr_type(RecordType::AAAA);
-        record.set_rdata(RData::AAAA(Ipv6Addr::new(1, 2, 3, 4, 5, 6, 7, 8)));
+        record.set_data(Some(RData::AAAA(Ipv6Addr::new(1, 2, 3, 4, 5, 6, 7, 8))));
         let message = update_message::create(
             record.clone().into(),
             Name::from_str("example.com.").unwrap(),

--- a/crates/server/tests/forwarder.rs
+++ b/crates/server/tests/forwarder.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 
 use tokio::runtime::Runtime;
 
-use trust_dns_client::rr::{Name, RecordType};
+use trust_dns_client::rr::{Name, RData, RecordType};
 use trust_dns_resolver::TokioHandle;
 use trust_dns_server::authority::{Authority, LookupObject};
 use trust_dns_server::store::forwarder::ForwardAuthority;
@@ -29,6 +29,9 @@ fn test_lookup() {
         .unwrap();
 
     let address = lookup.iter().next().expect("no addresses returned!");
-    let address = address.rdata().as_a().expect("not an A record");
+    let address = address
+        .data()
+        .and_then(RData::as_a)
+        .expect("not an A record");
     assert_eq!(*address, Ipv4Addr::new(93, 184, 216, 34));
 }

--- a/crates/server/tests/sqlite_tests.rs
+++ b/crates/server/tests/sqlite_tests.rs
@@ -36,7 +36,7 @@ fn create_test_journal() -> (Record, Journal) {
     let mut record = Record::new();
     record.set_name(www);
     record.set_rr_type(RecordType::A);
-    record.set_rdata(RData::A(Ipv4Addr::from_str("127.0.0.1").unwrap()));
+    record.set_data(Some(RData::A(Ipv4Addr::from_str("127.0.0.1").unwrap())));
 
     // test that this message can be inserted
     let conn = Connection::open_in_memory().expect("could not create in memory DB");
@@ -47,7 +47,7 @@ fn create_test_journal() -> (Record, Journal) {
     journal.insert_record(0, &record).unwrap();
 
     // insert another...
-    record.set_rdata(RData::A(Ipv4Addr::from_str("127.0.1.1").unwrap()));
+    record.set_data(Some(RData::A(Ipv4Addr::from_str("127.0.1.1").unwrap())));
     journal.insert_record(0, &record).unwrap();
 
     (record, journal)
@@ -62,7 +62,7 @@ fn test_insert_and_select_record() {
         .select_record(0)
         .expect("persistence error")
         .expect("none");
-    record.set_rdata(RData::A(Ipv4Addr::from_str("127.0.0.1").unwrap()));
+    record.set_data(Some(RData::A(Ipv4Addr::from_str("127.0.0.1").unwrap())));
     assert_eq!(journal_record, record);
 
     // test another
@@ -70,7 +70,7 @@ fn test_insert_and_select_record() {
         .select_record(row_id + 1)
         .expect("persistence error")
         .expect("none");
-    record.set_rdata(RData::A(Ipv4Addr::from_str("127.0.1.1").unwrap()));
+    record.set_data(Some(RData::A(Ipv4Addr::from_str("127.0.1.1").unwrap())));
     assert_eq!(journal_record, record);
 
     // check that we get nothing for id over row_id
@@ -87,11 +87,11 @@ fn test_iterator() {
     let mut iter = journal.iter();
 
     assert_eq!(
-        record.set_rdata(RData::A(Ipv4Addr::from_str("127.0.0.1").unwrap())),
+        record.set_data(Some(RData::A(Ipv4Addr::from_str("127.0.0.1").unwrap()))),
         &iter.next().unwrap()
     );
     assert_eq!(
-        record.set_rdata(RData::A(Ipv4Addr::from_str("127.0.1.1").unwrap())),
+        record.set_data(Some(RData::A(Ipv4Addr::from_str("127.0.1.1").unwrap()))),
         &iter.next().unwrap()
     );
     assert_eq!(None, iter.next());

--- a/crates/server/tests/txt_tests.rs
+++ b/crates/server/tests/txt_tests.rs
@@ -80,7 +80,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     assert_eq!(&Name::from_str("isi.edu").unwrap(), soa_record.name()); // i.e. the origin or domain
     assert_eq!(3_600_000, soa_record.ttl());
     assert_eq!(DNSClass::IN, soa_record.dns_class());
-    if let RData::SOA(ref soa) = *soa_record.rdata() {
+    if let Some(RData::SOA(ref soa)) = soa_record.data() {
         // this should all be lowercased
         assert_eq!(&Name::from_str("venera.isi.edu").unwrap(), soa.mname());
         assert_eq!(
@@ -108,7 +108,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     .unwrap();
     assert_eq!(&Name::from_str("tech.").unwrap(), lowercase_record.name());
     assert_eq!(DNSClass::IN, lowercase_record.dns_class());
-    if let RData::SOA(ref lower_soa) = *lowercase_record.rdata() {
+    if let Some(RData::SOA(ref lower_soa)) = lowercase_record.data() {
         assert_eq!(
             &Name::from_str("ns0.centralnic.net").unwrap(),
             lower_soa.mname()
@@ -152,7 +152,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         assert_eq!(60, record.ttl()); // TODO: should this be minimum or expire?
         assert_eq!(DNSClass::IN, record.dns_class());
         assert_eq!(RecordType::NS, record.rr_type());
-        if let RData::NS(nsdname) = record.rdata() {
+        if let Some(RData::NS(nsdname)) = record.data() {
             assert_eq!(name, *nsdname);
         } else {
             panic!("Not an NS record!!!") // valid panic, test code
@@ -183,7 +183,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         assert_eq!(60, record.ttl()); // TODO: should this be minimum or expire?
         assert_eq!(DNSClass::IN, record.dns_class());
         assert_eq!(RecordType::MX, record.rr_type());
-        if let RData::MX(ref rdata) = *record.rdata() {
+        if let Some(RData::MX(ref rdata)) = record.data() {
             assert_eq!(num, rdata.preference());
             assert_eq!(name, rdata.exchange());
         } else {
@@ -206,7 +206,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     assert_eq!(60, a_record.ttl()); // TODO: should this be minimum or expire?
     assert_eq!(DNSClass::IN, a_record.dns_class());
     assert_eq!(RecordType::A, a_record.rr_type());
-    if let RData::A(ref address) = *a_record.rdata() {
+    if let Some(RData::A(ref address)) = a_record.data() {
         assert_eq!(&Ipv4Addr::new(26u8, 3u8, 0u8, 103u8), address);
     } else {
         panic!("Not an A record!!!") // valid panic, test code
@@ -224,7 +224,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     .cloned()
     .unwrap();
     assert_eq!(&Name::from_str("aaaa.isi.edu").unwrap(), aaaa_record.name());
-    if let RData::AAAA(ref address) = *aaaa_record.rdata() {
+    if let Some(RData::AAAA(ref address)) = aaaa_record.data() {
         assert_eq!(
             &Ipv6Addr::from_str("4321:0:1:2:3:4:567:89ab").unwrap(),
             address
@@ -249,7 +249,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         short_record.name()
     );
     assert_eq!(70, short_record.ttl());
-    if let RData::A(ref address) = *short_record.rdata() {
+    if let Some(RData::A(ref address)) = short_record.data() {
         assert_eq!(&Ipv4Addr::new(26u8, 3u8, 0u8, 104u8), address);
     } else {
         panic!("Not an A record!!!") // valid panic, test code
@@ -292,7 +292,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     let compare = txt_records.iter().zip(compare);
 
     for (record, ref vector) in compare {
-        if let RData::TXT(ref rdata) = *record.rdata() {
+        if let Some(RData::TXT(ref rdata)) = record.data() {
             assert_eq!(vector as &[Box<[u8]>], rdata.txt_data());
         } else {
             panic!("Not a TXT record!!!") // valid panic, test code
@@ -310,7 +310,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     .next()
     .cloned()
     .unwrap();
-    if let RData::PTR(ref ptrdname) = *ptr_record.rdata() {
+    if let Some(RData::PTR(ref ptrdname)) = ptr_record.data() {
         assert_eq!(&Name::from_str("a.isi.edu").unwrap(), ptrdname);
     } else {
         panic!("Not a PTR record!!!") // valid panic, test code
@@ -327,7 +327,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     .next()
     .cloned()
     .unwrap();
-    if let RData::SRV(ref rdata) = *srv_record.rdata() {
+    if let Some(RData::SRV(ref rdata)) = srv_record.data() {
         assert_eq!(rdata.priority(), 1);
         assert_eq!(rdata.weight(), 2);
         assert_eq!(rdata.port(), 3);
@@ -351,7 +351,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         &Name::from_str("rust-❤️-🦀.isi.edu").unwrap(),
         idna_record.name()
     );
-    if let RData::A(ref address) = *idna_record.rdata() {
+    if let Some(RData::A(ref address)) = idna_record.data() {
         assert_eq!(&Ipv4Addr::new(192u8, 0u8, 2u8, 1u8), address);
     } else {
         panic!("Not an A record!!!") // valid panic, test code
@@ -368,7 +368,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     .next()
     .cloned()
     .expect("nocerts not found");
-    if let RData::CAA(ref rdata) = *caa_record.rdata() {
+    if let Some(RData::CAA(ref rdata)) = caa_record.data() {
         assert!(!rdata.issuer_critical());
         assert!(rdata.tag().is_issue());
         assert!(rdata.value().is_issuer());
@@ -391,7 +391,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     .next()
     .cloned()
     .expect("tlsa record not found");
-    if let RData::TLSA(ref rdata) = *tlsa_record.rdata() {
+    if let Some(RData::TLSA(ref rdata)) = tlsa_record.data() {
         assert_eq!(rdata.cert_usage(), CertUsage::CA);
         assert_eq!(rdata.selector(), Selector::Full);
         assert_eq!(rdata.matching(), Matching::Sha256);

--- a/tests/compatibility-tests/tests/sig0_tests.rs
+++ b/tests/compatibility-tests/tests/sig0_tests.rs
@@ -48,8 +48,8 @@ fn test_get() {
     assert_eq!(result.answers().len(), 1);
     assert_eq!(result.answers()[0].rr_type(), RecordType::A);
 
-    let rdata = result.answers()[0].rdata();
-    if let RData::A(address) = rdata {
+    let rdata = result.answers()[0].data();
+    if let Some(RData::A(address)) = rdata {
         assert_eq!(address, &Ipv4Addr::new(127, 0, 0, 1));
     } else {
         panic!("RData::A wasn't here");
@@ -106,7 +106,7 @@ fn test_create() {
         RecordType::A,
         Duration::minutes(5).whole_seconds() as u32,
     );
-    record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+    record.set_data(Some(RData::A(Ipv4Addr::new(100, 10, 100, 10))));
 
     let result = client
         .create(record.clone(), origin.clone())
@@ -128,7 +128,7 @@ fn test_create() {
 
     // will fail if already set and not the same value.
     let mut record = record;
-    record.set_rdata(RData::A(Ipv4Addr::new(101, 11, 101, 11)));
+    record.set_data(Some(RData::A(Ipv4Addr::new(101, 11, 101, 11))));
 
     let result = client.create(record, origin).expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::YXRRSet);

--- a/tests/compatibility-tests/tests/tsig_tests.rs
+++ b/tests/compatibility-tests/tests/tsig_tests.rs
@@ -66,7 +66,7 @@ fn test_create() {
         RecordType::A,
         Duration::minutes(5).whole_seconds() as u32,
     );
-    record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+    record.set_data(Some(RData::A(Ipv4Addr::new(100, 10, 100, 10))));
 
     let result = client
         .create(record.clone(), origin.clone())
@@ -88,7 +88,7 @@ fn test_create() {
 
     // will fail if already set and not the same value.
     let mut record = record;
-    record.set_rdata(RData::A(Ipv4Addr::new(101, 11, 101, 11)));
+    record.set_data(Some(RData::A(Ipv4Addr::new(101, 11, 101, 11))));
 
     let result = client.create(record, origin).expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::YXRRSet);

--- a/tests/compatibility-tests/tests/zone_transfer.rs
+++ b/tests/compatibility-tests/tests/zone_transfer.rs
@@ -25,8 +25,8 @@ use trust_dns_compatibility::named_process;
 #[allow(unused)]
 macro_rules! assert_serial {
     ( $record:expr, $serial:expr  ) => {{
-        let rdata = $record.rdata();
-        if let RData::SOA(soa) = rdata {
+        let rdata = $record.data();
+        if let Some(RData::SOA(soa)) = rdata {
             assert_eq!(soa.serial(), $serial);
         } else {
             assert!(false, "record was not a SOA");
@@ -52,7 +52,7 @@ fn test_zone_transfer() {
         2000 + 3
     );
 
-    let soa = if let RData::SOA(soa) = result[0].answers()[0].rdata() {
+    let soa = if let Some(RData::SOA(soa)) = result[0].answers()[0].data() {
         soa
     } else {
         panic!("First answer was not an SOA record")
@@ -69,7 +69,7 @@ fn test_zone_transfer() {
         RecordType::A,
         Duration::minutes(5).whole_seconds() as u32,
     );
-    record.set_rdata(RData::A(Ipv4Addr::new(100, 10, 100, 10)));
+    record.set_data(Some(RData::A(Ipv4Addr::new(100, 10, 100, 10))));
 
     client.create(record, name.clone()).expect("create failed");
 

--- a/tests/integration-tests/src/authority.rs
+++ b/tests/integration-tests/src/authority.rs
@@ -21,7 +21,7 @@ pub fn create_example() -> InMemoryAuthority {
             .set_ttl(3600)
             .set_rr_type(RecordType::SOA)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::SOA(SOA::new(
+            .set_data(Some(RData::SOA(SOA::new(
                 Name::parse("sns.dns.icann.org.", None).unwrap(),
                 Name::parse("noc.dns.icann.org.", None).unwrap(),
                 2015082403,
@@ -29,7 +29,7 @@ pub fn create_example() -> InMemoryAuthority {
                 3600,
                 1209600,
                 3600,
-            )))
+            ))))
             .clone(),
         0,
     );
@@ -40,7 +40,9 @@ pub fn create_example() -> InMemoryAuthority {
             .set_ttl(86400)
             .set_rr_type(RecordType::NS)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
+            .set_data(Some(RData::NS(
+                Name::parse("a.iana-servers.net.", None).unwrap(),
+            )))
             .clone(),
         0,
     );
@@ -50,7 +52,9 @@ pub fn create_example() -> InMemoryAuthority {
             .set_ttl(86400)
             .set_rr_type(RecordType::NS)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
+            .set_data(Some(RData::NS(
+                Name::parse("b.iana-servers.net.", None).unwrap(),
+            )))
             .clone(),
         0,
     );
@@ -64,11 +68,11 @@ pub fn create_example() -> InMemoryAuthority {
             .set_ttl(60)
             .set_rr_type(RecordType::TXT)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::TXT(TXT::new(vec![
+            .set_data(Some(RData::TXT(TXT::new(vec![
                 "$Id: example.com 4415 2015-08-24 \
                  20:12:23Z davids $"
                     .to_string(),
-            ])))
+            ]))))
             .clone(),
         0,
     );
@@ -80,7 +84,7 @@ pub fn create_example() -> InMemoryAuthority {
             .set_ttl(86400)
             .set_rr_type(RecordType::A)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
+            .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 34))))
             .clone(),
         0,
     );
@@ -92,9 +96,9 @@ pub fn create_example() -> InMemoryAuthority {
             .set_ttl(86400)
             .set_rr_type(RecordType::AAAA)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::AAAA(Ipv6Addr::new(
+            .set_data(Some(RData::AAAA(Ipv6Addr::new(
                 0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
-            )))
+            ))))
             .clone(),
         0,
     );
@@ -123,7 +127,7 @@ pub fn create_example() -> InMemoryAuthority {
             .set_ttl(86400)
             .set_rr_type(RecordType::TXT)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::TXT(TXT::new(vec!["v=spf1 -all".to_string()])))
+            .set_data(Some(RData::TXT(TXT::new(vec!["v=spf1 -all".to_string()]))))
             .clone(),
         0,
     );
@@ -135,7 +139,7 @@ pub fn create_example() -> InMemoryAuthority {
             .set_ttl(86400)
             .set_rr_type(RecordType::A)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
+            .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 34))))
             .clone(),
         0,
     );
@@ -147,9 +151,9 @@ pub fn create_example() -> InMemoryAuthority {
             .set_ttl(86400)
             .set_rr_type(RecordType::AAAA)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::AAAA(Ipv6Addr::new(
+            .set_data(Some(RData::AAAA(Ipv6Addr::new(
                 0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
-            )))
+            ))))
             .clone(),
         0,
     );
@@ -161,7 +165,7 @@ pub fn create_example() -> InMemoryAuthority {
             .set_ttl(86400)
             .set_rr_type(RecordType::CNAME)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::CNAME(www_name))
+            .set_data(Some(RData::CNAME(www_name)))
             .clone(),
         0,
     );
@@ -173,7 +177,9 @@ pub fn create_example() -> InMemoryAuthority {
             .set_ttl(86400)
             .set_rr_type(RecordType::CNAME)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::CNAME(Name::from_str("alias.example.com.").unwrap()))
+            .set_data(Some(RData::CNAME(
+                Name::from_str("alias.example.com.").unwrap(),
+            )))
             .clone(),
         0,
     );

--- a/tests/integration-tests/tests/catalog_tests.rs
+++ b/tests/integration-tests/tests/catalog_tests.rs
@@ -26,7 +26,7 @@ pub fn create_test() -> InMemoryAuthority {
             .set_ttl(3600)
             .set_rr_type(RecordType::SOA)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::SOA(SOA::new(
+            .set_data(Some(RData::SOA(SOA::new(
                 Name::parse("sns.dns.icann.org.", None).unwrap(),
                 Name::parse("noc.dns.icann.org.", None).unwrap(),
                 2015082403,
@@ -34,7 +34,7 @@ pub fn create_test() -> InMemoryAuthority {
                 3600,
                 1209600,
                 3600,
-            )))
+            ))))
             .clone(),
         0,
     );
@@ -45,7 +45,9 @@ pub fn create_test() -> InMemoryAuthority {
             .set_ttl(86400)
             .set_rr_type(RecordType::NS)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
+            .set_data(Some(RData::NS(
+                Name::parse("a.iana-servers.net.", None).unwrap(),
+            )))
             .clone(),
         0,
     );
@@ -55,7 +57,9 @@ pub fn create_test() -> InMemoryAuthority {
             .set_ttl(86400)
             .set_rr_type(RecordType::NS)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
+            .set_data(Some(RData::NS(
+                Name::parse("b.iana-servers.net.", None).unwrap(),
+            )))
             .clone(),
         0,
     );
@@ -66,7 +70,7 @@ pub fn create_test() -> InMemoryAuthority {
             .set_ttl(86400)
             .set_rr_type(RecordType::A)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::A(Ipv4Addr::new(94, 184, 216, 34)))
+            .set_data(Some(RData::A(Ipv4Addr::new(94, 184, 216, 34))))
             .clone(),
         0,
     );
@@ -76,9 +80,9 @@ pub fn create_test() -> InMemoryAuthority {
             .set_ttl(86400)
             .set_rr_type(RecordType::AAAA)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::AAAA(Ipv6Addr::new(
+            .set_data(Some(RData::AAAA(Ipv6Addr::new(
                 0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
-            )))
+            ))))
             .clone(),
         0,
     );
@@ -90,7 +94,7 @@ pub fn create_test() -> InMemoryAuthority {
             .set_ttl(86400)
             .set_rr_type(RecordType::A)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::A(Ipv4Addr::new(94, 184, 216, 34)))
+            .set_data(Some(RData::A(Ipv4Addr::new(94, 184, 216, 34))))
             .clone(),
         0,
     );
@@ -100,9 +104,9 @@ pub fn create_test() -> InMemoryAuthority {
             .set_ttl(86400)
             .set_rr_type(RecordType::AAAA)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::AAAA(Ipv6Addr::new(
+            .set_data(Some(RData::AAAA(Ipv6Addr::new(
                 0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
-            )))
+            ))))
             .clone(),
         0,
     );
@@ -148,7 +152,7 @@ async fn test_catalog_lookup() {
     assert!(!answers.is_empty());
     assert_eq!(answers.first().unwrap().rr_type(), RecordType::A);
     assert_eq!(
-        answers.first().unwrap().rdata(),
+        answers.first().unwrap().data().unwrap(),
         &RData::A(Ipv4Addr::new(93, 184, 216, 34))
     );
 
@@ -182,7 +186,7 @@ async fn test_catalog_lookup() {
     assert!(!answers.is_empty());
     assert_eq!(answers.first().unwrap().rr_type(), RecordType::A);
     assert_eq!(
-        answers.first().unwrap().rdata(),
+        answers.first().unwrap().data().unwrap(),
         &RData::A(Ipv4Addr::new(94, 184, 216, 34))
     );
 }
@@ -226,7 +230,7 @@ async fn test_catalog_lookup_soa() {
     assert!(!answers.is_empty());
     assert_eq!(answers.first().unwrap().rr_type(), RecordType::SOA);
     assert_eq!(
-        answers.first().unwrap().rdata(),
+        answers.first().unwrap().data().unwrap(),
         &RData::SOA(SOA::new(
             Name::parse("sns.dns.icann.org.", None).unwrap(),
             Name::parse("noc.dns.icann.org.", None).unwrap(),
@@ -245,12 +249,12 @@ async fn test_catalog_lookup_soa() {
     assert_eq!(ns.len(), 2);
     assert_eq!(ns.first().unwrap().rr_type(), RecordType::NS);
     assert_eq!(
-        ns.first().unwrap().rdata(),
+        ns.first().unwrap().data().unwrap(),
         &RData::NS(Name::parse("a.iana-servers.net.", None).unwrap())
     );
     assert_eq!(ns.last().unwrap().rr_type(), RecordType::NS);
     assert_eq!(
-        ns.last().unwrap().rdata(),
+        ns.last().unwrap().data().unwrap(),
         &RData::NS(Name::parse("b.iana-servers.net.", None).unwrap())
     );
 }
@@ -291,7 +295,7 @@ async fn test_catalog_nx_soa() {
     assert_eq!(ns.len(), 1);
     assert_eq!(ns.first().unwrap().rr_type(), RecordType::SOA);
     assert_eq!(
-        ns.first().unwrap().rdata(),
+        ns.first().unwrap().data().unwrap(),
         &RData::SOA(SOA::new(
             Name::parse("sns.dns.icann.org.", None).unwrap(),
             Name::parse("noc.dns.icann.org.", None).unwrap(),
@@ -352,7 +356,7 @@ async fn test_axfr() {
         .set_ttl(3600)
         .set_rr_type(RecordType::SOA)
         .set_dns_class(DNSClass::IN)
-        .set_rdata(RData::SOA(SOA::new(
+        .set_data(Some(RData::SOA(SOA::new(
             Name::parse("sns.dns.icann.org.", None).unwrap(),
             Name::parse("noc.dns.icann.org.", None).unwrap(),
             2015082403,
@@ -360,7 +364,7 @@ async fn test_axfr() {
             3600,
             1209600,
             3600,
-        )))
+        ))))
         .clone();
 
     let mut catalog: Catalog = Catalog::new();
@@ -398,7 +402,7 @@ async fn test_axfr() {
             .set_ttl(3600)
             .set_rr_type(RecordType::SOA)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::SOA(SOA::new(
+            .set_data(Some(RData::SOA(SOA::new(
                 Name::parse("sns.dns.icann.org.", None).unwrap(),
                 Name::parse("noc.dns.icann.org.", None).unwrap(),
                 2015082403,
@@ -406,6 +410,15 @@ async fn test_axfr() {
                 3600,
                 1209600,
                 3600,
+            ))))
+            .clone(),
+        Record::new()
+            .set_name(origin.clone().into())
+            .set_ttl(86400)
+            .set_rr_type(RecordType::NS)
+            .set_dns_class(DNSClass::IN)
+            .set_data(Some(RData::NS(
+                Name::parse("a.iana-servers.net.", None).unwrap(),
             )))
             .clone(),
         Record::new()
@@ -413,53 +426,48 @@ async fn test_axfr() {
             .set_ttl(86400)
             .set_rr_type(RecordType::NS)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
-            .clone(),
-        Record::new()
-            .set_name(origin.clone().into())
-            .set_ttl(86400)
-            .set_rr_type(RecordType::NS)
-            .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
+            .set_data(Some(RData::NS(
+                Name::parse("b.iana-servers.net.", None).unwrap(),
+            )))
             .clone(),
         Record::new()
             .set_name(origin.clone().into())
             .set_ttl(86400)
             .set_rr_type(RecordType::A)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::A(Ipv4Addr::new(94, 184, 216, 34)))
+            .set_data(Some(RData::A(Ipv4Addr::new(94, 184, 216, 34))))
             .clone(),
         Record::new()
             .set_name(origin.clone().into())
             .set_ttl(86400)
             .set_rr_type(RecordType::AAAA)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::AAAA(Ipv6Addr::new(
+            .set_data(Some(RData::AAAA(Ipv6Addr::new(
                 0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
-            )))
+            ))))
             .clone(),
         Record::new()
             .set_name(www_name.clone())
             .set_ttl(86400)
             .set_rr_type(RecordType::A)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::A(Ipv4Addr::new(94, 184, 216, 34)))
+            .set_data(Some(RData::A(Ipv4Addr::new(94, 184, 216, 34))))
             .clone(),
         Record::new()
             .set_name(www_name)
             .set_ttl(86400)
             .set_rr_type(RecordType::AAAA)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::AAAA(Ipv6Addr::new(
+            .set_data(Some(RData::AAAA(Ipv6Addr::new(
                 0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
-            )))
+            ))))
             .clone(),
         Record::new()
             .set_name(origin.into())
             .set_ttl(3600)
             .set_rr_type(RecordType::SOA)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::SOA(SOA::new(
+            .set_data(Some(RData::SOA(SOA::new(
                 Name::parse("sns.dns.icann.org.", None).unwrap(),
                 Name::parse("noc.dns.icann.org.", None).unwrap(),
                 2015082403,
@@ -467,7 +475,7 @@ async fn test_axfr() {
                 3600,
                 1209600,
                 3600,
-            )))
+            ))))
             .clone(),
     ];
 
@@ -551,7 +559,7 @@ async fn test_cname_additionals() {
     assert_eq!(answers.len(), 1);
     assert_eq!(answers.first().unwrap().rr_type(), RecordType::CNAME);
     assert_eq!(
-        answers.first().unwrap().rdata(),
+        answers.first().unwrap().data().unwrap(),
         &RData::CNAME(Name::from_str("www.example.com.").unwrap())
     );
 
@@ -559,7 +567,7 @@ async fn test_cname_additionals() {
     assert!(!additionals.is_empty());
     assert_eq!(additionals.first().unwrap().rr_type(), RecordType::A);
     assert_eq!(
-        additionals.first().unwrap().rdata(),
+        additionals.first().unwrap().data().unwrap(),
         &RData::A(Ipv4Addr::new(93, 184, 216, 34))
     );
 }
@@ -598,7 +606,7 @@ async fn test_multiple_cname_additionals() {
     assert_eq!(answers.len(), 1);
     assert_eq!(answers.first().unwrap().rr_type(), RecordType::CNAME);
     assert_eq!(
-        answers.first().unwrap().rdata(),
+        answers.first().unwrap().data().unwrap(),
         &RData::CNAME(Name::from_str("alias.example.com.").unwrap())
     );
 
@@ -607,7 +615,7 @@ async fn test_multiple_cname_additionals() {
     assert!(!additionals.is_empty());
     assert_eq!(additionals.first().unwrap().rr_type(), RecordType::CNAME);
     assert_eq!(
-        additionals.first().unwrap().rdata(),
+        additionals.first().unwrap().data().unwrap(),
         &RData::CNAME(Name::from_str("www.example.com.").unwrap())
     );
 
@@ -616,7 +624,7 @@ async fn test_multiple_cname_additionals() {
     assert!(!additionals.is_empty());
     assert_eq!(additionals.last().unwrap().rr_type(), RecordType::A);
     assert_eq!(
-        additionals.last().unwrap().rdata(),
+        additionals.last().unwrap().data().unwrap(),
         &RData::A(Ipv4Addr::new(93, 184, 216, 34))
     );
 }

--- a/tests/integration-tests/tests/dnssec_client_handle_tests.rs
+++ b/tests/integration-tests/tests/dnssec_client_handle_tests.rs
@@ -58,7 +58,7 @@ where
     assert_eq!(record.rr_type(), RecordType::A);
     assert_eq!(record.dns_class(), DNSClass::IN);
 
-    if let RData::A(ref address) = *record.rdata() {
+    if let RData::A(ref address) = *record.data().unwrap() {
         assert_eq!(address, &Ipv4Addr::new(93, 184, 216, 34))
     } else {
         panic!();

--- a/tests/integration-tests/tests/lookup_tests.rs
+++ b/tests/integration-tests/tests/lookup_tests.rs
@@ -105,7 +105,7 @@ fn create_ip_like_example() -> InMemoryAuthority {
             .set_ttl(86400)
             .set_rr_type(RecordType::A)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::A(Ipv4Addr::new(198, 51, 100, 35)))
+            .set_data(Some(RData::A(Ipv4Addr::new(198, 51, 100, 35))))
             .clone(),
         0,
     );
@@ -262,7 +262,7 @@ fn test_cname_lookup_preserve() {
     let lookup = io_loop.block_on(lookup).unwrap();
 
     let mut iter = lookup.iter();
-    assert_eq!(iter.next().unwrap(), cname_record.rdata());
+    assert_eq!(iter.next().unwrap(), cname_record.data().unwrap());
     assert_eq!(
         *iter.next().unwrap(),
         RData::A(Ipv4Addr::new(93, 184, 216, 34))
@@ -341,7 +341,7 @@ fn test_chained_cname_lookup_preserve() {
     let lookup = io_loop.block_on(lookup).unwrap();
 
     let mut iter = lookup.iter();
-    assert_eq!(iter.next().unwrap(), cname_record.rdata());
+    assert_eq!(iter.next().unwrap(), cname_record.data().unwrap());
     assert_eq!(
         *iter.next().unwrap(),
         RData::A(Ipv4Addr::new(93, 184, 216, 34))

--- a/tests/integration-tests/tests/server_future_tests.rs
+++ b/tests/integration-tests/tests/server_future_tests.rs
@@ -311,7 +311,7 @@ where
     assert_eq!(record.rr_type(), RecordType::A);
     assert_eq!(record.dns_class(), DNSClass::IN);
 
-    if let RData::A(ref address) = *record.rdata() {
+    if let RData::A(ref address) = *record.data().unwrap() {
         assert_eq!(address, &Ipv4Addr::new(93, 184, 216, 34))
     } else {
         panic!();

--- a/tests/integration-tests/tests/sqlite_authority_tests.rs
+++ b/tests/integration-tests/tests/sqlite_authority_tests.rs
@@ -974,10 +974,12 @@ async fn test_journal() {
     let delete_name = Name::from_str("www.example.com").unwrap();
     let new_record = Record::new()
         .set_name(new_name.clone())
+        .set_record_type(RecordType::A)
         .set_rdata(RData::A(Ipv4Addr::new(10, 11, 12, 13)))
         .clone();
     let delete_record = Record::new()
         .set_name(delete_name.clone())
+        .set_record_type(RecordType::A)
         .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
         .set_dns_class(DNSClass::NONE)
         .clone();

--- a/tests/integration-tests/tests/sqlite_authority_tests.rs
+++ b/tests/integration-tests/tests/sqlite_authority_tests.rs
@@ -43,7 +43,10 @@ async fn test_search() {
         let record = result.iter().next().unwrap();
         assert_eq!(record.rr_type(), RecordType::A);
         assert_eq!(record.dns_class(), DNSClass::IN);
-        assert_eq!(record.rdata(), &RData::A(Ipv4Addr::new(93, 184, 216, 34)));
+        assert_eq!(
+            record.data().unwrap(),
+            &RData::A(Ipv4Addr::new(93, 184, 216, 34))
+        );
     } else {
         panic!("expected a result"); // valid panic, in test
     }
@@ -67,7 +70,10 @@ async fn test_search_www() {
         let record = result.iter().next().unwrap();
         assert_eq!(record.rr_type(), RecordType::A);
         assert_eq!(record.dns_class(), DNSClass::IN);
-        assert_eq!(record.rdata(), &RData::A(Ipv4Addr::new(93, 184, 216, 34)));
+        assert_eq!(
+            record.data().unwrap(),
+            &RData::A(Ipv4Addr::new(93, 184, 216, 34))
+        );
     } else {
         panic!("expected a result"); // valid panic, in test
     }
@@ -111,7 +117,9 @@ async fn test_authority() {
             .set_ttl(86400)
             .set_rr_type(RecordType::NS)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::NS(Name::parse("a.iana-servers.net.", None).unwrap()))
+            .set_data(Some(RData::NS(
+                Name::parse("a.iana-servers.net.", None).unwrap()
+            )))
             .clone()
     );
     assert_eq!(
@@ -121,7 +129,9 @@ async fn test_authority() {
             .set_ttl(86400)
             .set_rr_type(RecordType::NS)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::NS(Name::parse("b.iana-servers.net.", None).unwrap()))
+            .set_data(Some(RData::NS(
+                Name::parse("b.iana-servers.net.", None).unwrap()
+            )))
             .clone()
     );
 
@@ -155,11 +165,11 @@ async fn test_authority() {
             .set_ttl(60)
             .set_rr_type(RecordType::TXT)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::TXT(TXT::new(vec![
+            .set_data(Some(RData::TXT(TXT::new(vec![
                 "$Id: example.com 4415 2015-08-24 \
                  20:12:23Z davids $"
                     .to_string(),
-            ])))
+            ]))))
             .clone()
     );
 
@@ -176,7 +186,7 @@ async fn test_authority() {
             .set_ttl(86400)
             .set_rr_type(RecordType::A)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
+            .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 34))))
             .clone()
     );
 }
@@ -225,7 +235,7 @@ async fn test_prerequisites() {
                 .set_ttl(86400)
                 .set_rr_type(RecordType::A)
                 .set_dns_class(DNSClass::IN)
-                .set_rdata(RData::NULL(NULL::new()))
+                .set_data(Some(RData::NULL(NULL::new())))
                 .clone()],)
             .await,
         Err(ResponseCode::FormErr)
@@ -237,7 +247,7 @@ async fn test_prerequisites() {
                 .set_ttl(0)
                 .set_rr_type(RecordType::A)
                 .set_dns_class(DNSClass::IN)
-                .set_rdata(RData::NULL(NULL::new()))
+                .set_data(Some(RData::NULL(NULL::new())))
                 .clone()],)
             .await,
         Err(ResponseCode::NotZone)
@@ -250,7 +260,7 @@ async fn test_prerequisites() {
             .set_ttl(0)
             .set_dns_class(DNSClass::ANY)
             .set_rr_type(RecordType::ANY)
-            .set_rdata(RData::NULL(NULL::new()))
+            .set_data(Some(RData::NULL(NULL::new())))
             .clone()])
         .await
         .is_ok());
@@ -261,7 +271,7 @@ async fn test_prerequisites() {
                 .set_ttl(0)
                 .set_dns_class(DNSClass::ANY)
                 .set_rr_type(RecordType::ANY)
-                .set_rdata(RData::NULL(NULL::new()))
+                .set_data(Some(RData::NULL(NULL::new())))
                 .clone()],)
             .await,
         Err(ResponseCode::NXDomain)
@@ -274,7 +284,7 @@ async fn test_prerequisites() {
             .set_ttl(0)
             .set_dns_class(DNSClass::ANY)
             .set_rr_type(RecordType::A)
-            .set_rdata(RData::NULL(NULL::new()))
+            .set_data(Some(RData::NULL(NULL::new())))
             .clone()])
         .await
         .is_ok());
@@ -285,7 +295,7 @@ async fn test_prerequisites() {
                 .set_ttl(0)
                 .set_dns_class(DNSClass::ANY)
                 .set_rr_type(RecordType::A)
-                .set_rdata(RData::NULL(NULL::new()))
+                .set_data(Some(RData::NULL(NULL::new())))
                 .clone()],)
             .await,
         Err(ResponseCode::NXRRSet)
@@ -298,7 +308,7 @@ async fn test_prerequisites() {
             .set_ttl(0)
             .set_dns_class(DNSClass::NONE)
             .set_rr_type(RecordType::ANY)
-            .set_rdata(RData::NULL(NULL::new()))
+            .set_data(Some(RData::NULL(NULL::new())))
             .clone()])
         .await
         .is_ok());
@@ -309,7 +319,7 @@ async fn test_prerequisites() {
                 .set_ttl(0)
                 .set_dns_class(DNSClass::NONE)
                 .set_rr_type(RecordType::ANY)
-                .set_rdata(RData::NULL(NULL::new()))
+                .set_data(Some(RData::NULL(NULL::new())))
                 .clone()],)
             .await,
         Err(ResponseCode::YXDomain)
@@ -322,7 +332,7 @@ async fn test_prerequisites() {
             .set_ttl(0)
             .set_dns_class(DNSClass::NONE)
             .set_rr_type(RecordType::A)
-            .set_rdata(RData::NULL(NULL::new()))
+            .set_data(Some(RData::NULL(NULL::new())))
             .clone()])
         .await
         .is_ok());
@@ -333,7 +343,7 @@ async fn test_prerequisites() {
                 .set_ttl(0)
                 .set_dns_class(DNSClass::NONE)
                 .set_rr_type(RecordType::A)
-                .set_rdata(RData::NULL(NULL::new()))
+                .set_data(Some(RData::NULL(NULL::new())))
                 .clone()],)
             .await,
         Err(ResponseCode::YXRRSet)
@@ -346,7 +356,7 @@ async fn test_prerequisites() {
             .set_ttl(0)
             .set_dns_class(DNSClass::IN)
             .set_rr_type(RecordType::A)
-            .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
+            .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 34))))
             .clone()])
         .await
         .is_ok());
@@ -358,7 +368,7 @@ async fn test_prerequisites() {
                 .set_ttl(0)
                 .set_dns_class(DNSClass::CH)
                 .set_rr_type(RecordType::A)
-                .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
+                .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 34))))
                 .clone()],)
             .await,
         Err(ResponseCode::FormErr)
@@ -371,7 +381,7 @@ async fn test_prerequisites() {
                 .set_ttl(0)
                 .set_dns_class(DNSClass::IN)
                 .set_rr_type(RecordType::A)
-                .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+                .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 24))))
                 .clone()],)
             .await,
         Err(ResponseCode::NXRRSet)
@@ -384,7 +394,7 @@ async fn test_prerequisites() {
                 .set_ttl(0)
                 .set_dns_class(DNSClass::IN)
                 .set_rr_type(RecordType::A)
-                .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+                .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 24))))
                 .clone()],)
             .await,
         Err(ResponseCode::NXRRSet)
@@ -405,7 +415,7 @@ async fn test_pre_scan() {
                 .set_ttl(86400)
                 .set_rr_type(RecordType::A)
                 .set_dns_class(DNSClass::IN)
-                .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+                .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 24))))
                 .clone()],)
             .await,
         Err(ResponseCode::NotZone)
@@ -418,7 +428,7 @@ async fn test_pre_scan() {
                 .set_ttl(86400)
                 .set_rr_type(RecordType::ANY)
                 .set_dns_class(DNSClass::IN)
-                .set_rdata(RData::NULL(NULL::new()))
+                .set_data(Some(RData::NULL(NULL::new())))
                 .clone()],)
             .await,
         Err(ResponseCode::FormErr)
@@ -430,7 +440,7 @@ async fn test_pre_scan() {
                 .set_ttl(86400)
                 .set_rr_type(RecordType::AXFR)
                 .set_dns_class(DNSClass::IN)
-                .set_rdata(RData::NULL(NULL::new()))
+                .set_data(Some(RData::NULL(NULL::new())))
                 .clone()],)
             .await,
         Err(ResponseCode::FormErr)
@@ -442,7 +452,7 @@ async fn test_pre_scan() {
                 .set_ttl(86400)
                 .set_rr_type(RecordType::IXFR)
                 .set_dns_class(DNSClass::IN)
-                .set_rdata(RData::NULL(NULL::new()))
+                .set_data(Some(RData::NULL(NULL::new())))
                 .clone()],)
             .await,
         Err(ResponseCode::FormErr)
@@ -453,7 +463,7 @@ async fn test_pre_scan() {
             .set_ttl(86400)
             .set_rr_type(RecordType::A)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+            .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 24))))
             .clone()])
         .await
         .is_ok());
@@ -463,7 +473,7 @@ async fn test_pre_scan() {
             .set_ttl(86400)
             .set_rr_type(RecordType::A)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::NULL(NULL::new()))
+            .set_data(Some(RData::NULL(NULL::new())))
             .clone()])
         .await
         .is_ok());
@@ -475,7 +485,7 @@ async fn test_pre_scan() {
                 .set_ttl(86400)
                 .set_rr_type(RecordType::A)
                 .set_dns_class(DNSClass::ANY)
-                .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+                .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 24))))
                 .clone()],)
             .await,
         Err(ResponseCode::FormErr)
@@ -487,7 +497,7 @@ async fn test_pre_scan() {
                 .set_ttl(0)
                 .set_rr_type(RecordType::A)
                 .set_dns_class(DNSClass::ANY)
-                .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+                .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 24))))
                 .clone()],)
             .await,
         Err(ResponseCode::FormErr)
@@ -499,7 +509,7 @@ async fn test_pre_scan() {
                 .set_ttl(0)
                 .set_rr_type(RecordType::AXFR)
                 .set_dns_class(DNSClass::ANY)
-                .set_rdata(RData::NULL(NULL::new()))
+                .set_data(Some(RData::NULL(NULL::new())))
                 .clone()],)
             .await,
         Err(ResponseCode::FormErr)
@@ -511,7 +521,7 @@ async fn test_pre_scan() {
                 .set_ttl(0)
                 .set_rr_type(RecordType::IXFR)
                 .set_dns_class(DNSClass::ANY)
-                .set_rdata(RData::NULL(NULL::new()))
+                .set_data(Some(RData::NULL(NULL::new())))
                 .clone()],)
             .await,
         Err(ResponseCode::FormErr)
@@ -522,7 +532,7 @@ async fn test_pre_scan() {
             .set_ttl(0)
             .set_rr_type(RecordType::ANY)
             .set_dns_class(DNSClass::ANY)
-            .set_rdata(RData::NULL(NULL::new()))
+            .set_data(Some(RData::NULL(NULL::new())))
             .clone()])
         .await
         .is_ok());
@@ -532,7 +542,7 @@ async fn test_pre_scan() {
             .set_ttl(0)
             .set_rr_type(RecordType::A)
             .set_dns_class(DNSClass::ANY)
-            .set_rdata(RData::NULL(NULL::new()))
+            .set_data(Some(RData::NULL(NULL::new())))
             .clone()])
         .await
         .is_ok());
@@ -544,7 +554,7 @@ async fn test_pre_scan() {
                 .set_ttl(86400)
                 .set_rr_type(RecordType::A)
                 .set_dns_class(DNSClass::NONE)
-                .set_rdata(RData::NULL(NULL::new()))
+                .set_data(Some(RData::NULL(NULL::new())))
                 .clone()],)
             .await,
         Err(ResponseCode::FormErr)
@@ -556,7 +566,7 @@ async fn test_pre_scan() {
                 .set_ttl(0)
                 .set_rr_type(RecordType::ANY)
                 .set_dns_class(DNSClass::NONE)
-                .set_rdata(RData::NULL(NULL::new()))
+                .set_data(Some(RData::NULL(NULL::new())))
                 .clone()],)
             .await,
         Err(ResponseCode::FormErr)
@@ -568,7 +578,7 @@ async fn test_pre_scan() {
                 .set_ttl(0)
                 .set_rr_type(RecordType::AXFR)
                 .set_dns_class(DNSClass::NONE)
-                .set_rdata(RData::NULL(NULL::new()))
+                .set_data(Some(RData::NULL(NULL::new())))
                 .clone()],)
             .await,
         Err(ResponseCode::FormErr)
@@ -580,7 +590,7 @@ async fn test_pre_scan() {
                 .set_ttl(0)
                 .set_rr_type(RecordType::IXFR)
                 .set_dns_class(DNSClass::NONE)
-                .set_rdata(RData::NULL(NULL::new()))
+                .set_data(Some(RData::NULL(NULL::new())))
                 .clone()],)
             .await,
         Err(ResponseCode::FormErr)
@@ -591,7 +601,7 @@ async fn test_pre_scan() {
             .set_ttl(0)
             .set_rr_type(RecordType::A)
             .set_dns_class(DNSClass::NONE)
-            .set_rdata(RData::NULL(NULL::new()))
+            .set_data(Some(RData::NULL(NULL::new())))
             .clone()])
         .await
         .is_ok());
@@ -601,7 +611,7 @@ async fn test_pre_scan() {
             .set_ttl(0)
             .set_rr_type(RecordType::A)
             .set_dns_class(DNSClass::NONE)
-            .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+            .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 24))))
             .clone()])
         .await
         .is_ok());
@@ -613,7 +623,7 @@ async fn test_pre_scan() {
                 .set_ttl(86400)
                 .set_rr_type(RecordType::A)
                 .set_dns_class(DNSClass::CH)
-                .set_rdata(RData::NULL(NULL::new()))
+                .set_data(Some(RData::NULL(NULL::new())))
                 .clone()],)
             .await,
         Err(ResponseCode::FormErr)
@@ -635,23 +645,23 @@ async fn test_update() {
             .set_ttl(86400)
             .set_rr_type(RecordType::TXT)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::TXT(TXT::new(vec!["v=spf1 -all".to_string()])))
+            .set_data(Some(RData::TXT(TXT::new(vec!["v=spf1 -all".to_string()]))))
             .clone(),
         Record::new()
             .set_name(www_name.clone())
             .set_ttl(86400)
             .set_rr_type(RecordType::A)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
+            .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 34))))
             .clone(),
         Record::new()
             .set_name(www_name.clone())
             .set_ttl(86400)
             .set_rr_type(RecordType::AAAA)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::AAAA(Ipv6Addr::new(
+            .set_data(Some(RData::AAAA(Ipv6Addr::new(
                 0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
-            )))
+            ))))
             .clone(),
     ];
 
@@ -693,7 +703,7 @@ async fn test_update() {
         .set_ttl(86400)
         .set_rr_type(RecordType::A)
         .set_dns_class(DNSClass::IN)
-        .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+        .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 24))))
         .clone()];
     assert!(authority
         .update_records(add_record, true,)
@@ -719,7 +729,7 @@ async fn test_update() {
         .set_ttl(86400)
         .set_rr_type(RecordType::A)
         .set_dns_class(DNSClass::IN)
-        .set_rdata(RData::A(Ipv4Addr::new(10, 0, 0, 1)))
+        .set_data(Some(RData::A(Ipv4Addr::new(10, 0, 0, 1))))
         .clone()];
     assert!(authority
         .update_records(add_www_record, true,)
@@ -754,7 +764,7 @@ async fn test_update() {
         .set_ttl(86400)
         .set_rr_type(RecordType::A)
         .set_dns_class(DNSClass::NONE)
-        .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 24)))
+        .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 24))))
         .clone()];
     assert!(authority
         .update_records(del_record, true,)
@@ -777,7 +787,7 @@ async fn test_update() {
         .set_ttl(86400)
         .set_rr_type(RecordType::A)
         .set_dns_class(DNSClass::NONE)
-        .set_rdata(RData::A(Ipv4Addr::new(10, 0, 0, 1)))
+        .set_data(Some(RData::A(Ipv4Addr::new(10, 0, 0, 1))))
         .clone()];
     assert!(authority
         .update_records(del_record, true,)
@@ -808,7 +818,7 @@ async fn test_update() {
         .set_ttl(86400)
         .set_rr_type(RecordType::A)
         .set_dns_class(DNSClass::ANY)
-        .set_rdata(RData::NULL(NULL::new()))
+        .set_data(Some(RData::NULL(NULL::new())))
         .clone()];
     assert!(authority
         .update_records(del_record, true,)
@@ -821,16 +831,16 @@ async fn test_update() {
             .set_ttl(86400)
             .set_rr_type(RecordType::TXT)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::TXT(TXT::new(vec!["v=spf1 -all".to_string()])))
+            .set_data(Some(RData::TXT(TXT::new(vec!["v=spf1 -all".to_string()]))))
             .clone(),
         Record::new()
             .set_name(www_name.clone())
             .set_ttl(86400)
             .set_rr_type(RecordType::AAAA)
             .set_dns_class(DNSClass::IN)
-            .set_rdata(RData::AAAA(Ipv6Addr::new(
+            .set_data(Some(RData::AAAA(Ipv6Addr::new(
                 0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
-            )))
+            ))))
             .clone(),
     ];
     removed_a_vec.sort();
@@ -860,7 +870,7 @@ async fn test_update() {
         .set_ttl(86400)
         .set_rr_type(RecordType::ANY)
         .set_dns_class(DNSClass::ANY)
-        .set_rdata(RData::NULL(NULL::new()))
+        .set_data(Some(RData::NULL(NULL::new())))
         .clone()];
 
     assert!(authority
@@ -928,7 +938,7 @@ async fn test_zone_signing() {
                 .iter()
                 .any(|r| r.rr_type() == RecordType::RRSIG
                     && r.name() == record.name()
-                    && if let RData::DNSSEC(DNSSECRData::SIG(ref rrsig)) = *r.rdata() {
+                    && if let RData::DNSSEC(DNSSECRData::SIG(ref rrsig)) = *r.data().unwrap() {
                         rrsig.type_covered() == record.rr_type()
                     } else {
                         false
@@ -975,12 +985,12 @@ async fn test_journal() {
     let new_record = Record::new()
         .set_name(new_name.clone())
         .set_record_type(RecordType::A)
-        .set_rdata(RData::A(Ipv4Addr::new(10, 11, 12, 13)))
+        .set_data(Some(RData::A(Ipv4Addr::new(10, 11, 12, 13))))
         .clone();
     let delete_record = Record::new()
         .set_name(delete_name.clone())
         .set_record_type(RecordType::A)
-        .set_rdata(RData::A(Ipv4Addr::new(93, 184, 216, 34)))
+        .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 216, 34))))
         .set_dns_class(DNSClass::NONE)
         .clone();
     authority
@@ -1092,7 +1102,7 @@ async fn test_recovery() {
             .records_without_rrsigs()
             .zip(other_rr_set.records_without_rrsigs())
             .all(|(record, other_record)| {
-                record.ttl() == other_record.ttl() && record.rdata() == other_record.rdata()
+                record.ttl() == other_record.ttl() && record.data() == other_record.data()
             })
     },));
 
@@ -1104,7 +1114,7 @@ async fn test_recovery() {
             .records_without_rrsigs()
             .zip(other_rr_set.records_without_rrsigs())
             .all(|(record, other_record)| {
-                record.ttl() == other_record.ttl() && record.rdata() == other_record.rdata()
+                record.ttl() == other_record.ttl() && record.data() == other_record.data()
             })
     }));
 }

--- a/util/src/resolve.rs
+++ b/util/src/resolve.rs
@@ -245,14 +245,19 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     for r in lookup.record_iter() {
-        println!(
-            "\t{name} {ttl} {class} {ty} {rdata}",
+        print!(
+            "\t{name} {ttl} {class} {ty}",
             name = style(r.name()).blue(),
             ttl = style(r.ttl()).blue(),
             class = style(r.dns_class()).blue(),
             ty = style(r.record_type()).blue(),
-            rdata = style(r.rdata()).yellow()
         );
+
+        if let Some(rdata) = r.data() {
+            println!(" {rdata}", rdata = rdata);
+        } else {
+            println!("NULL")
+        }
     }
 
     Ok(())


### PR DESCRIPTION
This is an alternate fix for #1594. It allows Dynamic DNS records to continue to work properly, ~~but maintains the ZERO rdata with the ZERO record type~~ and makes the `Record::rdata` optional to better reflect the ZERO and NULL types. 

Closes: #1594
Fixes: #1571