### PR TITLE
Make the Name API more principled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +279,9 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -783,6 +792,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +829,17 @@ name = "libc"
 version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beb09950ae85a0a94b27676cccf37da5ff13f27076aa1adbc6545dd0d0e1bd4e"
+dependencies = [
+ "arbitrary",
+ "cc",
+ "once_cell",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1921,6 +1950,14 @@ dependencies = [
  "wasm-bindgen",
  "webpki",
  "webpki-roots",
+]
+
+[[package]]
+name = "trust-dns-proto-fuzz"
+version = "0.0.0"
+dependencies = [
+ "libfuzzer-sys",
+ "trust-dns-proto",
 ]
 
 [[package]]

--- a/crates/proto/src/rr/domain/name.rs
+++ b/crates/proto/src/rr/domain/name.rs
@@ -24,7 +24,7 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use tinyvec::TinyVec;
 
 /// A domain name
-#[derive(Clone, Default, Eq)]
+#[derive(Clone, Eq)]
 pub struct Name {
     is_fqdn: bool,
     label_data: TinyVec<[u8; 32]>,
@@ -36,7 +36,11 @@ pub struct Name {
 impl Name {
     /// Create a new domain::Name, i.e. label
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            is_fqdn: false,
+            label_data: TinyVec::new(),
+            label_ends: TinyVec::new(),
+        }
     }
 
     /// Returns the root label, i.e. no labels, can probably make this better in the future.
@@ -90,7 +94,7 @@ impl Name {
 
         let mut name = Self {
             is_fqdn: true,
-            ..Self::default()
+            ..Self::new()
         };
         for label in labels {
             name = name.append_label(label)?;

--- a/crates/proto/src/rr/domain/name.rs
+++ b/crates/proto/src/rr/domain/name.rs
@@ -198,7 +198,11 @@ impl Name {
         Self::from_str(name).or_else(|_| Self::from_ascii(name))
     }
 
-    fn from_encoded_str<E: LabelEnc>(local: &str, origin: Option<&Self>) -> ProtoResult<Self> {
+    fn from_encoded_str<E: LabelEnc>(
+        local: &str,
+        origin: Option<&Self>,
+        //allow_underscore: bool,
+    ) -> ProtoResult<Self> {
         let mut name = Self::new();
         let mut label = String::new();
 
@@ -1798,8 +1802,22 @@ mod tests {
     #[test]
     fn test_underscore() {
         Name::from_str("_begin.example.com").expect("failed at beginning");
+        assert_eq!(
+            Name::from_str("_begin.example.com").unwrap(),
+            Name::from_ascii("_begin.example.com").unwrap(),
+        );
+
         Name::from_str_relaxed("mid_dle.example.com").expect("failed in the middle");
+        assert_eq!(
+            Name::from_str("mid_dle.example.com").is_ok(),
+            Name::from_ascii("mid_dle.example.com").is_ok(),
+        );
+
         Name::from_str_relaxed("end_.example.com").expect("failed at the end");
+        assert_eq!(
+            Name::from_str("end_.example.com").is_ok(),
+            Name::from_ascii("end_.example.com").is_ok(),
+        );
     }
 
     #[test]

--- a/crates/proto/src/rr/lower_name.rs
+++ b/crates/proto/src/rr/lower_name.rs
@@ -22,7 +22,7 @@ use crate::serialize::binary::*;
 
 /// TODO: all LowerNames should be stored in a global "intern" space, and then everything that uses
 ///  them should be through references. As a workaround the Strings are all Rc as well as the array
-#[derive(Default, Debug, Eq, Clone)]
+#[derive(Debug, Eq, Clone)]
 pub struct LowerName(Name);
 
 impl LowerName {

--- a/crates/proto/src/rr/rdata/svcb.rs
+++ b/crates/proto/src/rr/rdata/svcb.rs
@@ -1179,6 +1179,7 @@ impl fmt::Display for SVCB {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::str::FromStr;
 
     #[test]
     fn read_svcb_key() {
@@ -1227,12 +1228,12 @@ mod tests {
     fn test_encode_decode_svcb() {
         test_encode_decode(SVCB::new(
             0,
-            Name::from_utf8("www.example.com.").unwrap(),
+            Name::from_str("www.example.com.").unwrap(),
             vec![],
         ));
         test_encode_decode(SVCB::new(
             0,
-            Name::from_utf8(".").unwrap(),
+            Name::from_str(".").unwrap(),
             vec![(
                 SvcParamKey::Alpn,
                 SvcParamValue::Alpn(Alpn(vec!["h2".to_string()])),
@@ -1240,7 +1241,7 @@ mod tests {
         ));
         test_encode_decode(SVCB::new(
             0,
-            Name::from_utf8("example.com.").unwrap(),
+            Name::from_str("example.com.").unwrap(),
             vec![
                 (
                     SvcParamKey::Mandatory,
@@ -1259,7 +1260,7 @@ mod tests {
     fn test_encode_decode_svcb_bad_order() {
         test_encode_decode(SVCB::new(
             0,
-            Name::from_utf8(".").unwrap(),
+            Name::from_str(".").unwrap(),
             vec![
                 (
                     SvcParamKey::Alpn,
@@ -1286,7 +1287,7 @@ mod tests {
     fn test_unrestricted_output_size() {
         let svcb = SVCB::new(
             8224,
-            Name::from_utf8(".").unwrap(),
+            Name::from_str(".").unwrap(),
             vec![(
                 SvcParamKey::Unknown(8224),
                 SvcParamValue::Unknown(Unknown(vec![32; 257])),

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -10,7 +10,6 @@ use std::fmt;
 use std::net::IpAddr;
 use std::sync::Arc;
 
-use proto::error::ProtoResult;
 use proto::op::Query;
 use proto::rr::domain::usage::ONION;
 use proto::rr::domain::TryParseIp;
@@ -381,13 +380,13 @@ impl<P: RuntimeProvider> AsyncResolver<P> {
         &self,
         host: N,
     ) -> Result<LookupIp, ResolveError> {
-        let mut finally_ip_addr: Option<Record> = None;
+        let mut finally_ip_addr = None;
         let maybe_ip = host.try_parse_ip();
-        let maybe_name: ProtoResult<Name> = host.into_name();
+        let maybe_name = host.into_name();
 
         // if host is a ip address, return directly.
         if let Some(ip_addr) = maybe_ip {
-            let name = maybe_name.clone().unwrap_or_default();
+            let name = maybe_name.clone().unwrap_or_else(|_| Name::root());
             let record = Record::from_rdata(name.clone(), dns_lru::MAX_TTL, ip_addr.clone());
 
             // if ndots are greater than 4, then we can't assume the name is an IpAddr

--- a/tests/integration-tests/src/mock_client.rs
+++ b/tests/integration-tests/src/mock_client.rs
@@ -9,6 +9,7 @@ use std::any::TypeId;
 use std::error::Error;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::pin::Pin;
+use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
@@ -226,7 +227,7 @@ pub fn v4_record(name: Name, ip: Ipv4Addr) -> Record {
 pub fn soa_record(name: Name, mname: Name) -> Record {
     let soa = SOA::new(
         mname,
-        Name::from_utf8("webmaster.example.com").unwrap(),
+        Name::from_str("webmaster.example.com").unwrap(),
         1,
         3600,
         60,

--- a/tests/integration-tests/src/mock_client.rs
+++ b/tests/integration-tests/src/mock_client.rs
@@ -224,7 +224,15 @@ pub fn v4_record(name: Name, ip: Ipv4Addr) -> Record {
 }
 
 pub fn soa_record(name: Name, mname: Name) -> Record {
-    let soa = SOA::new(mname, Default::default(), 1, 3600, 60, 86400, 3600);
+    let soa = SOA::new(
+        mname,
+        Name::from_utf8("webmaster.example.com").unwrap(),
+        1,
+        3600,
+        60,
+        86400,
+        3600,
+    );
     Record::from_rdata(name, 86400, RData::SOA(soa))
 }
 


### PR DESCRIPTION
So I started to work towards a better API to accomodate the discussion in #1904. Ideally I think we'd want to allow underscore by default in host names, and potentially provide a separate API that does not allow them. So here are some things that I ran into that seem to have surprising error potential:

* `Name` implements `Default`, and `Default` yields an empty `Name` that is not `root` (`is_fqdn` is `false`). This seems like a weird default value that's probably not valid in most cases? My second commit here removes the `Default` impl for `Name` and `LowerName` instead.

* `Name` has a `FromStr` impl and several implementations for the local `IntoName` trait, but `FromStr` relies on `Name::from_str_relaxed()` while the `IntoName` impls rely on `from_utf8()`. I think a reasonably expectation would be that `FromStr` exactly calls `from_utf8()`, so I implemented that and deprecated `Name::from_utf8()` in favor of the `FromStr` impl for good measure, which seems like a cleaner API. I think maybe the `IntoName` trait predates `TryFrom` and could be removed in favor of `TryFrom` impls these days?

* I noticed that `from_ascii()` and `from_utf8()` have quite different behavior. `Label::from_utf8()` switches to calling `Label::from_ascii()` when the first character of the label is `_`. However, `Name::from_utf8()` and `Name::from_ascii()` have the documented behavioral difference that `from_utf8()` always normalizes to lowercase whereas `from_ascii()` preserves case. This seems like very surprising behavior -- IMO `from_ascii()` should also normalize to lowercase. What do you think?

cc @nrempel @cpu