### PR TITLE
fix(proto): fix internal representation of OPT

### DIFF
--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -8,6 +8,7 @@
 //! option record for passing protocol options between the client and server
 #![allow(clippy::use_self)]
 
+use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 
@@ -185,8 +186,7 @@ impl OPT {
     pub fn get(&self, code: EdnsCode) -> Option<&EdnsOption> {
         self.options
             .iter()
-            .find(|(c, _)| code == *c)
-            .map(|(_, option)| option)
+            .find_map(|(c, option)| if code == *c { Some(option) } else { None })
     }
 
     /// Insert a new option, the key is derived from the `EdnsOption`
@@ -220,8 +220,8 @@ impl AsMut<Vec<(EdnsCode, EdnsOption)>> for OPT {
     }
 }
 
-impl AsRef<Vec<(EdnsCode, EdnsOption)>> for OPT {
-    fn as_ref(&self) -> &Vec<(EdnsCode, EdnsOption)> {
+impl AsRef<[(EdnsCode, EdnsOption)]> for OPT {
+    fn as_ref(&self) -> &[(EdnsCode, EdnsOption)] {
         &self.options
     }
 }

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -31,6 +31,8 @@ use crate::rr::dnssec::SupportedAlgorithms;
 /// These allow for additional information to be associated with the DNS request that otherwise
 /// would require changes to the DNS protocol.
 ///
+/// Multiple options with the same code are allowed to appear in this record
+///
 /// [RFC 6891, EDNS(0) Extensions, April 2013](https://tools.ietf.org/html/rfc6891#section-6)
 ///
 /// ```text
@@ -189,12 +191,20 @@ impl OPT {
             .find_map(|(c, option)| if code == *c { Some(option) } else { None })
     }
 
+    /// Get all options based on the code
+    pub fn get_all(&self, code: EdnsCode) -> Vec<&EdnsOption> {
+        self.options
+            .iter()
+            .filter_map(|(c, option)| if code == *c { Some(option) } else { None })
+            .collect()
+    }
+
     /// Insert a new option, the key is derived from the `EdnsOption`
     pub fn insert(&mut self, option: EdnsOption) {
         self.options.push(((&option).into(), option));
     }
 
-    /// Remove an option, the key is derived from the `EdnsOption`
+    /// Removes all options based on the code
     pub fn remove(&mut self, option: EdnsCode) {
         self.options.retain(|(c, _)| *c != option)
     }

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -862,6 +862,42 @@ mod tests {
     }
 
     #[test]
+    fn test_multiple_options_with_same_code() {
+        let bytes: Vec<u8> = vec![
+            0x00, 0x0f, 0x00, 0x02, 0x00, 0x06, 0x00, 0x0f, 0x00, 0x0f, 0x00, 0x09, 0x55, 0x6E,
+            0x6B, 0x6E, 0x6F, 0x77, 0x6E, 0x20, 0x65, 0x72, 0x72, 0x6F, 0x72,
+        ];
+
+        let mut decoder: BinDecoder<'_> = BinDecoder::new(&bytes);
+        let read_rdata = OPT::read_data(&mut decoder, Restrict::new(bytes.len() as u16));
+        assert!(
+            read_rdata.is_ok(),
+            "error decoding: {:?}",
+            read_rdata.unwrap_err()
+        );
+
+        let opt = read_rdata.unwrap();
+        let options = vec![
+            (
+                EdnsCode::Unknown(15u16),
+                EdnsOption::Unknown(15u16, vec![0x00, 0x06]),
+            ),
+            (
+                EdnsCode::Unknown(15u16),
+                EdnsOption::Unknown(
+                    15u16,
+                    vec![
+                        0x00, 0x09, 0x55, 0x6E, 0x6B, 0x6E, 0x6F, 0x77, 0x6E, 0x20, 0x65, 0x72,
+                        0x72, 0x6F, 0x72,
+                    ],
+                ),
+            ),
+        ];
+        let options = OPT::new(options);
+        assert_eq!(opt, options);
+    }
+
+    #[test]
     fn test_write_client_subnet() {
         let expected_bytes: Vec<u8> = vec![0x00, 0x01, 0x18, 0x00, 0xac, 0x01, 0x01];
         let ecs: ClientSubnet = "172.1.1.1/24".parse().unwrap();

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -846,16 +846,17 @@ mod tests {
         );
 
         let opt = read_rdata.unwrap();
-        let mut options = Vec::default();
-        options.push((
-            EdnsCode::Subnet,
-            EdnsOption::Subnet("0.0.0.0/0".parse().unwrap()),
-        ));
-        options.push((
-            EdnsCode::Cookie,
-            EdnsOption::Unknown(10, vec![0x0b, 0x64, 0xb4, 0xdc, 0xd7, 0xb0, 0xcc, 0x8f]),
-        ));
-        options.push((EdnsCode::Keepalive, EdnsOption::Unknown(11, vec![])));
+        let options = vec![
+            (
+                EdnsCode::Subnet,
+                EdnsOption::Subnet("0.0.0.0/0".parse().unwrap()),
+            ),
+            (
+                EdnsCode::Cookie,
+                EdnsOption::Unknown(10, vec![0x0b, 0x64, 0xb4, 0xdc, 0xd7, 0xb0, 0xcc, 0x8f]),
+            ),
+            (EdnsCode::Keepalive, EdnsOption::Unknown(11, vec![])),
+        ];
         let options = OPT::new(options);
         assert_eq!(opt, options);
     }

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -8,7 +8,6 @@
 //! option record for passing protocol options between the client and server
 #![allow(clippy::use_self)]
 
-use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 
@@ -208,7 +207,6 @@ impl PartialEq for OPT {
             .iter()
             .filter(|entry| other.options.contains(entry))
             .count();
-        println!("Number of matching elements: {}", matching_elements_count);
         matching_elements_count == self.options.len()
             && matching_elements_count == other.options.len()
     }


### PR DESCRIPTION
Current implementation of OPT represents options as hash map, which prevents same `EdnsCode` from appearing more than once. There are options that may appear more than once
(e.g. EDE https://www.rfc-editor.org/rfc/rfc8914.html).

Unfortunately, this is a breaking change. I haven't figured out a solution that would not break the API and would not introduce some kind of overhead.

BREAKING CHANGE: Changes representation of OPT from `HashMap` to a `Vec`, which means that `as_ref` and `as_mut` also now return `&Vec` rather than `&HashMap`.