### PR TITLE
Fix formatting issue in crates/proto/src/op/message.rs

### DIFF
--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -1259,7 +1259,7 @@ mod tests {
         }
 
         let mut decoder = BinDecoder::new(&byte_vec);
-        
+
         Message::read(&mut decoder).unwrap()
     }
 


### PR DESCRIPTION
[A recent commit](https://github.com/hickory-dns/hickory-dns/commit/966bc27c6e2354475ec7e883f7c9e09aa08703be) introduced a formatting issue that is causing CI to fail. This PR fixes that warning.

```
cargo ws exec cargo fmt -- --check
Diff in /home/runner/work/hickory-dns/hickory-dns/crates/proto/src/op/message.rs at line 1259:
         }
 
         let mut decoder = BinDecoder::new(&byte_vec);
-        
+
         Message::read(&mut decoder).unwrap()
     }
 
error: child command failed to exit successfully
error: Recipe `fmt` failed on line 89 with exit code 1
Error: Process completed with exit code 1.
```