### PR TITLE
Initial chained store and blocklist authority implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ hickory-resolver = { version = "0.24.0", path = "crates/resolver", default-featu
 hickory-server = { version = "0.24.0", path = "crates/server", default-features = false }
 hickory-proto = { version = "0.24.0", path = "crates/proto", default-features = false }
 
-
 # logging
 tracing = "0.1.30"
 tracing-subscriber = "0.3"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -53,6 +53,7 @@ dnssec = []
 recursor = ["hickory-server/recursor"]
 # Recursive Resolution is Experimental!
 resolver = ["hickory-server/resolver"]
+blocklist = ["hickory-server/blocklist"]
 sqlite = ["hickory-server/sqlite"]
 
 # TODO: Need to figure out how to be consistent with ring/openssl usage...

--- a/bin/src/hickory-dns.rs
+++ b/bin/src/hickory-dns.rs
@@ -58,8 +58,6 @@ use tracing_subscriber::{
 };
 
 use hickory_client::rr::Name;
-#[cfg(feature = "blocklist")]
-use hickory_server::store::blocklist::BlockListAuthority;
 #[cfg(feature = "dns-over-tls")]
 use hickory_server::config::dnssec::{self, TlsCertConfig};
 #[cfg(feature = "blocklist")]
@@ -147,7 +145,7 @@ async fn load_keys<T>(
 async fn load_zone(
     zone_dir: &Path,
     zone_config: &ZoneConfig,
-) -> Result<Box<dyn AuthorityObject>, String> {
+) -> Result<Vec<Box<dyn AuthorityObject>>, String> {
     debug!("loading zone with config: {:#?}", zone_config);
 
     let zone_name: Name = zone_config.get_zone().expect("bad zone name");

--- a/bin/src/hickory-dns.rs
+++ b/bin/src/hickory-dns.rs
@@ -58,6 +58,8 @@ use tracing_subscriber::{
 };
 
 use hickory_client::rr::Name;
+#[cfg(feature = "blocklist")]
+use hickory_server::store::blocklist::BlockListAuthority;
 #[cfg(feature = "dns-over-tls")]
 use hickory_server::config::dnssec::{self, TlsCertConfig};
 #[cfg(feature = "resolver")]
@@ -158,115 +160,150 @@ async fn load_zone(
         warn!("allow_update is deprecated in [[zones]] section, it belongs in [[zones.stores]]");
     }
 
-    // load the zone
-    let authority: Box<dyn AuthorityObject> = match zone_config.stores {
-        #[cfg(feature = "sqlite")]
-        Some(StoreConfig::Sqlite(ref config)) => {
-            if zone_path.is_some() {
-                warn!("ignoring [[zones.file]] instead using [[zones.stores.zone_file_path]]");
+    let mut normalized_stores = vec![];
+    if let Some(StoreConfig::Single(store)) = &zone_config.stores {
+        normalized_stores.push(store);
+    } else if let Some(StoreConfig::Chained(chained_stores)) = &zone_config.stores {
+        for store in chained_stores {
+            normalized_stores.push(store);
+        }
+    } else {
+        normalized_stores.push(&StoreConfigElement::Default);
+        debug!("No stores specified for {}, using default config processing", zone_name.clone());
+    }
+
+    // Load the zone and build a vector of associated authorities to load in the catalog.
+    debug!("Loading authorities for {} with stores {:?}", &zone_name, &normalized_stores);
+    let mut authorities: Vec<Box<dyn AuthorityObject>> = vec![];
+    for store in normalized_stores {
+        let authority: Box<dyn AuthorityObject> = match store {
+            #[cfg(feature = "sqlite")]
+            StoreConfig::Sqlite(ref config) => {
+                if zone_path.is_some() {
+                    warn!("ignoring [[zones.file]] instead using [[zones.stores.zone_file_path]]");
+                }
+
+                let mut authority = SqliteAuthority::try_from_config(
+                    zone_name.clone(),
+                    zone_type,
+                    is_axfr_allowed,
+                    is_dnssec_enabled,
+                    Some(zone_dir),
+                    config,
+                )
+                .await?;
+
+                // load any keys for the Zone, if it is a dynamic update zone, then keys are required
+                load_keys(&mut authority, zone_name_for_signer.clone(), zone_config).await?;
+                Box::new(Arc::new(authority)) as Box<dyn AuthorityObject>
             }
+            StoreConfig::File(ref config) => {
+                if zone_path.is_some() {
+                    warn!("ignoring [[zones.file]] instead using [[zones.stores.zone_file_path]]");
+                }
 
-            let mut authority = SqliteAuthority::try_from_config(
-                zone_name,
-                zone_type,
-                is_axfr_allowed,
-                is_dnssec_enabled,
-                Some(zone_dir),
-                config,
-            )
-            .await?;
+                let mut authority = FileAuthority::try_from_config(
+                    zone_name.clone(),
+                    zone_type,
+                    is_axfr_allowed,
+                    Some(zone_dir),
+                    config,
+                )?;
 
-            // load any keys for the Zone, if it is a dynamic update zone, then keys are required
-            load_keys(&mut authority, zone_name_for_signer, zone_config).await?;
-            Box::new(Arc::new(authority)) as Box<dyn AuthorityObject>
-        }
-        Some(StoreConfig::File(ref config)) => {
-            if zone_path.is_some() {
-                warn!("ignoring [[zones.file]] instead using [[zones.stores.zone_file_path]]");
+                // load any keys for the Zone, if it is a dynamic update zone, then keys are required
+                load_keys(&mut authority, zone_name_for_signer.clone(), zone_config).await?;
+                Box::new(Arc::new(authority)) as Box<dyn AuthorityObject>
             }
+            #[cfg(feature = "resolver")]
+            StoreConfig::Forward(ref config) => {
+                let forwarder =
+                    ForwardAuthority::try_from_config(zone_name.clone(), zone_type, config)?;
 
-            let mut authority = FileAuthority::try_from_config(
-                zone_name,
-                zone_type,
-                is_axfr_allowed,
-                Some(zone_dir),
-                config,
-            )?;
+                Box::new(Arc::new(forwarder)) as Box<dyn AuthorityObject>
+            }
+            #[cfg(feature = "recursor")]
+            StoreConfig::Recursor(ref config) => {
+                let recursor = RecursiveAuthority::try_from_config(
+                    zone_name.clone(),
+                    zone_type,
+                    config,
+                    Some(zone_dir),
+                );
+                let authority = recursor.await?;
 
-            // load any keys for the Zone, if it is a dynamic update zone, then keys are required
-            load_keys(&mut authority, zone_name_for_signer, zone_config).await?;
-            Box::new(Arc::new(authority)) as Box<dyn AuthorityObject>
-        }
-        #[cfg(feature = "resolver")]
-        Some(StoreConfig::Forward(ref config)) => {
-            let forwarder = ForwardAuthority::try_from_config(zone_name, zone_type, config)?;
+                Box::new(Arc::new(authority)) as Box<dyn AuthorityObject>
+            }
+            #[cfg(feature = "blocklist")]
+            StoreConfig::Blocklist(ref config) => {
+                let blocklist = BlocklistAuthority::try_from_config(
+                    zone_name.clone(),
+                    zone_type,
+                    config,
+                    Some(zone_dir),
+                );
+                let authority = blocklist.await?;
+                Box::new(Arc::new(authority)) as Box<dyn AuthorityObject>
+            }
+            #[cfg(feature = "sqlite")]
+            _ if zone_config.is_update_allowed() => {
+                warn!(
+                    "using deprecated SQLite load configuration, please move to [[zones.stores]] form"
+                );
+                let zone_file_path = zone_path
+                    .clone()
+                    .ok_or("file is a necessary parameter of zone_config")?;
+                let journal_file_path = PathBuf::from(zone_file_path.clone())
+                    .with_extension("jrnl")
+                    .to_str()
+                    .map(String::from)
+                    .ok_or("non-unicode characters in file name")?;
 
-            Box::new(Arc::new(forwarder)) as Box<dyn AuthorityObject>
-        }
-        #[cfg(feature = "recursor")]
-        Some(StoreConfig::Recursor(ref config)) => {
-            let recursor =
-                RecursiveAuthority::try_from_config(zone_name, zone_type, config, Some(zone_dir));
-            let authority = recursor.await?;
+                let config = SqliteConfig {
+                    zone_file_path,
+                    journal_file_path,
+                    allow_update: zone_config.is_update_allowed(),
+                };
 
-            Box::new(Arc::new(authority)) as Box<dyn AuthorityObject>
-        }
-        #[cfg(feature = "sqlite")]
-        None if zone_config.is_update_allowed() => {
-            warn!(
-                "using deprecated SQLite load configuration, please move to [[zones.stores]] form"
-            );
-            let zone_file_path = zone_path.ok_or("file is a necessary parameter of zone_config")?;
-            let journal_file_path = PathBuf::from(zone_file_path.clone())
-                .with_extension("jrnl")
-                .to_str()
-                .map(String::from)
-                .ok_or("non-unicode characters in file name")?;
+                let mut authority = SqliteAuthority::try_from_config(
+                    zone_name.clone(),
+                    zone_type,
+                    is_axfr_allowed,
+                    is_dnssec_enabled,
+                    Some(zone_dir),
+                    &config,
+                )
+                .await?;
 
-            let config = SqliteConfig {
-                zone_file_path,
-                journal_file_path,
-                allow_update: zone_config.is_update_allowed(),
-            };
+                // load any keys for the Zone, if it is a dynamic update zone, then keys are required
+                load_keys(&mut authority, zone_name_for_signer.clone(), zone_config).await?;
+                Box::new(Arc::new(authority)) as Box<dyn AuthorityObject>
+            }
+            _ => {
+                let config = FileConfig {
+                    zone_file_path: zone_path
+                        .clone()
+                        .ok_or("file is a necessary parameter of zone_config")?,
+                };
 
-            let mut authority = SqliteAuthority::try_from_config(
-                zone_name,
-                zone_type,
-                is_axfr_allowed,
-                is_dnssec_enabled,
-                Some(zone_dir),
-                &config,
-            )
-            .await?;
+                let mut authority = FileAuthority::try_from_config(
+                    zone_name.clone(),
+                    zone_type,
+                    is_axfr_allowed,
+                    Some(zone_dir),
+                    &config,
+                )?;
 
-            // load any keys for the Zone, if it is a dynamic update zone, then keys are required
-            load_keys(&mut authority, zone_name_for_signer, zone_config).await?;
-            Box::new(Arc::new(authority)) as Box<dyn AuthorityObject>
-        }
-        None => {
-            let config = FileConfig {
-                zone_file_path: zone_path.ok_or("file is a necessary parameter of zone_config")?,
-            };
+                // load any keys for the Zone, if it is a dynamic update zone, then keys are required
+                load_keys(&mut authority, zone_name_for_signer.clone(), zone_config).await?;
+                Box::new(Arc::new(authority)) as Box<dyn AuthorityObject>
+            }
+        };
 
-            let mut authority = FileAuthority::try_from_config(
-                zone_name,
-                zone_type,
-                is_axfr_allowed,
-                Some(zone_dir),
-                &config,
-            )?;
-
-            // load any keys for the Zone, if it is a dynamic update zone, then keys are required
-            load_keys(&mut authority, zone_name_for_signer, zone_config).await?;
-            Box::new(Arc::new(authority)) as Box<dyn AuthorityObject>
-        }
-        Some(_) => {
-            panic!("unrecognized authority type, check enabled features");
-        }
-    };
+        authorities.push(authority);
+    }
 
     info!("zone successfully loaded: {}", zone_config.get_zone()?);
-    Ok(authority)
+    Ok(authorities)
 }
 
 /// Cli struct for all options managed with clap derive api.

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -53,6 +53,8 @@ dnssec = []
 recursor = ["hickory-recursor"]
 resolver = ["hickory-resolver"]
 sqlite = ["rusqlite"]
+blocklist = ["resolver"]
+
 toml = ["dep:basic-toml"]
 
 # TODO: Need to figure out how to be consistent with ring/openssl usage...

--- a/crates/server/src/authority/authority.rs
+++ b/crates/server/src/authority/authority.rs
@@ -129,7 +129,7 @@ pub trait Authority: Send + Sync {
         name: &LowerName,
         rtype: RecordType,
         lookup_options: LookupOptions,
-    ) -> Result<Self::Lookup, LookupError>;
+    ) -> Result<Option<Self::Lookup>, LookupError>;
 
     /// Using the specified query, perform a lookup against this zone.
     ///
@@ -146,12 +146,17 @@ pub trait Authority: Send + Sync {
         &self,
         request: RequestInfo<'_>,
         lookup_options: LookupOptions,
-    ) -> Result<Self::Lookup, LookupError>;
+    ) -> Result<Option<Self::Lookup>, LookupError>;
 
     /// Get the NS, NameServer, record for the zone
     async fn ns(&self, lookup_options: LookupOptions) -> Result<Self::Lookup, LookupError> {
-        self.lookup(self.origin(), RecordType::NS, lookup_options)
-            .await
+        let lookup = self
+            .lookup(self.origin(), RecordType::NS, lookup_options)
+            .await;
+        match lookup {
+            Ok(lookup) => Ok(lookup.expect("")),
+            Err(e) => Err(e),
+        }
     }
 
     /// Return the NSEC records based on the given name
@@ -173,14 +178,26 @@ pub trait Authority: Send + Sync {
     ///  should be used, see `soa_secure()`, which will optionally return RRSIGs.
     async fn soa(&self) -> Result<Self::Lookup, LookupError> {
         // SOA should be origin|SOA
-        self.lookup(self.origin(), RecordType::SOA, LookupOptions::default())
-            .await
+        let lookup = self
+            .lookup(self.origin(), RecordType::SOA, LookupOptions::default())
+            .await;
+
+        match lookup {
+            Ok(lookup) => Ok(lookup.expect("")),
+            Err(e) => Err(e),
+        }
     }
 
     /// Returns the SOA record for the zone
     async fn soa_secure(&self, lookup_options: LookupOptions) -> Result<Self::Lookup, LookupError> {
-        self.lookup(self.origin(), RecordType::SOA, lookup_options)
-            .await
+        let lookup = self
+            .lookup(self.origin(), RecordType::SOA, lookup_options)
+            .await;
+
+        match lookup {
+            Ok(lookup) => Ok(lookup.expect("")),
+            Err(e) => Err(e),
+        }
     }
 }
 

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -348,7 +348,7 @@ impl Catalog {
         response_handle: R,
     ) -> ResponseInfo {
         let request_info = request.request_info();
-        let authority = self.find(request_info.query.name());
+        let authorities = self.find(request_info.query.name());
 
         if let Some(authorities) = authorities {
             for authority in authorities {

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -549,7 +549,7 @@ async fn build_response(
 }
 
 async fn send_authoritative_response(
-    future: Result<Option<Box<dyn LookupObject>>, LookupError>,
+    response: Result<Option<Box<dyn LookupObject>>, LookupError>,
     authority: &dyn AuthorityObject,
     response_header: &mut Header,
     lookup_options: LookupOptions,
@@ -560,7 +560,7 @@ async fn send_authoritative_response(
     // NS records, which indicate an authoritative response.
     //
     // On Errors, the transition depends on the type of error.
-    let answers = match response.await {
+    let answers = match response {
         Ok(records) => {
             response_header.set_response_code(ResponseCode::NoError);
             response_header.set_authoritative(true);
@@ -661,7 +661,7 @@ async fn send_authoritative_response(
 }
 
 async fn send_forwarded_response(
-    future: Result<Option<Box<dyn LookupObject>>, LookupError>,
+    response: Result<Option<Box<dyn LookupObject>>, LookupError>,
     request_header: &Header,
     response_header: &mut Header,
 ) -> LookupSections {
@@ -677,7 +677,7 @@ async fn send_forwarded_response(
 
         Box::new(EmptyLookup)
     } else {
-        match response.await {
+        match response {
             Err(e) => {
                 if e.is_nx_domain() {
                     response_header.set_response_code(ResponseCode::NXDomain);

--- a/crates/server/src/config/mod.rs
+++ b/crates/server/src/config/mod.rs
@@ -28,7 +28,7 @@ use crate::proto::rr::Name;
 use crate::authority::ZoneType;
 #[cfg(feature = "toml")]
 use crate::error::ConfigResult;
-use crate::store::StoreConfig;
+use crate::store::StoreConfigContainer;
 
 static DEFAULT_PATH: &str = "/var/named"; // TODO what about windows (do I care? ;)
 static DEFAULT_PORT: u16 = 53;
@@ -199,7 +199,7 @@ pub struct ZoneConfig {
     pub keys: Vec<dnssec::KeyConfig>,
     /// Store configurations, TODO: allow chained Stores
     #[serde(default)]
-    pub stores: Option<StoreConfig>,
+    pub stores: Option<StoreConfigContainer>,
 }
 
 impl ZoneConfig {

--- a/crates/server/src/server/request_handler.rs
+++ b/crates/server/src/server/request_handler.rs
@@ -107,7 +107,7 @@ impl<'a> RequestInfo<'a> {
 }
 
 /// Information about the response sent for a request
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 #[repr(transparent)]
 pub struct ResponseInfo(Header);
 

--- a/crates/server/src/store/blocklist/authority.rs
+++ b/crates/server/src/store/blocklist/authority.rs
@@ -1,0 +1,423 @@
+// Copyright 2015-2022 Benjamin Fry <benjaminfry@me.com>
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// https://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// https://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use std::{io, path::Path};
+
+use tracing::{debug, info, trace};
+
+use crate::{
+    authority::{
+        Authority, LookupError, LookupObject, LookupOptions, MessageRequest, UpdateResult, ZoneType,
+    },
+    proto::{
+        op::{Query, ResponseCode},
+        rr::{rdata::A, LowerName, Name, RData, Record, RecordType},
+    },
+    server::RequestInfo,
+    store::blocklist::BlocklistConfig,
+};
+
+use crate::resolver::lookup::Lookup;
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::prelude::*;
+use std::str::FromStr;
+
+/// A conditional authority that will resolve queries against one or more block lists.  The typical use case will be to use this in a
+/// chained configuration before a forwarding or recursive resolver:
+///
+///   [[zones]]
+///   zone = "."
+///   zone_type = "hint"
+///   stores = [{ type = "blocklist", lists = ["default/bl.txt", "default/bl2.txt"]}, { type = "recursor", roots = "default/root.zone"}]
+///
+/// Note: the order of the stores is important: the first one specified in the store list will be the first consulted.  Subsequent stores
+/// will only be consulted if each prior store returns None in response to the query.
+pub struct BlocklistAuthority {
+    origin: LowerName,
+    blocklist: HashMap<LowerName, bool>,
+    wildcard_match: bool,
+    min_wildcard_depth: u8,
+}
+
+impl BlocklistAuthority {
+    /// Read the Authority for the origin from the specified configuration
+    pub async fn try_from_config(
+        origin: Name,
+        _zone_type: ZoneType,
+        config: &BlocklistConfig,
+        root_dir: Option<&Path>,
+    ) -> Result<Self, String> {
+        info!("loading blocklist config: {}", origin);
+
+        let mut authority = Self {
+            origin: origin.into(),
+            blocklist: HashMap::new(),
+            wildcard_match: config.wildcard_match,
+            min_wildcard_depth: config.min_wildcard_depth,
+        };
+
+        // Load block lists into the block table cache for this authority.
+        for bl in &config.lists {
+            info!("Adding blocklist {bl:?}");
+            authority
+                .add(format!("{}/{bl}", root_dir.unwrap().display()))
+                .await;
+        }
+
+        Ok(authority)
+    }
+
+    /// Add a configured block list to the in-memory cache.
+    pub async fn add(&mut self, file: String) -> bool {
+        let mut handle =
+            File::open(&file).expect(&format!("unable to open block list file '{}'", &file)[..]);
+        let mut contents = String::new();
+        let _ = handle.read_to_string(&mut contents);
+
+        for mut entry in contents.split('\n') {
+            // Strip comments and leading/trailing whitespace
+            if let Some(idx) = entry.chars().position(|c| c == '#') {
+                entry = &entry[0..idx].trim();
+            }
+
+            if entry.is_empty() {
+                continue;
+            }
+
+            let mut str_entry = entry.to_string();
+            if !entry.ends_with('.') {
+                str_entry += ".";
+            }
+
+            trace!("Inserting blocklist entry {str_entry:?}");
+            self.blocklist
+                .insert(LowerName::from_str(&str_entry[..]).unwrap(), true);
+        }
+
+        true
+    }
+
+    /// Build a wildcard match list for a given host
+    pub fn get_wildcards(&self, host: &LowerName) -> Vec<LowerName> {
+        let mut wildcards = vec![];
+        let mut host = Name::from(host);
+
+        if host.num_labels() > self.min_wildcard_depth {
+            for _ in 0..host.num_labels() - self.min_wildcard_depth {
+                wildcards.push(host.clone().into_wildcard().into());
+                host = host.trim_to((host.num_labels() - 1) as usize);
+            }
+        }
+
+        debug!("Built wildcard list: {wildcards:?}");
+
+        wildcards
+    }
+}
+
+#[async_trait::async_trait]
+impl Authority for BlocklistAuthority {
+    type Lookup = BlocklistLookup;
+
+    /// Always Recursive
+    fn zone_type(&self) -> ZoneType {
+        ZoneType::Hint
+    }
+
+    /// Always false for Forward zones
+    fn is_axfr_allowed(&self) -> bool {
+        false
+    }
+
+    async fn update(&self, _update: &MessageRequest) -> UpdateResult<bool> {
+        Err(ResponseCode::NotImp)
+    }
+
+    /// Get the origin of this zone, i.e. example.com is the origin for www.example.com
+    ///
+    /// In the context of a forwarder, this is either a zone which this forwarder is associated,
+    ///   or `.`, the root zone for all zones. If this is not the root zone, then it will only forward
+    ///   for lookups which match the given zone name.
+    fn origin(&self) -> &LowerName {
+        &self.origin
+    }
+
+    /// Forwards a lookup given the resolver configuration for this Forwarded zone
+    async fn lookup(
+        &self,
+        name: &LowerName,
+        rtype: RecordType,
+        _lookup_options: LookupOptions,
+    ) -> Result<Option<Self::Lookup>, LookupError> {
+        debug!("blocklist lookup: {} {}", name, rtype);
+
+        let mut match_list = vec![name.to_owned()];
+        if self.wildcard_match {
+            match_list.append(&mut self.get_wildcards(name));
+        }
+        debug!("Blocklist match list: {match_list:?}");
+
+        for host in match_list {
+            if self.blocklist.contains_key(&host) {
+                return Ok(Some(BlocklistLookup(Lookup::from_rdata(
+                    Query::query(name.into(), rtype),
+                    RData::A(A::new(0, 0, 0, 0)),
+                ))));
+            }
+        }
+        debug!("Query '{name}' is not in blocklist; returning None...");
+        Ok(None)
+    }
+
+    async fn search(
+        &self,
+        request_info: RequestInfo<'_>,
+        lookup_options: LookupOptions,
+    ) -> Result<Option<Self::Lookup>, LookupError> {
+        self.lookup(
+            request_info.query.name(),
+            request_info.query.query_type(),
+            lookup_options,
+        )
+        .await
+    }
+
+    async fn get_nsec_records(
+        &self,
+        _name: &LowerName,
+        _lookup_options: LookupOptions,
+    ) -> Result<Self::Lookup, LookupError> {
+        Err(LookupError::from(io::Error::new(
+            io::ErrorKind::Other,
+            "Getting NSEC records is unimplemented for the blocklist",
+        )))
+    }
+}
+
+pub struct BlocklistLookup(Lookup);
+
+impl LookupObject for BlocklistLookup {
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Record> + Send + 'a> {
+        Box::new(self.0.record_iter())
+    }
+
+    fn take_additionals(&mut self) -> Option<Box<dyn LookupObject>> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        authority::{AuthorityObject, LookupOptions, ZoneType},
+        proto::rr::domain::Name,
+        proto::rr::{rdata::A, LowerName, RData, RecordType},
+    };
+    use std::path::Path;
+    use std::str::FromStr;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_blocklist_basic() {
+        let config = super::BlocklistConfig {
+            wildcard_match: true,
+            min_wildcard_depth: 2,
+            lists: vec!["default/blocklist.txt".to_string()],
+        };
+
+        let blocklist = super::BlocklistAuthority::try_from_config(
+            Name::from_str(".").unwrap(),
+            ZoneType::Hint,
+            &config,
+
+            Some(Path::new("../../tests/test-data/test_configs/")),
+        );
+
+        let authority = blocklist.await;
+
+        // Test: verify the blocklist authority was successfully created.
+        match authority {
+            Ok(ref _authority) => {}
+            Err(e) => {
+                panic!("Unable to create blocklist authority: {e}");
+            }
+        }
+
+        let ao = Box::new(Arc::new(authority.unwrap())) as Box<dyn AuthorityObject>;
+
+        // Test: lookup a record that is explicitly in the blocklist and that should match without a wildcard.
+        let res = ao
+            .lookup(
+                &LowerName::from_str("foo.com.").unwrap(),
+                RecordType::A,
+                LookupOptions::default(),
+            )
+            .await;
+        match res {
+            Ok(Some(l)) => {
+                if !l.iter().all(|x| {
+                    x.name() == &Name::from_str("foo.com.").unwrap()
+                        && x.data() == Some(&RData::A(A::new(0, 0, 0, 0)))
+                }) {
+                    panic!("foo.com lookup data is incorrect.");
+                }
+            }
+            Ok(None) => {
+                panic!("Lookup returned Ok(None); expected Ok(Some)");
+            }
+            Err(e) => {
+                panic!("Lookup error: {e}!");
+            }
+        }
+
+        // Test: lookup a record that is not in the blocklist. This test should fail.
+        let res = ao
+            .lookup(
+                &LowerName::from_str("test.com.").unwrap(),
+                RecordType::A,
+                LookupOptions::default(),
+            )
+            .await;
+        match res {
+            Ok(Some(_l)) => {
+                panic!("test.com lookup returned Ok; expected failure");
+            }
+            Ok(None) => {}
+            Err(_e) => {
+                panic!("test.com lookup returned Err; expected Ok(None)");
+            }
+        }
+
+        // Test: lookup a record that will match a wildcard that is in the blocklist.
+        let res = ao
+            .lookup(
+                &LowerName::from_str("www.foo.com.").unwrap(),
+                RecordType::A,
+                LookupOptions::default(),
+            )
+            .await;
+        match res {
+            Ok(Some(l)) => {
+                if !l.iter().all(|x| {
+                    x.name() == &Name::from_str("www.foo.com.").unwrap()
+                        && x.data() == Some(&RData::A(A::new(0, 0, 0, 0)))
+                }) {
+                    panic!("www.foo.com lookup data is incorrect.");
+                }
+            }
+            Ok(None) => {
+                panic!("Lookup returned Ok(None); expected Ok(Some)");
+            }
+            Err(e) => {
+                panic!("Lookup error: {e}!");
+            }
+        }
+
+        // Test: lookup a record that will match a wildcard that is in the blocklist.
+        let res = ao
+            .lookup(
+                &LowerName::from_str("www.com.foo.com.").unwrap(),
+                RecordType::A,
+                LookupOptions::default(),
+            )
+            .await;
+        match res {
+            Ok(Some(l)) => {
+                if !l.iter().all(|x| {
+                    x.name() == &Name::from_str("www.com.foo.com.").unwrap()
+                        && x.data() == Some(&RData::A(A::new(0, 0, 0, 0)))
+                }) {
+                    panic!("www.com.foo.com lookup data is incorrect.");
+                }
+            }
+            Ok(None) => {
+                panic!("lookup returned Ok(None); expected Ok(Some)");
+            }
+            Err(e) => {
+                panic!("Lookup error: {e}!");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_blocklist_wildcard_disabled() {
+        let config = super::BlocklistConfig {
+            min_wildcard_depth: 2,
+            wildcard_match: false,
+            lists: vec!["default/blocklist.txt".to_string()],
+        };
+
+        let blocklist = super::BlocklistAuthority::try_from_config(
+            Name::from_str(".").unwrap(),
+            ZoneType::Hint,
+            &config,
+
+            Some(Path::new("../../tests/test-data/test_configs/")),
+        );
+
+        let authority = blocklist.await;
+
+        // Test: verify the blocklist authority was successfully created.
+        match authority {
+            Ok(ref _authority) => {}
+            Err(e) => {
+                panic!("Unable to create blocklist authority: {e}");
+            }
+        }
+
+        let ao = Box::new(Arc::new(authority.unwrap())) as Box<dyn AuthorityObject>;
+
+        // Test: lookup a record that is explicitly in the blocklist and that should match with a wildcard.
+        let res = ao
+            .lookup(
+                &LowerName::from_str("foo.com.").unwrap(),
+                RecordType::A,
+                LookupOptions::default(),
+            )
+            .await;
+        match res {
+            Ok(Some(l)) => {
+                if !l.iter().all(|x| {
+                    x.name() == &Name::from_str("foo.com.").unwrap()
+                        && x.data() == Some(&RData::A(A::new(0, 0, 0, 0)))
+                }) {
+                    panic!("foo.com lookup data is incorrect.");
+                }
+            }
+            Ok(None) => {
+                panic!("Lookup returned Ok(None); expected Ok(Some)");
+            }
+            Err(e) => {
+                panic!("Lookup error: {e}!");
+            }
+        }
+
+        // Test: lookup a record that is not in the blocklist, but would match a wildcard; this should fail.
+        let res = ao
+            .lookup(
+                &LowerName::from_str("www.foo.com.").unwrap(),
+                RecordType::A,
+                LookupOptions::default(),
+            )
+            .await;
+        match res {
+            Ok(Some(_l)) => {
+                panic!("www.foo.com lookup returned Ok(Some); expected Ok(None)");
+            }
+            Ok(None) => {}
+            Err(_e) => {
+                panic!("www.foo.com lookup returned Err; expected Ok(None)");
+            }
+        }
+    }
+}

--- a/crates/server/src/store/blocklist/config.rs
+++ b/crates/server/src/store/blocklist/config.rs
@@ -1,0 +1,40 @@
+// Copyright 2015-2022 Benjamin Fry <benjaminfry@me.com>
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// https://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// https://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use serde::Deserialize;
+
+/// Configuration for file based zones
+#[derive(Clone, Deserialize, Eq, PartialEq, Debug)]
+pub struct BlocklistConfig {
+    /// Support wildcards?  If set to true, block list entries containing asterisks will be expanded to match queries.
+    #[serde(default = "wildcard_match_default")]
+    pub wildcard_match: bool,
+
+    /// Minimum wildcard depth.  Defaults to 2.  Any wildcard entries without at least this many static elements will not be expanded
+    /// (e.g., *.com has a depth of 1; *.example.com has a depth of two.)
+    #[serde(default = "min_wildcard_depth_default")]
+    pub min_wildcard_depth: u8,
+
+    /// This is meant as a safeguard against an errant block list entry, such as * or *.com that
+    /// might block many more hosts than intended.  
+    /// block lists to load.  These should be specified as relative (to the server zone directory) paths in the config file.
+    pub lists: Vec<String>,
+}
+
+impl BlocklistConfig {
+    /// the set of block lists which should be loaded
+    pub fn get_block_lists(&self) -> &Vec<String> {
+        &self.lists
+    }
+}
+
+fn wildcard_match_default() -> bool {
+    true
+}
+fn min_wildcard_depth_default() -> u8 {
+    2
+}

--- a/crates/server/src/store/blocklist/mod.rs
+++ b/crates/server/src/store/blocklist/mod.rs
@@ -1,0 +1,16 @@
+// Copyright 2015-2022 Benjamin Fry <benjaminfry@me.com>
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// https://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// https://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#![cfg(feature = "blocklist")]
+
+//! Blocklist resolver related types
+
+mod authority;
+mod config;
+
+pub use self::authority::BlocklistAuthority;
+pub use self::config::BlocklistConfig;

--- a/crates/server/src/store/config.rs
+++ b/crates/server/src/store/config.rs
@@ -9,6 +9,8 @@
 
 use serde::Deserialize;
 
+#[cfg(feature = "blocklist")]
+use crate::store::blocklist::BlockListConfig;
 use crate::store::file::FileConfig;
 #[cfg(feature = "hickory-resolver")]
 use crate::store::forwarder::ForwardConfig;
@@ -37,4 +39,9 @@ pub enum StoreConfig {
     #[cfg(feature = "hickory-recursor")]
     #[cfg_attr(docsrs, doc(cfg(feature = "recursor")))]
     Recursor(RecursiveConfig),
+    /// Blocklist Resolver
+    #[cfg(feature = "blocklist")]
+    BlockList(BlockListConfig),
+    /// This is used by the configuration processing code to represent a deprecated or main-block config without an associated store.
+    Default,
 }

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -156,7 +156,7 @@ impl Authority for FileAuthority {
         name: &LowerName,
         rtype: RecordType,
         lookup_options: LookupOptions,
-    ) -> Result<Self::Lookup, LookupError> {
+    ) -> Result<Option<Self::Lookup>, LookupError> {
         self.0.lookup(name, rtype, lookup_options).await
     }
 
@@ -175,7 +175,7 @@ impl Authority for FileAuthority {
         &self,
         request_info: RequestInfo<'_>,
         lookup_options: LookupOptions,
-    ) -> Result<Self::Lookup, LookupError> {
+    ) -> Result<Option<Self::Lookup>, LookupError> {
         self.0.search(request_info, lookup_options).await
     }
 
@@ -272,6 +272,7 @@ mod tests {
         .expect("lookup failed");
 
         match lookup
+            .expect("Lookup returned None")
             .into_iter()
             .next()
             .expect("A record not found in authority")
@@ -290,6 +291,7 @@ mod tests {
         .expect("INCLUDE lookup failed");
 
         match include_lookup
+            .expect("Lookup returned None")
             .into_iter()
             .next()
             .expect("A record not found in authority")

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -122,7 +122,7 @@ impl Authority for ForwardAuthority {
         name: &LowerName,
         rtype: RecordType,
         _lookup_options: LookupOptions,
-    ) -> Result<Self::Lookup, LookupError> {
+    ) -> Result<Option<Self::Lookup>, LookupError> {
         // TODO: make this an error?
         debug_assert!(self.origin.zone_of(name));
 
@@ -130,14 +130,17 @@ impl Authority for ForwardAuthority {
         let name: LowerName = name.clone();
         let resolve = self.resolver.lookup(name, rtype).await;
 
-        resolve.map(ForwardLookup).map_err(LookupError::from)
+        resolve
+            .map(ForwardLookup)
+            .map(Some)
+            .map_err(LookupError::from)
     }
 
     async fn search(
         &self,
         request_info: RequestInfo<'_>,
         lookup_options: LookupOptions,
-    ) -> Result<Self::Lookup, LookupError> {
+    ) -> Result<Option<Self::Lookup>, LookupError> {
         self.lookup(
             request_info.query.name(),
             request_info.query.query_type(),

--- a/crates/server/src/store/mod.rs
+++ b/crates/server/src/store/mod.rs
@@ -7,6 +7,7 @@
 
 //! All persistent store implementations
 
+pub mod blocklist;
 mod config;
 pub mod file;
 pub mod forwarder;
@@ -19,3 +20,4 @@ pub mod sqlite;
 // TODO: add a dynamic library option?
 
 pub use self::config::StoreConfig;
+pub use self::config::StoreConfigContainer;

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -116,7 +116,7 @@ impl Authority for RecursiveAuthority {
         name: &LowerName,
         rtype: RecordType,
         _lookup_options: LookupOptions,
-    ) -> Result<Self::Lookup, LookupError> {
+    ) -> Result<Option<Self::Lookup>, LookupError> {
         debug!("recursive lookup: {} {}", name, rtype);
 
         let query = Query::query(name.into(), rtype);
@@ -126,6 +126,7 @@ impl Authority for RecursiveAuthority {
             .resolve(query, now)
             .await
             .map(RecursiveLookup)
+            .map(Some)
             .map_err(Into::into)
     }
 
@@ -133,7 +134,7 @@ impl Authority for RecursiveAuthority {
         &self,
         request_info: RequestInfo<'_>,
         lookup_options: LookupOptions,
-    ) -> Result<Self::Lookup, LookupError> {
+    ) -> Result<Option<Self::Lookup>, LookupError> {
         self.lookup(
             request_info.query.name(),
             request_info.query.query_type(),

--- a/crates/server/src/store/sqlite/authority.rs
+++ b/crates/server/src/store/sqlite/authority.rs
@@ -335,6 +335,7 @@ impl SqliteAuthority {
                                     )
                                     .await
                                     .unwrap_or_default()
+                                    .unwrap_or_default()
                                     .was_empty()
                                 {
                                     return Err(ResponseCode::NXDomain);
@@ -347,6 +348,7 @@ impl SqliteAuthority {
                                 if self
                                     .lookup(&required_name, rrset, LookupOptions::default())
                                     .await
+                                    .unwrap_or_default()
                                     .unwrap_or_default()
                                     .was_empty()
                                 {
@@ -373,6 +375,7 @@ impl SqliteAuthority {
                                     )
                                     .await
                                     .unwrap_or_default()
+                                    .unwrap_or_default()
                                     .was_empty()
                                 {
                                     return Err(ResponseCode::YXDomain);
@@ -385,6 +388,7 @@ impl SqliteAuthority {
                                 if !self
                                     .lookup(&required_name, rrset, LookupOptions::default())
                                     .await
+                                    .unwrap_or_default()
                                     .unwrap_or_default()
                                     .was_empty()
                                 {
@@ -408,6 +412,7 @@ impl SqliteAuthority {
                             LookupOptions::default(),
                         )
                         .await
+                        .unwrap_or_default()
                         .unwrap_or_default()
                         .iter()
                         .any(|rr| rr == require)
@@ -488,7 +493,7 @@ impl SqliteAuthority {
                     .await;
 
                 let keys = match keys {
-                    Ok(keys) => keys,
+                    Ok(keys) => keys.unwrap_or_default(),
                     Err(_) => continue, // error trying to lookup a key by that name, try the next one.
                 };
 
@@ -957,7 +962,7 @@ impl Authority for SqliteAuthority {
         name: &LowerName,
         rtype: RecordType,
         lookup_options: LookupOptions,
-    ) -> Result<Self::Lookup, LookupError> {
+    ) -> Result<Option<Self::Lookup>, LookupError> {
         self.in_memory.lookup(name, rtype, lookup_options).await
     }
 
@@ -965,7 +970,7 @@ impl Authority for SqliteAuthority {
         &self,
         request_info: RequestInfo<'_>,
         lookup_options: LookupOptions,
-    ) -> Result<Self::Lookup, LookupError> {
+    ) -> Result<Option<Self::Lookup>, LookupError> {
         self.in_memory.search(request_info, lookup_options).await
     }
 

--- a/crates/server/tests/authority_battery/basic.rs
+++ b/crates/server/tests/authority_battery/basic.rs
@@ -33,6 +33,7 @@ pub fn test_a_lookup<A: Authority<Lookup = AuthLookup>>(authority: A) {
     let lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
 
     match lookup
+        .unwrap()
         .into_iter()
         .next()
         .expect("A record not found in authority")
@@ -93,7 +94,9 @@ pub fn test_ns_lookup<A: Authority<Lookup = AuthLookup>>(authority: A) {
         &query,
     );
 
-    let mut lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+    let mut lookup = block_on(authority.search(request_info, LookupOptions::default()))
+        .unwrap()
+        .unwrap();
 
     let additionals = dbg!(lookup
         .take_additionals()
@@ -128,7 +131,9 @@ pub fn test_mx<A: Authority<Lookup = AuthLookup>>(authority: A) {
         &query,
     );
 
-    let mut lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+    let mut lookup = block_on(authority.search(request_info, LookupOptions::default()))
+        .unwrap()
+        .unwrap();
 
     let additionals = dbg!(lookup
         .take_additionals()
@@ -188,7 +193,9 @@ pub fn test_mx_to_null<A: Authority<Lookup = AuthLookup>>(authority: A) {
         &query,
     );
 
-    let mut lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+    let mut lookup = block_on(authority.search(request_info, LookupOptions::default()))
+        .unwrap()
+        .unwrap();
 
     // In this case there should be no additional records
     assert!(lookup.take_additionals().is_none());
@@ -217,7 +224,9 @@ pub fn test_cname<A: Authority<Lookup = AuthLookup>>(authority: A) {
         &query,
     );
 
-    let lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+    let lookup = block_on(authority.search(request_info, LookupOptions::default()))
+        .unwrap()
+        .unwrap();
 
     let cname = lookup
         .into_iter()
@@ -239,7 +248,9 @@ pub fn test_cname_alias<A: Authority<Lookup = AuthLookup>>(authority: A) {
         &query,
     );
 
-    let mut lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+    let mut lookup = block_on(authority.search(request_info, LookupOptions::default()))
+        .unwrap()
+        .unwrap();
 
     let additionals = lookup
         .take_additionals()
@@ -280,7 +291,9 @@ pub fn test_cname_chain<A: Authority<Lookup = AuthLookup>>(authority: A) {
         &query,
     );
 
-    let mut lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+    let mut lookup = block_on(authority.search(request_info, LookupOptions::default()))
+        .unwrap()
+        .unwrap();
 
     let additionals = lookup
         .take_additionals()
@@ -328,7 +341,9 @@ pub fn test_aname<A: Authority<Lookup = AuthLookup>>(authority: A) {
         &query,
     );
 
-    let mut lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+    let mut lookup = block_on(authority.search(request_info, LookupOptions::default()))
+        .unwrap()
+        .unwrap();
 
     let additionals = lookup
         .take_additionals()
@@ -374,7 +389,9 @@ pub fn test_aname_a_lookup<A: Authority<Lookup = AuthLookup>>(authority: A) {
         &query,
     );
 
-    let mut lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+    let mut lookup = block_on(authority.search(request_info, LookupOptions::default()))
+        .unwrap()
+        .unwrap();
 
     let additionals = lookup.take_additionals().expect("no additionals for aname");
 
@@ -417,7 +434,9 @@ pub fn test_aname_chain<A: Authority<Lookup = AuthLookup>>(authority: A) {
         &query,
     );
 
-    let mut lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+    let mut lookup = block_on(authority.search(request_info, LookupOptions::default()))
+        .unwrap()
+        .unwrap();
 
     let additionals = lookup.take_additionals().expect("no additionals");
 
@@ -484,7 +503,9 @@ pub fn test_dots_in_name<A: Authority<Lookup = AuthLookup>>(authority: A) {
         &query,
     );
 
-    let lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+    let lookup = block_on(authority.search(request_info, LookupOptions::default()))
+        .unwrap()
+        .unwrap();
 
     assert_eq!(
         *lookup
@@ -559,7 +580,9 @@ pub fn test_wildcard<A: Authority<Lookup = AuthLookup>>(authority: A) {
         &query,
     );
 
-    let lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+    let lookup = block_on(authority.search(request_info, LookupOptions::default()))
+        .unwrap()
+        .unwrap();
 
     assert_eq!(
         lookup
@@ -591,6 +614,7 @@ pub fn test_wildcard<A: Authority<Lookup = AuthLookup>>(authority: A) {
 
     assert_eq!(
         lookup
+            .unwrap()
             .into_iter()
             .next()
             .map(|r| {
@@ -624,6 +648,7 @@ pub fn test_wildcard_chain<A: Authority<Lookup = AuthLookup>>(authority: A) {
     );
 
     let mut lookup = block_on(authority.search(request_info, LookupOptions::default()))
+        .unwrap()
         .expect("lookup of www.wildcard.example.com. failed");
 
     // the name should match the lookup, not the A records
@@ -664,7 +689,9 @@ pub fn test_srv<A: Authority<Lookup = AuthLookup>>(authority: A) {
         &query,
     );
 
-    let mut lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+    let mut lookup = block_on(authority.search(request_info, LookupOptions::default()))
+        .unwrap()
+        .unwrap();
 
     let additionals = dbg!(lookup
         .take_additionals()

--- a/crates/server/tests/authority_battery/dnssec.rs
+++ b/crates/server/tests/authority_battery/dnssec.rs
@@ -36,6 +36,7 @@ pub fn test_a_lookup<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DN
         request_info,
         LookupOptions::for_dnssec(true, SupportedAlgorithms::new()),
     ))
+    .unwrap()
     .unwrap();
 
     let (a_records, other_records): (Vec<_>, Vec<_>) = lookup
@@ -139,6 +140,7 @@ pub fn test_aname_lookup<A: Authority<Lookup = AuthLookup>>(authority: A, keys: 
         request_info,
         LookupOptions::for_dnssec(true, SupportedAlgorithms::new()),
     ))
+    .unwrap()
     .unwrap();
 
     let (a_records, other_records): (Vec<_>, Vec<_>) = lookup
@@ -173,7 +175,8 @@ pub fn test_wildcard<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DN
         request_info,
         LookupOptions::for_dnssec(true, SupportedAlgorithms::new()),
     ))
-    .expect("lookup of www.wildcard.example.com. failed");
+    .expect("lookup of www.wildcard.example.com. failed")
+    .unwrap();
 
     let (cname_records, other_records): (Vec<_>, Vec<_>) = lookup
         .into_iter()
@@ -340,6 +343,7 @@ pub fn test_rfc_6975_supported_algorithms<A: Authority<Lookup = AuthLookup>>(
             request_info,
             LookupOptions::for_dnssec(true, SupportedAlgorithms::from(key.algorithm())),
         ))
+        .unwrap()
         .unwrap();
 
         let (a_records, other_records): (Vec<_>, Vec<_>) = lookup

--- a/crates/server/tests/authority_battery/dynamic_update.rs
+++ b/crates/server/tests/authority_battery/dynamic_update.rs
@@ -63,7 +63,9 @@ pub fn test_create<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys: &[
             &query,
         );
 
-        let lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+        let lookup = block_on(authority.search(request_info, LookupOptions::default()))
+            .unwrap()
+            .unwrap();
 
         match lookup
             .into_iter()
@@ -117,7 +119,9 @@ pub fn test_create_multi<A: Authority<Lookup = AuthLookup>>(mut authority: A, ke
             &query,
         );
 
-        let lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+        let lookup = block_on(authority.search(request_info, LookupOptions::default()))
+            .unwrap()
+            .unwrap();
 
         assert!(lookup.iter().any(|rr| *rr == record));
         assert!(lookup.iter().any(|rr| *rr == record2));
@@ -173,7 +177,9 @@ pub fn test_append<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys: &[
             &query,
         );
 
-        let lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+        let lookup = block_on(authority.search(request_info, LookupOptions::default()))
+            .unwrap()
+            .unwrap();
 
         assert_eq!(lookup.iter().count(), 1);
         assert!(lookup.iter().any(|rr| *rr == record));
@@ -198,7 +204,9 @@ pub fn test_append<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys: &[
             &query,
         );
 
-        let lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+        let lookup = block_on(authority.search(request_info, LookupOptions::default()))
+            .unwrap()
+            .unwrap();
 
         assert_eq!(lookup.iter().count(), 2);
 
@@ -222,7 +230,9 @@ pub fn test_append<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys: &[
             &query,
         );
 
-        let lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+        let lookup = block_on(authority.search(request_info, LookupOptions::default()))
+            .unwrap()
+            .unwrap();
 
         assert_eq!(lookup.iter().count(), 2);
 
@@ -278,7 +288,9 @@ pub fn test_append_multi<A: Authority<Lookup = AuthLookup>>(mut authority: A, ke
             &query,
         );
 
-        let lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+        let lookup = block_on(authority.search(request_info, LookupOptions::default()))
+            .unwrap()
+            .unwrap();
 
         assert_eq!(lookup.iter().count(), 3);
 
@@ -304,7 +316,9 @@ pub fn test_append_multi<A: Authority<Lookup = AuthLookup>>(mut authority: A, ke
             &query,
         );
 
-        let lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+        let lookup = block_on(authority.search(request_info, LookupOptions::default()))
+            .unwrap()
+            .unwrap();
 
         assert_eq!(lookup.iter().count(), 3);
 
@@ -358,7 +372,9 @@ pub fn test_compare_and_swap<A: Authority<Lookup = AuthLookup>>(
             &query,
         );
 
-        let lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+        let lookup = block_on(authority.search(request_info, LookupOptions::default()))
+            .unwrap()
+            .unwrap();
 
         assert_eq!(lookup.iter().count(), 1);
         assert!(lookup.iter().any(|rr| *rr == new));
@@ -388,7 +404,9 @@ pub fn test_compare_and_swap<A: Authority<Lookup = AuthLookup>>(
             &query,
         );
 
-        let lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+        let lookup = block_on(authority.search(request_info, LookupOptions::default()))
+            .unwrap()
+            .unwrap();
 
         assert_eq!(lookup.iter().count(), 1);
         assert!(lookup.iter().any(|rr| *rr == new));
@@ -447,7 +465,9 @@ pub fn test_compare_and_swap_multi<A: Authority<Lookup = AuthLookup>>(
             &query,
         );
 
-        let lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+        let lookup = block_on(authority.search(request_info, LookupOptions::default()))
+            .unwrap()
+            .unwrap();
 
         assert_eq!(lookup.iter().count(), 2);
         assert!(lookup.iter().any(|rr| *rr == new1));
@@ -479,7 +499,9 @@ pub fn test_compare_and_swap_multi<A: Authority<Lookup = AuthLookup>>(
             &query,
         );
 
-        let lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+        let lookup = block_on(authority.search(request_info, LookupOptions::default()))
+            .unwrap()
+            .unwrap();
 
         assert_eq!(lookup.iter().count(), 2);
         assert!(lookup.iter().any(|rr| *rr == new1));
@@ -544,7 +566,9 @@ pub fn test_delete_by_rdata<A: Authority<Lookup = AuthLookup>>(
             &query,
         );
 
-        let lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+        let lookup = block_on(authority.search(request_info, LookupOptions::default()))
+            .unwrap()
+            .unwrap();
 
         assert_eq!(lookup.iter().count(), 1);
         assert!(lookup.iter().any(|rr| *rr == record1));
@@ -623,7 +647,9 @@ pub fn test_delete_by_rdata_multi<A: Authority<Lookup = AuthLookup>>(
             &query,
         );
 
-        let lookup = block_on(authority.search(request_info, LookupOptions::default())).unwrap();
+        let lookup = block_on(authority.search(request_info, LookupOptions::default()))
+            .unwrap()
+            .unwrap();
 
         assert_eq!(lookup.iter().count(), 2);
         assert!(!lookup.iter().any(|rr| *rr == record1));

--- a/crates/server/tests/forwarder.rs
+++ b/crates/server/tests/forwarder.rs
@@ -26,6 +26,7 @@ fn test_lookup() {
             RecordType::A,
             Default::default(),
         ))
+        .unwrap()
         .unwrap();
 
     let address = lookup.iter().next().expect("no addresses returned!");

--- a/crates/server/tests/in_memory.rs
+++ b/crates/server/tests/in_memory.rs
@@ -68,6 +68,7 @@ fn test_cname_loop() {
             RecordType::A,
             Default::default(),
         ))
+        .unwrap()
         .unwrap();
 
     let records: Vec<&Record> = lookup.iter().collect();
@@ -92,6 +93,7 @@ fn test_cname_loop() {
             RecordType::A,
             Default::default(),
         ))
+        .unwrap()
         .unwrap();
 
     let records: Vec<&Record> = lookup.iter().collect();
@@ -125,6 +127,7 @@ fn test_cname_loop() {
             RecordType::A,
             Default::default(),
         ))
+        .unwrap()
         .unwrap();
 
     let records: Vec<&Record> = lookup.iter().collect();

--- a/crates/server/tests/store_file_tests.rs
+++ b/crates/server/tests/store_file_tests.rs
@@ -90,6 +90,7 @@ async fn test_ttl_wilcard() {
     let rr = authority
         .lookup(&name, RecordType::A, LookupOptions::default())
         .await
+        .unwrap()
         .unwrap();
     let data = rr
         .into_iter()

--- a/crates/server/tests/txt_tests.rs
+++ b/crates/server/tests/txt_tests.rs
@@ -99,6 +99,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         LookupOptions::default(),
     ))
     .unwrap()
+    .unwrap()
     .iter()
     .next()
     .cloned()
@@ -129,6 +130,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         RecordType::NS,
         LookupOptions::default(),
     ))
+    .unwrap()
     .unwrap()
     .iter()
     .cloned()
@@ -163,6 +165,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         LookupOptions::default(),
     ))
     .unwrap()
+    .unwrap()
     .iter()
     .cloned()
     .collect();
@@ -195,6 +198,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         LookupOptions::default(),
     ))
     .unwrap()
+    .unwrap()
     .iter()
     .next()
     .cloned()
@@ -216,6 +220,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         LookupOptions::default(),
     ))
     .unwrap()
+    .unwrap()
     .iter()
     .next()
     .cloned()
@@ -233,6 +238,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         RecordType::A,
         LookupOptions::default(),
     ))
+    .unwrap()
     .unwrap()
     .iter()
     .next()
@@ -255,6 +261,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         RecordType::TXT,
         LookupOptions::default(),
     ))
+    .unwrap()
     .unwrap()
     .iter()
     .cloned()
@@ -300,6 +307,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         LookupOptions::default(),
     ))
     .unwrap()
+    .unwrap()
     .iter()
     .next()
     .cloned()
@@ -316,6 +324,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         RecordType::SRV,
         LookupOptions::default(),
     ))
+    .unwrap()
     .unwrap()
     .iter()
     .next()
@@ -337,6 +346,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         LookupOptions::default(),
     ))
     .unwrap()
+    .unwrap()
     .iter()
     .next()
     .cloned()
@@ -357,6 +367,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         RecordType::CAA,
         LookupOptions::default(),
     ))
+    .unwrap()
     .unwrap()
     .iter()
     .next()
@@ -380,6 +391,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
             LookupOptions::default(),
         ),
     )
+    .unwrap()
     .unwrap()
     .iter()
     .next()

--- a/tests/integration-tests/tests/catalog_tests.rs
+++ b/tests/integration-tests/tests/catalog_tests.rs
@@ -126,8 +126,8 @@ async fn test_catalog_lookup() {
     let test_origin = test.origin().clone();
 
     let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(origin.clone(), Box::new(Arc::new(example)));
-    catalog.upsert(test_origin.clone(), Box::new(Arc::new(test)));
+    catalog.upsert(origin.clone(), vec![Box::new(Arc::new(example))]);
+    catalog.upsert(test_origin.clone(), vec![Box::new(Arc::new(test))]);
 
     let mut question: Message = Message::new();
 
@@ -203,8 +203,8 @@ async fn test_catalog_lookup_soa() {
     let test_origin = test.origin().clone();
 
     let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(origin.clone(), Box::new(Arc::new(example)));
-    catalog.upsert(test_origin, Box::new(Arc::new(test)));
+    catalog.upsert(origin.clone(), vec![Box::new(Arc::new(example))]);
+    catalog.upsert(test_origin, vec![Box::new(Arc::new(test))]);
 
     let mut question: Message = Message::new();
 
@@ -270,7 +270,7 @@ async fn test_catalog_nx_soa() {
     let origin = example.origin().clone();
 
     let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(origin, Box::new(Arc::new(example)));
+    catalog.upsert(origin, vec![Box::new(Arc::new(example))]);
 
     let mut question: Message = Message::new();
 
@@ -318,7 +318,7 @@ async fn test_non_authoritive_nx_refused() {
     let origin = example.origin().clone();
 
     let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(origin, Box::new(Arc::new(example)));
+    catalog.upsert(origin, vec![Box::new(Arc::new(example))]);
 
     let mut question: Message = Message::new();
 
@@ -372,7 +372,7 @@ async fn test_axfr() {
         .clone();
 
     let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(origin.clone(), Box::new(Arc::new(test)));
+    catalog.upsert(origin.clone(), vec![Box::new(Arc::new(test))]);
 
     let mut query: Query = Query::new();
     query.set_name(origin.clone().into());
@@ -500,7 +500,7 @@ async fn test_axfr_refused() {
     let origin = test.origin().clone();
 
     let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(origin.clone(), Box::new(Arc::new(test)));
+    catalog.upsert(origin.clone(), vec![Box::new(Arc::new(test))]);
 
     let mut query: Query = Query::new();
     query.set_name(origin.into());
@@ -539,7 +539,7 @@ async fn test_cname_additionals() {
     let origin = example.origin().clone();
 
     let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(origin, Box::new(Arc::new(example)));
+    catalog.upsert(origin, vec![Box::new(Arc::new(example))]);
 
     let mut question: Message = Message::new();
 
@@ -586,7 +586,7 @@ async fn test_multiple_cname_additionals() {
     let origin = example.origin().clone();
 
     let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(origin, Box::new(Arc::new(example)));
+    catalog.upsert(origin, vec![Box::new(Arc::new(example))]);
 
     let mut question: Message = Message::new();
 

--- a/tests/integration-tests/tests/client_future_tests.rs
+++ b/tests/integration-tests/tests/client_future_tests.rs
@@ -48,7 +48,10 @@ fn test_query_nonet() {
 
     let authority = create_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(
+        authority.origin().clone(),
+        vec![Box::new(Arc::new(authority))],
+    );
 
     let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
@@ -264,7 +267,10 @@ fn test_notify() {
     let io_loop = Runtime::new().unwrap();
     let authority = create_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(
+        authority.origin().clone(),
+        vec![Box::new(Arc::new(authority))],
+    );
 
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
     let client = AsyncClient::new(stream, sender, None);
@@ -325,7 +331,10 @@ async fn create_sig0_ready_client() -> (
 
     // setup the catalog
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(
+        authority.origin().clone(),
+        vec![Box::new(Arc::new(authority))],
+    );
 
     let signer = Arc::new(signer.into());
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));

--- a/tests/integration-tests/tests/client_tests.rs
+++ b/tests/integration-tests/tests/client_tests.rs
@@ -62,7 +62,10 @@ impl ClientConnection for TestClientConnection {
 fn test_query_nonet() {
     let authority = create_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(
+        authority.origin().clone(),
+        vec![Box::new(Arc::new(authority))],
+    );
 
     let client = SyncClient::new(TestClientConnection::new(catalog));
 
@@ -477,7 +480,11 @@ fn create_sig0_ready_client(mut catalog: Catalog) -> (SyncClient<TestClientConne
     )))));
     authority.upsert_mut(auth_key, 0);
 
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(
+        authority.origin().clone(),
+        vec![Box::new(Arc::new(authority))],
+    );
+
     let client = SyncClient::with_signer(TestClientConnection::new(catalog), signer);
 
     (client, origin.into())

--- a/tests/integration-tests/tests/dnssec_client_handle_tests.rs
+++ b/tests/integration-tests/tests/dnssec_client_handle_tests.rs
@@ -232,7 +232,10 @@ where
     };
 
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(
+        authority.origin().clone(),
+        vec![Box::new(Arc::new(authority))],
+    );
 
     let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));

--- a/tests/integration-tests/tests/lookup_tests.rs
+++ b/tests/integration-tests/tests/lookup_tests.rs
@@ -30,7 +30,10 @@ use hickory_integration::{example_authority::create_example, mock_client::*, Tes
 fn test_lookup() {
     let authority = create_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(
+        authority.origin().clone(),
+        vec![Box::new(Arc::new(authority))],
+    );
 
     let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
@@ -58,7 +61,10 @@ fn test_lookup() {
 fn test_lookup_hosts() {
     let authority = create_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(
+        authority.origin().clone(),
+        vec![Box::new(Arc::new(authority))],
+    );
 
     let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
@@ -116,7 +122,10 @@ fn create_ip_like_example() -> InMemoryAuthority {
 fn test_lookup_ipv4_like() {
     let authority = create_ip_like_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(
+        authority.origin().clone(),
+        vec![Box::new(Arc::new(authority))],
+    );
 
     let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
@@ -146,7 +155,10 @@ fn test_lookup_ipv4_like() {
 fn test_lookup_ipv4_like_fall_through() {
     let authority = create_ip_like_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(
+        authority.origin().clone(),
+        vec![Box::new(Arc::new(authority))],
+    );
 
     let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));

--- a/tests/integration-tests/tests/server_future_tests.rs
+++ b/tests/integration-tests/tests/server_future_tests.rs
@@ -362,7 +362,7 @@ fn new_catalog() -> Catalog {
     let origin = example.origin().clone();
 
     let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(origin, Box::new(Arc::new(example)));
+    catalog.upsert(origin, vec![Box::new(Arc::new(example))]);
     catalog
 }
 

--- a/tests/integration-tests/tests/sqlite_authority_tests.rs
+++ b/tests/integration-tests/tests/sqlite_authority_tests.rs
@@ -47,6 +47,7 @@ async fn test_search() {
     let result = example
         .search(request_info, LookupOptions::default())
         .await
+        .unwrap()
         .unwrap();
     if !result.is_empty() {
         let record = result.iter().next().unwrap();
@@ -77,6 +78,7 @@ async fn test_search_www() {
     let result = example
         .search(request_info, LookupOptions::default())
         .await
+        .unwrap()
         .unwrap();
     if !result.is_empty() {
         let record = result.iter().next().unwrap();
@@ -107,6 +109,7 @@ async fn test_authority() {
     assert!(!authority
         .lookup(authority.origin(), RecordType::NS, LookupOptions::default())
         .await
+        .unwrap()
         .unwrap()
         .was_empty());
 
@@ -156,6 +159,7 @@ async fn test_authority() {
         )
         .await
         .unwrap()
+        .unwrap()
         .was_empty());
 
     let mut lookup: Vec<_> = authority
@@ -165,6 +169,7 @@ async fn test_authority() {
             LookupOptions::default(),
         )
         .await
+        .unwrap()
         .unwrap()
         .iter()
         .cloned()
@@ -190,6 +195,7 @@ async fn test_authority() {
         *authority
             .lookup(authority.origin(), RecordType::A, LookupOptions::default())
             .await
+            .unwrap()
             .unwrap()
             .iter()
             .next()
@@ -690,6 +696,7 @@ async fn test_update() {
             )
             .await
             .unwrap()
+            .unwrap()
             .iter()
             .cloned()
             .collect();
@@ -705,6 +712,7 @@ async fn test_update() {
                 LookupOptions::default()
             )
             .await
+            .unwrap()
             .unwrap()
             .was_empty());
     }
@@ -730,6 +738,7 @@ async fn test_update() {
                 LookupOptions::default()
             )
             .await
+            .unwrap()
             .unwrap()
             .iter()
             .collect::<Vec<_>>(),
@@ -758,6 +767,7 @@ async fn test_update() {
                 LookupOptions::default(),
             )
             .await
+            .unwrap()
             .unwrap()
             .iter()
             .cloned()
@@ -788,6 +798,7 @@ async fn test_update() {
         let lookup = authority
             .lookup(&new_name.into(), RecordType::ANY, LookupOptions::default())
             .await
+            .unwrap()
             .unwrap();
 
         println!("after delete of specific record: {lookup:?}");
@@ -815,6 +826,7 @@ async fn test_update() {
                 LookupOptions::default(),
             )
             .await
+            .unwrap()
             .unwrap()
             .iter()
             .cloned()
@@ -867,6 +879,7 @@ async fn test_update() {
             )
             .await
             .unwrap()
+            .unwrap()
             .iter()
             .cloned()
             .collect();
@@ -895,6 +908,7 @@ async fn test_update() {
         .lookup(&www_name.into(), RecordType::ANY, LookupOptions::default())
         .await
         .unwrap()
+        .unwrap()
         .was_empty());
 
     assert_eq!(serial + 6, authority.serial().await);
@@ -915,6 +929,7 @@ async fn test_zone_signing() {
             LookupOptions::for_dnssec(true, SupportedAlgorithms::all()),
         )
         .await
+        .unwrap()
         .unwrap();
 
     assert!(
@@ -931,6 +946,7 @@ async fn test_zone_signing() {
             LookupOptions::for_dnssec(true, SupportedAlgorithms::all()),
         )
         .await
+        .unwrap()
         .unwrap();
 
     for record in &results {
@@ -948,6 +964,7 @@ async fn test_zone_signing() {
                 LookupOptions::for_dnssec(true, SupportedAlgorithms::all()),
             )
             .await
+            .unwrap()
             .unwrap();
 
         // validate all records have associated RRSIGs after signing
@@ -1027,6 +1044,7 @@ async fn test_journal() {
         )
         .await
         .unwrap()
+        .unwrap()
         .iter()
         .cloned()
         .collect();
@@ -1036,6 +1054,7 @@ async fn test_journal() {
     let delete_rrset = authority
         .lookup(&lower_delete_name, RecordType::A, LookupOptions::default())
         .await
+        .unwrap()
         .unwrap();
     assert!(delete_rrset.was_empty());
 
@@ -1060,6 +1079,7 @@ async fn test_journal() {
         .lookup(&new_name.into(), RecordType::A, LookupOptions::default())
         .await
         .unwrap()
+        .unwrap()
         .iter()
         .cloned()
         .collect();
@@ -1068,6 +1088,7 @@ async fn test_journal() {
     let delete_rrset = authority
         .lookup(&lower_delete_name, RecordType::A, LookupOptions::default())
         .await
+        .unwrap()
         .unwrap();
     assert!(delete_rrset.was_empty());
 }
@@ -1162,6 +1183,7 @@ async fn test_axfr() {
     let result = authority
         .search(request_info, LookupOptions::default())
         .await
+        .unwrap()
         .unwrap();
 
     // just update this if the count goes up in the authority

--- a/tests/integration-tests/tests/truncation_tests.rs
+++ b/tests/integration-tests/tests/truncation_tests.rs
@@ -104,7 +104,7 @@ pub fn new_large_catalog(num_records: u32) -> Catalog {
         InMemoryAuthority::new(Name::root(), records, ZoneType::Primary, false).unwrap();
 
     let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(Name::root().into(), Box::new(Arc::new(authority)));
+    catalog.upsert(Name::root().into(), vec![Box::new(Arc::new(authority))]);
     catalog
 }
 

--- a/tests/test-data/test_configs/default/blocklist.txt
+++ b/tests/test-data/test_configs/default/blocklist.txt
@@ -1,0 +1,5 @@
+# This is a test list for the blocklist authority.  It should not be used for production purposes.
+baddomain.com
+foo.com. #Inline Comment
+*.foo.com
+example.com

--- a/tests/test-data/test_configs/default/blocklist2.txt
+++ b/tests/test-data/test_configs/default/blocklist2.txt
@@ -1,0 +1,2 @@
+malware.com.
+malc0de.com

--- a/tests/test-data/test_configs/example_chained_recursor.toml
+++ b/tests/test-data/test_configs/example_chained_recursor.toml
@@ -1,0 +1,42 @@
+## Default zones, these should be present on all nameservers, except in rare
+##  configuration cases
+[[zones]]
+zone = "localhost"
+zone_type = "Primary"
+file = "default/localhost.zone"
+
+[[zones]]
+zone = "0.0.127.in-addr.arpa"
+zone_type = "Primary"
+file = "default/127.0.0.1.zone"
+
+[[zones]]
+zone = "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa"
+zone_type = "Primary"
+file = "default/ipv6_1.zone"
+
+[[zones]]
+zone = "255.in-addr.arpa"
+zone_type = "Primary"
+file = "default/255.zone"
+
+[[zones]]
+zone = "0.in-addr.arpa"
+zone_type = "Primary"
+file = "default/0.zone"
+
+[[zones]]
+## zone: this is the ORIGIN of the zone, aka the base name, '.' is implied on the end
+##  specifying something other than '.' here, will restrict this recursor to only queries
+##  where the search name is a subzone of the name, e.g. if zone is "example.com.", then
+##  queries for "www.example.com" or "example.com" would be recursively queried.
+zone = "."
+
+## zone_type: Primary, Secondary, Hint, Forward
+zone_type = "Hint"
+
+## remember the port, defaults: 53 for Udp & Tcp, 853 for Tls and 443 for Https.
+##   Tls and/or Https require features dns-over-tls and/or dns-over-https
+
+## Example chained recursor configuration with two block lists.
+stores = [{ type = "blocklist", wildcard_match = true, min_wildcard_depth = 2, lists = ["default/blocklist.txt", "default/blocklist2.txt"]}, { type = "recursor", roots = "default/root.zone"}]


### PR DESCRIPTION
Hi.  This PR contains an implementation of the chained store concept as well as a blocklist authority as discussed in issue #13.  There is an example config file in tests/test-data/test_configs/example_chained_recursor.toml that shows how to configure the two features.