### PR TITLE
recursor: respect DO bit in incoming queries

### DIFF
--- a/crates/proto/src/xfer/dns_handle.rs
+++ b/crates/proto/src/xfer/dns_handle.rs
@@ -85,7 +85,8 @@ fn build_message(query: Query, options: DnsRequestOptions) -> Message {
             .extensions_mut()
             .get_or_insert_with(Edns::new)
             .set_max_payload(MAX_PAYLOAD_LEN)
-            .set_version(0);
+            .set_version(0)
+            .set_dnssec_ok(options.edns_set_dnssec_ok);
     }
     message
 }

--- a/crates/proto/src/xfer/dns_request.rs
+++ b/crates/proto/src/xfer/dns_request.rs
@@ -25,6 +25,8 @@ pub struct DnsRequestOptions {
     // TODO: add EDNS options here?
     /// When true, will add EDNS options to the request.
     pub use_edns: bool,
+    /// When true, sets the DO bit in the EDNS options
+    pub edns_set_dnssec_ok: bool,
     /// Specifies maximum request depth for DNSSEC validation.
     pub max_request_depth: usize,
     /// set recursion desired (or not) for any requests
@@ -38,6 +40,7 @@ impl Default for DnsRequestOptions {
             max_request_depth: 26,
             expects_multiple_responses: false,
             use_edns: false,
+            edns_set_dnssec_ok: false,
             recursion_desired: true,
         }
     }

--- a/crates/recursor/src/lib.rs
+++ b/crates/recursor/src/lib.rs
@@ -35,3 +35,7 @@ pub use hickory_proto as proto;
 pub use hickory_resolver as resolver;
 pub use hickory_resolver::config::NameServerConfig;
 pub use recursor::Recursor;
+
+fn is_security_aware() -> bool {
+    cfg!(feature = "dnssec")
+}

--- a/crates/recursor/src/lib.rs
+++ b/crates/recursor/src/lib.rs
@@ -34,7 +34,7 @@ pub use error::{Error, ErrorKind};
 pub use hickory_proto as proto;
 pub use hickory_resolver as resolver;
 pub use hickory_resolver::config::NameServerConfig;
-pub use recursor::Recursor;
+pub use recursor::{Recursor, RecursorBuilder};
 
 fn is_security_aware() -> bool {
     cfg!(feature = "dnssec")

--- a/crates/recursor/src/recursor_pool.rs
+++ b/crates/recursor/src/recursor_pool.rs
@@ -90,8 +90,8 @@ where
                 info!("querying {} for {}", self.zone, query_cpy);
 
                 let mut options = DnsRequestOptions::default();
-                options.use_edns = false; // TODO: this should be configurable
-                options.recursion_desired = false;
+                options.use_edns = crate::is_security_aware();
+                options.edns_set_dnssec_ok = crate::is_security_aware();
 
                 // convert the lookup into a shared future
                 let lookup = ns

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -48,7 +48,7 @@ dnssec-ring = [
     "hickory-proto/dnssec-ring",
     "hickory-resolver/dnssec-ring",
 ]
-dnssec = []
+dnssec = ["hickory-recursor?/dnssec"]
 # Recursive Resolution is Experimental!
 recursor = ["hickory-recursor"]
 resolver = ["hickory-resolver"]

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -73,7 +73,10 @@ impl RecursiveAuthority {
             });
         }
 
-        let recursor = Recursor::new(roots, config.ns_cache_size, config.record_cache_size)
+        let recursor = Recursor::new()
+            .ns_cache_size(config.ns_cache_size)
+            .record_cache_size(config.record_cache_size)
+            .build(roots)
             .map_err(|e| format!("failed to initialize recursor: {e}"))?;
 
         Ok(Self {

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -73,9 +73,13 @@ impl RecursiveAuthority {
             });
         }
 
-        let recursor = Recursor::new()
+        let mut recursor = Recursor::new();
+        recursor
             .ns_cache_size(config.ns_cache_size)
-            .record_cache_size(config.record_cache_size)
+            .record_cache_size(config.record_cache_size);
+        #[cfg(feature = "dnssec")]
+        recursor.security_aware(config.security_aware);
+        let recursor = recursor
             .build(roots)
             .map_err(|e| format!("failed to initialize recursor: {e}"))?;
 

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -115,15 +115,15 @@ impl Authority for RecursiveAuthority {
         &self,
         name: &LowerName,
         rtype: RecordType,
-        _lookup_options: LookupOptions,
+        lookup_options: LookupOptions,
     ) -> Result<Self::Lookup, LookupError> {
-        debug!("recursive lookup: {} {}", name, rtype);
+        debug!("recursive lookup: {} {} {:?}", name, rtype, lookup_options);
 
         let query = Query::query(name.into(), rtype);
         let now = Instant::now();
 
         self.recursor
-            .resolve(query, now)
+            .resolve(query, now, lookup_options.is_dnssec())
             .await
             .map(RecursiveLookup)
             .map_err(Into::into)

--- a/crates/server/src/store/recursor/config.rs
+++ b/crates/server/src/store/recursor/config.rs
@@ -24,6 +24,7 @@ use crate::resolver::Name;
 
 /// Configuration for file based zones
 #[derive(Clone, Deserialize, Eq, PartialEq, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct RecursiveConfig {
     /// File with roots, aka hints
     pub roots: PathBuf,
@@ -35,6 +36,11 @@ pub struct RecursiveConfig {
     /// Maximum DNS record cache size
     #[serde(default = "record_cache_size_default")]
     pub record_cache_size: usize,
+
+    /// Whether the recursor is security-aware (RFC4035 section 3.2)
+    #[cfg(feature = "dnssec")]
+    #[serde(default)]
+    pub security_aware: bool,
 }
 
 impl RecursiveConfig {

--- a/util/src/bin/recurse.rs
+++ b/util/src/bin/recurse.rs
@@ -157,7 +157,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let name = opts.domainname;
     let ty = opts.ty;
 
-    let recursor = Recursor::new(roots, 1024, 1048576)?;
+    let recursor = Recursor::new().build(roots)?;
 
     // execute query
     println!(

--- a/util/src/bin/recurse.rs
+++ b/util/src/bin/recurse.rs
@@ -168,7 +168,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let now = Instant::now();
     let query = Query::query(name, ty);
-    let lookup = recursor.resolve(query, now).await?;
+    let lookup = recursor.resolve(query, now, false).await?;
 
     // report response, TODO: better display of errors
     println!(


### PR DESCRIPTION
At the moment this implements the first half of [RFC 4035, section 3.2.1](https://datatracker.ietf.org/doc/html/rfc4035#section-3.2.1): the DO bit is set in the queries the recursive resolver sends on behalf of the client. On the wire, I can see that the name servers it communicates with include extra DNSSEC records in their response to the resolver. However, the `Recursor` removes those extra DNSSEC records before answering the client. That stripping of DNSSEC records does the opposite of the second half of what the RFC dictates (when the DO bit is set).

AFAICT, the stripping of those DNSSEC records happens [here](https://github.com/hickory-dns/hickory-dns/blob/6334a01430088ead8642cafaee592ec7bf49831f/crates/recursor/src/recursor.rs#L324). That function caches all the received records but only responds with the ones that *exactly* match the query and as DNSSEC records like RRSIG were not included in the original query it discards them.

I still have to figure out how to best avoid stripping so I'm leaving this as a draft PR for now.

P.S. I'm checking conformance with the tests in https://github.com/ferrous-systems/dnssec-tests/pull/53

cc #2193 