### PR TITLE
Make ```hickory_proto::quic::QuicClientStream``` Clonable

### DIFF
--- a/crates/proto/src/quic/quic_client_stream.rs
+++ b/crates/proto/src/quic/quic_client_stream.rs
@@ -31,6 +31,7 @@ use super::{quic_config, quic_stream};
 
 /// A DNS client connection for DNS-over-QUIC
 #[must_use = "futures do nothing unless polled"]
+#[derive(Clone)]
 pub struct QuicClientStream {
     quic_connection: Connection,
     name_server_name: Arc<str>,


### PR DESCRIPTION
```quinn::Connection``` is clonable. This can reuse ```hickory_proto::quic::QuicClientStream```.