### PR TITLE
proto: fix feature dependencies for dns-over-https*

### DIFF
--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -35,8 +35,8 @@ dns-over-rustls = ["dns-over-tls", "rustls", "rustls-pemfile", "tokio-rustls", "
 dns-over-native-tls = ["dns-over-tls", "native-tls", "tokio-native-tls", "tokio-runtime"]
 dns-over-openssl = ["dns-over-tls", "openssl", "tokio-openssl", "tokio-runtime"]
 
-dns-over-https-rustls = ["dns-over-https"]
-dns-over-https = ["bytes", "h2", "http", "dns-over-rustls", "webpki-roots", "tokio-runtime"]
+dns-over-https-rustls = ["dns-over-https", "dns-over-rustls", "webpki-roots"]
+dns-over-https = ["bytes", "dns-over-tls", "h2", "http", "tokio-runtime"]
 
 dns-over-quic = ["quinn", "rustls/quic", "dns-over-rustls", "bytes", "webpki-roots", "tokio-runtime"]
 


### PR DESCRIPTION
This fixes a regression between v0.22 and v0.23 that caused Rustls to be pulled in as a dependency even when using an OpenSSL backend. The change moves the `dns-over-rustls` and `webpki-roots` feature dependences from the `dns-over-https` feature back to the `dns-over-https-rustls` feature, where they were in v0.22.

see #2072