### PR TITLE
Separate default `rustls::ClientConfig` for each protocol (take 2)

### DIFF
--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -923,6 +923,15 @@ pub struct ResolverOpts {
     pub authentic_data: bool,
     /// Shuffle DNS servers before each query.
     pub shuffle_dns_servers: bool,
+    #[cfg(feature = "dns-over-rustls")]
+    #[cfg_attr(feature = "serde-config", serde(skip))]
+    pub(crate) tls_client_config: Option<TlsClientConfig>,
+    #[cfg(feature = "dns-over-https-rustls")]
+    #[cfg_attr(feature = "serde-config", serde(skip))]
+    pub(crate) https_client_config: Option<TlsClientConfig>,
+    #[cfg(all(feature = "dns-over-quic", feature = "dns-over-rustls"))]
+    #[cfg_attr(feature = "serde-config", serde(skip))]
+    pub(crate) quic_client_config: Option<TlsClientConfig>,
 }
 
 impl Default for ResolverOpts {
@@ -955,6 +964,12 @@ impl Default for ResolverOpts {
             recursion_desired: true,
             authentic_data: false,
             shuffle_dns_servers: false,
+            #[cfg(feature = "dns-over-rustls")]
+            tls_client_config: None,
+            #[cfg(feature = "dns-over-https-rustls")]
+            https_client_config: None,
+            #[cfg(feature = "dns-over-quic")]
+            quic_client_config: None,
         }
     }
 }

--- a/crates/resolver/src/quic.rs
+++ b/crates/resolver/src/quic.rs
@@ -8,15 +8,35 @@
 use rustls::ClientConfig as CryptoConfig;
 use std::future::Future;
 use std::net::SocketAddr;
+use trust_dns_proto::error::ProtoError;
 use trust_dns_proto::udp::QuicLocalAddr;
 
 use proto::udp::DnsUdpSocket;
 use proto::xfer::{DnsExchange, DnsExchangeConnect};
 use proto::TokioTime;
+use rustls::ClientConfig;
 use trust_dns_proto::quic::{QuicClientConnect, QuicClientStream};
 
 use crate::config::TlsClientConfig;
-use crate::tls::CLIENT_CONFIG;
+
+const ALPN_DOQ: &[u8] = b"doq";
+
+pub(crate) fn quic_client_config() -> Result<ClientConfig, ProtoError> {
+    let mut client_config = ClientConfig::builder()
+        .with_safe_default_cipher_suites()
+        .with_safe_default_kx_groups()
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .with_root_certificates(crate::tls::root_store()?)
+        .with_no_client_auth();
+
+    // The port (853) of DOQ is for dns dedicated, SNI is unnecessary. (ISP block by the SNI name)
+    client_config.enable_sni = false;
+
+    client_config.alpn_protocols.push(ALPN_DOQ.to_vec());
+
+    Ok(client_config)
+}
 
 #[allow(clippy::type_complexity)]
 #[allow(unused)]
