### PR TITLE
Chained authority implementation

### DIFF
--- a/crates/server/src/authority/authority.rs
+++ b/crates/server/src/authority/authority.rs
@@ -149,6 +149,41 @@ pub trait Authority: Send + Sync {
         lookup_options: LookupOptions,
     ) -> LookupControlFlow<Self::Lookup>;
 
+    /// Consulting lookup for all Resource Records matching the giving `Name` and `RecordType`.
+    /// This will be called in a chained authority configuration after an authority in the chain
+    /// has returned a lookup with a LookupControlFlow::Continue action. Every other authority in
+    /// the chain will be called via this consult method, until one either returns a
+    /// LookupControlFlow::Break action, or all authorities have been consulted.  The authority that
+    /// generated the primary lookup (the one returned via 'lookup') will not be consulted.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The `Name`, label, to lookup.
+    /// * `rtype` - The `RecordType`, to lookup. `RecordType::ANY` will return all records matching
+    ///             `name`. `RecordType::AXFR` will return all record types except `RecordType::SOA`
+    ///             due to the requirements that on zone transfers the `RecordType::SOA` must both
+    ///             precede and follow all other records.
+    /// * `lookup_options` - Query-related lookup options (e.g., DNSSEC DO bit, supported hash
+    ///                      algorithms, etc.)
+    /// * `last_result` - The lookup returned by a previous authority in a chained configuration.
+    ///                   If a subsequent authority does not modify this lookup, it will be returned
+    ///                   to the client after consulting all authorities in the chain.
+    ///
+    /// # Return value
+    ///
+    /// A LookupControlFlow containing the lookup that should be returned to the client.  This can
+    /// be the same last_result that was passed in, or a new lookup, depending on the logic of the
+    /// authority in question.
+    async fn consult(
+        &self,
+        _name: &LowerName,
+        _rtype: RecordType,
+        _lookup_options: LookupOptions,
+        last_result: LookupControlFlow<Box<dyn LookupObject>>,
+    ) -> LookupControlFlow<Box<dyn LookupObject>> {
+        last_result
+    }
+
     /// Using the specified query, perform a lookup against this zone.
     ///
     /// # Arguments

--- a/crates/server/src/config/mod.rs
+++ b/crates/server/src/config/mod.rs
@@ -28,7 +28,7 @@ use crate::proto::rr::Name;
 use crate::authority::ZoneType;
 #[cfg(feature = "toml")]
 use crate::error::ConfigResult;
-use crate::store::StoreConfig;
+use crate::store::StoreConfigContainer;
 
 static DEFAULT_PATH: &str = "/var/named"; // TODO what about windows (do I care? ;)
 static DEFAULT_PORT: u16 = 53;
@@ -248,7 +248,7 @@ pub struct ZoneConfig {
     pub keys: Vec<dnssec::KeyConfig>,
     /// Store configurations, TODO: allow chained Stores
     #[serde(default)]
-    pub stores: Option<StoreConfig>,
+    pub stores: Option<StoreConfigContainer>,
     /// The kind of non-existence proof provided by the nameserver
     #[cfg(feature = "dnssec")]
     pub nx_proof_kind: Option<dnssec::NxProofKind>,

--- a/crates/server/src/store/config.rs
+++ b/crates/server/src/store/config.rs
@@ -18,6 +18,22 @@ use crate::store::recursor::RecursiveConfig;
 use crate::store::sqlite::SqliteConfig;
 
 /// Enumeration over all Store configurations
+
+/// This is the outer container enum, covering the single- and chained-store variants.
+/// The chained store variant is a vector of StoreConfigs that should be consulted in-order during the lookup process.
+/// An example of this (currently the only example,) is when the blocklist feature is used: the blocklist should be queried first, then
+/// a recursor or forwarder second if the blocklist authority does not match on the query.
+#[derive(Deserialize, PartialEq, Eq, Debug)]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum StoreConfigContainer {
+    /// For a zone with a single store
+    Single(StoreConfig),
+    /// For a zone with multiple stores.  E.g., a recursive or forwarding zone with block lists.
+    Chained(Vec<StoreConfig>),
+}
+
+/// Enumeration over all store types
 #[derive(Deserialize, PartialEq, Eq, Debug)]
 #[serde(tag = "type")]
 #[serde(rename_all = "lowercase")]
@@ -37,4 +53,6 @@ pub enum StoreConfig {
     #[cfg(feature = "hickory-recursor")]
     #[cfg_attr(docsrs, doc(cfg(feature = "recursor")))]
     Recursor(RecursiveConfig),
+    /// This is used by the configuration processing code to represent a deprecated or main-block config without an associated store.
+    Default,
 }

