### PR TITLE
update to use ring 0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,7 +894,7 @@ dependencies = [
  "openssl",
  "quinn",
  "rand",
- "ring",
+ "ring 0.17.5",
  "rustls",
  "rustls-native-certs",
  "rustls-pemfile",
@@ -1478,7 +1478,7 @@ checksum = "2c78e758510582acc40acb90458401172d41f1016f8c9dde89e49677afb7eec1"
 dependencies = [
  "bytes",
  "rand",
- "ring",
+ "ring 0.16.20",
  "rustc-hash",
  "rustls",
  "slab",
@@ -1621,10 +1621,24 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
- "untrusted",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1683,12 +1697,12 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.7"
+version = "0.21.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+checksum = "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c"
 dependencies = [
  "log",
- "ring",
+ "ring 0.17.5",
  "rustls-webpki",
  "sct",
 ]
@@ -1716,12 +1730,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.6"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.5",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -1741,12 +1755,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.5",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -1860,6 +1874,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
@@ -2143,6 +2163,12 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,11 +61,11 @@ parking_lot = "0.12"
 # ssl
 native-tls = "0.2"
 openssl = "0.10.55"
-rustls = "0.21.6"
+rustls = "0.21.8"
 rustls-native-certs = "0.6.3"
 rustls-pemfile = "1.0.0"
 webpki-roots = "0.25.0"
-ring = "0.16"
+ring = "0.17"
 
 
 # net proto

--- a/crates/proto/src/rr/dnssec/key_format.rs
+++ b/crates/proto/src/rr/dnssec/key_format.rs
@@ -5,6 +5,8 @@ use openssl::rsa::Rsa;
 #[cfg(feature = "openssl")]
 use openssl::symm::Cipher;
 #[cfg(feature = "ring")]
+use ring::rand::SystemRandom;
+#[cfg(feature = "ring")]
 use ring::signature::{
     EcdsaKeyPair, Ed25519KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING, ECDSA_P384_SHA384_FIXED_SIGNING,
 };
@@ -86,12 +88,13 @@ impl KeyFormat {
                 }
                 #[cfg(feature = "ring")]
                 Self::Pkcs8 => {
+                    let rng = SystemRandom::new();
                     let ring_algorithm = if algorithm == Algorithm::ECDSAP256SHA256 {
                         &ECDSA_P256_SHA256_FIXED_SIGNING
                     } else {
                         &ECDSA_P384_SHA384_FIXED_SIGNING
                     };
-                    let key = EcdsaKeyPair::from_pkcs8(ring_algorithm, bytes)?;
+                    let key = EcdsaKeyPair::from_pkcs8(ring_algorithm, bytes, &rng)?;
 
                     Ok(KeyPair::from_ecdsa(key))
                 }

--- a/crates/proto/src/rr/dnssec/rdata/tsig.rs
+++ b/crates/proto/src/rr/dnssec/rdata/tsig.rs
@@ -635,9 +635,9 @@ impl TsigAlgorithm {
         use TsigAlgorithm::*;
 
         let len = match self {
-            HmacSha256 => hmac::HMAC_SHA256.digest_algorithm().output_len,
-            HmacSha384 => hmac::HMAC_SHA384.digest_algorithm().output_len,
-            HmacSha512 => hmac::HMAC_SHA512.digest_algorithm().output_len,
+            HmacSha256 => hmac::HMAC_SHA256.digest_algorithm().output_len(),
+            HmacSha384 => hmac::HMAC_SHA384.digest_algorithm().output_len(),
+            HmacSha512 => hmac::HMAC_SHA512.digest_algorithm().output_len(),
             _ => return Err(ProtoErrorKind::TsigUnsupportedMacAlgorithm(self.clone()).into()),
         };
 


### PR DESCRIPTION
May be should wait for https://github.com/rustls/rustls/pull/1525 to have a more clean Cargo.lock?