@@ -24,21 +44,12 @@ pub(crate) fn new_quic_stream(
     socket_addr: SocketAddr,
     bind_addr: Option<SocketAddr>,
     dns_name: String,
-    client_config: Option<TlsClientConfig>,
+    client_config: TlsClientConfig,
 ) -> DnsExchangeConnect<QuicClientConnect, QuicClientStream, TokioTime> {
-    let client_config = if let Some(TlsClientConfig(client_config)) = client_config {
-        client_config
-    } else {
-        match CLIENT_CONFIG.clone() {
-            Ok(client_config) => client_config,
-            Err(error) => return DnsExchange::error(error),
-        }
-    };
-
     let mut quic_builder = QuicClientStream::builder();
 
     // TODO: normalize the crypto config settings, can we just use common ALPN settings?
-    let crypto_config: CryptoConfig = (*client_config).clone();
+    let crypto_config: CryptoConfig = (*client_config.0).clone();
 
     quic_builder.crypto_config(crypto_config);
     if let Some(bind_addr) = bind_addr {
@@ -52,26 +63,101 @@ pub(crate) fn new_quic_stream_with_future<S, F>(
     future: F,
     socket_addr: SocketAddr,
     dns_name: String,
-    client_config: Option<TlsClientConfig>,
+    client_config: TlsClientConfig,
 ) -> DnsExchangeConnect<QuicClientConnect, QuicClientStream, TokioTime>
 where
     S: DnsUdpSocket + QuicLocalAddr + 'static,
     F: Future<Output = std::io::Result<S>> + Send + 'static,
 {
-    let client_config = if let Some(TlsClientConfig(client_config)) = client_config {
-        client_config
-    } else {
-        match CLIENT_CONFIG.clone() {
-            Ok(client_config) => client_config,
-            Err(error) => return DnsExchange::error(error),
-        }
-    };
-
     let mut quic_builder = QuicClientStream::builder();
 
     // TODO: normalize the crypto config settings, can we just use common ALPN settings?
-    let crypto_config: CryptoConfig = (*client_config).clone();
+    let crypto_config: CryptoConfig = (*client_config.0).clone();
 
     quic_builder.crypto_config(crypto_config);
     DnsExchange::connect(quic_builder.build_with_future(future, socket_addr, dns_name))
+}
+
+#[cfg(any(feature = "webpki-roots", feature = "native-certs"))]
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use std::sync::Arc;
+
+    use tokio::runtime::Runtime;
+
+    use crate::config::{NameServerConfigGroup, ResolverConfig, ResolverOpts};
+    use crate::name_server::TokioConnectionProvider;
+    use crate::TokioAsyncResolver;
+
+    fn quic_test(config: ResolverConfig) {
+        let io_loop = Runtime::new().unwrap();
+
+        let resolver = TokioAsyncResolver::new(
+            config,
+            ResolverOpts {
+                try_tcp_on_error: true,
+                ..ResolverOpts::default()
+            },
+            TokioConnectionProvider::default(),
+        );
+
+        let response = io_loop
+            .block_on(resolver.lookup_ip("www.example.com."))
+            .expect("failed to run lookup");
+
+        assert_eq!(response.iter().count(), 1);
+        for address in response.iter() {
+            if address.is_ipv4() {
+                assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)));
+            } else {
+                assert_eq!(
+                    address,
+                    IpAddr::V6(Ipv6Addr::new(
+                        0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
+                    ))
+                );
+            }
+        }
+
+        // check if there is another connection created
+        let response = io_loop
+            .block_on(resolver.lookup_ip("www.example.com."))
+            .expect("failed to run lookup");
+
+        assert_eq!(response.iter().count(), 1);
+        for address in response.iter() {
+            if address.is_ipv4() {
+                assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)));
+            } else {
+                assert_eq!(
+                    address,
+                    IpAddr::V6(Ipv6Addr::new(
+                        0x2606, 0x2800, 0x220, 0x1, 0x248, 0x1893, 0x25c8, 0x1946,
+                    ))
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_adguard_quic() {
+        // AdGuard requires SNI.
+        let mut config = super::quic_client_config().unwrap();
+        config.enable_sni = true;
+
+        let name_servers = NameServerConfigGroup::from_ips_quic(
+            &[
+                IpAddr::from([94, 140, 14, 140]),
+                IpAddr::from([94, 140, 15, 141]),
+                IpAddr::from([0x2a10, 0x50c0, 0, 0, 0, 0, 0x1, 0xff]),
+                IpAddr::from([0x2a10, 0x50c0, 0, 0, 0, 0, 0x2, 0xff]),
+            ],
+            853,
+            String::from("unfiltered.adguard-dns.com"),
+            true,
+        )
+        .with_client_config(Arc::new(config));
+        quic_test(ResolverConfig::from_parts(None, Vec::new(), name_servers))
+    }
 }

--- a/crates/resolver/src/tls/mod.rs
+++ b/crates/resolver/src/tls/mod.rs
@@ -13,9 +13,9 @@ mod dns_over_rustls;
 
 cfg_if! {
     if #[cfg(feature = "dns-over-rustls")] {
-        pub(crate) use self::dns_over_rustls::new_tls_stream_with_future;
+        pub(crate) use self::dns_over_rustls::{tls_client_config, new_tls_stream_with_future};
         #[cfg(any(feature = "dns-over-https-rustls", feature = "dns-over-quic"))]
-        pub(crate) use self::dns_over_rustls::CLIENT_CONFIG;
+        pub(crate) use self::dns_over_rustls::root_store;
     } else if #[cfg(feature = "dns-over-native-tls")] {
         pub(crate) use self::dns_over_native_tls::new_tls_stream_with_future;
     } else if #[cfg(feature = "dns-over-openssl")] {


### PR DESCRIPTION
WIP!

1. I have to store the configs as in `Option`s to allow `Default` to work. ~~Probably the simplest solution is to remove the `Default` implementation and add a `ResolverOpts::new()`~~.
2. This is just temporary but currently we don't reuse certificates, for that I would have to either add another field or apply the solution in 1.
3. Current DoQ takes a `ClientConfig` instead of a `Arc<ClientConfig>`, as far as I can see the only reason for that is that it adds the correct ALPN, which is obviously unnecessary when using a default supplied one. I would propose to actually remove this ALPN correction completely.

Originally in #2001 I have added those configs to `GenericConnector` instead of `ResolverOpts`, maybe this is also an alternative to consider. I was trying to keep in mind that somewhere we will want to dynamically be able to select between native or WebPKI roots, which will be weird if done in `ResolverOpts`, because it's holding these configs but it doesn't have a builder or something to select it before constructing those configs.

I hope I'm making sense here, I'm happy to talk this out in realtime on Discord or wherever if it's easier.

This is take two of #2001.
Fixes #1990.