### PR TITLE
Validate response query section

### DIFF
--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -368,10 +368,9 @@ async fn send_serial_message_inner<S: DnsUdpSocket + Send>(
                 let request_queries = request_message.queries();
                 let response_queries = message.queries();
 
-                if !response_queries.is_empty()
-                    && !response_queries
-                        .iter()
-                        .any(|elem| request_queries.contains(elem))
+                if !response_queries
+                    .iter()
+                    .all(|elem| request_queries.contains(elem))
                 {
                     warn!("detected forged question section: we expected '{:?}', but received '{:?}' from server {}",
                         &request_queries, &response_queries, src);


### PR DESCRIPTION
This patch improves resistance against cache poisoning by validating that if a candidate response message has a questions section, that each query name was present in the query section of the original request.  So, for instance, if a client queries for 'example.com' and the remote resolver returns either an answer for 'baddomain.com' OR answers for both 'example.com' and 'baddomain.com', we log a warning message and drop the response.
