### PR TITLE
Gate tests on required features

### DIFF
--- a/crates/proto/src/rr/dnssec/rdata/tsig.rs
+++ b/crates/proto/src/rr/dnssec/rdata/tsig.rs
@@ -895,6 +895,7 @@ mod tests {
         assert_eq!(tbs, tbv);
     }
 
+    #[cfg(any(feature = "dnssec-ring", feature = "dnssec-openssl"))]
     #[test]
     fn test_sign_encode_id_changed() {
         let mut message = Message::new();

--- a/crates/proto/tests/dnssec_presentation_format_tests.rs
+++ b/crates/proto/tests/dnssec_presentation_format_tests.rs
@@ -30,6 +30,7 @@ fn test_dnskey_display() {
     assert_eq!(result, exp_result);
 }
 
+#[cfg(any(feature = "dnssec-ring", feature = "dnssec-openssl"))]
 #[test]
 #[allow(deprecated)]
 fn test_ds_display() {


### PR DESCRIPTION
Without this patch we get this error from `cargo test --no-default-features --features dnssec` :

```
error[E0599]: no method named `to_vec` found for reference `&Digest` in the current scope
  --> crates/proto/tests/dnssec_presentation_format_tests.rs:53:25
   |
53 |         digest.as_ref().to_vec(),
   |                         ^^^^^^ method not found in `&Digest`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `hickory-proto` (test "dnssec_presentation_format_tests") due to previous error
```