### PR TITLE
Retry tcp on udp io errors

### DIFF
--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -381,6 +381,12 @@ impl ProtoError {
         matches!(*self.kind, ProtoErrorKind::NoConnections)
     }
 
+    /// Returns true if this is a std::io::Error
+    #[inline]
+    pub fn is_io(&self) -> bool {
+        matches!(*self.kind, ProtoErrorKind::Io(..))
+    }
+
     pub(crate) fn as_dyn(&self) -> &(dyn std::error::Error + 'static) {
         self
     }

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -264,7 +264,7 @@ where
                         debug!("truncated response received, retrying over TCP");
                         Ok(response)
                     }
-                    Err(e) if opts.try_tcp_on_error || e.is_no_connections() => {
+                    Err(e) if opts.try_tcp_on_error || e.is_no_connections() || e.is_io() => {
                         debug!("error from UDP, retrying over TCP: {}", e);
                         Err(e)
                     }


### PR DESCRIPTION
fixes: #2197
closes: #2204

@djc, I took a slightly different and simpler tack with this. It will retry TCP on any IO error, which feels correct to me.