### PR TITLE
error: wrap io::Error in Arc for clone

### DIFF
--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -10,6 +10,7 @@
 #![deny(missing_docs)]
 
 use std::cmp::Ordering;
+use std::sync::Arc;
 use std::{fmt, io, sync};
 
 #[cfg(feature = "backtrace")]
@@ -233,7 +234,7 @@ pub enum ProtoErrorKind {
     // foreign
     /// An error got returned from IO
     #[error("io error: {0}")]
-    Io(io::Error),
+    Io(Arc<io::Error>),
 
     /// Any sync poised error
     #[error("lock poisoned error")]
@@ -554,7 +555,7 @@ impl From<io::Error> for ProtoErrorKind {
     fn from(e: io::Error) -> Self {
         match e.kind() {
             io::ErrorKind::TimedOut => Self::Timeout,
-            _ => Self::Io(e),
+            _ => Self::Io(e.into()),
         }
     }
 }
@@ -641,11 +642,7 @@ impl Clone for ProtoErrorKind {
             UnrecognizedLabelCode(value) => UnrecognizedLabelCode(value),
             UnrecognizedNsec3Flags(flags) => UnrecognizedNsec3Flags(flags),
             UnrecognizedCsyncFlags(flags) => UnrecognizedCsyncFlags(flags),
-            Io(ref e) => Io(if let Some(raw) = e.raw_os_error() {
-                io::Error::from_raw_os_error(raw)
-            } else {
-                io::Error::from(e.kind())
-            }),
+            Io(ref e) => Io(e.clone()),
             Poisoned => Poisoned,
             Ring(ref _e) => Ring(Unspecified),
             SSL(ref e) => Msg(format!("there was an SSL error: {e}")),


### PR DESCRIPTION
`ProtoErrorKind` is `Clone`, but the `Io` variant holding `io::Error` runs into trouble with this: since the `io::Error` error can't be cloned we have to reconstruct it and this is a lossy proces resulting in a "simple" `io::Error` that only holds the error type from the parent it was cloned from. This loses important details like the underlying error source/message.

This branch changes `ProtoErrorKind::Io` to hold `Arc<io::Error>` instead (**Note: this is a breaking change**). This makes implementing `Clone` trivial - we clone the arc - and no error information is lost.

With this fix in place we get a much better error fidelity from failures like trying to perform DNS-over-HTTPS using Rustls but without a source of trust anchors (e.g. https://github.com/hickory-dns/hickory-dns/issues/2066). Previously the error was surfaced as:

```
failed to lookup HTTPS record type: ResolveError { kind: Proto(ProtoError { kind: Io(Kind(InvalidData)) }) }'
```

With this change in place, the error is now surfaced with much more detail:

```
failed to lookup HTTPS record type: ResolveError { kind: Proto(ProtoError { kind: Io(Custom { kind: InvalidData, error: InvalidCertificate(UnknownIssuer) }) }) }
```

Updates https://github.com/hickory-dns/hickory-dns/issues/2066