--- a/crates/server/src/store/mod.rs
+++ b/crates/server/src/store/mod.rs
@@ -19,3 +19,4 @@ pub mod sqlite;
 // TODO: add a dynamic library option?
 
 pub use self::config::StoreConfig;
+pub use self::config::StoreConfigContainer;

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -80,6 +80,7 @@ dns-over-openssl = [
 ]
 dns-over-rustls = [
     "dns-over-tls",
+    "dnssec-ring",
     "hickory-proto/dns-over-rustls",
     "hickory-resolver/dns-over-rustls",
     "hickory-server/dns-over-rustls",

--- a/tests/integration-tests/tests/integration/catalog_tests.rs
+++ b/tests/integration-tests/tests/integration/catalog_tests.rs
@@ -125,8 +125,8 @@ async fn test_catalog_lookup() {
     let test_origin = test.origin().clone();
 
     let mut catalog = Catalog::new();
-    catalog.upsert(origin.clone(), Arc::new(example));
-    catalog.upsert(test_origin.clone(), Arc::new(test));
+    catalog.upsert(origin.clone(), vec![Arc::new(example)]);
+    catalog.upsert(test_origin.clone(), vec![Arc::new(test)]);
 
     let mut question: Message = Message::new();
 
@@ -202,8 +202,8 @@ async fn test_catalog_lookup_soa() {
     let test_origin = test.origin().clone();
 
     let mut catalog = Catalog::new();
-    catalog.upsert(origin.clone(), Arc::new(example));
-    catalog.upsert(test_origin, Arc::new(test));
+    catalog.upsert(origin.clone(), vec![Arc::new(example)]);
+    catalog.upsert(test_origin, vec![Arc::new(test)]);
 
     let mut question: Message = Message::new();
 
@@ -269,7 +269,7 @@ async fn test_catalog_nx_soa() {
     let origin = example.origin().clone();
 
     let mut catalog = Catalog::new();
-    catalog.upsert(origin, Arc::new(example));
+    catalog.upsert(origin, vec![Arc::new(example)]);
 
     let mut question: Message = Message::new();
 
@@ -317,7 +317,7 @@ async fn test_non_authoritive_nx_refused() {
     let origin = example.origin().clone();
 
     let mut catalog = Catalog::new();
-    catalog.upsert(origin, Arc::new(example));
+    catalog.upsert(origin, vec![Arc::new(example)]);
 
     let mut question: Message = Message::new();
 
@@ -371,7 +371,7 @@ async fn test_axfr() {
     .clone();
 
     let mut catalog = Catalog::new();
-    catalog.upsert(origin.clone(), Arc::new(test));
+    catalog.upsert(origin.clone(), vec![Arc::new(test)]);
 
     let mut query: Query = Query::new();
     query.set_name(origin.clone().into());
@@ -487,7 +487,7 @@ async fn test_axfr_refused() {
     let origin = test.origin().clone();
 
     let mut catalog = Catalog::new();
-    catalog.upsert(origin.clone(), Arc::new(test));
+    catalog.upsert(origin.clone(), vec![Arc::new(test)]);
 
     let mut query: Query = Query::new();
     query.set_name(origin.into());
@@ -526,7 +526,7 @@ async fn test_cname_additionals() {
     let origin = example.origin().clone();
 
     let mut catalog = Catalog::new();
-    catalog.upsert(origin, Arc::new(example));
+    catalog.upsert(origin, vec![Arc::new(example)]);
 
     let mut question: Message = Message::new();
 
@@ -573,7 +573,7 @@ async fn test_multiple_cname_additionals() {
     let origin = example.origin().clone();
 
     let mut catalog = Catalog::new();
-    catalog.upsert(origin, Arc::new(example));
+    catalog.upsert(origin, vec![Arc::new(example)]);
 
     let mut question: Message = Message::new();
 

--- a/tests/integration-tests/tests/integration/chained_authority_tests.rs
+++ b/tests/integration-tests/tests/integration/chained_authority_tests.rs
@@ -1,0 +1,361 @@
+use std::sync::Arc;
+
+use hickory_integration::TestResponseHandler;
+use hickory_proto::{
+    op::{Message, MessageType, Query, ResponseCode},
+    rr::{rdata::A, LowerName, Name, RData, Record, RecordSet, RecordType},
+    serialize::binary::{BinDecodable, BinEncodable},
+};
+#[cfg(feature = "dnssec")]
+use hickory_server::{authority::Nsec3QueryInfo, config::dnssec::NxProofKind};
+use hickory_server::{
+    authority::{
+        Authority, Catalog, LookupControlFlow, LookupError, LookupObject, LookupOptions,
+        LookupRecords, MessageRequest, UpdateResult, ZoneType,
+    },
+    server::{Protocol, Request, RequestInfo, ResponseInfo},
+};
+use test_support::subscribe;
+
+/// Tests for the chained authority catalog.
+#[tokio::test]
+async fn chained_authority_test() {
+    subscribe();
+    let mut catalog = Catalog::new();
+
+    let all_zeros = A::new(0, 0, 0, 0);
+    let pri_lookup_ip = A::new(192, 0, 2, 1);
+    let sec_lookup_ip = A::new(192, 0, 2, 2);
+    let sec_consult_ip = A::new(192, 0, 2, 3);
+
+    let pri_lookup_records = vec![
+        (
+            "primaryonly.example.com.",
+            Some((ResponseType::ContinueOk, pri_lookup_ip)),
+        ),
+        (
+            "primaryerr.example.com.",
+            Some((ResponseType::ContinueErr, all_zeros)),
+        ),
+        (
+            "breakerr.example.com.",
+            Some((ResponseType::BreakErr, all_zeros)),
+        ),
+        (
+            "continueboth.example.com.",
+            Some((ResponseType::ContinueOk, pri_lookup_ip)),
+        ),
+        (
+            "overwrite.example.com.",
+            Some((ResponseType::ContinueOk, pri_lookup_ip)),
+        ),
+        (
+            "breakok.example.com.",
+            Some((ResponseType::BreakOk, pri_lookup_ip)),
+        ),
+        (
+            "skipboth.example.com.",
+            Some((ResponseType::Skip, all_zeros)),
+        ),
+        (
+            "skipprimary.example.com.",
+            Some((ResponseType::Skip, all_zeros)),
+        ),
+    ];
+
+    let pri_consult_records = vec![
+        ("breakok.example.com.", None),
+        ("overwrite.example.com.", None),
+    ];
+
+    let sec_lookup_records = vec![
+        (
+            "continueboth.example.com.",
+            Some((ResponseType::ContinueOk, sec_lookup_ip)),
+        ),
+        (
+            "breakok.example.com.",
+            Some((ResponseType::BreakOk, sec_lookup_ip)),
+        ),
+        (
+            "skipboth.example.com.",
+            Some((ResponseType::Skip, all_zeros)),
+        ),
+        (
+            "skipprimary.example.com.",
+            Some((ResponseType::ContinueOk, sec_lookup_ip)),
+        ),
+    ];
+
+    let sec_consult_records = vec![
+        ("breakok.example.com.", None),
+        (
+            "overwrite.example.com.",
+            Some((ResponseType::ContinueOk, sec_consult_ip)),
+        ),
+        (
+            "primaryerr.example.com.",
+            Some((ResponseType::ContinueOk, sec_consult_ip)),
+        ),
+        (
+            "breakerr.example.com.",
+            Some((ResponseType::ContinueOk, sec_consult_ip)),
+        ),
+    ];
+
+    let primary_authority = TestAuthority::new(
+        Name::from_ascii("example.com.").unwrap(),
+        pri_lookup_records,
+        pri_consult_records,
+    );
+
+    let secondary_authority = TestAuthority::new(
+        Name::from_ascii("example.com.").unwrap(),
+        sec_lookup_records,
+        sec_consult_records,
+    );
+
+    catalog.upsert(
+        primary_authority.origin().clone(),
+        vec![Arc::new(primary_authority), Arc::new(secondary_authority)],
+    );
+
+    // First test - the record only exists in the primary authority
+    basic_test(&catalog, "primaryonly.example.com.", pri_lookup_ip).await;
+
+    // Second test -- the record exists in both authorities; confirm the primary authority data
+    // is returned
+    basic_test(&catalog, "continueboth.example.com.", pri_lookup_ip).await;
+
+    // Third test -- the record exists in the primary authority, but is overwritten by a record in
+    // the secondary authority
+    basic_test(&catalog, "overwrite.example.com.", sec_consult_ip).await;
+
+    // Fourth test -- the record exists in the primary authority and is returned with Break -
+    // verify consult methods are not consulted for any authority.
+    basic_test(&catalog, "breakok.example.com.", pri_lookup_ip).await;
+
+    // Fifth test -- primary returns skip, and the second authority has the record - verify the
+    // rdata from the secondary authority is returned.
+    basic_test(&catalog, "skipprimary.example.com.", sec_lookup_ip).await;
+
+    // Sixth test - both authorities skip.  Verify the catalog returns Servfail
+    error_test(&catalog, "skipboth.example.com.", ResponseCode::ServFail).await;
+
+    // Seventh test -- Primary returns Continue(Err), secondary returns Ok with a record
+    basic_test(&catalog, "primaryerr.example.com.", sec_consult_ip).await;
+
+    // Eighth test -- Primary returns Break(Err); secondary consult WOULD result in a record
+    // returned; verify no records
+    error_test(&catalog, "breakerr.example.com.", ResponseCode::NoError).await;
+}
+
+struct TestAuthority {
+    origin: LowerName,
+    zone_type: ZoneType,
+    lookup_records: TestRecords,
+    consult_records: TestRecords,
+}
+
+impl TestAuthority {
+    pub fn new(origin: Name, lookup_records: TestRecords, consult_records: TestRecords) -> Self {
+        TestAuthority {
+            origin: origin.into(),
+            zone_type: ZoneType::Hint,
+            lookup_records,
+            consult_records,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Authority for TestAuthority {
+    type Lookup = LookupRecords;
+
+    fn origin(&self) -> &LowerName {
+        &self.origin
+    }
+
+    /// What type is this zone
+    fn zone_type(&self) -> ZoneType {
+        self.zone_type
+    }
+
+    /// Return true if AXFR is allowed
+    fn is_axfr_allowed(&self) -> bool {
+        false
+    }
+
+    async fn update(&self, _update: &MessageRequest) -> UpdateResult<bool> {
+        Err(ResponseCode::NotImp)
+    }
+
+    async fn get_nsec_records(
+        &self,
+        _name: &LowerName,
+        _lookup_options: LookupOptions,
+    ) -> LookupControlFlow<Self::Lookup> {
+        LookupControlFlow::Continue(Ok(LookupRecords::Empty))
+    }
+
+    #[cfg(feature = "dnssec")]
+    async fn get_nsec3_records(
+        &self,
+        _info: Nsec3QueryInfo<'_>,
+        _lookup_options: LookupOptions,
+    ) -> LookupControlFlow<Self::Lookup> {
+        LookupControlFlow::Continue(Ok(LookupRecords::Empty))
+    }
+
+    #[cfg(feature = "dnssec")]
+    fn nx_proof_kind(&self) -> Option<&NxProofKind> {
+        None
+    }
+
+    async fn lookup(
+        &self,
+        name: &LowerName,
+        _query_type: RecordType,
+        lookup_options: LookupOptions,
+    ) -> LookupControlFlow<Self::Lookup> {
+        let Some(res) = inner_lookup(name, &self.lookup_records, &lookup_options) else {
+            panic!("reached end of records without a match");
+        };
+        res
+    }
+
+    async fn search(
+        &self,
+        request_info: RequestInfo<'_>,
+        lookup_options: LookupOptions,
+    ) -> LookupControlFlow<Self::Lookup> {
+        self.lookup(
+            request_info.query.name(),
+            request_info.query.query_type(),
+            lookup_options,
+        )
+        .await
+    }
+
+    async fn consult(
+        &self,
+        name: &LowerName,
+        _rtype: RecordType,
+        lookup_options: LookupOptions,
+        last_result: LookupControlFlow<Box<dyn LookupObject>>,
+    ) -> LookupControlFlow<Box<dyn LookupObject>> {
+        let Some(res) = inner_lookup(name, &self.consult_records, &lookup_options) else {
+            return last_result;
+        };
+        res.map_dyn()
+    }
+}
+
+#[derive(Debug)]
+enum ResponseType {
+    ContinueOk,
+    BreakOk,
+    ContinueErr,
+    BreakErr,
+    Skip,
+}
+
+/// This is a lookup table for inner_lookup, which is called by the test authority lookup and
+/// consult methods.  Each entry in the Vec is a tuple, which represent a query string and action
+/// pair.  The action is wrapped in an Option - for None variants, if the lookup or consult method
+/// is queried for that name, the test will panic.  This covers cases where lookup and/or consult
+/// should not be called, such as verifying that LookupControlFlow::Break is working properly.
+/// The Some variant will include a ResponseType and a record. ResponseType is an enum that maps 1:1
+/// to LookupControlFlow, and controls the control flow type returned to the catalog.  The record is
+/// always an A record, and will be returned with the lookup records in Continue(Ok) and Break(Ok)
+/// responses. It is used to distinguish between the primary and secondary authority having been the
+/// source of the answer returned by the catalog.
+type TestRecords = Vec<(&'static str, Option<(ResponseType, A)>)>;
+
+fn inner_lookup(
+    name: &LowerName,
+    records: &TestRecords,
+    lookup_options: &LookupOptions,
+) -> Option<LookupControlFlow<LookupRecords>> {
+    let ascii_name = &Name::from(name).to_ascii()[..];
+
+    for record in records.iter() {
+        let (record_name, action) = record;
+
+        if *record_name == ascii_name {
+            let Some((response_type, response_record)) = action else {
+                panic!("unexpected query for {record_name} in lookup");
+            };
+
+            let mut rset = RecordSet::new(name.into(), RecordType::A, 1);
+            rset.insert(
+                Record::from_rdata(name.into(), 3600, RData::A(*response_record)),
+                1,
+            );
+
+            let lookup = LookupRecords::new(*lookup_options, rset.into());
+
+            use LookupControlFlow::*;
+            match response_type {
+                ResponseType::ContinueOk => return Some(Continue(Ok(lookup))),
+                ResponseType::BreakOk => return Some(Break(Ok(lookup))),
+                ResponseType::ContinueErr => {
+                    return Some(Continue(Err(LookupError::ResponseCode(
+                        ResponseCode::NXDomain,
+                    ))))
+                }
+                ResponseType::BreakErr => {
+                    return Some(Break(Err(LookupError::ResponseCode(
+                        ResponseCode::NXDomain,
+                    ))))
+                }
+                ResponseType::Skip => return Some(LookupControlFlow::Skip),
+            }
+        }
+    }
+
+    None
+}
+
+// Boilerplate to query the catalog
+async fn do_query(catalog: &Catalog, query_name: &str) -> (ResponseInfo, TestResponseHandler) {
+    let mut question: Message = Message::new();
+
+    let mut query: Query = Query::new();
+    query.set_name(Name::from_ascii(query_name).unwrap());
+    question.add_query(query);
+    question.set_recursion_desired(true);
+    question.set_authentic_data(true);
+
+    let question_bytes = question.to_bytes().unwrap();
+    let question_req = MessageRequest::from_bytes(&question_bytes).unwrap();
+    let question_req = Request::new(question_req, ([127, 0, 0, 1], 5553).into(), Protocol::Udp);
+    let response_handler = TestResponseHandler::new();
+
+    let res = catalog
+        .lookup(&question_req, None, response_handler.clone())
+        .await;
+    (res, response_handler)
+}
+
+// Handle boilerplate for the most common test case pattern: a positive response with a single A
+// record.
+async fn basic_test(catalog: &Catalog, query_name: &'static str, answer: A) {
+    let (_, response_handler) = do_query(catalog, query_name).await;
+    let result = response_handler.into_message().await;
+
+    let answers: &[Record] = result.answers();
+
+    assert_eq!(result.response_code(), ResponseCode::NoError);
+    assert_eq!(result.message_type(), MessageType::Response);
+    assert!(!answers.is_empty());
+    assert_eq!(answers.first().unwrap().record_type(), RecordType::A);
+    assert_eq!(answers.first().unwrap().data(), &RData::A(answer));
+}
+
+async fn error_test(catalog: &Catalog, query_name: &str, r_code: ResponseCode) {
+    let (res, _) = do_query(catalog, query_name).await;
+
+    assert_eq!(res.response_code(), r_code);
+    assert_eq!(res.answer_count(), 0);
+}

--- a/tests/integration-tests/tests/integration/client_future_tests.rs
+++ b/tests/integration-tests/tests/integration/client_future_tests.rs
@@ -48,7 +48,7 @@ fn test_query_nonet() {
 
     let authority = create_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Arc::new(authority));
+    catalog.upsert(authority.origin().clone(), vec![Arc::new(authority)]);
 
     let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
@@ -261,7 +261,7 @@ fn test_notify() {
     let io_loop = Runtime::new().unwrap();
     let authority = create_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Arc::new(authority));
+    catalog.upsert(authority.origin().clone(), vec![Arc::new(authority)]);
 
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
     let client = AsyncClient::new(stream, sender, None);
@@ -321,7 +321,7 @@ async fn create_sig0_ready_client() -> (
 
     // setup the catalog
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Arc::new(authority));
+    catalog.upsert(authority.origin().clone(), vec![Arc::new(authority)]);
 
     let signer = Arc::new(signer.into());
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));

--- a/tests/integration-tests/tests/integration/client_tests.rs
+++ b/tests/integration-tests/tests/integration/client_tests.rs
@@ -64,7 +64,7 @@ impl ClientConnection for TestClientConnection {
 fn test_query_nonet() {
     let authority = create_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Arc::new(authority));
+    catalog.upsert(authority.origin().clone(), vec![Arc::new(authority)]);
 
     let client = SyncClient::new(TestClientConnection::new(catalog));
 
@@ -535,7 +535,7 @@ fn create_sig0_ready_client(mut catalog: Catalog) -> (SyncClient<TestClientConne
     );
     authority.upsert_mut(auth_key, 0);
 
-    catalog.upsert(authority.origin().clone(), Arc::new(authority));
+    catalog.upsert(authority.origin().clone(), vec![Arc::new(authority)]);
     let client = SyncClient::with_signer(TestClientConnection::new(catalog), signer);
 
     (client, origin.into())

--- a/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
+++ b/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
@@ -230,7 +230,7 @@ where
     };
 
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Arc::new(authority));
+    catalog.upsert(authority.origin().clone(), vec![Arc::new(authority)]);
 
     let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));

--- a/tests/integration-tests/tests/integration/lookup_tests.rs
+++ b/tests/integration-tests/tests/integration/lookup_tests.rs
@@ -30,7 +30,7 @@ use hickory_integration::{example_authority::create_example, mock_client::*, Tes
 fn test_lookup() {
     let authority = create_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Arc::new(authority));
+    catalog.upsert(authority.origin().clone(), vec![Arc::new(authority)]);
 
     let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
@@ -58,7 +58,7 @@ fn test_lookup() {
 fn test_lookup_hosts() {
     let authority = create_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Arc::new(authority));
+    catalog.upsert(authority.origin().clone(), vec![Arc::new(authority)]);
 
     let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
@@ -116,7 +116,7 @@ fn create_ip_like_example() -> InMemoryAuthority {
 fn test_lookup_ipv4_like() {
     let authority = create_ip_like_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Arc::new(authority));
+    catalog.upsert(authority.origin().clone(), vec![Arc::new(authority)]);
 
     let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
@@ -146,7 +146,7 @@ fn test_lookup_ipv4_like() {
 fn test_lookup_ipv4_like_fall_through() {
     let authority = create_ip_like_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Arc::new(authority));
+    catalog.upsert(authority.origin().clone(), vec![Arc::new(authority)]);
 
     let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));

--- a/tests/integration-tests/tests/integration/main.rs
+++ b/tests/integration-tests/tests/integration/main.rs
@@ -1,4 +1,5 @@
 mod catalog_tests;
+mod chained_authority_tests;
 mod client_future_tests;
 mod client_tests;
 mod dnssec_client_handle_tests;

--- a/tests/integration-tests/tests/integration/server_future_tests.rs
+++ b/tests/integration-tests/tests/integration/server_future_tests.rs
@@ -363,7 +363,7 @@ fn new_catalog() -> Catalog {
     let origin = example.origin().clone();
 
     let mut catalog = Catalog::new();
-    catalog.upsert(origin, Arc::new(example));
+    catalog.upsert(origin, vec![Arc::new(example)]);
     catalog
 }
 

--- a/tests/integration-tests/tests/integration/truncation_tests.rs
+++ b/tests/integration-tests/tests/integration/truncation_tests.rs
@@ -115,7 +115,7 @@ pub fn new_large_catalog(num_records: u32) -> Catalog {
     .unwrap();
 
     let mut catalog = Catalog::new();
-    catalog.upsert(Name::root().into(), Arc::new(authority));
+    catalog.upsert(Name::root().into(), vec![Arc::new(authority)]);
     catalog
 }
 


### PR DESCRIPTION
This is a standalone PR for the chained authority feature discussed in [PR #2113](https://github.com/hickory-dns/hickory-dns/pull/2113)

It implements the cases discussed earlier, including the consult case where an authority can modify an answer -- positive or negative -- from a previous authority, except when LookupControlFlow::Break is returned, which will result in an immediate response being sent.

While working on this, I found that the LookupControlFlow logic in the catalog was spread out and duplicated across more of the code base than it really needed to be, so there's a separate commit here to clean that up.  Hopefully it makes reviewing the core changes a bit easier.

closes: #2113 