### PR TITLE
proto: fix feature dependencies for dns-over-https*

### DIFF
--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -46,8 +46,8 @@ dns-over-native-tls = [
 ]
 dns-over-openssl = ["dns-over-tls", "openssl", "tokio-openssl", "tokio-runtime"]
 
-dns-over-https-rustls = ["dns-over-https"]
-dns-over-https = ["bytes", "h2", "http", "dns-over-rustls", "tokio-runtime"]
+dns-over-https-rustls = ["dns-over-https", "dns-over-rustls"]
+dns-over-https = ["bytes", "h2", "http", "tokio-runtime"]
 dns-over-quic = [
     "quinn",
     "rustls/quic",


### PR DESCRIPTION
This fixes a regression between v0.22 and v0.23 that caused Rustls to be pulled in as a dependency even when using an OpenSSL backend. The change moves the `dns-over-rustls` feature dependency from the `dns-over-https` feature back to the `dns-over-https-rustls` feature, where it used to be in v0.22.

see #2072 #2073 