### PR TITLE
Add getters for resolver config and options

### DIFF
--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -175,6 +175,16 @@ impl<R: ConnectionProvider> AsyncResolver<R> {
     pub fn clear_cache(&self) {
         self.client_cache.clear_cache();
     }
+
+    /// Read the config for this resolver.
+    pub fn config(&self) -> &ResolverConfig {
+        &self.config
+    }
+
+    /// Read the options for this resolver.
+    pub fn options(&self) -> &ResolverOpts {
+        &self.options
+    }
 }
 
 impl<P: ConnectionProvider> AsyncResolver<P> {

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -120,6 +120,16 @@ impl Resolver {
         self.async_resolver.clear_cache();
     }
 
+    /// Read the config for this resolver.
+    pub fn config(&self) -> &ResolverConfig {
+        &self.async_resolver.config()
+    }
+
+    /// Read the options for this resolver.
+    pub fn options(&self) -> &ResolverOpts {
+        &self.async_resolver.options()
+    }
+
     /// Generic lookup for any RecordType
     ///
     /// *WARNING* This interface may change in the future, please use [`Self::lookup_ip`] or another variant for more stable interfaces.

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -122,12 +122,12 @@ impl Resolver {
 
     /// Read the config for this resolver.
     pub fn config(&self) -> &ResolverConfig {
-        &self.async_resolver.config()
+        self.async_resolver.config()
     }
 
     /// Read the options for this resolver.
     pub fn options(&self) -> &ResolverOpts {
-        &self.async_resolver.options()
+        self.async_resolver.options()
     }
 
     /// Generic lookup for any RecordType


### PR DESCRIPTION
This PR adds getters to `Resolver` and `AsyncResolver` for the `config` and `options` fields of the struct, to enable inspecting a resolver's configuration after instantiation.