### PR TITLE
recursor: send DS queries to the parent zone

### DIFF
--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -318,7 +318,8 @@ impl Recursor {
 
         // not in cache, let's look for an ns record for lookup
         let zone = match query.query_type() {
-            RecordType::NS => query.name().base_name(),
+            // (RFC4035 section 3.1.4.1) the DS record needs to be queried in the parent zone
+            RecordType::NS | RecordType::DS => query.name().base_name(),
             // look for the NS records "inside" the zone
             _ => query.name().clone(),
         };


### PR DESCRIPTION
the DS records have to be signed by the parent so they are stored in the parent zone. therefore, the resolver needs to send the query to the parent zone.

this fixes the conformance tests added in https://github.com/ferrous-systems/dnssec-tests/pull/54

with this change, `delv` works with `hickory-dns`:

``` console
$ delv -p 1053 @127.0.0.1 +rtrace www.example.com.
;; fetch: www.example.com/A
;; fetch: example.com/DNSKEY
;; fetch: example.com/DS
;; fetch: com/DNSKEY
;; fetch: com/DS
;; fetch: ./DNSKEY
; fully validated
``` 

this PR builds on top of #2196 so I'm going to leave in draft state until that one is merged