### PR TITLE
`DnssecDnsHandle`: check RRSIG validity as per RFC4035

### DIFF
--- a/crates/proto/src/rr/resource.rs
+++ b/crates/proto/src/rr/resource.rs
@@ -114,6 +114,14 @@ impl Record {
             proof: Proof::default(),
         }
     }
+
+    /// Tries the borrow this record as the specific record type, T
+    pub fn try_borrow<T>(&self) -> Option<RecordRef<'_, T>>
+    where
+        T: RecordData,
+    {
+        RecordRef::try_from(self).ok()
+    }
 }
 
 impl<R: RecordData> Record<R> {
@@ -713,6 +721,14 @@ pub struct RecordRef<'a, R: RecordData> {
     #[cfg(feature = "dnssec")]
     proof: Proof,
 }
+
+impl<'a, R: RecordData> Clone for RecordRef<'a, R> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, R: RecordData> Copy for RecordRef<'a, R> {}
 
 impl<'a, R: RecordData> RecordRef<'a, R> {
     /// Allocates space for a Record with the same fields

--- a/crates/server/tests/authority_battery/dnssec.rs
+++ b/crates/server/tests/authority_battery/dnssec.rs
@@ -205,9 +205,8 @@ pub fn test_nsec_nodata<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &
     let nsecs: Vec<&Record> = nsec_records.iter().collect();
 
     let query = Query::query(name, RecordType::TXT);
-    let query = Arc::new(query);
     assert!(xfer::dnssec_dns_handle::verify_nsec(
-        query,
+        &query,
         &Name::from_str("example.com.").unwrap(),
         &nsecs
     )
@@ -239,9 +238,8 @@ pub fn test_nsec_nxdomain_start<A: Authority<Lookup = AuthLookup>>(authority: A,
     let nsecs: Vec<&Record> = nsec_records.iter().collect();
 
     let query = Query::query(name, RecordType::A);
-    let query = Arc::new(query);
     assert!(xfer::dnssec_dns_handle::verify_nsec(
-        query,
+        &query,
         &Name::from_str("example.com.").unwrap(),
         &nsecs
     )
@@ -272,9 +270,8 @@ pub fn test_nsec_nxdomain_middle<A: Authority<Lookup = AuthLookup>>(authority: A
     let nsecs: Vec<&Record> = nsec_records.iter().collect();
 
     let query = Query::query(name, RecordType::A);
-    let query = Arc::new(query);
     assert!(xfer::dnssec_dns_handle::verify_nsec(
-        query,
+        &query,
         &Name::from_str("example.com.").unwrap(),
         &nsecs
     )
@@ -308,9 +305,8 @@ pub fn test_nsec_nxdomain_wraps_end<A: Authority<Lookup = AuthLookup>>(
     let nsecs: Vec<&Record> = nsec_records.iter().collect();
 
     let query = Query::query(name, RecordType::A);
-    let query = Arc::new(query);
     assert!(xfer::dnssec_dns_handle::verify_nsec(
-        query,
+        &query,
         &Name::from_str("example.com.").unwrap(),
         &nsecs
     )


### PR DESCRIPTION
this PR adds the validity checks specified in section 5.3.1 of RFC4035, including the time check that was reported as missing in issue #2209 

these new checks overlap with some of the existing ones but I opted for not removing the existing ones because I do not know how well the existing code is covered by tests.

I checked that I did not break this query:
``` rust
let config = ResolverConfig::default();
let mut opts = ResolverOpts::default();
opts.validate = true;

let resolver = Resolver::new(config, opts)?;

let lookup = resolver.lookup("example.com.", RecordType::A)?;
lookup.record_iter().for_each(|record| {
    assert_eq!(Proof::Secure, record.proof());
});
```

It would be good to check that expired signatures are rejected. There are plans to add those kind of tests to the conformance test suite (https://github.com/ferrous-systems/dnssec-tests/issues/61) but given that `Recursor` does not use `DnssecDnsHandle` those tests won't exercise the code paths added here. I'm looking into reusing some of the existing code in `DnssecDnsHandle` to implement DNSSEC validation in `Recursor` (then conformance tests will cover some of `DnssecDnsHandle` code) but that's still ways off time-wise.

Another way to check the code here end to end would be to modify `util/src/bin/resolve.rs` to do DNSSEC validation (e.g. via a new CLI flag) then it would behave just like `delv`. That updated `resolve` could be comparatively against `delv` using the `dns-test` framework, that is without relying on external services / the internet.

I'm leaving this in draft state because the implementation will be cleaner when #2211 is implemented.