### PR TITLE
Remove generic Error from DnsHandle

### DIFF
--- a/bin/tests/server_harness/mut_message_client.rs
+++ b/bin/tests/server_harness/mut_message_client.rs
@@ -22,7 +22,6 @@ impl<C: ClientHandle + Unpin> MutMessageHandle<C> {
 
 impl<C: ClientHandle + Unpin> DnsHandle for MutMessageHandle<C> {
     type Response = <C as DnsHandle>::Response;
-    type Error = <C as DnsHandle>::Error;
 
     fn is_verifying_dnssec(&self) -> bool {
         true

--- a/crates/async-std-resolver/src/tests.rs
+++ b/crates/async-std-resolver/src/tests.rs
@@ -10,7 +10,6 @@ use crate::proto::xfer::DnsRequest;
 use crate::proto::Executor;
 use crate::runtime::AsyncStdConnectionProvider;
 use crate::AsyncStdResolver;
-use crate::ResolveError;
 
 fn is_send_t<T: Send>() -> bool {
     true
@@ -31,8 +30,8 @@ fn test_send_sync() {
     assert!(is_sync_t::<AsyncStdResolver>());
 
     assert!(is_send_t::<DnsRequest>());
-    assert!(is_send_t::<LookupIpFuture<GenericConnection, ResolveError>>());
-    assert!(is_send_t::<LookupFuture<GenericConnection, ResolveError>>());
+    assert!(is_send_t::<LookupIpFuture<GenericConnection>>());
+    assert!(is_send_t::<LookupFuture<GenericConnection>>());
 }
 
 #[test]

--- a/crates/client/src/client/async_client.rs
+++ b/crates/client/src/client/async_client.rs
@@ -145,7 +145,6 @@ impl AsyncClient {
 
 impl DnsHandle for AsyncClient {
     type Response = DnsExchangeSend;
-    type Error = ProtoError;
 
     fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&self, request: R) -> Self::Response {
         self.exchange.send(request)
@@ -156,10 +155,10 @@ impl DnsHandle for AsyncClient {
     }
 }
 
-impl<T> ClientHandle for T where T: DnsHandle<Error = ProtoError> {}
+impl<T> ClientHandle for T where T: DnsHandle {}
 
 /// A trait for implementing high level functions of DNS.
-pub trait ClientHandle: 'static + Clone + DnsHandle<Error = ProtoError> + Send {
+pub trait ClientHandle: 'static + Clone + DnsHandle + Send {
     /// A *classic* DNS query
     ///
     /// *Note* As of now, this will not recurse on PTR or CNAME record responses, that is up to

--- a/crates/client/src/client/async_secure_client.rs
+++ b/crates/client/src/client/async_secure_client.rs
@@ -69,7 +69,6 @@ impl Clone for AsyncDnssecClient {
 
 impl DnsHandle for AsyncDnssecClient {
     type Response = Pin<Box<(dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send + 'static)>>;
-    type Error = ProtoError;
 
     fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&self, request: R) -> Self::Response {
         self.client.send(request)

--- a/crates/client/src/client/client.rs
+++ b/crates/client/src/client/client.rs
@@ -71,7 +71,7 @@ pub trait Client {
     /// The result stream that will resolve into a DnsResponse
     type Response: Stream<Item = Result<DnsResponse, ProtoError>> + 'static + Send + Unpin;
     /// The AsyncClient type used
-    type Handle: DnsHandle<Response = Self::Response, Error = ProtoError> + 'static + Send + Unpin;
+    type Handle: DnsHandle<Response = Self::Response> + 'static + Send + Unpin;
 
     /// Return the inner Futures items
     ///

--- a/crates/client/src/client/memoize_client_handle.rs
+++ b/crates/client/src/client/memoize_client_handle.rs
@@ -75,7 +75,6 @@ where
     H: ClientHandle,
 {
     type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send>>;
-    type Error = ProtoError;
 
     fn send<R: Into<DnsRequest>>(&self, request: R) -> Self::Response {
         let request = request.into();
@@ -117,7 +116,6 @@ mod test {
 
     impl DnsHandle for TestClient {
         type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send>>;
-        type Error = ProtoError;
 
         fn send<R: Into<DnsRequest> + Send + 'static>(&self, request: R) -> Self::Response {
             let i = Arc::clone(&self.i);

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -105,7 +105,6 @@ impl Clone for DnsExchange {
 
 impl DnsHandle for DnsExchange {
     type Response = DnsExchangeSend;
-    type Error = ProtoError;
 
     fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&self, request: R) -> Self::Response {
         DnsExchangeSend {

--- a/crates/proto/src/xfer/dns_handle.rs
+++ b/crates/proto/src/xfer/dns_handle.rs
@@ -6,7 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 
 //! `DnsHandle` types perform conversions of the raw DNS messages before sending the messages on the specified streams.
-use std::error::Error;
 
 use futures_util::stream::Stream;
 use rand;
@@ -30,9 +29,7 @@ pub trait DnsStreamHandle: 'static + Send {
 /// A trait for implementing high level functions of DNS.
 pub trait DnsHandle: 'static + Clone + Send + Sync + Unpin {
     /// The associated response from the response stream, this should resolve to the Response messages
-    type Response: Stream<Item = Result<DnsResponse, Self::Error>> + Send + Unpin + 'static;
-    /// Error of the response, generally this will be `ProtoError`
-    type Error: From<ProtoError> + Error + Clone + Send + Unpin + 'static;
+    type Response: Stream<Item = Result<DnsResponse, ProtoError>> + Send + Unpin + 'static;
 
     /// Only returns true if and only if this DNS handle is validating DNSSEC.
     ///

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -164,7 +164,6 @@ macro_rules! try_oneshot {
 
 impl DnsHandle for BufDnsRequestStreamHandle {
     type Response = DnsResponseReceiver;
-    type Error = ProtoError;
 
     fn send<R: Into<DnsRequest>>(&self, request: R) -> Self::Response {
         let request: DnsRequest = request.into();

--- a/crates/proto/src/xfer/retry_dns_handle.rs
+++ b/crates/proto/src/xfer/retry_dns_handle.rs
@@ -33,7 +33,6 @@ use crate::DnsHandle;
 pub struct RetryDnsHandle<H>
 where
     H: DnsHandle + Unpin + Send,
-    H::Error: RetryableError,
 {
     handle: H,
     attempts: usize,
@@ -42,7 +41,6 @@ where
 impl<H> RetryDnsHandle<H>
 where
     H: DnsHandle + Unpin + Send,
-    H::Error: RetryableError,
 {
     /// Creates a new Client handler for reattempting requests on failures.
     ///
@@ -58,10 +56,8 @@ where
 impl<H> DnsHandle for RetryDnsHandle<H>
 where
     H: DnsHandle + Send + Unpin + 'static,
-    H::Error: RetryableError,
 {
-    type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, Self::Error>> + Send + Unpin>>;
-    type Error = <H as DnsHandle>::Error;
+    type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send + Unpin>>;
 
     fn send<R: Into<DnsRequest>>(&self, request: R) -> Self::Response {
         let request = request.into();
@@ -90,11 +86,8 @@ where
     remaining_attempts: usize,
 }
 
-impl<H: DnsHandle + Unpin> Stream for RetrySendStream<H>
-where
-    <H as DnsHandle>::Error: RetryableError,
-{
-    type Item = Result<DnsResponse, <H as DnsHandle>::Error>;
+impl<H: DnsHandle + Unpin> Stream for RetrySendStream<H> {
+    type Item = Result<DnsResponse, ProtoError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         // loop over the stream, on errors, spawn a new stream
@@ -131,7 +124,10 @@ pub trait RetryableError {
 
 impl RetryableError for ProtoError {
     fn should_retry(&self) -> bool {
-        true
+        !matches!(
+            self.kind(),
+            ProtoErrorKind::NoConnections | ProtoErrorKind::NoRecordsFound { .. }
+        )
     }
 
     fn attempted(&self) -> bool {
@@ -163,7 +159,6 @@ mod test {
 
     impl DnsHandle for TestClient {
         type Response = Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send + Unpin>;
-        type Error = ProtoError;
 
         fn send<R: Into<DnsRequest>>(&self, _: R) -> Self::Response {
             let i = self.attempts.load(Ordering::SeqCst);

--- a/crates/recursor/src/error.rs
+++ b/crates/recursor/src/error.rs
@@ -12,15 +12,13 @@
 use std::{fmt, io};
 
 use enum_as_inner::EnumAsInner;
+use hickory_proto::error::ProtoErrorKind;
 use hickory_resolver::Name;
 use thiserror::Error;
 
 #[cfg(feature = "backtrace")]
 use crate::proto::{trace, ExtBacktrace};
-use crate::{
-    proto::error::ProtoError,
-    resolver::error::{ResolveError, ResolveErrorKind},
-};
+use crate::{proto::error::ProtoError, resolver::error::ResolveError};
 
 /// The error kind for errors that get returned in the crate
 #[derive(Debug, EnumAsInner, Error)]
@@ -134,7 +132,7 @@ impl From<Error> for String {
 
 impl From<ResolveError> for Error {
     fn from(e: ResolveError) -> Self {
-        if let ResolveErrorKind::NoRecordsFound { soa, .. } = e.kind() {
+        if let Some(ProtoErrorKind::NoRecordsFound { soa, .. }) = e.proto().map(ProtoError::kind) {
             match soa {
                 Some(soa) => ErrorKind::Forward(soa.name().clone()).into(),
                 _ => ErrorKind::Resolve(e).into(),

--- a/crates/recursor/src/recursor_pool.rs
+++ b/crates/recursor/src/recursor_pool.rs
@@ -97,7 +97,7 @@ where
                 let lookup = ns
                     .lookup(query_cpy, options)
                     .into_future()
-                    .map(|(next, _)| next)
+                    .map(|(next, _)| next.map(|r| r.map_err(ResolveError::from)))
                     .boxed()
                     .shared();
 

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -60,7 +60,7 @@ use crate::Hosts;
 pub struct AsyncResolver<P: ConnectionProvider> {
     config: ResolverConfig,
     options: ResolverOpts,
-    client_cache: CachingClient<LookupEither<P>, ResolveError>,
+    client_cache: CachingClient<LookupEither<P>>,
     hosts: Option<Arc<Hosts>>,
 }
 
@@ -1083,8 +1083,8 @@ mod tests {
         assert!(is_sync_t::<AsyncResolver<TokioConnectionProvider>>());
 
         assert!(is_send_t::<DnsRequest>());
-        assert!(is_send_t::<LookupIpFuture<GenericConnection, ResolveError>>());
-        assert!(is_send_t::<LookupFuture<GenericConnection, ResolveError>>());
+        assert!(is_send_t::<LookupIpFuture<GenericConnection>>());
+        assert!(is_send_t::<LookupFuture<GenericConnection>>());
     }
 
     #[test]

--- a/crates/resolver/src/lookup.rs
+++ b/crates/resolver/src/lookup.rs
@@ -668,7 +668,7 @@ pub mod tests {
         ))
         .expect_err("this should have been a NoRecordsFound")
         .proto()
-        .expect("it sould have been a ProtoError")
+        .expect("it should have been a ProtoError")
         .kind()
         {
             assert_eq!(**query, Query::query(Name::root(), RecordType::A));

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -309,7 +309,7 @@ async fn parallel_conn_loop<P>(
 where
     P: ConnectionProvider + 'static,
 {
-    let mut err: ProtoError = ProtoErrorKind::NoConnections.into();
+    let mut err = ProtoError::from(ProtoErrorKind::NoConnections);
     // If the name server we're trying is giving us backpressure by returning ProtoErrorKind::Busy,
     // we will first try the other name servers (as for other error types). However, if the other
     // servers are also busy, we're going to wait for a little while and then retry each server that

--- a/tests/integration-tests/tests/lookup_tests.rs
+++ b/tests/integration-tests/tests/lookup_tests.rs
@@ -15,7 +15,6 @@ use hickory_proto::{
 use hickory_resolver::{
     caching_client::CachingClient,
     config::LookupIpStrategy,
-    error::ResolveError,
     lookup::{Lookup, LookupFuture},
     lookup_ip::LookupIpFuture,
     Hosts,
@@ -181,7 +180,7 @@ fn test_mock_lookup() {
         Ipv4Addr::new(93, 184, 216, 34),
     );
     let message = message(resp_query, vec![v4_record], vec![], vec![]);
-    let client: MockClientHandle<_, ResolveError> =
+    let client: MockClientHandle<_> =
         MockClientHandle::mock(vec![Ok(DnsResponse::from_message(message).unwrap())]);
 
     let lookup = LookupFuture::lookup(
@@ -212,7 +211,7 @@ fn test_cname_lookup() {
         Ipv4Addr::new(93, 184, 216, 34),
     );
     let message = message(resp_query, vec![cname_record, v4_record], vec![], vec![]);
-    let client: MockClientHandle<_, ResolveError> =
+    let client: MockClientHandle<_> =
         MockClientHandle::mock(vec![Ok(DnsResponse::from_message(message).unwrap())]);
 
     let lookup = LookupFuture::lookup(
@@ -248,7 +247,7 @@ fn test_cname_lookup_preserve() {
         vec![],
         vec![],
     );
-    let client: MockClientHandle<_, ResolveError> =
+    let client: MockClientHandle<_> =
         MockClientHandle::mock(vec![Ok(DnsResponse::from_message(message).unwrap())]);
 
     let lookup = LookupFuture::lookup(
@@ -283,7 +282,7 @@ fn test_chained_cname_lookup() {
     let message2 = message(resp_query, vec![v4_record], vec![], vec![]);
 
     // the mock pops messages...
-    let client: MockClientHandle<_, ResolveError> = MockClientHandle::mock(vec![
+    let client: MockClientHandle<_> = MockClientHandle::mock(vec![
         Ok(DnsResponse::from_message(message2).unwrap()),
         Ok(DnsResponse::from_message(message1).unwrap()),
     ]);
@@ -326,7 +325,7 @@ fn test_chained_cname_lookup_preserve() {
     let message2 = message(resp_query, vec![v4_record], vec![], vec![]);
 
     // the mock pops messages...
-    let client: MockClientHandle<_, ResolveError> = MockClientHandle::mock(vec![
+    let client: MockClientHandle<_> = MockClientHandle::mock(vec![
         Ok(DnsResponse::from_message(message2).unwrap()),
         Ok(DnsResponse::from_message(message1).unwrap()),
     ]);
@@ -403,7 +402,7 @@ fn test_max_chained_lookup_depth() {
     let message10 = message(resp_query, vec![v4_record], vec![], vec![]);
 
     // the mock pops messages...
-    let client: MockClientHandle<_, ResolveError> = MockClientHandle::mock(vec![
+    let client: MockClientHandle<_> = MockClientHandle::mock(vec![
         Ok(DnsResponse::from_message(message10).unwrap()),
         Ok(DnsResponse::from_message(message9).unwrap()),
         Ok(DnsResponse::from_message(message8).unwrap()),


### PR DESCRIPTION
While working on #2084, there was a huge amount of type golf with `DnsHandle` that seemed really pointless and had very little gain. I've simplified that by making `DnsHandle` always return `ProtoError` which should make inter-crate implementations of DnsHandle simpler. 