### PR TITLE
Update h2_client_connection.rs

### DIFF
--- a/crates/client/src/h2_client_connection.rs
+++ b/crates/client/src/h2_client_connection.rs
@@ -42,6 +42,7 @@ pub struct HttpsClientConnection<T> {
 /// use hickory_proto::iocompat::AsyncIoTokioAsStd;
 /// use rustls::{ClientConfig, OwnedTrustAnchor, RootCertStore};
 /// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+/// use webpki_roots;
 ///
 /// let name_server = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 443);
 /// let host_to_lookup = "example.com".to_string();


### PR DESCRIPTION
Documentation on using DNS over HTTPS
Was tested to work with these in `Cargo.toml`
```
[dependencies]
rustls = { version = "0.21.7" }
hickory-proto = { version = "0.24.0" }
hickory-client = { version = "0.24.0", default-features = false,features=["dns-over-https", "dns-over-https-rustls"]}
webpki-roots = { version = "0.23.1" }
tokio = { version = "1.27.0", features = ["full"] }
```
This should compile without errors or warnings, checked with `cargo check` and `cargo clippy`.