### PR TITLE
⌛ Lower the default timeout for dns resolves

### DIFF
--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -991,7 +991,7 @@ impl Default for ResolverOpts {
     fn default() -> Self {
         Self {
             ndots: 1,
-            timeout: Duration::from_secs(5),
+            timeout: Duration::from_millis(100),
             attempts: 2,
             rotate: false,
             check_names: true,


### PR DESCRIPTION
Partially addresses #2225 

I think it would be good to have more control over this ultimately, specifically in the `from_system_conf` case, but for now this addresses my needs at least.