### PR TITLE
Recursor: make nameserver and record cache sizes configurable

### DIFF
--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -49,7 +49,11 @@ impl Recursor {
     /// # Panics
     ///
     /// This will panic if the roots are empty.
-    pub fn new(roots: impl Into<NameServerConfigGroup>, ns_cache_size: usize, record_cache_size: usize) -> Result<Self, ResolveError> {
+    pub fn new(
+        roots: impl Into<NameServerConfigGroup>,
+        ns_cache_size: usize,
+        record_cache_size: usize,
+    ) -> Result<Self, ResolveError> {
         // configure the hickory-resolver
         let roots: NameServerConfigGroup = roots.into();
 

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -74,7 +74,7 @@ impl RecursiveAuthority {
         }
 
         let recursor =
-            Recursor::new(roots).map_err(|e| format!("failed to initialize recursor: {e}"))?;
+            Recursor::new(roots, config.ns_cache_size, config.record_cache_size).map_err(|e| format!("failed to initialize recursor: {e}"))?;
 
         Ok(Self {
             origin: origin.into(),

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -73,8 +73,8 @@ impl RecursiveAuthority {
             });
         }
 
-        let recursor =
-            Recursor::new(roots, config.ns_cache_size, config.record_cache_size).map_err(|e| format!("failed to initialize recursor: {e}"))?;
+        let recursor = Recursor::new(roots, config.ns_cache_size, config.record_cache_size)
+            .map_err(|e| format!("failed to initialize recursor: {e}"))?;
 
         Ok(Self {
             origin: origin.into(),

--- a/crates/server/src/store/recursor/config.rs
+++ b/crates/server/src/store/recursor/config.rs
@@ -66,5 +66,9 @@ impl RecursiveConfig {
     }
 }
 
-fn ns_cache_size_default() -> usize { 1024 }
-fn record_cache_size_default() -> usize { 1048576 }
+fn ns_cache_size_default() -> usize {
+    1024
+}
+fn record_cache_size_default() -> usize {
+    1048576
+}

--- a/crates/server/src/store/recursor/config.rs
+++ b/crates/server/src/store/recursor/config.rs
@@ -27,6 +27,14 @@ use crate::resolver::Name;
 pub struct RecursiveConfig {
     /// File with roots, aka hints
     pub roots: PathBuf,
+
+    /// Maximum nameserver cache size
+    #[serde(default = "ns_cache_size_default")]
+    pub ns_cache_size: usize,
+
+    /// Maximum DNS record cache size
+    #[serde(default = "record_cache_size_default")]
+    pub record_cache_size: usize,
 }
 
 impl RecursiveConfig {
@@ -57,3 +65,6 @@ impl RecursiveConfig {
             .collect())
     }
 }
+
+fn ns_cache_size_default() -> usize { 1024 }
+fn record_cache_size_default() -> usize { 1048576 }

--- a/tests/test-data/test_configs/example_recursor.toml
+++ b/tests/test-data/test_configs/example_recursor.toml
@@ -37,4 +37,4 @@ zone_type = "Hint"
 
 ## remember the port, defaults: 53 for Udp & Tcp, 853 for Tls and 443 for Https.
 ##   Tls and/or Https require features dns-over-tls and/or dns-over-https
-stores = { type = "recursor", roots = "default/root.zone" }
+stores = { type = "recursor", roots = "default/root.zone", ns_cache_size = 1024, record_cache_size = 1048576 }

--- a/util/src/bin/recurse.rs
+++ b/util/src/bin/recurse.rs
@@ -157,7 +157,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let name = opts.domainname;
     let ty = opts.ty;
 
-    let recursor = Recursor::new(roots)?;
+    let recursor = Recursor::new(roots, 1024, 1048576)?;
 
     // execute query
     println!(


### PR DESCRIPTION
In addition to being too small for real-world use, the small default cache sizes (100 entries each) are impacting some testing I'm doing.  This PR introduces two new (optional) recursor store configuration options: ns_cache_size and record_cache_size, which default to 1024 and 1048576, respectively, if they are not specified in the config file.