### PR TITLE
resolver: err for dns-over-rustls w/o roots

### DIFF
--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -382,6 +382,12 @@ where
                 _ if e.is_busy() => {
                     busy.push(conn);
                 }
+                // If our current error is the default err we start with, replace it with the
+                // new error under consideration. It was produced trying to make a connection
+                // and is more specific than the default.
+                _ if matches!(err.kind(), ProtoErrorKind::NoConnections) => {
+                    err = e;
+                }
                 _ if err.cmp_specificity(&e) == Ordering::Less => {
                     err = e;
                 }

--- a/crates/resolver/src/tls/dns_over_rustls.rs
+++ b/crates/resolver/src/tls/dns_over_rustls.rs
@@ -59,6 +59,16 @@ pub(crate) static CLIENT_CONFIG: Lazy<Result<Arc<ClientConfig>, ProtoError>> = L
         )
     }));
 
+    // If by the time we reach this point the root store remains empty then
+    // our feature config hasn't resulted in a populated root store. Return an
+    // early error rather than trying to validate a peer certificate without any
+    // trust anchors.
+    if root_store.is_empty() {
+        return Err(ProtoError::from(
+         "no root certificates configured: you must enable the webpki-roots or native-certs feature".to_owned(),
+        ));
+    }
+
     let mut client_config = ClientConfig::builder()
         .with_safe_default_cipher_suites()
         .with_safe_default_kx_groups()


### PR DESCRIPTION
If we're setting up dns-over-rustls and find that we've constructed a Rustls root cert store that has no trust anchors, return an early error. This makes the problem obvious and avoids surfacing some other less specific error cause when we first try to validate a peer certificate with an empty root store.

In order for our new early error to be surfaced correctly the `name_sever_pool.rs` [`parallel_conn_loop` fn](https://github.com/hickory-dns/hickory-dns/blob/6c2a1e2c238eaecff2b6b6c1c0e435685bc0997e/crates/resolver/src/name_server/name_server_pool.rs#L304-L392) needs its error handling adjusted. Previously it would always compare the new error produced by trying to build the TLS config against [the default error](https://github.com/hickory-dns/hickory-dns/blob/6c2a1e2c238eaecff2b6b6c1c0e435685bc0997e/crates/resolver/src/name_server/name_server_pool.rs#L312) it starts its loop with, `ProtoErrorKind::NoConnections`. Since the error being returned is another `ProtoErrorKind` that isn't `NoRecordsFound`, `Io`, or `Timeout` the error specificity comparison considers the two errors equivalent [in the general case](https://github.com/hickory-dns/hickory-dns/blob/6c2a1e2c238eaecff2b6b6c1c0e435685bc0997e/crates/proto/src/error.rs#L487), and the default error was always returned and the new error thrown away.

~There is still a small mystery around why a more specific error from tokio-rustls isn't returned when peer validation inevitably fails. In my testing upstream we get a nice `io::Error` like `err: Custom { kind: InvalidData, error: InvalidCertificate(UnknownIssuer) }`. I can't figure out where or why, but something in the Hickory DNS stack is reducing this down to just a simple io error with type `InvalidData` - no nested source error or message.~ See [my comment here](https://github.com/hickory-dns/hickory-dns/issues/2066#issuecomment-2053743003) I think this is a side-effect of the `Clone` impl on `ProtoErrorKind`.

Updates https://github.com/hickory-dns/hickory-dns/issues/2066