### PR TITLE
Use cargo environment variables for path to executable.

### DIFF
--- a/bin/benches/comparison_benches.rs
+++ b/bin/benches/comparison_benches.rs
@@ -86,7 +86,7 @@ fn hickory_process() -> (NamedProcess, u16) {
     let test_port = find_test_port();
 
     let ws_root = env::var("WORKSPACE_ROOT").unwrap_or_else(|_| "..".to_owned());
-    let named_path = format!("{}/target/release/hickory-dns", ws_root);
+    let named_path = env!("CARGO_BIN_EXE_hickory-dns");
     let config_path = format!("{}/tests/test-data/test_configs/example.toml", ws_root);
     let zone_dir = format!("{}/tests/test-data/test_configs", ws_root);
 

--- a/bin/tests/server_harness/mod.rs
+++ b/bin/tests/server_harness/mod.rs
@@ -83,7 +83,7 @@ where
     let server_path = env::var("TDNS_WORKSPACE_ROOT").unwrap_or_else(|_| "..".to_owned());
     println!("using server src path: {server_path}");
 
-    let mut command = Command::new(format!("{server_path}/target/debug/hickory-dns"));
+    let mut command = Command::new(env!("CARGO_BIN_EXE_hickory-dns"));
     command
         .stdout(Stdio::piped())
         .env(


### PR DESCRIPTION
Two files have hardcoded paths to compiled executables. Cargo provides environment variables for those, allowing for alternative target directories. This allows something like ``cargo test --release``.