### PR TITLE
Make AsyncResolver take hosts file into account

### DIFF
--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -367,9 +367,15 @@ impl<P: ConnectionProvider> AsyncResolver<P> {
         L: From<Lookup> + Send + Sync + 'static,
     {
         let names = self.build_names(name);
-        LookupFuture::lookup(names, record_type, options, self.client_cache.clone())
-            .await
-            .map(L::from)
+        LookupFuture::lookup_with_hosts(
+            names,
+            record_type,
+            options,
+            self.client_cache.clone(),
+            self.hosts.clone(),
+        )
+        .await
+        .map(L::from)
     }
 
     /// Performs a dual-stack DNS lookup for the IP for the given hostname.

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -19,7 +19,7 @@ use proto::xfer::{DnsRequestOptions, RetryDnsHandle};
 use tracing::{debug, trace};
 
 use crate::caching_client::CachingClient;
-use crate::config::{ResolverConfig, ResolverOpts};
+use crate::config::{ResolveHosts, ResolverConfig, ResolverOpts};
 use crate::dns_lru::{self, DnsLru};
 use crate::error::*;
 use crate::lookup::{self, Lookup, LookupEither, LookupFuture};
@@ -223,10 +223,9 @@ impl<P: ConnectionProvider> AsyncResolver<P> {
             either = LookupEither::Retry(client);
         }
 
-        let hosts = if options.use_hosts_file {
-            Some(Arc::new(Hosts::new()))
-        } else {
-            None
+        let hosts = match options.use_hosts_file {
+            ResolveHosts::Always | ResolveHosts::Auto => Some(Arc::new(Hosts::new())),
+            ResolveHosts::Never => None,
         };
 
         trace!("handle passed back");

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -886,6 +886,21 @@ impl Default for ServerOrderingStrategy {
     }
 }
 
+/// Whether the system hosts file should be respected by the resolver.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum ResolveHosts {
+    /// Always attempt to look up IP addresses from the system hosts file.
+    /// If the hostname cannot be found, query the DNS.
+    Always,
+    /// The DNS will always be queried.
+    Never,
+    /// Use local resolver configurations only when this resolver is not used in
+    /// a DNS forwarder. This is the default.
+    #[default]
+    Auto,
+}
+
 /// Configuration for the Resolver
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
@@ -913,8 +928,8 @@ pub struct ResolverOpts {
     pub ip_strategy: LookupIpStrategy,
     /// Cache size is in number of records (some records can be large)
     pub cache_size: usize,
-    /// Check /ect/hosts file before dns requery (only works for unix like OS)
-    pub use_hosts_file: bool,
+    /// Check /etc/hosts file before dns requery (only works for unix like OS)
+    pub use_hosts_file: ResolveHosts,
     /// Optional minimum TTL for positive responses.
     ///
     /// If this is set, any positive responses with a TTL lower than this value will have a TTL of
@@ -975,7 +990,7 @@ impl Default for ResolverOpts {
             validate: false,
             ip_strategy: LookupIpStrategy::default(),
             cache_size: 32,
-            use_hosts_file: true,
+            use_hosts_file: ResolveHosts::default(),
             positive_min_ttl: None,
             negative_min_ttl: None,
             positive_max_ttl: None,

--- a/crates/resolver/src/lookup.rs
+++ b/crates/resolver/src/lookup.rs
@@ -26,6 +26,7 @@ use crate::{
     caching_client::CachingClient,
     dns_lru::MAX_TTL,
     error::*,
+    hosts::Hosts,
     lookup_ip::LookupIpIter,
     name_server::{ConnectionProvider, NameServerPool},
     proto::{
@@ -280,19 +281,45 @@ where
     /// * `client_cache` - cache with a connection to use for performing all lookups
     #[doc(hidden)]
     pub fn lookup(
+        names: Vec<Name>,
+        record_type: RecordType,
+        options: DnsRequestOptions,
+        client_cache: CachingClient<C>,
+    ) -> Self {
+        Self::lookup_with_hosts(names, record_type, options, client_cache, None)
+    }
+
+    /// Perform a lookup from a name and type to a set of RDatas, taking the local
+    /// hosts file into account.
+    ///
+    /// # Arguments
+    ///
+    /// * `names` - a set of DNS names to attempt to resolve, they will be attempted in queue order, i.e. the first is `names.pop()`. Upon each failure, the next will be attempted.
+    /// * `record_type` - type of record being sought
+    /// * `client_cache` - cache with a connection to use for performing all lookups
+    /// * `hosts` - the local host file, the records inside it will be prioritized over the upstream DNS server
+    #[doc(hidden)]
+    pub fn lookup_with_hosts(
         mut names: Vec<Name>,
         record_type: RecordType,
         options: DnsRequestOptions,
         mut client_cache: CachingClient<C>,
+        hosts: Option<Arc<Hosts>>,
     ) -> Self {
         let name = names.pop().ok_or_else(|| {
             ResolveError::from(ResolveErrorKind::Message("can not lookup for no names"))
         });
 
         let query: Pin<Box<dyn Future<Output = Result<Lookup, ResolveError>> + Send>> = match name {
-            Ok(name) => client_cache
-                .lookup(Query::query(name, record_type), options)
-                .boxed(),
+            Ok(name) => {
+                let query = Query::query(name, record_type);
+
+                if let Some(lookup) = hosts.and_then(|h| h.lookup_static_host(&query)) {
+                    future::ok(lookup).boxed()
+                } else {
+                    client_cache.lookup(query, options).boxed()
+                }
+            }
             Err(err) => future::err(err).boxed(),
         };
 

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -127,7 +127,11 @@ impl Authority for ForwardAuthority {
         debug_assert!(self.origin.zone_of(name));
 
         debug!("forwarding lookup: {} {}", name, rtype);
-        let name: LowerName = name.clone();
+
+        // Ignore FQDN when we forward DNS queries. Without this we can't look
+        // up addresses from system hosts file.
+        let mut name: Name = name.clone().into();
+        name.set_fqdn(false);
         let resolve = self.resolver.lookup(name, rtype).await;
 
         resolve.map(ForwardLookup).map_err(LookupError::from)

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -7,7 +7,7 @@
 
 use std::io;
 
-use hickory_resolver::name_server::TokioConnectionProvider;
+use hickory_resolver::{config::ResolveHosts, name_server::TokioConnectionProvider};
 use tracing::{debug, info};
 
 use crate::{
@@ -73,6 +73,12 @@ impl ForwardAuthority {
                 for a forwarder; switching to true"
             );
             options.preserve_intermediates = true;
+        }
+
+        // Require people to explicitly request for /etc/hosts usage in forwarder
+        // configs
+        if options.use_hosts_file == ResolveHosts::Auto {
+            options.use_hosts_file = ResolveHosts::Never;
         }
 
         let config = ResolverConfig::from_parts(None, vec![], name_servers);


### PR DESCRIPTION
Closes #2148.

 I'm creating the PR for feedback.

~This does not actually work. Given a `/etc/hosts` file containing `201.11.11.11 example.com`, looking up the A record for `example.com.` using `AsyncResolver` will still return `93.184.216.34`, so FQDN seems to trip `Hosts::lookup_static_host()` up.~ This is fixed by 9564566.