### PR TITLE
refactor the `Resource` data structure

### DIFF
--- a/bin/tests/named_tests.rs
+++ b/bin/tests/named_tests.rs
@@ -311,7 +311,7 @@ fn test_forward() {
         )
         .unwrap();
         assert_eq!(
-            *response.answers()[0].data().and_then(RData::as_a).unwrap(),
+            *response.answers()[0].data().as_a().unwrap(),
             A::new(93, 184, 215, 14)
         );
 
@@ -334,7 +334,7 @@ fn test_forward() {
         )
         .unwrap();
         assert_eq!(
-            *response.answers()[0].data().and_then(RData::as_a).unwrap(),
+            *response.answers()[0].data().as_a().unwrap(),
             A::new(93, 184, 215, 14)
         );
         assert!(!response.header().authoritative());

--- a/bin/tests/server_harness/mod.rs
+++ b/bin/tests/server_harness/mod.rs
@@ -248,7 +248,7 @@ pub fn query_a<C: ClientHandle>(io_loop: &mut Runtime, client: &mut C) {
     let response = query_message(io_loop, client, name, RecordType::A).unwrap();
     let record = &response.answers()[0];
 
-    if let Some(RData::A(ref address)) = record.data() {
+    if let RData::A(ref address) = record.data() {
         assert_eq!(address, &A::new(127, 0, 0, 1))
     } else {
         panic!("wrong RDATA")
@@ -296,7 +296,7 @@ pub fn query_all_dnssec(
     let dnskey = response
         .answers()
         .iter()
-        .filter_map(Record::data)
+        .map(Record::data)
         .filter_map(DNSKEY::try_borrow)
         .find(|d| d.algorithm() == algorithm);
     assert!(dnskey.is_some(), "DNSKEY not found");
@@ -306,7 +306,7 @@ pub fn query_all_dnssec(
     let rrsig = response
         .answers()
         .iter()
-        .filter_map(Record::data)
+        .map(Record::data)
         .filter_map(RRSIG::try_borrow)
         .filter(|rrsig| rrsig.algorithm() == algorithm)
         .find(|rrsig| rrsig.type_covered() == RecordType::DNSKEY);

--- a/crates/client/src/client/async_client.rs
+++ b/crates/client/src/client/async_client.rs
@@ -34,7 +34,7 @@ use crate::{
         },
         TokioTime,
     },
-    rr::{rdata::SOA, DNSClass, Name, RData, Record, RecordSet, RecordType},
+    rr::{rdata::SOA, DNSClass, Name, Record, RecordSet, RecordType},
 };
 
 /// A DNS Client implemented over futures-rs.
@@ -709,7 +709,7 @@ impl<R> ClientStreamXfrState<R> {
     fn process(&mut self, answers: &[Record]) -> Result<(), ClientError> {
         use ClientStreamXfrState::*;
         fn get_serial(r: &Record) -> Option<u32> {
-            r.data().and_then(RData::as_soa).map(SOA::serial)
+            r.data().as_soa().map(SOA::serial)
         }
 
         if answers.is_empty() {
@@ -864,6 +864,7 @@ mod tests {
 
     use crate::rr::rdata::{A, SOA};
     use futures_util::stream::iter;
+    use hickory_proto::rr::RData;
     use ClientStreamXfrState::*;
 
     fn soa_record(serial: u32) -> Record {
@@ -1116,7 +1117,7 @@ mod tests {
         let (message_returned, buffer) = query.await.unwrap().into_parts();
 
         // validate it's what we expected
-        if let Some(RData::A(addr)) = message_returned.answers()[0].data() {
+        if let RData::A(addr) = message_returned.answers()[0].data() {
             assert_eq!(*addr, A::new(93, 184, 215, 14));
         }
 
@@ -1124,7 +1125,7 @@ mod tests {
             .expect("buffer was parsed already by AsyncClient so we should be able to do it again");
 
         // validate it's what we expected
-        if let Some(RData::A(addr)) = message_parsed.answers()[0].data() {
+        if let RData::A(addr) = message_parsed.answers()[0].data() {
             assert_eq!(*addr, A::new(93, 184, 215, 14));
         }
     }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -128,7 +128,7 @@
 //! // Records are generic objects which can contain any data.
 //! //  In order to access it we need to first check what type of record it is
 //! //  In this case we are interested in A, IPv4 address
-//! if let Some(RData::A(ref ip)) = answers[0].data() {
+//! if let RData::A(ref ip) = answers[0].data() {
 //!     assert_eq!(*ip, A::new(93, 184, 215, 14))
 //! } else {
 //!     assert!(false, "unexpected result")
@@ -263,7 +263,7 @@
 //!     let response = query.await.unwrap();
 //!
 //!     // validate it's what we expected
-//!     if let Some(RData::A(addr)) = response.answers()[0].data() {
+//!     if let RData::A(addr) = response.answers()[0].data() {
 //!         assert_eq!(*addr, A::new(93, 184, 215, 14));
 //!     }
 //! }

--- a/crates/proto/src/h2/h2_client_stream.rs
+++ b/crates/proto/src/h2/h2_client_stream.rs
@@ -540,7 +540,7 @@ mod tests {
     use crate::iocompat::AsyncIoTokioAsStd;
     use crate::op::{Message, Query, ResponseCode};
     use crate::rr::rdata::{A, AAAA};
-    use crate::rr::{Name, RData, RecordType};
+    use crate::rr::{Name, RecordType};
     use crate::xfer::{DnsRequestOptions, FirstAnswer};
 
     use super::*;
@@ -572,10 +572,7 @@ mod tests {
             .expect("send_message failed");
 
         let record = &response.answers()[0];
-        let addr = record
-            .data()
-            .and_then(RData::as_a)
-            .expect("Expected A record");
+        let addr = record.data().as_a().expect("Expected A record");
 
         assert_eq!(addr, &A::new(93, 184, 215, 14));
 
@@ -600,7 +597,7 @@ mod tests {
             let record = &response.answers()[0];
             let addr = record
                 .data()
-                .and_then(RData::as_aaaa)
+                .as_aaaa()
                 .expect("invalid response, expected A record");
 
             assert_eq!(
@@ -637,10 +634,7 @@ mod tests {
             .expect("send_message failed");
 
         let record = &response.answers()[0];
-        let addr = record
-            .data()
-            .and_then(RData::as_a)
-            .expect("Expected A record");
+        let addr = record.data().as_a().expect("Expected A record");
 
         assert_eq!(addr, &A::new(93, 184, 215, 14));
 
@@ -665,7 +659,7 @@ mod tests {
             let record = &response.answers()[0];
             let addr = record
                 .data()
-                .and_then(RData::as_aaaa)
+                .as_aaaa()
                 .expect("invalid response, expected A record");
 
             assert_eq!(
@@ -705,7 +699,7 @@ mod tests {
         let record = &response.answers()[0];
         let addr = record
             .data()
-            .and_then(RData::as_a)
+            .as_a()
             .expect("invalid response, expected A record");
 
         assert_eq!(addr, &A::new(93, 184, 215, 14));
@@ -727,7 +721,7 @@ mod tests {
         let record = &response.answers()[0];
         let addr = record
             .data()
-            .and_then(RData::as_aaaa)
+            .as_aaaa()
             .expect("invalid response, expected A record");
 
         assert_eq!(

--- a/crates/proto/src/h3/h3_client_stream.rs
+++ b/crates/proto/src/h3/h3_client_stream.rs
@@ -475,7 +475,7 @@ mod tests {
 
     use crate::op::{Message, Query, ResponseCode};
     use crate::rr::rdata::{A, AAAA};
-    use crate::rr::{Name, RData, RecordType};
+    use crate::rr::{Name, RecordType};
     use crate::xfer::{DnsRequestOptions, FirstAnswer};
 
     use super::*;
@@ -507,10 +507,7 @@ mod tests {
             .expect("send_message failed");
 
         let record = &response.answers()[0];
-        let addr = record
-            .data()
-            .and_then(RData::as_a)
-            .expect("Expected A record");
+        let addr = record.data().as_a().expect("Expected A record");
 
         assert_eq!(addr, &A::new(93, 184, 215, 14));
 
@@ -535,7 +532,7 @@ mod tests {
             let record = &response.answers()[0];
             let addr = record
                 .data()
-                .and_then(RData::as_aaaa)
+                .as_aaaa()
                 .expect("invalid response, expected A record");
 
             assert_eq!(
@@ -572,10 +569,7 @@ mod tests {
             .expect("send_message failed");
 
         let record = &response.answers()[0];
-        let addr = record
-            .data()
-            .and_then(RData::as_a)
-            .expect("Expected A record");
+        let addr = record.data().as_a().expect("Expected A record");
 
         assert_eq!(addr, &A::new(93, 184, 215, 14));
 
@@ -600,7 +594,7 @@ mod tests {
             let record = &response.answers()[0];
             let addr = record
                 .data()
-                .and_then(RData::as_aaaa)
+                .as_aaaa()
                 .expect("invalid response, expected A record");
 
             assert_eq!(
@@ -641,7 +635,7 @@ mod tests {
         let record = &response.answers()[0];
         let addr = record
             .data()
-            .and_then(RData::as_a)
+            .as_a()
             .expect("invalid response, expected A record");
 
         assert_eq!(addr, &A::new(93, 184, 215, 14));
@@ -663,7 +657,7 @@ mod tests {
         let record = &response.answers()[0];
         let addr = record
             .data()
-            .and_then(RData::as_aaaa)
+            .as_aaaa()
             .expect("invalid response, expected A record");
 
         assert_eq!(

--- a/crates/proto/src/op/edns.rs
+++ b/crates/proto/src/op/edns.rs
@@ -156,11 +156,11 @@ impl<'a> From<&'a Record> for Edns {
         let max_payload: u16 = u16::from(value.dns_class());
 
         let options: OPT = match value.data() {
-            Some(RData::NULL(..)) | None => {
+            RData::Update0(..) | RData::NULL(..) => {
                 // NULL, there was no data in the OPT
                 OPT::default()
             }
-            Some(RData::OPT(ref option_data)) => {
+            RData::OPT(ref option_data) => {
                 option_data.clone() // TODO: Edns should just refer to this, have the same lifetime as the Record
             }
             _ => {
@@ -183,24 +183,18 @@ impl<'a> From<&'a Edns> for Record {
     /// This returns a Resource Record that is formatted for Edns(0).
     /// Note: the rcode_high value is only part of the rcode, the rest is part of the base
     fn from(value: &'a Edns) -> Self {
-        let mut record = Self::new();
-
-        record.set_name(Name::root());
-        record.set_record_type(RecordType::OPT);
-        record.set_dns_class(DNSClass::for_opt(value.max_payload()));
-
         // rebuild the TTL field
         let mut ttl: u32 = u32::from(value.rcode_high()) << 24;
         ttl |= u32::from(value.version()) << 16;
         ttl |= u32::from(value.flags);
 
-        record.set_ttl(ttl);
-
         // now for each option, write out the option array
         //  also, since this is a hash, there is no guarantee that ordering will be preserved from
         //  the original binary format.
         // maybe switch to: https://crates.io/crates/linked-hash-map/
-        record.set_data(Some(RData::OPT(value.options().clone())));
+        let mut record = Self::from_rdata(Name::root(), ttl, RData::OPT(value.options().clone()));
+
+        record.set_dns_class(DNSClass::for_opt(value.max_payload()));
 
         record
     }

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -1191,9 +1191,9 @@ mod tests {
             .set_checking_disabled(true)
             .set_response_code(ResponseCode::ServFail);
 
-        message.add_answer(Record::new());
-        message.add_name_server(Record::new());
-        message.add_additional(Record::new());
+        message.add_answer(Record::stub());
+        message.add_name_server(Record::stub());
+        message.add_additional(Record::stub());
         message.update_counts();
 
         test_emit_and_read(message);
@@ -1229,9 +1229,9 @@ mod tests {
             .set_checking_disabled(true)
             .set_response_code(ResponseCode::ServFail);
 
-        message.add_answer(Record::new());
-        message.add_name_server(Record::new());
-        message.add_additional(Record::new());
+        message.add_answer(Record::stub());
+        message.add_name_server(Record::stub());
+        message.add_additional(Record::stub());
 
         // at here, we don't call update_counts and we even set wrong count,
         // because we are trying to test whether the counts in the header

--- a/crates/proto/src/rr/dnssec/signer.rs
+++ b/crates/proto/src/rr/dnssec/signer.rs
@@ -530,23 +530,15 @@ impl MessageFinalizer for SigSigner {
 
         // this is based on RFCs 2535, 2931 and 3007
 
-        // 'For all SIG(0) RRs, the owner name, class, TTL, and original TTL, are
-        //  meaningless.' - 2931
-        let mut sig0 = Record::new();
-
-        // The TTL fields SHOULD be zero
-        sig0.set_ttl(0);
-
-        // The CLASS field SHOULD be ANY
-        sig0.set_dns_class(DNSClass::ANY);
-
         // The owner name SHOULD be root (a single zero octet).
-        sig0.set_name(Name::root());
-        let num_labels = sig0.name().num_labels();
+        let name = Name::root();
+        // The TTL fields SHOULD be zero
+        let ttl = 0;
+
+        let num_labels = name.num_labels();
 
         let expiration_time: u32 = current_time + (5 * 60); // +5 minutes in seconds
 
-        sig0.set_record_type(RecordType::SIG);
         let pre_sig0 = SIG::new(
             // type covered in SIG(0) is 0 which is what makes this SIG0 vs a standard SIG
             RecordType::ZERO,
@@ -565,9 +557,14 @@ impl MessageFinalizer for SigSigner {
             Vec::new(),
         );
         let signature: Vec<u8> = self.sign_message(message, &pre_sig0)?;
-        sig0.set_data(Some(RData::DNSSEC(DNSSECRData::SIG(
-            pre_sig0.set_sig(signature),
-        ))));
+        let rdata = RData::DNSSEC(DNSSECRData::SIG(pre_sig0.set_sig(signature)));
+
+        // 'For all SIG(0) RRs, the owner name, class, TTL, and original TTL, are
+        //  meaningless.' - 2931
+        let mut sig0 = Record::from_rdata(name, ttl, rdata);
+
+        // The CLASS field SHOULD be ANY
+        sig0.set_dns_class(DNSClass::ANY);
 
         Ok((vec![sig0], None))
     }
@@ -659,7 +656,7 @@ mod tests {
         let sig = signer.sign_message(&question, &pre_sig0);
         println!("sig after sign: {sig:?}");
 
-        if let Some(RData::DNSSEC(DNSSECRData::SIG(ref sig))) = question.sig0()[0].data() {
+        if let RData::DNSSEC(DNSSECRData::SIG(ref sig)) = question.sig0()[0].data() {
             assert!(sig0key.verify_message(&question, sig.sig(), sig).is_ok());
         }
     }
@@ -692,28 +689,20 @@ mod tests {
         );
 
         let rrset = vec![
-            Record::new()
-                .set_name(origin.clone())
-                .set_ttl(86400)
-                .set_record_type(RecordType::NS)
-                .set_dns_class(DNSClass::IN)
-                .set_data(Some(RData::NS(NS(Name::parse(
-                    "a.iana-servers.net.",
-                    None,
-                )
-                .unwrap()))))
-                .clone(),
-            Record::new()
-                .set_name(origin)
-                .set_ttl(86400)
-                .set_record_type(RecordType::NS)
-                .set_dns_class(DNSClass::IN)
-                .set_data(Some(RData::NS(NS(Name::parse(
-                    "b.iana-servers.net.",
-                    None,
-                )
-                .unwrap()))))
-                .clone(),
+            Record::from_rdata(
+                origin.clone(),
+                86400,
+                RData::NS(NS(Name::parse("a.iana-servers.net.", None).unwrap())),
+            )
+            .set_dns_class(DNSClass::IN)
+            .clone(),
+            Record::from_rdata(
+                origin,
+                86400,
+                RData::NS(NS(Name::parse("b.iana-servers.net.", None).unwrap())),
+            )
+            .set_dns_class(DNSClass::IN)
+            .clone(),
         ];
 
         let tbs = tbs::rrset_tbs_with_rrsig(&rrsig, &rrset).unwrap();
@@ -829,87 +818,61 @@ MC0CAQACBQC+L6pNAgMBAAECBQCYj0ZNAgMA9CsCAwDHZwICeEUCAnE/AgMA3u0=
                 ),
             );
             let rrset = vec![
-                Record::new()
-                    .set_name(origin.clone())
-                    .set_ttl(86400)
-                    .set_record_type(RecordType::NS)
-                    .set_dns_class(DNSClass::IN)
-                    .set_data(Some(RData::NS(NS(Name::parse(
-                        "a.iana-servers.net.",
-                        None,
-                    )
-                    .unwrap()))))
-                    .clone(),
-                Record::new()
-                    .set_name(origin.clone())
-                    .set_ttl(86400)
-                    .set_record_type(RecordType::NS)
-                    .set_dns_class(DNSClass::IN)
-                    .set_data(Some(RData::NS(NS(Name::parse(
-                        "b.iana-servers.net.",
-                        None,
-                    )
-                    .unwrap()))))
-                    .clone(),
+                Record::from_rdata(
+                    origin.clone(),
+                    86400,
+                    RData::NS(NS(Name::parse("a.iana-servers.net.", None).unwrap())),
+                )
+                .set_dns_class(DNSClass::IN)
+                .clone(),
+                Record::from_rdata(
+                    origin.clone(),
+                    86400,
+                    RData::NS(NS(Name::parse("b.iana-servers.net.", None).unwrap())),
+                )
+                .set_dns_class(DNSClass::IN)
+                .clone(),
             ];
 
             let tbs = rrset_tbs_with_rrsig(&rrsig, &rrset).unwrap();
             assert!(!tbs.as_ref().is_empty());
 
             let rrset = vec![
-                Record::new()
-                    .set_name(origin.clone())
-                    .set_ttl(86400)
-                    .set_record_type(RecordType::CNAME)
-                    .set_dns_class(DNSClass::IN)
-                    .set_data(Some(RData::CNAME(CNAME(
-                        Name::parse("a.iana-servers.net.", None).unwrap(),
-                    ))))
-                    .clone(), // different type
-                Record::new()
-                    .set_name(Name::parse("www.example.com.", None).unwrap())
-                    .set_ttl(86400)
-                    .set_record_type(RecordType::NS)
-                    .set_dns_class(DNSClass::IN)
-                    .set_data(Some(RData::NS(NS(Name::parse(
-                        "a.iana-servers.net.",
-                        None,
-                    )
-                    .unwrap()))))
-                    .clone(), // different name
-                Record::new()
-                    .set_name(origin.clone())
-                    .set_ttl(86400)
-                    .set_record_type(RecordType::NS)
-                    .set_dns_class(DNSClass::CH)
-                    .set_data(Some(RData::NS(NS(Name::parse(
-                        "a.iana-servers.net.",
-                        None,
-                    )
-                    .unwrap()))))
-                    .clone(), // different class
-                Record::new()
-                    .set_name(origin.clone())
-                    .set_ttl(86400)
-                    .set_record_type(RecordType::NS)
-                    .set_dns_class(DNSClass::IN)
-                    .set_data(Some(RData::NS(NS(Name::parse(
-                        "a.iana-servers.net.",
-                        None,
-                    )
-                    .unwrap()))))
-                    .clone(),
-                Record::new()
-                    .set_name(origin)
-                    .set_ttl(86400)
-                    .set_record_type(RecordType::NS)
-                    .set_dns_class(DNSClass::IN)
-                    .set_data(Some(RData::NS(NS(Name::parse(
-                        "b.iana-servers.net.",
-                        None,
-                    )
-                    .unwrap()))))
-                    .clone(),
+                Record::from_rdata(
+                    origin.clone(),
+                    86400,
+                    RData::CNAME(CNAME(Name::parse("a.iana-servers.net.", None).unwrap())),
+                )
+                .set_dns_class(DNSClass::IN)
+                .clone(), // different type
+                Record::from_rdata(
+                    Name::parse("www.example.com.", None).unwrap(),
+                    86400,
+                    RData::NS(NS(Name::parse("a.iana-servers.net.", None).unwrap())),
+                )
+                .set_dns_class(DNSClass::IN)
+                .clone(), // different name
+                Record::from_rdata(
+                    origin.clone(),
+                    86400,
+                    RData::NS(NS(Name::parse("a.iana-servers.net.", None).unwrap())),
+                )
+                .set_dns_class(DNSClass::CH)
+                .clone(), // different class
+                Record::from_rdata(
+                    origin.clone(),
+                    86400,
+                    RData::NS(NS(Name::parse("a.iana-servers.net.", None).unwrap())),
+                )
+                .set_dns_class(DNSClass::IN)
+                .clone(),
+                Record::from_rdata(
+                    origin,
+                    86400,
+                    RData::NS(NS(Name::parse("b.iana-servers.net.", None).unwrap())),
+                )
+                .set_dns_class(DNSClass::IN)
+                .clone(),
             ];
 
             let filtered_tbs = rrset_tbs_with_rrsig(&rrsig, &rrset).unwrap();

--- a/crates/proto/src/rr/dnssec/tbs.rs
+++ b/crates/proto/src/rr/dnssec/tbs.rs
@@ -170,9 +170,7 @@ pub fn rrset_tbs<B: Borrow<Record>>(
             {
                 let mut rdata_encoder = BinEncoder::new(&mut rdata_buf);
                 rdata_encoder.set_canonical_names(true);
-                if let Some(rdata) = record.data() {
-                    assert!(rdata.emit(&mut rdata_encoder).is_ok());
-                }
+                assert!(record.data().emit(&mut rdata_encoder).is_ok());
             }
             assert!(encoder.emit_u16(rdata_buf.len() as u16).is_ok());
             //
@@ -199,11 +197,7 @@ pub fn rrset_tbs_with_rrsig<B: Borrow<Record>>(
     rrsig: &Record<RRSIG>,
     records: &[B],
 ) -> ProtoResult<TBS> {
-    if let Some(sig) = rrsig.data() {
-        rrset_tbs_with_sig(rrsig.name(), rrsig.dns_class(), sig, records)
-    } else {
-        Err(format!("could not determine name from {}", rrsig.name()).into())
-    }
+    rrset_tbs_with_sig(rrsig.name(), rrsig.dns_class(), rrsig.data(), records)
 }
 
 /// Returns the to-be-signed serialization of the given record set using the information

--- a/crates/proto/src/rr/dnssec/tsig.rs
+++ b/crates/proto/src/rr/dnssec/tsig.rs
@@ -128,7 +128,7 @@ impl TSigner {
         first_message: bool,
     ) -> ProtoResult<(Vec<u8>, Range<u64>, u64)> {
         let (tbv, record) = signed_bitmessage_to_buf(previous_hash, message, first_message)?;
-        let tsig = if let Some(RData::DNSSEC(DNSSECRData::TSIG(tsig))) = record.data() {
+        let tsig = if let RData::DNSSEC(DNSSECRData::TSIG(tsig)) = record.data() {
             tsig
         } else {
             unreachable!("tsig::signed_message_to_buff always returns a TSIG record")

--- a/crates/proto/src/rr/mod.rs
+++ b/crates/proto/src/rr/mod.rs
@@ -57,6 +57,11 @@ pub trait RecordData: Clone + Sized + PartialEq + Eq + Display + Debug + BinEnco
 
     /// Converts this RecordData into generic RecordData
     fn into_rdata(self) -> RData;
+
+    /// RDLENGTH = 0
+    fn is_update(&self) -> bool {
+        false
+    }
 }
 
 trait RecordDataDecodable<'r>: Sized {

--- a/crates/proto/src/rr/rdata/update.rs
+++ b/crates/proto/src/rr/rdata/update.rs
@@ -1,0 +1,1 @@
+pub struct UpdateRdata(pub RecordType);

--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -691,6 +691,9 @@ pub enum RData {
         rdata: NULL,
     },
 
+    /// Update record with RDLENGTH = 0 (RFC2136)
+    Update0(RecordType),
+
     /// This corresponds to a record type of 0, unspecified
     #[deprecated(note = "Use None for the RData in the resource record instead")]
     ZERO,
@@ -735,6 +738,7 @@ impl RData {
             #[cfg(feature = "dnssec")]
             Self::DNSSEC(ref rdata) => DNSSECRData::to_record_type(rdata),
             Self::Unknown { code, .. } => code,
+            Self::Update0(record_type) => record_type,
             Self::ZERO => RecordType::ZERO,
         }
     }
@@ -975,6 +979,7 @@ impl BinEncodable for RData {
             #[cfg(feature = "dnssec")]
             Self::DNSSEC(ref rdata) => encoder.with_canonical_names(|encoder| rdata.emit(encoder)),
             Self::Unknown { ref rdata, .. } => rdata.emit(encoder),
+            Self::Update0(_) => Ok(()),
         }
     }
 }
@@ -994,6 +999,10 @@ impl RecordData for RData {
 
     fn into_rdata(self) -> RData {
         self
+    }
+
+    fn is_update(&self) -> bool {
+        matches!(self, RData::Update0(_))
     }
 }
 
@@ -1034,6 +1043,7 @@ impl fmt::Display for RData {
             #[cfg(feature = "dnssec")]
             Self::DNSSEC(ref rdata) => w(f, rdata),
             Self::Unknown { ref rdata, .. } => w(f, rdata),
+            Self::Update0(_) => w(f, "UPDATE"),
         }
     }
 }
@@ -1274,6 +1284,7 @@ mod tests {
             #[cfg(feature = "dnssec")]
             RData::DNSSEC(ref rdata) => rdata.to_record_type(),
             RData::Unknown { code, .. } => code,
+            RData::Update0(record_type) => record_type,
             RData::ZERO => RecordType::ZERO,
         }
     }

--- a/crates/proto/src/rr/resource.rs
+++ b/crates/proto/src/rr/resource.rs
@@ -75,25 +75,23 @@ const MDNS_ENABLE_CACHE_FLUSH: u16 = 1 << 15;
 // TODO: make Record carry a lifetime for more efficient storage options in the future
 pub struct Record<R: RecordData = RData> {
     name_labels: Name,
-    rr_type: RecordType,
     dns_class: DNSClass,
     ttl: u32,
-    rdata: Option<R>,
+    rdata: R,
     #[cfg(feature = "mdns")]
     mdns_cache_flush: bool,
     #[cfg(feature = "dnssec")]
     proof: Proof,
 }
 
-impl Default for Record<RData> {
-    fn default() -> Self {
+impl Record {
+    #[cfg(test)]
+    pub fn stub() -> Self {
         Self {
-            // TODO: make these part of a Builder instead to cleanup Records at runtime?
             name_labels: Name::new(),
-            rr_type: RecordType::NULL,
             dns_class: DNSClass::IN,
             ttl: 0,
-            rdata: None,
+            rdata: RData::Update0(RecordType::NULL),
             #[cfg(feature = "mdns")]
             mdns_cache_flush: false,
             #[cfg(feature = "dnssec")]
@@ -102,61 +100,19 @@ impl Default for Record<RData> {
     }
 }
 
-impl Record<RData> {
-    /// Creates a default record, use the setters to build a more useful object.
-    ///
-    /// There are no optional elements in this object, defaults are an empty name, type A, class IN,
-    /// ttl of 0 and the 0.0.0.0 ip address.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Create a record with the specified initial values.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - name of the resource records
-    /// * `rr_type` - the record type
-    /// * `ttl` - time-to-live is the amount of time this record should be cached before refreshing
-    // TODO: maybe deprecate in the future, there are valid use cases for null data...
-    // #[deprecated = "consider using the typed variant `from_rdata`"]
-    pub fn with(name: Name, rr_type: RecordType, ttl: u32) -> Self {
+impl Record {
+    /// Creates an update record with RDLENGTH=0
+    pub fn update0(name: Name, ttl: u32, rr_type: RecordType) -> Self {
         Self {
             name_labels: name,
-            rr_type,
             dns_class: DNSClass::IN,
             ttl,
-            rdata: None,
+            rdata: RData::Update0(rr_type),
             #[cfg(feature = "mdns")]
             mdns_cache_flush: false,
             #[cfg(feature = "dnssec")]
             proof: Proof::default(),
         }
-    }
-
-    /// ```text
-    /// TYPE            two octets containing one of the RR type codes.  This
-    ///                 field specifies the meaning of the data in the RDATA
-    ///                 field.
-    /// ```
-    #[deprecated(note = "use `set_record_type`")]
-    pub fn set_rr_type(&mut self, rr_type: RecordType) -> &mut Self {
-        self.rr_type = rr_type;
-        self
-    }
-
-    /// Generally Speaking, this is redundant to the RecordType stored in the associated RData and not recommended
-    ///   to set this separately. Exceptions to this are for Update Messages, where the RecordType is used distinctly
-    ///   as a means to express certain Update instructions. For queries and responses, it will always match the RData
-    ///
-    /// ```text
-    /// TYPE            two octets containing one of the RR type codes.  This
-    ///                 field specifies the meaning of the data in the RDATA
-    ///                 field.
-    /// ```
-    pub fn set_record_type(&mut self, rr_type: RecordType) -> &mut Self {
-        self.rr_type = rr_type;
-        self
     }
 }
 
@@ -171,10 +127,9 @@ impl<R: RecordData> Record<R> {
     pub fn from_rdata(name: Name, ttl: u32, rdata: R) -> Self {
         Self {
             name_labels: name,
-            rr_type: rdata.record_type(),
             dns_class: DNSClass::IN,
             ttl,
-            rdata: Some(rdata),
+            rdata,
             #[cfg(feature = "mdns")]
             mdns_cache_flush: false,
             #[cfg(feature = "dnssec")]
@@ -187,7 +142,6 @@ impl<R: RecordData> Record<R> {
     pub fn try_from(record: Record<RData>) -> Result<Self, Record<RData>> {
         let Record {
             name_labels,
-            rr_type,
             dns_class,
             ttl,
             rdata,
@@ -197,35 +151,22 @@ impl<R: RecordData> Record<R> {
             proof,
         } = record;
 
-        match rdata.map(R::try_from_rdata) {
-            None => Err(Record {
+        match R::try_from_rdata(rdata) {
+            Ok(rdata) => Ok(Self {
                 name_labels,
-                rr_type,
                 dns_class,
                 ttl,
-                rdata: None,
+                rdata,
                 #[cfg(feature = "mdns")]
                 mdns_cache_flush,
                 #[cfg(feature = "dnssec")]
                 proof,
             }),
-            Some(Ok(rdata)) => Ok(Self {
+            Err(rdata) => Err(Record {
                 name_labels,
-                rr_type: rdata.record_type(),
                 dns_class,
                 ttl,
-                rdata: Some(rdata),
-                #[cfg(feature = "mdns")]
-                mdns_cache_flush,
-                #[cfg(feature = "dnssec")]
-                proof,
-            }),
-            Some(Err(rdata)) => Err(Record {
-                name_labels,
-                rr_type,
-                dns_class,
-                ttl,
-                rdata: Some(rdata),
+                rdata,
                 #[cfg(feature = "mdns")]
                 mdns_cache_flush,
                 #[cfg(feature = "dnssec")]
@@ -238,7 +179,6 @@ impl<R: RecordData> Record<R> {
     pub fn into_record_of_rdata(self) -> Record<RData> {
         let Self {
             name_labels,
-            rr_type,
             dns_class,
             ttl,
             rdata,
@@ -248,11 +188,10 @@ impl<R: RecordData> Record<R> {
             proof,
         } = self;
 
-        let rdata: Option<RData> = rdata.map(RecordData::into_rdata);
+        let rdata: RData = RecordData::into_rdata(rdata);
 
         Record {
             name_labels,
-            rr_type,
             dns_class,
             ttl,
             rdata,
@@ -300,18 +239,7 @@ impl<R: RecordData> Record<R> {
     ///                 the RDATA field is a 4 octet ARPA Internet address.
     /// ```
     #[track_caller]
-    pub fn set_data(&mut self, rdata: Option<R>) -> &mut Self {
-        debug_assert!(
-            if let Some(rdata) = &rdata {
-                rdata.record_type() == self.rr_type || rdata.record_type() == RecordType::NULL
-            } else {
-                true
-            },
-            "record types do not match, {} <> {:?}",
-            self.rr_type,
-            rdata.map(|r| r.record_type())
-        );
-
+    pub fn set_data(&mut self, rdata: R) -> &mut Self {
         self.rdata = rdata;
         self
     }
@@ -342,7 +270,7 @@ impl<R: RecordData> Record<R> {
     /// Returns the type of the RecordData in the record
     #[inline]
     pub fn record_type(&self) -> RecordType {
-        self.rr_type
+        self.rdata.record_type()
     }
 
     /// Returns the DNSClass of the Record, generally IN fro internet
@@ -359,19 +287,19 @@ impl<R: RecordData> Record<R> {
 
     /// Returns the Record Data, i.e. the record information
     #[inline]
-    pub fn data(&self) -> Option<&R> {
-        self.rdata.as_ref()
+    pub fn data(&self) -> &R {
+        &self.rdata
     }
 
     /// Returns a mutable reference to the Record Data
     #[inline]
-    pub fn data_mut(&mut self) -> Option<&mut R> {
-        self.rdata.as_mut()
+    pub fn data_mut(&mut self) -> &mut R {
+        &mut self.rdata
     }
 
     /// Returns the RData consuming the Record
     #[inline]
-    pub fn into_data(self) -> Option<R> {
+    pub fn into_data(self) -> R {
         self.rdata
     }
 
@@ -405,14 +333,12 @@ impl<R: RecordData> Record<R> {
 pub struct RecordParts<R: RecordData = RData> {
     /// label names
     pub name_labels: Name,
-    /// record type
-    pub rr_type: RecordType,
     /// dns class
     pub dns_class: DNSClass,
     /// time to live
     pub ttl: u32,
     /// rdata
-    pub rdata: Option<R>,
+    pub rdata: R,
     /// mDNS cache flush
     #[cfg(feature = "mdns")]
     #[cfg_attr(docsrs, doc(cfg(feature = "mdns")))]
@@ -427,7 +353,6 @@ impl<R: RecordData> From<Record<R>> for RecordParts<R> {
     fn from(record: Record<R>) -> Self {
         let Record {
             name_labels,
-            rr_type,
             dns_class,
             ttl,
             rdata,
@@ -439,7 +364,6 @@ impl<R: RecordData> From<Record<R>> for RecordParts<R> {
 
         Self {
             name_labels,
-            rr_type,
             dns_class,
             ttl,
             rdata,
@@ -461,7 +385,7 @@ impl IntoRecordSet for Record {
 impl<R: RecordData> BinEncodable for Record<R> {
     fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
         self.name_labels.emit(encoder)?;
-        self.rr_type.emit(encoder)?;
+        self.record_type().emit(encoder)?;
 
         #[cfg(not(feature = "mdns"))]
         self.dns_class.emit(encoder)?;
@@ -483,8 +407,8 @@ impl<R: RecordData> BinEncodable for Record<R> {
         // write the RData
         //   the None case is handled below by writing `0` for the length of the RData
         //   this is in turn read as `None` during the `read` operation.
-        if let Some(rdata) = &self.rdata {
-            rdata.emit(encoder)?;
+        if !self.rdata.is_update() {
+            self.rdata.emit(encoder)?;
         }
 
         // get the length written
@@ -568,30 +492,18 @@ impl<'r> BinDecodable<'r> for Record<RData> {
         // this is to handle updates, RFC 2136, which uses 0 to indicate certain aspects of pre-requisites
         //   Null represents any data.
         let rdata = if rd_length == 0 {
-            None
+            RData::Update0(record_type)
         } else {
             // RDATA           a variable length string of octets that describes the
             //                resource.  The format of this information varies
             //                according to the TYPE and CLASS of the resource record.
             // Adding restrict to the rdata length because it's used for many calculations later
             //  and must be validated before hand
-            Some(RData::read(decoder, record_type, Restrict::new(rd_length))?)
+            RData::read(decoder, record_type, Restrict::new(rd_length))?
         };
-
-        debug_assert!(
-            if let Some(rdata) = &rdata {
-                rdata.record_type() == record_type
-            } else {
-                true
-            },
-            "record types do not match, {} <> {:?}",
-            record_type,
-            rdata.map(|r| r.record_type())
-        );
 
         Ok(Self {
             name_labels,
-            rr_type: record_type,
             dns_class: class,
             ttl,
             rdata,
@@ -649,16 +561,13 @@ impl<R: RecordData> fmt::Display for Record<R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,
-            "{name} {ttl} {class} {ty}",
+            "{name} {ttl} {class} {ty} {rdata}",
             name = self.name_labels,
             ttl = self.ttl,
             class = self.dns_class,
-            ty = self.rr_type,
+            ty = self.record_type(),
+            rdata = self.rdata,
         )?;
-
-        if let Some(rdata) = &self.rdata {
-            write!(f, " {rdata}")?;
-        }
 
         Ok(())
     }
@@ -679,7 +588,6 @@ impl<R: RecordData> PartialEq for Record<R> {
     fn eq(&self, other: &Self) -> bool {
         // self == other && // the same pointer
         self.name_labels == other.name_labels
-            && self.rr_type == other.rr_type
             && self.dns_class == other.dns_class
             && self.rdata == other.rdata
     }
@@ -732,7 +640,10 @@ impl Ord for Record {
         //  resource records be maintained in binary?
 
         compare_or_equal!(self, other, name_labels);
-        compare_or_equal!(self, other, rr_type);
+        match self.record_type().cmp(&other.record_type()) {
+            o @ Ordering::Less | o @ Ordering::Greater => return o,
+            Ordering::Equal => {}
+        }
         compare_or_equal!(self, other, dns_class);
         compare_or_equal!(self, other, ttl);
         compare_or_equal!(self, other, rdata);
@@ -794,10 +705,9 @@ impl<'a> From<&'a Record> for Proven<&'a Record> {
 /// A Record where the RecordData type is already known
 pub struct RecordRef<'a, R: RecordData> {
     name_labels: &'a Name,
-    rr_type: RecordType,
     dns_class: DNSClass,
     ttl: u32,
-    rdata: Option<&'a R>,
+    rdata: &'a R,
     #[cfg(feature = "mdns")]
     mdns_cache_flush: bool,
     #[cfg(feature = "dnssec")]
@@ -809,10 +719,9 @@ impl<'a, R: RecordData> RecordRef<'a, R> {
     pub fn to_owned(&self) -> Record<R> {
         Record {
             name_labels: self.name_labels.to_owned(),
-            rr_type: self.rr_type,
             dns_class: self.dns_class,
             ttl: self.ttl,
-            rdata: self.rdata.cloned(),
+            rdata: self.rdata.clone(),
             #[cfg(feature = "mdns")]
             mdns_cache_flush: self.mdns_cache_flush,
             #[cfg(feature = "dnssec")]
@@ -829,7 +738,7 @@ impl<'a, R: RecordData> RecordRef<'a, R> {
     /// Returns the type of the RecordData in the record
     #[inline]
     pub fn record_type(&self) -> RecordType {
-        self.rr_type
+        self.rdata.record_type()
     }
 
     /// Returns the DNSClass of the Record, generally IN fro internet
@@ -846,7 +755,7 @@ impl<'a, R: RecordData> RecordRef<'a, R> {
 
     /// Returns the Record Data, i.e. the record information
     #[inline]
-    pub fn data(&self) -> Option<&R> {
+    pub fn data(&self) -> &R {
         self.rdata
     }
 
@@ -874,7 +783,6 @@ impl<'a, R: RecordData> TryFrom<&'a Record> for RecordRef<'a, R> {
     fn try_from(record: &'a Record) -> Result<Self, Self::Error> {
         let Record {
             name_labels,
-            rr_type,
             dns_class,
             ttl,
             rdata,
@@ -884,24 +792,13 @@ impl<'a, R: RecordData> TryFrom<&'a Record> for RecordRef<'a, R> {
             proof,
         } = record;
 
-        match rdata.as_ref().and_then(R::try_borrow) {
-            None => Ok(Self {
-                name_labels,
-                rr_type: *rr_type,
-                dns_class: *dns_class,
-                ttl: *ttl,
-                rdata: None,
-                #[cfg(feature = "mdns")]
-                mdns_cache_flush: *mdns_cache_flush,
-                #[cfg(feature = "dnssec")]
-                proof: *proof,
-            }),
+        match R::try_borrow(rdata) {
+            None => Err(record),
             Some(rdata) => Ok(Self {
                 name_labels,
-                rr_type: *rr_type,
                 dns_class: *dns_class,
                 ttl: *ttl,
-                rdata: Some(rdata),
+                rdata,
                 #[cfg(feature = "mdns")]
                 mdns_cache_flush: *mdns_cache_flush,
                 #[cfg(feature = "dnssec")]
@@ -920,9 +817,8 @@ mod tests {
 
     use super::*;
     use crate::rr::dns_class::DNSClass;
-    use crate::rr::rdata::A;
+    use crate::rr::rdata::{A, AAAA};
     use crate::rr::record_data::RData;
-    use crate::rr::record_type::RecordType;
     use crate::rr::Name;
     #[allow(clippy::useless_attribute)]
     #[allow(unused)]
@@ -930,13 +826,11 @@ mod tests {
 
     #[test]
     fn test_emit_and_read() {
-        let mut record = Record::new();
-        record
-            .set_name(Name::from_str("www.example.com").unwrap())
-            .set_record_type(RecordType::A)
-            .set_dns_class(DNSClass::IN)
-            .set_ttl(5)
-            .set_data(Some(RData::A(A::new(192, 168, 0, 1))));
+        let record = Record::from_rdata(
+            Name::from_str("www.example.com").unwrap(),
+            5,
+            RData::A(A::new(192, 168, 0, 1)),
+        );
 
         let mut vec_bytes: Vec<u8> = Vec::with_capacity(512);
         {
@@ -953,25 +847,24 @@ mod tests {
 
     #[test]
     fn test_order() {
-        let mut record = Record::new();
-        record
-            .set_name(Name::from_str("www.example.com").unwrap())
-            .set_record_type(RecordType::A)
-            .set_dns_class(DNSClass::IN)
-            .set_ttl(5)
-            .set_data(Some(RData::A(A::new(192, 168, 0, 1))));
+        let mut record = Record::from_rdata(
+            Name::from_str("www.example.com").unwrap(),
+            5,
+            RData::A(A::new(192, 168, 0, 1)),
+        );
+        record.set_dns_class(DNSClass::IN);
 
         let mut greater_name = record.clone();
         greater_name.set_name(Name::from_str("zzz.example.com").unwrap());
 
         let mut greater_type = record.clone().into_record_of_rdata();
-        greater_type.set_record_type(RecordType::AAAA);
+        greater_type.set_data(RData::AAAA(AAAA::new(0, 0, 0, 0, 0, 0, 0, 0)));
 
         let mut greater_class = record.clone();
         greater_class.set_dns_class(DNSClass::NONE);
 
         let mut greater_rdata = record.clone();
-        greater_rdata.set_data(Some(RData::A(A::new(192, 168, 0, 255))));
+        greater_rdata.set_data(RData::A(A::new(192, 168, 0, 255)));
 
         let compares = vec![
             (&record, &greater_name),
@@ -993,7 +886,7 @@ mod tests {
         const RR_CLASS_OFFSET: usize = 1 /* empty name */ +
             std::mem::size_of::<u16>() /* rr_type */;
 
-        let mut record = Record::<RData>::new();
+        let mut record = Record::<RData>::stub();
         record.set_mdns_cache_flush(true);
 
         let mut vec_bytes: Vec<u8> = Vec::with_capacity(512);

--- a/crates/proto/src/serialize/txt/rdata_parsers/svcb.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/svcb.rs
@@ -377,12 +377,7 @@ mod tests {
             .expect("failed to parse record")
             .1;
         let record_set = records.into_iter().next().expect("no record found").1;
-        record_set
-            .into_iter()
-            .next()
-            .unwrap()
-            .data()
-            .and_then(D::try_borrow)
+        D::try_borrow(record_set.into_iter().next().unwrap().data())
             .expect("Not the correct record")
             .clone()
     }

--- a/crates/proto/src/serialize/txt/zone.rs
+++ b/crates/proto/src/serialize/txt/zone.rs
@@ -369,44 +369,41 @@ impl<'a> Parser<'a> {
         )?;
 
         // verify that we have everything we need for the record
-        let mut record = Record::new();
         // TODO COW or RC would reduce mem usage, perhaps Name should have an intern()...
         //  might want to wait until RC.weak() stabilizes, as that would be needed for global
         //  memory where you want
-        record.set_name(current_name.clone().ok_or_else(|| {
+        let name = current_name.clone().ok_or_else(|| {
             ParseError::from(ParseErrorKind::Message("record name not specified"))
-        })?);
-        record.set_record_type(rtype);
-        record.set_dns_class(class);
+        })?;
 
         // slightly annoying, need to grab the TTL, then move rdata into the record,
         //  then check the Type again and have custom add logic.
-        match rtype {
+        let set_ttl = match rtype {
             RecordType::SOA => {
                 // TTL for the SOA is set internally...
                 // expire is for the SOA, minimum is default for records
                 if let RData::SOA(ref soa) = rdata {
                     // TODO, this looks wrong, get_expire() should be get_minimum(), right?
-                    record.set_ttl(soa.expire() as u32); // the spec seems a little inaccurate with u32 and i32
+                    let set_ttl = soa.expire() as u32; // the spec seems a little inaccurate with u32 and i32
                     if ttl.is_none() {
                         *ttl = Some(soa.minimum());
                     } // TODO: should this only set it if it's not set?
+                    set_ttl
                 } else {
                     let msg = format!("Invalid RData here, expected SOA: {rdata:?}");
                     return ParseResult::Err(ParseError::from(ParseErrorKind::Msg(msg)));
                 }
             }
-            _ => {
-                record.set_ttl(ttl.ok_or_else(|| {
-                    ParseError::from(ParseErrorKind::Message("record ttl not specified"))
-                })?);
-            }
-        }
+            _ => ttl.ok_or_else(|| {
+                ParseError::from(ParseErrorKind::Message("record ttl not specified"))
+            })?,
+        };
 
         // TODO: validate record, e.g. the name of SRV record allows _ but others do not.
 
         // move the rdata into record...
-        record.set_data(Some(rdata));
+        let mut record = Record::from_rdata(name, set_ttl, rdata);
+        record.set_dns_class(class);
 
         // add to the map
         let key = RrKey::new(LowerName::new(record.name()), record.record_type());

--- a/crates/proto/src/tests/udp.rs
+++ b/crates/proto/src/tests/udp.rs
@@ -224,7 +224,7 @@ pub fn udp_client_stream_test<S: UdpSocket + Send + 'static, E: Executor>(
         println!("client got response {i}");
 
         let response = Message::from(response);
-        if let Some(RData::NULL(null)) = response.answers()[0].data() {
+        if let RData::NULL(null) = response.answers()[0].data() {
             assert_eq!(null.anything(), test_bytes);
         } else {
             panic!("not a NULL response");

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -548,13 +548,13 @@ mod test {
 
         let query = msg.clone();
         msg.set_message_type(MessageType::Response).add_answer(
-            Record::new()
-                .set_name(name)
-                .set_ttl(86400)
-                .set_record_type(RecordType::A)
-                .set_dns_class(DNSClass::IN)
-                .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 215, 14).into())))
-                .clone(),
+            Record::from_rdata(
+                name,
+                86400,
+                RData::A(Ipv4Addr::new(93, 184, 215, 14).into()),
+            )
+            .set_dns_class(DNSClass::IN)
+            .clone(),
         );
         (
             DnsRequest::new(query, DnsRequestOptions::default()),
@@ -580,12 +580,10 @@ mod test {
     fn axfr_response() -> Vec<Record> {
         use crate::rr::rdata::*;
         let origin = Name::from_ascii("example.com").unwrap();
-        let soa = Record::new()
-            .set_name(origin.clone())
-            .set_ttl(3600)
-            .set_record_type(RecordType::SOA)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::SOA(SOA::new(
+        let soa = Record::from_rdata(
+            origin.clone(),
+            3600,
+            RData::SOA(SOA::new(
                 Name::parse("sns.dns.icann.org.", None).unwrap(),
                 Name::parse("noc.dns.icann.org.", None).unwrap(),
                 2015082403,
@@ -593,52 +591,46 @@ mod test {
                 3600,
                 1209600,
                 3600,
-            ))))
-            .clone();
+            )),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone();
 
         vec![
             soa.clone(),
-            Record::new()
-                .set_name(origin.clone())
-                .set_ttl(86400)
-                .set_record_type(RecordType::NS)
-                .set_dns_class(DNSClass::IN)
-                .set_data(Some(RData::NS(NS(Name::parse(
-                    "a.iana-servers.net.",
-                    None,
-                )
-                .unwrap()))))
-                .clone(),
-            Record::new()
-                .set_name(origin.clone())
-                .set_ttl(86400)
-                .set_record_type(RecordType::NS)
-                .set_dns_class(DNSClass::IN)
-                .set_data(Some(RData::NS(NS(Name::parse(
-                    "b.iana-servers.net.",
-                    None,
-                )
-                .unwrap()))))
-                .clone(),
-            Record::new()
-                .set_name(origin.clone())
-                .set_ttl(86400)
-                .set_record_type(RecordType::A)
-                .set_dns_class(DNSClass::IN)
-                .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 215, 14).into())))
-                .clone(),
-            Record::new()
-                .set_name(origin)
-                .set_ttl(86400)
-                .set_record_type(RecordType::AAAA)
-                .set_dns_class(DNSClass::IN)
-                .set_data(Some(RData::AAAA(
+            Record::from_rdata(
+                origin.clone(),
+                86400,
+                RData::NS(NS(Name::parse("a.iana-servers.net.", None).unwrap())),
+            )
+            .set_dns_class(DNSClass::IN)
+            .clone(),
+            Record::from_rdata(
+                origin.clone(),
+                86400,
+                RData::NS(NS(Name::parse("b.iana-servers.net.", None).unwrap())),
+            )
+            .set_dns_class(DNSClass::IN)
+            .clone(),
+            Record::from_rdata(
+                origin.clone(),
+                86400,
+                RData::A(Ipv4Addr::new(93, 184, 215, 14).into()),
+            )
+            .set_dns_class(DNSClass::IN)
+            .clone(),
+            Record::from_rdata(
+                origin,
+                86400,
+                RData::AAAA(
                     Ipv6Addr::new(
                         0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c,
                     )
                     .into(),
-                )))
-                .clone(),
+                ),
+            )
+            .set_dns_class(DNSClass::IN)
+            .clone(),
             soa,
         ]
     }

--- a/crates/proto/src/xfer/dns_response.rs
+++ b/crates/proto/src/xfer/dns_response.rs
@@ -22,7 +22,7 @@ use futures_util::{ready, stream::Stream};
 use crate::{
     error::{ProtoError, ProtoErrorKind, ProtoResult},
     op::{Message, ResponseCode},
-    rr::{rdata::SOA, resource::RecordRef, RData, RecordType},
+    rr::{rdata::SOA, resource::RecordRef, RecordType},
 };
 
 /// A stream returning DNS responses
@@ -217,12 +217,7 @@ impl DnsResponse {
         // TODO: should this ensure that the SOA zone matches the Queried Zone?
         self.name_servers()
             .iter()
-            .filter_map(|record| {
-                record
-                    .data()
-                    .and_then(RData::as_soa)
-                    .map(|soa| (record.ttl(), soa))
-            })
+            .filter_map(|record| record.data().as_soa().map(|soa| (record.ttl(), soa)))
             .next()
             .map(|(ttl, soa)| (ttl).min(soa.minimum()))
     }

--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -476,7 +476,7 @@ impl Recursor {
 
         // unpack all glued records
         for zns in response.record_iter() {
-            if let Some(ns_data) = zns.data().and_then(RData::as_ns) {
+            if let Some(ns_data) = zns.data().as_ns() {
                 // let glue_ips = glue
                 //     .iter()
                 //     .filter(|g| g.name() == ns_data)

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -426,7 +426,7 @@ impl<P: ConnectionProvider> AsyncResolver<P> {
             self.client_cache.clone(),
             self.request_options(),
             hosts,
-            finally_ip_addr.and_then(Record::into_data),
+            finally_ip_addr.map(Record::into_data),
         )
         .await
     }

--- a/crates/resolver/src/caching_client.rs
+++ b/crates/resolver/src/caching_client.rs
@@ -345,7 +345,7 @@ where
                         (Cow::Borrowed(query.name()), INITIAL_TTL, false),
                         |(search_name, cname_ttl, was_cname), r| {
                             match r.data() {
-                                Some(RData::CNAME(CNAME(ref cname))) => {
+                                RData::CNAME(CNAME(ref cname)) => {
                                     // take the minimum TTL of the cname_ttl and the next record in the chain
                                     let ttl = cname_ttl.min(r.ttl());
                                     debug_assert_eq!(r.record_type(), RecordType::CNAME);
@@ -353,7 +353,7 @@ where
                                         return (Cow::Owned(cname.clone()), ttl, true);
                                     }
                                 }
-                                Some(RData::SRV(ref srv)) => {
+                                RData::SRV(ref srv) => {
                                     // take the minimum TTL of the cname_ttl and the next record in the chain
                                     let ttl = cname_ttl.min(r.ttl());
                                     debug_assert_eq!(r.record_type(), RecordType::SRV);

--- a/crates/resolver/src/lookup.rs
+++ b/crates/resolver/src/lookup.rs
@@ -147,7 +147,7 @@ impl<'a> Iterator for LookupIter<'a> {
     type Item = &'a RData;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().and_then(Record::data)
+        self.0.next().map(Record::data)
     }
 }
 
@@ -161,7 +161,7 @@ impl<'a> Iterator for DnssecIter<'a> {
     type Item = Proven<&'a RData>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().and_then(|r| r.map(Record::data).transpose())
+        self.0.next().map(|r| r.map(Record::data))
     }
 }
 
@@ -218,7 +218,7 @@ impl Iterator for LookupIntoIter {
     type Item = RData;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let rdata = self.records.get(self.index).and_then(Record::data);
+        let rdata = self.records.get(self.index).map(Record::data);
         self.index += 1;
         rdata.cloned()
     }
@@ -658,7 +658,6 @@ pub mod tests {
                 .unwrap()
                 .records()[0]
             )
-            .unwrap()
             .ip_addr()
             .unwrap(),
             Ipv4Addr::new(127, 0, 0, 1)
@@ -769,11 +768,11 @@ pub mod tests {
 
         assert_eq!(
             *lookup.next().unwrap().require(Proof::Secure).unwrap(),
-            *a1.data().unwrap()
+            *a1.data()
         );
         assert_eq!(
             *lookup.next().unwrap().require(Proof::Insecure).unwrap(),
-            *a2.data().unwrap()
+            *a2.data()
         );
         assert_eq!(lookup.next(), None);
     }

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -483,7 +483,6 @@ mod tests {
 
     use tokio::runtime::Runtime;
 
-    use hickory_proto::rr::RData;
     use proto::op::Query;
     use proto::rr::{Name, RecordType};
     use proto::xfer::{DnsHandle, DnsRequestOptions};
@@ -619,7 +618,7 @@ mod tests {
         assert_eq!(
             *response.answers()[0]
                 .data()
-                .and_then(RData::as_a)
+                .as_a()
                 .expect("no a record available"),
             Ipv4Addr::new(93, 184, 215, 14).into()
         );
@@ -643,7 +642,7 @@ mod tests {
         assert_eq!(
             *response.answers()[0]
                 .data()
-                .and_then(RData::as_aaaa)
+                .as_aaaa()
                 .expect("no aaaa record available"),
             Ipv6Addr::new(0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c).into()
         );

--- a/crates/server/src/authority/message_response.rs
+++ b/crates/server/src/authority/message_response.rs
@@ -257,7 +257,7 @@ mod tests {
     use std::str::FromStr;
 
     use crate::proto::op::{Header, Message};
-    use crate::proto::rr::{DNSClass, Name, RData, Record, RecordType};
+    use crate::proto::rr::{DNSClass, Name, RData, Record};
     use crate::proto::serialize::binary::BinEncoder;
 
     use super::*;
@@ -269,12 +269,13 @@ mod tests {
             let mut encoder = BinEncoder::new(&mut buf);
             encoder.set_max_size(512);
 
-            let answer = Record::new()
-                .set_record_type(RecordType::A)
-                .set_name(Name::from_str("www.example.com.").unwrap())
-                .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 215, 14).into())))
-                .set_dns_class(DNSClass::NONE)
-                .clone();
+            let answer = Record::from_rdata(
+                Name::from_str("www.example.com.").unwrap(),
+                0,
+                RData::A(Ipv4Addr::new(93, 184, 215, 14).into()),
+            )
+            .set_dns_class(DNSClass::NONE)
+            .clone();
 
             let message = MessageResponse {
                 header: Header::new(),
@@ -306,12 +307,13 @@ mod tests {
             let mut encoder = BinEncoder::new(&mut buf);
             encoder.set_max_size(512);
 
-            let answer = Record::new()
-                .set_record_type(RecordType::A)
-                .set_name(Name::from_str("www.example.com.").unwrap())
-                .set_data(Some(RData::A(Ipv4Addr::new(93, 184, 215, 14).into())))
-                .set_dns_class(DNSClass::NONE)
-                .clone();
+            let answer = Record::from_rdata(
+                Name::from_str("www.example.com.").unwrap(),
+                0,
+                RData::A(Ipv4Addr::new(93, 184, 215, 14).into()),
+            )
+            .set_dns_class(DNSClass::NONE)
+            .clone();
 
             let message = MessageResponse {
                 header: Header::new(),

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -277,7 +277,7 @@ mod tests {
             .expect("A record not found in authority")
             .data()
         {
-            Some(RData::A(ip)) => assert_eq!(A::new(127, 0, 0, 1), *ip),
+            RData::A(ip) => assert_eq!(A::new(127, 0, 0, 1), *ip),
             _ => panic!("wrong rdata type returned"),
         }
 
@@ -295,7 +295,7 @@ mod tests {
             .expect("A record not found in authority")
             .data()
         {
-            Some(RData::A(ip)) => assert_eq!(A::new(127, 0, 0, 5), *ip),
+            RData::A(ip) => assert_eq!(A::new(127, 0, 0, 5), *ip),
             _ => panic!("wrong rdata type returned"),
         }
     }

--- a/crates/server/src/store/recursor/config.rs
+++ b/crates/server/src/store/recursor/config.rs
@@ -65,7 +65,7 @@ impl RecursiveConfig {
         Ok(roots_zone
             .values()
             .flat_map(RecordSet::records_without_rrsigs)
-            .filter_map(Record::data)
+            .map(Record::data)
             .filter_map(RData::ip_addr) // we only want IPs
             .map(|ip| SocketAddr::from((ip, 53))) // all the roots only have tradition DNS ports
             .collect())

--- a/crates/server/tests/authority_battery/basic.rs
+++ b/crates/server/tests/authority_battery/basic.rs
@@ -37,7 +37,7 @@ pub fn test_a_lookup<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("A record not found in authority")
         .data()
-        .and_then(RData::as_a)
+        .as_a()
     {
         Some(ip) => assert_eq!(A4::new(127, 0, 0, 1), *ip),
         _ => panic!("wrong rdata type returned"),
@@ -54,7 +54,7 @@ pub fn test_soa<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .expect("SOA record not found in authority")
         .data()
     {
-        Some(RData::SOA(soa)) => {
+        RData::SOA(soa) => {
             assert_eq!(Name::from_str("hickory-dns.org.").unwrap(), *soa.mname());
             assert_eq!(
                 Name::from_str("root.hickory-dns.org.").unwrap(),
@@ -79,7 +79,7 @@ pub fn test_ns<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .expect("NS record not found in authority")
         .data()
     {
-        Some(RData::NS(name)) => assert_eq!(Name::from_str("bbb.example.com.").unwrap(), name.0),
+        RData::NS(name) => assert_eq!(Name::from_str("bbb.example.com.").unwrap(), name.0),
         _ => panic!("wrong rdata type returned"),
     }
 }
@@ -104,7 +104,7 @@ pub fn test_ns_lookup<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("NS record not found in authority")
         .data()
-        .and_then(RData::as_ns)
+        .as_ns()
         .expect("Not an NS record");
 
     assert_eq!(Name::from_str("bbb.example.com.").unwrap(), ns.0);
@@ -114,7 +114,7 @@ pub fn test_ns_lookup<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("A record not found")
         .data()
-        .and_then(RData::as_a)
+        .as_a()
         .expect("Not an A record");
     assert_eq!(A4::new(127, 0, 0, 2), *a);
 }
@@ -139,7 +139,7 @@ pub fn test_mx<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("MX record not found in authority")
         .data()
-        .and_then(RData::as_mx)
+        .as_mx()
         .expect("Not an MX record");
 
     assert_eq!(
@@ -154,7 +154,7 @@ pub fn test_mx<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("CNAME record not found")
         .data()
-        .and_then(RData::as_cname)
+        .as_cname()
         .expect("Not an CNAME record");
     assert_eq!(Name::from_str("www.example.com.").unwrap(), cname.0);
 
@@ -162,7 +162,7 @@ pub fn test_mx<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("A record not found")
         .data()
-        .and_then(RData::as_a)
+        .as_a()
         .expect("Not an A record");
     assert_eq!(A4::new(127, 0, 0, 1), *a);
 
@@ -170,7 +170,7 @@ pub fn test_mx<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("AAAA record not found")
         .data()
-        .and_then(RData::as_aaaa)
+        .as_aaaa()
         .expect("Not an AAAA record");
     assert_eq!(AAAA::new(0, 0, 0, 0, 0, 0, 0, 1), *aaaa);
 }
@@ -198,7 +198,7 @@ pub fn test_mx_to_null<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("MX record not found in authority")
         .data()
-        .and_then(RData::as_mx)
+        .as_mx()
         .expect("Not an MX record");
 
     assert_eq!(Name::from_str(".").unwrap(), *mx.exchange());
@@ -224,7 +224,7 @@ pub fn test_cname<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("CNAME record not found in authority")
         .data()
-        .and_then(RData::as_cname)
+        .as_cname()
         .expect("Not an A record");
 
     assert_eq!(Name::from_str("www.example.com.").unwrap(), cname.0);
@@ -251,7 +251,7 @@ pub fn test_cname_alias<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("CNAME record not found in authority")
         .data()
-        .and_then(RData::as_cname)
+        .as_cname()
         .expect("Not a CNAME record");
 
     assert_eq!(Name::from_str("www.example.com.").unwrap(), cname.0);
@@ -262,7 +262,7 @@ pub fn test_cname_alias<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("A record not found")
         .data()
-        .and_then(RData::as_a)
+        .as_a()
         .expect("Not an A record");
     assert_eq!(A4::new(127, 0, 0, 1), *a);
 }
@@ -292,7 +292,7 @@ pub fn test_cname_chain<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("CNAME record not found in authority")
         .data()
-        .and_then(RData::as_cname)
+        .as_cname()
         .expect("Not a CNAME record");
 
     assert_eq!(Name::from_str("alias.example.com.").unwrap(), cname.0);
@@ -304,7 +304,7 @@ pub fn test_cname_chain<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("CNAME record not found")
         .data()
-        .and_then(RData::as_cname)
+        .as_cname()
         .expect("Not an CNAME record");
     assert_eq!(Name::from_str("www.example.com.").unwrap(), cname.0);
 
@@ -312,7 +312,7 @@ pub fn test_cname_chain<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("A record not found")
         .data()
-        .and_then(RData::as_a)
+        .as_a()
         .expect("Not an A record");
     assert_eq!(A4::new(127, 0, 0, 1), *a);
 }
@@ -339,7 +339,7 @@ pub fn test_aname<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("ANAME record not found in authority")
         .data()
-        .and_then(RData::as_aname)
+        .as_aname()
         .expect("Not an ANAME record");
 
     assert_eq!(Name::from_str("www.example.com.").unwrap(), aname.0);
@@ -348,7 +348,7 @@ pub fn test_aname<A: Authority<Lookup = AuthLookup>>(authority: A) {
     let a = additionals
         .iter()
         .find(|r| r.record_type() == RecordType::A)
-        .and_then(Record::data)
+        .map(Record::data)
         .and_then(RData::as_a)
         .expect("A not found");
     assert_eq!(A4::new(127, 0, 0, 1), *a);
@@ -356,7 +356,7 @@ pub fn test_aname<A: Authority<Lookup = AuthLookup>>(authority: A) {
     let aaaa = additionals
         .iter()
         .find(|r| r.record_type() == RecordType::AAAA)
-        .and_then(Record::data)
+        .map(Record::data)
         .and_then(RData::as_aaaa)
         .expect("AAAA not found");
     assert_eq!(AAAA::new(0, 0, 0, 0, 0, 0, 0, 1), *aaaa);
@@ -385,7 +385,7 @@ pub fn test_aname_a_lookup<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .map(|r| (r.name(), r.data()))
         .expect("No A answer");
 
-    let a = a.and_then(RData::as_a).expect("Not an A record");
+    let a = a.as_a().expect("Not an A record");
     assert_eq!(A4::new(127, 0, 0, 1), *a);
     assert_eq!(Name::from_str("example.com.").unwrap(), *name);
 
@@ -395,7 +395,7 @@ pub fn test_aname_a_lookup<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("ANAME record not found in authority")
         .data()
-        .and_then(RData::as_aname)
+        .as_aname()
         .expect("Not an ANAME record");
 
     assert_eq!(Name::from_str("www.example.com.").unwrap(), aname.0);
@@ -427,7 +427,7 @@ pub fn test_aname_chain<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .map(|r| (r.name(), r.data()))
         .expect("Not an A record");
 
-    let a = a.and_then(RData::as_a).expect("Not an A record");
+    let a = a.as_a().expect("Not an A record");
     assert_eq!(A4::new(127, 0, 0, 1), *a);
     assert_eq!(Name::from_str("aname-chain.example.com.").unwrap(), *name);
 
@@ -438,7 +438,7 @@ pub fn test_aname_chain<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("ANAME record not found in authority")
         .data()
-        .and_then(RData::as_aname)
+        .as_aname()
         .expect("Not an ANAME record");
 
     assert_eq!(Name::from_str("alias.example.com.").unwrap(), aname.0);
@@ -447,7 +447,7 @@ pub fn test_aname_chain<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("CNAME record not found")
         .data()
-        .and_then(RData::as_cname)
+        .as_cname()
         .expect("Not an CNAME record");
     assert_eq!(Name::from_str("www.example.com.").unwrap(), cname.0);
 
@@ -455,7 +455,7 @@ pub fn test_aname_chain<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("A record not found")
         .data()
-        .and_then(RData::as_a)
+        .as_a()
         .expect("Not an A record");
     assert_eq!(A4::new(127, 0, 0, 1), *a);
 }
@@ -492,7 +492,7 @@ pub fn test_dots_in_name<A: Authority<Lookup = AuthLookup>>(authority: A) {
             .next()
             .expect("A record not found in authority")
             .data()
-            .and_then(RData::as_a)
+            .as_a()
             .expect("wrong rdata type returned"),
         A4::new(127, 0, 0, 3)
     );
@@ -567,7 +567,7 @@ pub fn test_wildcard<A: Authority<Lookup = AuthLookup>>(authority: A) {
             .next()
             .expect("CNAME record not found in authority")
             .data()
-            .and_then(RData::as_cname)
+            .as_cname()
             .expect("wrong rdata type returned")
             .0,
         Name::from_str("www.example.com.").unwrap()
@@ -602,7 +602,7 @@ pub fn test_wildcard<A: Authority<Lookup = AuthLookup>>(authority: A) {
             })
             .expect("CNAME record not found in authority")
             .data()
-            .and_then(RData::as_cname)
+            .as_cname()
             .expect("wrong rdata type returned")
             .0,
         Name::from_str("www.example.com.").unwrap()
@@ -635,7 +635,7 @@ pub fn test_wildcard_chain<A: Authority<Lookup = AuthLookup>>(authority: A) {
             .next()
             .expect("CNAME record not found in authority")
             .data()
-            .and_then(RData::as_cname)
+            .as_cname()
             .expect("wrong rdata type returned")
             .0,
         Name::from_str("www.example.com.").unwrap()
@@ -646,7 +646,7 @@ pub fn test_wildcard_chain<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("A record not found")
         .data()
-        .and_then(RData::as_a)
+        .as_a()
         .expect("Not an A record");
     assert_eq!(A4::new(127, 0, 0, 1), *a);
 }
@@ -675,7 +675,7 @@ pub fn test_srv<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("SRV record not found in authority")
         .data()
-        .and_then(RData::as_srv)
+        .as_srv()
         .expect("Not an SRV record");
 
     assert_eq!(Name::from_str("alias.example.com.").unwrap(), *srv.target());
@@ -687,7 +687,7 @@ pub fn test_srv<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("CNAME record not found")
         .data()
-        .and_then(RData::as_cname)
+        .as_cname()
         .expect("Not an CNAME record");
     assert_eq!(Name::from_str("www.example.com.").unwrap(), cname.0);
 
@@ -695,7 +695,7 @@ pub fn test_srv<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("A record not found")
         .data()
-        .and_then(RData::as_a)
+        .as_a()
         .expect("Not an A record");
     assert_eq!(A4::new(127, 0, 0, 1), *a);
 
@@ -703,7 +703,7 @@ pub fn test_srv<A: Authority<Lookup = AuthLookup>>(authority: A) {
         .next()
         .expect("AAAA record not found")
         .data()
-        .and_then(RData::as_aaaa)
+        .as_aaaa()
         .expect("Not an AAAA record");
     assert_eq!(AAAA::new(0, 0, 0, 0, 0, 0, 0, 1), *aaaa);
 }

--- a/crates/server/tests/authority_battery/dnssec.rs
+++ b/crates/server/tests/authority_battery/dnssec.rs
@@ -64,12 +64,7 @@ pub fn test_soa<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DNSKEY]
 
     assert_eq!(soa_records.len(), 1);
 
-    let soa = soa_records
-        .first()
-        .unwrap()
-        .data()
-        .and_then(RData::as_soa)
-        .unwrap();
+    let soa = soa_records.first().unwrap().data().as_soa().unwrap();
 
     assert_eq!(Name::from_str("hickory-dns.org.").unwrap(), *soa.mname());
     assert_eq!(
@@ -102,13 +97,7 @@ pub fn test_ns<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DNSKEY])
         .partition(|r| r.record_type() == RecordType::NS);
 
     assert_eq!(
-        ns_records
-            .first()
-            .unwrap()
-            .data()
-            .and_then(RData::as_ns)
-            .unwrap()
-            .0,
+        ns_records.first().unwrap().data().as_ns().unwrap().0,
         Name::from_str("bbb.example.com.").unwrap()
     );
 
@@ -373,7 +362,7 @@ pub fn verify(records: &[&Record], rrsig_records: &[Record<RRSIG>], keys: &[DNSK
     // should be signed with all the keys
     assert!(keys.iter().all(|key| rrsig_records
         .iter()
-        .filter_map(|rrsig| rrsig.data())
+        .map(|rrsig| rrsig.data())
         .filter(|rrsig| rrsig.algorithm() == key.algorithm())
         .filter(|rrsig| rrsig.key_tag() == key.calculate_key_tag().unwrap())
         .filter(|rrsig| rrsig.type_covered() == record_type)

--- a/crates/server/tests/authority_battery/dynamic_update.rs
+++ b/crates/server/tests/authority_battery/dynamic_update.rs
@@ -71,7 +71,7 @@ pub fn test_create<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys: &[
             .expect("A record not found in authority")
             .data()
         {
-            Some(RData::A(ip)) => assert_eq!(A4::new(127, 0, 0, 10), *ip),
+            RData::A(ip) => assert_eq!(A4::new(127, 0, 0, 10), *ip),
             _ => panic!("wrong rdata type returned"),
         }
 
@@ -93,12 +93,10 @@ pub fn test_create_multi<A: Authority<Lookup = AuthLookup>>(mut authority: A, ke
             .append_name(&name)
             .unwrap();
         // create a record
-        let mut record = Record::with(name.clone(), RecordType::A, 8);
-        record.set_data(Some(RData::A(A4::new(100, 10, 100, 10))));
-        let record = record;
+        let record = Record::from_rdata(name.clone(), 8, RData::A(A4::new(100, 10, 100, 10)));
 
         let mut record2 = record.clone();
-        record2.set_data(Some(RData::A(A4::new(100, 10, 100, 11))));
+        record2.set_data(RData::A(A4::new(100, 10, 100, 11)));
         let record2 = record2;
 
         let mut rrset = RecordSet::from(record.clone());
@@ -140,8 +138,7 @@ pub fn test_append<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys: &[
             .unwrap();
 
         // append a record
-        let mut record = Record::with(name.clone(), RecordType::A, 8);
-        record.set_data(Some(RData::A(A4::new(100, 10, 100, 10))));
+        let record = Record::from_rdata(name.clone(), 8, RData::A(A4::new(100, 10, 100, 10)));
 
         // first check the must_exist option
         let mut message = update_message::append(
@@ -180,7 +177,7 @@ pub fn test_append<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys: &[
 
         // will fail if already set and not the same value.
         let mut record2 = record.clone();
-        record2.set_data(Some(RData::A(A4::new(101, 11, 101, 11))));
+        record2.set_data(RData::A(A4::new(101, 11, 101, 11)));
 
         let message = update_message::append(
             record2.clone().into(),
@@ -240,8 +237,7 @@ pub fn test_append_multi<A: Authority<Lookup = AuthLookup>>(mut authority: A, ke
             .unwrap();
 
         // append a record
-        let mut record = Record::with(name.clone(), RecordType::A, 8);
-        record.set_data(Some(RData::A(A4::new(100, 10, 100, 10))));
+        let record = Record::from_rdata(name.clone(), 8, RData::A(A4::new(100, 10, 100, 10)));
 
         // next append to a non-existent RRset
         let message = update_message::append(
@@ -254,9 +250,9 @@ pub fn test_append_multi<A: Authority<Lookup = AuthLookup>>(mut authority: A, ke
 
         // will fail if already set and not the same value.
         let mut record2 = record.clone();
-        record2.set_data(Some(RData::A(A4::new(101, 11, 101, 11))));
+        record2.set_data(RData::A(A4::new(101, 11, 101, 11)));
         let mut record3 = record.clone();
-        record3.set_data(Some(RData::A(A4::new(101, 11, 101, 12))));
+        record3.set_data(RData::A(A4::new(101, 11, 101, 12)));
 
         // build the append set
         let mut rrset = RecordSet::from(record2.clone());
@@ -326,8 +322,7 @@ pub fn test_compare_and_swap<A: Authority<Lookup = AuthLookup>>(
             .unwrap();
 
         // create a record
-        let mut record = Record::with(name.clone(), RecordType::A, 8);
-        record.set_data(Some(RData::A(A4::new(100, 10, 100, 10))));
+        let mut record = Record::from_rdata(name.clone(), 8, RData::A(A4::new(100, 10, 100, 10)));
         let record = record;
 
         let message = update_message::create(
@@ -339,7 +334,7 @@ pub fn test_compare_and_swap<A: Authority<Lookup = AuthLookup>>(
 
         let current = record;
         let mut new = current.clone();
-        new.set_data(Some(RData::A(A4::new(101, 11, 101, 11))));
+        new.set_data(RData::A(A4::new(101, 11, 101, 11)));
         let new = new;
 
         let message = update_message::compare_and_swap(
@@ -366,7 +361,7 @@ pub fn test_compare_and_swap<A: Authority<Lookup = AuthLookup>>(
 
         // check the it fails if tried again.
         let mut not = new.clone();
-        not.set_data(Some(RData::A(A4::new(102, 12, 102, 12))));
+        not.set_data(RData::A(A4::new(102, 12, 102, 12)));
         let not = not;
 
         let message = update_message::compare_and_swap(
@@ -457,7 +452,7 @@ pub fn test_compare_and_swap_multi<A: Authority<Lookup = AuthLookup>>(
 
         // check the it fails if tried again.
         let mut not = new1.clone();
-        not.set_data(Some(RData::A(A4::new(102, 12, 102, 12))));
+        not.set_data(RData::A(A4::new(102, 12, 102, 12)));
         let not = not;
 
         let message = update_message::compare_and_swap(
@@ -499,8 +494,7 @@ pub fn test_delete_by_rdata<A: Authority<Lookup = AuthLookup>>(
             .unwrap();
 
         // append a record
-        let mut record1 = Record::with(name.clone(), RecordType::A, 8);
-        record1.set_data(Some(RData::A(A4::new(100, 10, 100, 10))));
+        let record1 = Record::from_rdata(name.clone(), 8, RData::A(A4::new(100, 10, 100, 10)));
 
         // first check the must_exist option
         let mut message = update_message::delete_by_rdata(
@@ -519,7 +513,7 @@ pub fn test_delete_by_rdata<A: Authority<Lookup = AuthLookup>>(
         assert!(update_authority(message, key, &mut authority).expect("delete_by_rdata failed"));
 
         let mut record2 = record1.clone();
-        record2.set_data(Some(RData::A(A4::new(101, 11, 101, 11))));
+        record2.set_data(RData::A(A4::new(101, 11, 101, 11)));
         let message = update_message::append(
             record2.clone().into(),
             Name::from_str("example.com.").unwrap(),
@@ -595,8 +589,8 @@ pub fn test_delete_by_rdata_multi<A: Authority<Lookup = AuthLookup>>(
         // append a record
         let mut rrset = RecordSet::with_ttl(name.clone(), RecordType::A, 8);
 
-        let record1 = rrset.new_record(record1.data().unwrap()).clone();
-        let record3 = rrset.new_record(record3.data().unwrap()).clone();
+        let record1 = rrset.new_record(record1.data()).clone();
+        let record3 = rrset.new_record(record3.data()).clone();
         let rrset = rrset;
 
         let message = update_message::append(
@@ -642,8 +636,7 @@ pub fn test_delete_rrset<A: Authority<Lookup = AuthLookup>>(mut authority: A, ke
             .unwrap();
 
         // append a record
-        let mut record = Record::with(name.clone(), RecordType::A, 8);
-        record.set_data(Some(RData::A(A4::new(100, 10, 100, 10))));
+        let mut record = Record::from_rdata(name.clone(), 8, RData::A(A4::new(100, 10, 100, 10)));
 
         // first check the must_exist option
         let message = update_message::delete_rrset(
@@ -662,7 +655,7 @@ pub fn test_delete_rrset<A: Authority<Lookup = AuthLookup>>(mut authority: A, ke
         assert!(update_authority(message, key, &mut authority).expect("create failed"));
 
         let mut record = record.clone();
-        record.set_data(Some(RData::A(A4::new(101, 11, 101, 11))));
+        record.set_data(RData::A(A4::new(101, 11, 101, 11)));
         let message = update_message::append(
             record.clone().into(),
             Name::from_str("example.com.").unwrap(),
@@ -705,8 +698,7 @@ pub fn test_delete_all<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys
             .unwrap();
 
         // append a record
-        let mut record = Record::with(name.clone(), RecordType::A, 8);
-        record.set_data(Some(RData::A(A4::new(100, 10, 100, 10))));
+        let mut record = Record::from_rdata(name.clone(), 8, RData::A(A4::new(100, 10, 100, 10)));
 
         // first check the must_exist option
         let message = update_message::delete_all(
@@ -726,8 +718,7 @@ pub fn test_delete_all<A: Authority<Lookup = AuthLookup>>(mut authority: A, keys
         assert!(update_authority(message, key, &mut authority).expect("create failed"));
 
         let mut record = record.clone();
-        record.set_record_type(RecordType::AAAA);
-        record.set_data(Some(RData::AAAA(AAAA::new(1, 2, 3, 4, 5, 6, 7, 8))));
+        record.set_data(RData::AAAA(AAAA::new(1, 2, 3, 4, 5, 6, 7, 8)));
         let message = update_message::create(
             record.clone().into(),
             Name::from_str("example.com.").unwrap(),

--- a/crates/server/tests/forwarder.rs
+++ b/crates/server/tests/forwarder.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 
 use tokio::runtime::Runtime;
 
-use hickory_proto::rr::{Name, RData, RecordType};
+use hickory_proto::rr::{Name, RecordType};
 use hickory_resolver::name_server::TokioConnectionProvider;
 use hickory_server::{
     authority::{Authority, LookupObject},
@@ -29,9 +29,6 @@ fn test_lookup() {
         .unwrap();
 
     let address = lookup.iter().next().expect("no addresses returned!");
-    let address = address
-        .data()
-        .and_then(RData::as_a)
-        .expect("not an A record");
+    let address = address.data().as_a().expect("not an A record");
     assert_eq!(*address, Ipv4Addr::new(93, 184, 215, 14).into());
 }

--- a/crates/server/tests/in_memory.rs
+++ b/crates/server/tests/in_memory.rs
@@ -76,9 +76,7 @@ fn test_cname_loop() {
     assert_eq!(record.name(), &Name::from_str("foo.example.com.").unwrap());
     assert_eq!(
         record.data(),
-        Some(&RData::CNAME(CNAME(
-            Name::from_str("foo.example.com.").unwrap()
-        )))
+        &RData::CNAME(CNAME(Name::from_str("foo.example.com.").unwrap()))
     );
 
     assert!(
@@ -100,9 +98,7 @@ fn test_cname_loop() {
     assert_eq!(record.name(), &Name::from_str("bar.example.com.").unwrap());
     assert_eq!(
         record.data(),
-        Some(&RData::CNAME(CNAME(
-            Name::from_str("foo.example.com.").unwrap()
-        )))
+        &RData::CNAME(CNAME(Name::from_str("foo.example.com.").unwrap()))
     );
 
     let additionals = lookup
@@ -114,9 +110,7 @@ fn test_cname_loop() {
     assert_eq!(record.name(), &Name::from_str("foo.example.com.").unwrap());
     assert_eq!(
         record.data(),
-        Some(&RData::CNAME(CNAME(
-            Name::from_str("foo.example.com.").unwrap()
-        )))
+        &RData::CNAME(CNAME(Name::from_str("foo.example.com.").unwrap()))
     );
 
     let mut lookup = runtime
@@ -133,9 +127,7 @@ fn test_cname_loop() {
     assert_eq!(record.name(), &Name::from_str("baz.example.com.").unwrap());
     assert_eq!(
         record.data(),
-        Some(&RData::CNAME(CNAME(
-            Name::from_str("boz.example.com.").unwrap()
-        )))
+        &RData::CNAME(CNAME(Name::from_str("boz.example.com.").unwrap()))
     );
 
     let additionals = lookup
@@ -147,16 +139,12 @@ fn test_cname_loop() {
     assert_eq!(record.name(), &Name::from_str("boz.example.com.").unwrap());
     assert_eq!(
         record.data(),
-        Some(&RData::CNAME(CNAME(
-            Name::from_str("biz.example.com.").unwrap()
-        )))
+        &RData::CNAME(CNAME(Name::from_str("biz.example.com.").unwrap()))
     );
     let record = additionals[1];
     assert_eq!(record.name(), &Name::from_str("biz.example.com.").unwrap());
     assert_eq!(
         record.data(),
-        Some(&RData::CNAME(CNAME(
-            Name::from_str("baz.example.com.").unwrap()
-        )))
+        &RData::CNAME(CNAME(Name::from_str("baz.example.com.").unwrap()))
     );
 }

--- a/crates/server/tests/sqlite_tests.rs
+++ b/crates/server/tests/sqlite_tests.rs
@@ -32,10 +32,7 @@ fn test_init_journal() {
 fn create_test_journal() -> (Record, Journal) {
     let www = Name::from_str("www.example.com").unwrap();
 
-    let mut record = Record::new();
-    record.set_name(www);
-    record.set_record_type(RecordType::A);
-    record.set_data(Some(RData::A(A::from_str("127.0.0.1").unwrap())));
+    let mut record = Record::from_rdata(www, 0, RData::A(A::from_str("127.0.0.1").unwrap()));
 
     // test that this message can be inserted
     let conn = Connection::open_in_memory().expect("could not create in memory DB");
@@ -46,7 +43,7 @@ fn create_test_journal() -> (Record, Journal) {
     journal.insert_record(0, &record).unwrap();
 
     // insert another...
-    record.set_data(Some(RData::A(A::from_str("127.0.1.1").unwrap())));
+    record.set_data(RData::A(A::from_str("127.0.1.1").unwrap()));
     journal.insert_record(0, &record).unwrap();
 
     (record, journal)
@@ -61,7 +58,7 @@ fn test_insert_and_select_record() {
         .select_record(0)
         .expect("persistence error")
         .expect("none");
-    record.set_data(Some(RData::A(A::from_str("127.0.0.1").unwrap())));
+    record.set_data(RData::A(A::from_str("127.0.0.1").unwrap()));
     assert_eq!(journal_record, record);
 
     // test another
@@ -69,7 +66,7 @@ fn test_insert_and_select_record() {
         .select_record(row_id + 1)
         .expect("persistence error")
         .expect("none");
-    record.set_data(Some(RData::A(A::from_str("127.0.1.1").unwrap())));
+    record.set_data(RData::A(A::from_str("127.0.1.1").unwrap()));
     assert_eq!(journal_record, record);
 
     // check that we get nothing for id over row_id
@@ -86,11 +83,11 @@ fn test_iterator() {
     let mut iter = journal.iter();
 
     assert_eq!(
-        record.set_data(Some(RData::A(A::from_str("127.0.0.1").unwrap()))),
+        record.set_data(RData::A(A::from_str("127.0.0.1").unwrap())),
         &iter.next().unwrap()
     );
     assert_eq!(
-        record.set_data(Some(RData::A(A::from_str("127.0.1.1").unwrap()))),
+        record.set_data(RData::A(A::from_str("127.0.1.1").unwrap())),
         &iter.next().unwrap()
     );
     assert_eq!(None, iter.next());

--- a/crates/server/tests/txt_tests.rs
+++ b/crates/server/tests/txt_tests.rs
@@ -77,7 +77,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     assert_eq!(&Name::from_str("isi.edu").unwrap(), soa_record.name()); // i.e. the origin or domain
     assert_eq!(3_600_000, soa_record.ttl());
     assert_eq!(DNSClass::IN, soa_record.dns_class());
-    if let Some(RData::SOA(ref soa)) = soa_record.data() {
+    if let RData::SOA(ref soa) = soa_record.data() {
         // this should all be lowercased
         assert_eq!(&Name::from_str("venera.isi.edu").unwrap(), soa.mname());
         assert_eq!(
@@ -105,7 +105,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     .unwrap();
     assert_eq!(&Name::from_str("tech.").unwrap(), lowercase_record.name());
     assert_eq!(DNSClass::IN, lowercase_record.dns_class());
-    if let Some(RData::SOA(ref lower_soa)) = lowercase_record.data() {
+    if let RData::SOA(ref lower_soa) = lowercase_record.data() {
         assert_eq!(
             &Name::from_str("ns0.centralnic.net").unwrap(),
             lower_soa.mname()
@@ -149,7 +149,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         assert_eq!(60, record.ttl()); // TODO: should this be minimum or expire?
         assert_eq!(DNSClass::IN, record.dns_class());
         assert_eq!(RecordType::NS, record.record_type());
-        if let Some(RData::NS(nsdname)) = record.data() {
+        if let RData::NS(nsdname) = record.data() {
             assert_eq!(name, nsdname.0);
         } else {
             panic!("Not an NS record!!!") // valid panic, test code
@@ -180,7 +180,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         assert_eq!(60, record.ttl()); // TODO: should this be minimum or expire?
         assert_eq!(DNSClass::IN, record.dns_class());
         assert_eq!(RecordType::MX, record.record_type());
-        if let Some(RData::MX(ref rdata)) = record.data() {
+        if let RData::MX(ref rdata) = record.data() {
             assert_eq!(num, rdata.preference());
             assert_eq!(name, rdata.exchange());
         } else {
@@ -203,7 +203,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     assert_eq!(60, a_record.ttl()); // TODO: should this be minimum or expire?
     assert_eq!(DNSClass::IN, a_record.dns_class());
     assert_eq!(RecordType::A, a_record.record_type());
-    if let Some(RData::A(ref address)) = a_record.data() {
+    if let RData::A(ref address) = a_record.data() {
         assert_eq!(&A::new(26u8, 3u8, 0u8, 103u8), address);
     } else {
         panic!("Not an A record!!!") // valid panic, test code
@@ -221,7 +221,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     .cloned()
     .unwrap();
     assert_eq!(&Name::from_str("aaaa.isi.edu").unwrap(), aaaa_record.name());
-    if let Some(RData::AAAA(ref address)) = aaaa_record.data() {
+    if let RData::AAAA(ref address) = aaaa_record.data() {
         assert_eq!(&AAAA::from_str("4321:0:1:2:3:4:567:89ab").unwrap(), address);
     } else {
         panic!("Not a AAAA record!!!") // valid panic, test code
@@ -243,7 +243,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         short_record.name()
     );
     assert_eq!(70, short_record.ttl());
-    if let Some(RData::A(ref address)) = short_record.data() {
+    if let RData::A(ref address) = short_record.data() {
         assert_eq!(&A::new(26u8, 3u8, 0u8, 104u8), address);
     } else {
         panic!("Not an A record!!!") // valid panic, test code
@@ -286,7 +286,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     let compare = txt_records.iter().zip(compare);
 
     for (record, ref vector) in compare {
-        if let Some(RData::TXT(ref rdata)) = record.data() {
+        if let RData::TXT(ref rdata) = record.data() {
             assert_eq!(vector as &[Box<[u8]>], rdata.txt_data());
         } else {
             panic!("Not a TXT record!!!") // valid panic, test code
@@ -304,7 +304,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     .next()
     .cloned()
     .unwrap();
-    if let Some(RData::PTR(ref ptrdname)) = ptr_record.data() {
+    if let RData::PTR(ref ptrdname) = ptr_record.data() {
         assert_eq!(Name::from_str("a.isi.edu").unwrap(), ptrdname.0);
     } else {
         panic!("Not a PTR record!!!") // valid panic, test code
@@ -321,7 +321,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     .next()
     .cloned()
     .unwrap();
-    if let Some(RData::SRV(ref rdata)) = srv_record.data() {
+    if let RData::SRV(ref rdata) = srv_record.data() {
         assert_eq!(rdata.priority(), 1);
         assert_eq!(rdata.weight(), 2);
         assert_eq!(rdata.port(), 3);
@@ -345,7 +345,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         &Name::from_str("rust-❤️-🦀.isi.edu").unwrap(),
         idna_record.name()
     );
-    if let Some(RData::A(ref address)) = idna_record.data() {
+    if let RData::A(ref address) = idna_record.data() {
         assert_eq!(&A::new(192u8, 0u8, 2u8, 1u8), address);
     } else {
         panic!("Not an A record!!!") // valid panic, test code
@@ -362,7 +362,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     .next()
     .cloned()
     .expect("nocerts not found");
-    if let Some(RData::CAA(ref rdata)) = caa_record.data() {
+    if let RData::CAA(ref rdata) = caa_record.data() {
         assert!(!rdata.issuer_critical());
         assert!(rdata.tag().is_issue());
         assert!(rdata.value().is_issuer());
@@ -385,7 +385,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     .next()
     .cloned()
     .expect("tlsa record not found");
-    if let Some(RData::TLSA(ref rdata)) = tlsa_record.data() {
+    if let RData::TLSA(ref rdata) = tlsa_record.data() {
         assert_eq!(rdata.cert_usage(), CertUsage::CA);
         assert_eq!(rdata.selector(), Selector::Full);
         assert_eq!(rdata.matching(), Matching::Sha256);

--- a/fuzz/fuzz_targets/message.rs
+++ b/fuzz/fuzz_targets/message.rs
@@ -101,7 +101,7 @@ fn record_equal(record1: &Record, record2: &Record) -> bool {
 
     // custom rules to match..
     match (record1.data(), record2.data()) {
-        (None, Some(RData::OPT(opt))) | (Some(RData::OPT(opt)), None) => {
+        (RData::Update0(_), RData::OPT(opt)) | (RData::OPT(opt), RData::Update0(_)) => {
             if opt.as_ref().is_empty() {
                 return true;
             }

--- a/tests/compatibility-tests/tests/sig0_tests.rs
+++ b/tests/compatibility-tests/tests/sig0_tests.rs
@@ -51,7 +51,7 @@ fn test_get() {
     assert_eq!(result.answers()[0].record_type(), RecordType::A);
 
     let rdata = result.answers()[0].data();
-    if let Some(RData::A(address)) = rdata {
+    if let RData::A(address) = rdata {
         assert_eq!(address, &A::new(127, 0, 0, 1));
     } else {
         panic!("RData::A wasn't here");
@@ -104,12 +104,11 @@ fn test_create() {
     let origin = Name::from_str("example.com.").unwrap();
 
     // create a record
-    let mut record = Record::with(
+    let mut record = Record::from_rdata(
         Name::from_str("new.example.com.").unwrap(),
-        RecordType::A,
         Duration::minutes(5).whole_seconds() as u32,
+        RData::A(A::new(100, 10, 100, 10)),
     );
-    record.set_data(Some(RData::A(A::new(100, 10, 100, 10))));
 
     let result = client
         .create(record.clone(), origin.clone())
@@ -130,7 +129,7 @@ fn test_create() {
     assert_eq!(result.response_code(), ResponseCode::YXRRSet);
 
     // will fail if already set and not the same value.
-    record.set_data(Some(RData::A(A::new(101, 11, 101, 11))));
+    record.set_data(RData::A(A::new(101, 11, 101, 11)));
 
     let result = client.create(record, origin).expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::YXRRSet);

--- a/tests/compatibility-tests/tests/tsig_tests.rs
+++ b/tests/compatibility-tests/tests/tsig_tests.rs
@@ -60,12 +60,11 @@ fn test_create() {
     let origin = Name::from_str("example.net.").unwrap();
 
     // create a record
-    let mut record = Record::with(
+    let mut record = Record::from_rdata(
         Name::from_str("new.example.net.").unwrap(),
-        RecordType::A,
         Duration::minutes(5).whole_seconds() as u32,
+        RData::A(A::new(100, 10, 100, 10)),
     );
-    record.set_data(Some(RData::A(A::new(100, 10, 100, 10))));
 
     let result = client
         .create(record.clone(), origin.clone())
@@ -86,7 +85,7 @@ fn test_create() {
     assert_eq!(result.response_code(), ResponseCode::YXRRSet);
 
     // will fail if already set and not the same value.
-    record.set_data(Some(RData::A(A::new(101, 11, 101, 11))));
+    record.set_data(RData::A(A::new(101, 11, 101, 11)));
 
     let result = client.create(record, origin).expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::YXRRSet);

--- a/tests/compatibility-tests/tests/zone_transfer.rs
+++ b/tests/compatibility-tests/tests/zone_transfer.rs
@@ -26,7 +26,7 @@ use hickory_compatibility::named_process;
 macro_rules! assert_serial {
     ( $record:expr, $serial:expr  ) => {{
         let rdata = $record.data();
-        if let Some(RData::SOA(soa)) = rdata {
+        if let RData::SOA(soa) = rdata {
             assert_eq!(soa.serial(), $serial);
         } else {
             assert!(false, "record was not a SOA");
@@ -54,7 +54,7 @@ fn test_zone_transfer() {
         2000 + 3
     );
 
-    let soa = if let Some(RData::SOA(soa)) = result[0].answers()[0].data() {
+    let soa = if let RData::SOA(soa) = result[0].answers()[0].data() {
         soa
     } else {
         panic!("First answer was not an SOA record")
@@ -72,12 +72,11 @@ fn test_zone_transfer() {
         RecordType::SOA
     );
 
-    let mut record = Record::with(
+    let mut record = Record::from_rdata(
         Name::from_str("new.example.net.").unwrap(),
-        RecordType::A,
         Duration::minutes(5).whole_seconds() as u32,
+        RData::A(A::new(100, 10, 100, 10)),
     );
-    record.set_data(Some(RData::A(A::new(100, 10, 100, 10))));
 
     client.create(record, name.clone()).expect("create failed");
 

--- a/tests/integration-tests/src/example_authority.rs
+++ b/tests/integration-tests/src/example_authority.rs
@@ -16,12 +16,10 @@ pub fn create_example() -> InMemoryAuthority {
 
     // example.com.		3600	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082403 7200 3600 1209600 3600
     records.upsert_mut(
-        Record::new()
-            .set_name(origin.clone())
-            .set_ttl(3600)
-            .set_record_type(RecordType::SOA)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::SOA(SOA::new(
+        Record::from_rdata(
+            origin.clone(),
+            3600,
+            RData::SOA(SOA::new(
                 Name::parse("sns.dns.icann.org.", None).unwrap(),
                 Name::parse("noc.dns.icann.org.", None).unwrap(),
                 2015082403,
@@ -29,37 +27,31 @@ pub fn create_example() -> InMemoryAuthority {
                 3600,
                 1209600,
                 3600,
-            ))))
-            .clone(),
+            )),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
         0,
     );
 
     records.upsert_mut(
-        Record::new()
-            .set_name(origin.clone())
-            .set_ttl(86400)
-            .set_record_type(RecordType::NS)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::NS(NS(Name::parse(
-                "a.iana-servers.net.",
-                None,
-            )
-            .unwrap()))))
-            .clone(),
+        Record::from_rdata(
+            origin.clone(),
+            86400,
+            RData::NS(NS(Name::parse("a.iana-servers.net.", None).unwrap())),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
         0,
     );
     records.upsert_mut(
-        Record::new()
-            .set_name(origin.clone())
-            .set_ttl(86400)
-            .set_record_type(RecordType::NS)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::NS(NS(Name::parse(
-                "b.iana-servers.net.",
-                None,
-            )
-            .unwrap()))))
-            .clone(),
+        Record::from_rdata(
+            origin.clone(),
+            86400,
+            RData::NS(NS(Name::parse("b.iana-servers.net.", None).unwrap())),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
         0,
     );
 
@@ -67,43 +59,37 @@ pub fn create_example() -> InMemoryAuthority {
     //records.upsert(origin.clone(), Record::new().name(origin.clone()).ttl(60).rr_type(RecordType::TXT).dns_class(DNSClass::IN).rdata(RData::TXT{ txt_data: vec!["v=spf1 -all".to_string()] }).clone());
     // example.com.		60	IN	TXT	"$Id: example.com 4415 2015-08-24 20:12:23Z davids $"
     records.upsert_mut(
-        Record::new()
-            .set_name(origin.clone())
-            .set_ttl(60)
-            .set_record_type(RecordType::TXT)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::TXT(TXT::new(vec![
-                "$Id: example.com 4415 2015-08-24 \
+        Record::from_rdata(
+            origin.clone(),
+            60,
+            RData::TXT(TXT::new(vec!["$Id: example.com 4415 2015-08-24 \
                  20:12:23Z davids $"
-                    .to_string(),
-            ]))))
-            .clone(),
+                .to_string()])),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
         0,
     );
 
     // example.com.		86400	IN	A	93.184.215.14
     records.upsert_mut(
-        Record::new()
-            .set_name(origin.clone())
-            .set_ttl(86400)
-            .set_record_type(RecordType::A)
+        Record::from_rdata(origin.clone(), 86400, RData::A(A::new(93, 184, 215, 14)))
             .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::A(A::new(93, 184, 215, 14))))
             .clone(),
         0,
     );
 
     // example.com.		86400	IN	AAAA	2606:2800:21f:cb07:6820:80da:af6b:8b2c
     records.upsert_mut(
-        Record::new()
-            .set_name(origin)
-            .set_ttl(86400)
-            .set_record_type(RecordType::AAAA)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::AAAA(AAAA::new(
+        Record::from_rdata(
+            origin,
+            86400,
+            RData::AAAA(AAAA::new(
                 0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c,
-            ))))
-            .clone(),
+            )),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
         0,
     );
 
@@ -126,65 +112,59 @@ pub fn create_example() -> InMemoryAuthority {
 
     // www.example.com.	86400	IN	TXT	"v=spf1 -all"
     records.upsert_mut(
-        Record::new()
-            .set_name(www_name.clone())
-            .set_ttl(86400)
-            .set_record_type(RecordType::TXT)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::TXT(TXT::new(vec!["v=spf1 -all".to_string()]))))
-            .clone(),
+        Record::from_rdata(
+            www_name.clone(),
+            86400,
+            RData::TXT(TXT::new(vec!["v=spf1 -all".to_string()])),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
         0,
     );
 
     // www.example.com.	86400	IN	A	93.184.215.14
     records.upsert_mut(
-        Record::new()
-            .set_name(www_name.clone())
-            .set_ttl(86400)
-            .set_record_type(RecordType::A)
+        Record::from_rdata(www_name.clone(), 86400, RData::A(A::new(93, 184, 215, 14)))
             .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::A(A::new(93, 184, 215, 14))))
             .clone(),
         0,
     );
 
     // www.example.com.	86400	IN	AAAA	2606:2800:21f:cb07:6820:80da:af6b:8b2c
     records.upsert_mut(
-        Record::new()
-            .set_name(www_name.clone())
-            .set_ttl(86400)
-            .set_record_type(RecordType::AAAA)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::AAAA(AAAA::new(
+        Record::from_rdata(
+            www_name.clone(),
+            86400,
+            RData::AAAA(AAAA::new(
                 0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c,
-            ))))
-            .clone(),
+            )),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
         0,
     );
 
     // alias 86400 IN www
     records.upsert_mut(
-        Record::new()
-            .set_name(Name::from_str("alias.example.com.").unwrap())
-            .set_ttl(86400)
-            .set_record_type(RecordType::CNAME)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::CNAME(CNAME(www_name))))
-            .clone(),
+        Record::from_rdata(
+            Name::from_str("alias.example.com.").unwrap(),
+            86400,
+            RData::CNAME(CNAME(www_name)),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
         0,
     );
 
     // alias2 86400 IN www, multiple cname chains
     records.upsert_mut(
-        Record::new()
-            .set_name(Name::from_str("alias2.example.com.").unwrap())
-            .set_ttl(86400)
-            .set_record_type(RecordType::CNAME)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::CNAME(CNAME(
-                Name::from_str("alias.example.com.").unwrap(),
-            ))))
-            .clone(),
+        Record::from_rdata(
+            Name::from_str("alias2.example.com.").unwrap(),
+            86400,
+            RData::CNAME(CNAME(Name::from_str("alias.example.com.").unwrap())),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
         0,
     );
 

--- a/tests/integration-tests/tests/catalog_tests.rs
+++ b/tests/integration-tests/tests/catalog_tests.rs
@@ -21,12 +21,10 @@ pub fn create_test() -> InMemoryAuthority {
     let mut records = InMemoryAuthority::empty(origin.clone(), ZoneType::Primary, false);
 
     records.upsert_mut(
-        Record::new()
-            .set_name(origin.clone())
-            .set_ttl(3600)
-            .set_record_type(RecordType::SOA)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::SOA(SOA::new(
+        Record::from_rdata(
+            origin.clone(),
+            3600,
+            RData::SOA(SOA::new(
                 Name::parse("sns.dns.icann.org.", None).unwrap(),
                 Name::parse("noc.dns.icann.org.", None).unwrap(),
                 2015082403,
@@ -34,84 +32,70 @@ pub fn create_test() -> InMemoryAuthority {
                 3600,
                 1209600,
                 3600,
-            ))))
-            .clone(),
+            )),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
         0,
     );
 
     records.upsert_mut(
-        Record::new()
-            .set_name(origin.clone())
-            .set_ttl(86400)
-            .set_record_type(RecordType::NS)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::NS(NS(Name::parse(
-                "a.iana-servers.net.",
-                None,
-            )
-            .unwrap()))))
-            .clone(),
+        Record::from_rdata(
+            origin.clone(),
+            86400,
+            RData::NS(NS(Name::parse("a.iana-servers.net.", None).unwrap())),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
         0,
     );
     records.upsert_mut(
-        Record::new()
-            .set_name(origin.clone())
-            .set_ttl(86400)
-            .set_record_type(RecordType::NS)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::NS(NS(Name::parse(
-                "b.iana-servers.net.",
-                None,
-            )
-            .unwrap()))))
-            .clone(),
+        Record::from_rdata(
+            origin.clone(),
+            86400,
+            RData::NS(NS(Name::parse("b.iana-servers.net.", None).unwrap())),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
         0,
     );
 
     records.upsert_mut(
-        Record::new()
-            .set_name(origin.clone())
-            .set_ttl(86400)
-            .set_record_type(RecordType::A)
+        Record::from_rdata(origin.clone(), 86400, RData::A(A::new(94, 184, 216, 34)))
             .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::A(A::new(94, 184, 216, 34))))
             .clone(),
         0,
     );
     records.upsert_mut(
-        Record::new()
-            .set_name(origin)
-            .set_ttl(86400)
-            .set_record_type(RecordType::AAAA)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::AAAA(AAAA::new(
+        Record::from_rdata(
+            origin,
+            86400,
+            RData::AAAA(AAAA::new(
                 0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c,
-            ))))
-            .clone(),
+            )),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
         0,
     );
 
     let www_name: Name = Name::parse("www.test.com.", None).unwrap();
     records.upsert_mut(
-        Record::new()
-            .set_name(www_name.clone())
-            .set_ttl(86400)
-            .set_record_type(RecordType::A)
+        Record::from_rdata(www_name.clone(), 86400, RData::A(A::new(94, 184, 216, 34)))
             .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::A(A::new(94, 184, 216, 34))))
             .clone(),
         0,
     );
     records.upsert_mut(
-        Record::new()
-            .set_name(www_name)
-            .set_ttl(86400)
-            .set_record_type(RecordType::AAAA)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::AAAA(AAAA::new(
+        Record::from_rdata(
+            www_name,
+            86400,
+            RData::AAAA(AAAA::new(
                 0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c,
-            ))))
-            .clone(),
+            )),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
         0,
     );
 
@@ -156,7 +140,7 @@ async fn test_catalog_lookup() {
     assert!(!answers.is_empty());
     assert_eq!(answers.first().unwrap().record_type(), RecordType::A);
     assert_eq!(
-        answers.first().unwrap().data().unwrap(),
+        answers.first().unwrap().data(),
         &RData::A(A::new(93, 184, 215, 14))
     );
 
@@ -190,7 +174,7 @@ async fn test_catalog_lookup() {
     assert!(!answers.is_empty());
     assert_eq!(answers.first().unwrap().record_type(), RecordType::A);
     assert_eq!(
-        answers.first().unwrap().data().unwrap(),
+        answers.first().unwrap().data(),
         &RData::A(A::new(94, 184, 216, 34))
     );
 }
@@ -234,7 +218,7 @@ async fn test_catalog_lookup_soa() {
     assert!(!answers.is_empty());
     assert_eq!(answers.first().unwrap().record_type(), RecordType::SOA);
     assert_eq!(
-        answers.first().unwrap().data().unwrap(),
+        answers.first().unwrap().data(),
         &RData::SOA(SOA::new(
             Name::parse("sns.dns.icann.org.", None).unwrap(),
             Name::parse("noc.dns.icann.org.", None).unwrap(),
@@ -253,12 +237,12 @@ async fn test_catalog_lookup_soa() {
     assert_eq!(ns.len(), 2);
     assert_eq!(ns.first().unwrap().record_type(), RecordType::NS);
     assert_eq!(
-        ns.first().unwrap().data().unwrap(),
+        ns.first().unwrap().data(),
         &RData::NS(NS(Name::parse("a.iana-servers.net.", None).unwrap()))
     );
     assert_eq!(ns.last().unwrap().record_type(), RecordType::NS);
     assert_eq!(
-        ns.last().unwrap().data().unwrap(),
+        ns.last().unwrap().data(),
         &RData::NS(NS(Name::parse("b.iana-servers.net.", None).unwrap()))
     );
 }
@@ -299,7 +283,7 @@ async fn test_catalog_nx_soa() {
     assert_eq!(ns.len(), 1);
     assert_eq!(ns.first().unwrap().record_type(), RecordType::SOA);
     assert_eq!(
-        ns.first().unwrap().data().unwrap(),
+        ns.first().unwrap().data(),
         &RData::SOA(SOA::new(
             Name::parse("sns.dns.icann.org.", None).unwrap(),
             Name::parse("noc.dns.icann.org.", None).unwrap(),
@@ -355,12 +339,10 @@ async fn test_axfr() {
     test.set_allow_axfr(true);
 
     let origin = test.origin().clone();
-    let soa = Record::new()
-        .set_name(origin.clone().into())
-        .set_ttl(3600)
-        .set_record_type(RecordType::SOA)
-        .set_dns_class(DNSClass::IN)
-        .set_data(Some(RData::SOA(SOA::new(
+    let soa = Record::from_rdata(
+        origin.clone().into(),
+        3600,
+        RData::SOA(SOA::new(
             Name::parse("sns.dns.icann.org.", None).unwrap(),
             Name::parse("noc.dns.icann.org.", None).unwrap(),
             2015082403,
@@ -368,8 +350,10 @@ async fn test_axfr() {
             3600,
             1209600,
             3600,
-        ))))
-        .clone();
+        )),
+    )
+    .set_dns_class(DNSClass::IN)
+    .clone();
 
     let mut catalog: Catalog = Catalog::new();
     catalog.upsert(origin.clone(), Box::new(Arc::new(test)));
@@ -401,12 +385,10 @@ async fn test_axfr() {
 
     let www_name: Name = Name::parse("www.test.com.", None).unwrap();
     let mut expected_set = vec![
-        Record::new()
-            .set_name(origin.clone().into())
-            .set_ttl(3600)
-            .set_record_type(RecordType::SOA)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::SOA(SOA::new(
+        Record::from_rdata(
+            origin.clone().into(),
+            3600,
+            RData::SOA(SOA::new(
                 Name::parse("sns.dns.icann.org.", None).unwrap(),
                 Name::parse("noc.dns.icann.org.", None).unwrap(),
                 2015082403,
@@ -414,68 +396,56 @@ async fn test_axfr() {
                 3600,
                 1209600,
                 3600,
-            ))))
-            .clone(),
-        Record::new()
-            .set_name(origin.clone().into())
-            .set_ttl(86400)
-            .set_record_type(RecordType::NS)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::NS(NS(Name::parse(
-                "a.iana-servers.net.",
-                None,
-            )
-            .unwrap()))))
-            .clone(),
-        Record::new()
-            .set_name(origin.clone().into())
-            .set_ttl(86400)
-            .set_record_type(RecordType::NS)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::NS(NS(Name::parse(
-                "b.iana-servers.net.",
-                None,
-            )
-            .unwrap()))))
-            .clone(),
-        Record::new()
-            .set_name(origin.clone().into())
-            .set_ttl(86400)
-            .set_record_type(RecordType::A)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::A(A::new(94, 184, 216, 34))))
-            .clone(),
-        Record::new()
-            .set_name(origin.clone().into())
-            .set_ttl(86400)
-            .set_record_type(RecordType::AAAA)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::AAAA(AAAA::new(
+            )),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
+        Record::from_rdata(
+            origin.clone().into(),
+            86400,
+            RData::NS(NS(Name::parse("a.iana-servers.net.", None).unwrap())),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
+        Record::from_rdata(
+            origin.clone().into(),
+            86400,
+            RData::NS(NS(Name::parse("b.iana-servers.net.", None).unwrap())),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
+        Record::from_rdata(
+            origin.clone().into(),
+            86400,
+            RData::A(A::new(94, 184, 216, 34)),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
+        Record::from_rdata(
+            origin.clone().into(),
+            86400,
+            RData::AAAA(AAAA::new(
                 0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c,
-            ))))
-            .clone(),
-        Record::new()
-            .set_name(www_name.clone())
-            .set_ttl(86400)
-            .set_record_type(RecordType::A)
+            )),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
+        Record::from_rdata(www_name.clone(), 86400, RData::A(A::new(94, 184, 216, 34)))
             .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::A(A::new(94, 184, 216, 34))))
             .clone(),
-        Record::new()
-            .set_name(www_name)
-            .set_ttl(86400)
-            .set_record_type(RecordType::AAAA)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::AAAA(AAAA::new(
+        Record::from_rdata(
+            www_name,
+            86400,
+            RData::AAAA(AAAA::new(
                 0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c,
-            ))))
-            .clone(),
-        Record::new()
-            .set_name(origin.into())
-            .set_ttl(3600)
-            .set_record_type(RecordType::SOA)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::SOA(SOA::new(
+            )),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
+        Record::from_rdata(
+            origin.into(),
+            3600,
+            RData::SOA(SOA::new(
                 Name::parse("sns.dns.icann.org.", None).unwrap(),
                 Name::parse("noc.dns.icann.org.", None).unwrap(),
                 2015082403,
@@ -483,8 +453,10 @@ async fn test_axfr() {
                 3600,
                 1209600,
                 3600,
-            ))))
-            .clone(),
+            )),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
     ];
 
     expected_set.sort();
@@ -567,7 +539,7 @@ async fn test_cname_additionals() {
     assert_eq!(answers.len(), 1);
     assert_eq!(answers.first().unwrap().record_type(), RecordType::CNAME);
     assert_eq!(
-        answers.first().unwrap().data().unwrap(),
+        answers.first().unwrap().data(),
         &RData::CNAME(CNAME(Name::from_str("www.example.com.").unwrap()))
     );
 
@@ -575,7 +547,7 @@ async fn test_cname_additionals() {
     assert!(!additionals.is_empty());
     assert_eq!(additionals.first().unwrap().record_type(), RecordType::A);
     assert_eq!(
-        additionals.first().unwrap().data().unwrap(),
+        additionals.first().unwrap().data(),
         &RData::A(A::new(93, 184, 215, 14))
     );
 }
@@ -614,7 +586,7 @@ async fn test_multiple_cname_additionals() {
     assert_eq!(answers.len(), 1);
     assert_eq!(answers.first().unwrap().record_type(), RecordType::CNAME);
     assert_eq!(
-        answers.first().unwrap().data().unwrap(),
+        answers.first().unwrap().data(),
         &RData::CNAME(CNAME(Name::from_str("alias.example.com.").unwrap()))
     );
 
@@ -626,7 +598,7 @@ async fn test_multiple_cname_additionals() {
         RecordType::CNAME
     );
     assert_eq!(
-        additionals.first().unwrap().data().unwrap(),
+        additionals.first().unwrap().data(),
         &RData::CNAME(CNAME(Name::from_str("www.example.com.").unwrap()))
     );
 
@@ -635,7 +607,7 @@ async fn test_multiple_cname_additionals() {
     assert!(!additionals.is_empty());
     assert_eq!(additionals.last().unwrap().record_type(), RecordType::A);
     assert_eq!(
-        additionals.last().unwrap().data().unwrap(),
+        additionals.last().unwrap().data(),
         &RData::A(A::new(93, 184, 215, 14))
     );
 }

--- a/tests/integration-tests/tests/client_tests.rs
+++ b/tests/integration-tests/tests/client_tests.rs
@@ -125,7 +125,7 @@ where
     assert_eq!(record.record_type(), RecordType::A);
     assert_eq!(record.dns_class(), DNSClass::IN);
 
-    if let RData::A(ref address) = *record.data().unwrap() {
+    if let RData::A(ref address) = *record.data() {
         assert_eq!(address, &A::new(93, 184, 215, 14))
     } else {
         panic!();
@@ -183,7 +183,7 @@ where
         &EdnsOption::Subnet("1.2.0.0/16".parse().unwrap())
     );
 
-    if let RData::A(ref address) = *record.data().unwrap() {
+    if let RData::A(ref address) = *record.data() {
         assert_eq!(address, &A::new(93, 184, 215, 14))
     } else {
         panic!();
@@ -242,7 +242,7 @@ where
     assert_eq!(record.record_type(), RecordType::A);
     assert_eq!(record.dns_class(), DNSClass::IN);
 
-    if let RData::A(ref address) = *record.data().unwrap() {
+    if let RData::A(ref address) = *record.data() {
         assert_eq!(address, &A::new(93, 184, 215, 14))
     } else {
         panic!();
@@ -462,19 +462,18 @@ fn create_sig0_ready_client(mut catalog: Catalog) -> (SyncClient<TestClientConne
     );
 
     // insert the KEY for the trusted.example.com
-    let mut auth_key = Record::with(
+    let auth_key = Record::from_rdata(
         Name::from_str("trusted.example.com").unwrap(),
-        RecordType::KEY,
         Duration::minutes(5).whole_seconds() as u32,
+        RData::DNSSEC(DNSSECRData::KEY(KEY::new(
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            signer.algorithm(),
+            signer.key().to_public_bytes().expect("to_vec failed"),
+        ))),
     );
-    auth_key.set_data(Some(RData::DNSSEC(DNSSECRData::KEY(KEY::new(
-        Default::default(),
-        Default::default(),
-        Default::default(),
-        Default::default(),
-        signer.algorithm(),
-        signer.key().to_public_bytes().expect("to_vec failed"),
-    )))));
     authority.upsert_mut(auth_key, 0);
 
     catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
@@ -490,12 +489,11 @@ fn test_create() {
     let (client, origin) = create_sig0_ready_client(catalog);
 
     // create a record
-    let mut record = Record::with(
+    let mut record = Record::from_rdata(
         Name::from_str("new.example.com").unwrap(),
-        RecordType::A,
         Duration::minutes(5).whole_seconds() as u32,
+        RData::A(A::new(100, 10, 100, 10)),
     );
-    record.set_data(Some(RData::A(A::new(100, 10, 100, 10))));
 
     let result = client
         .create(record.clone(), origin.clone())
@@ -516,7 +514,7 @@ fn test_create() {
     assert_eq!(result.response_code(), ResponseCode::YXRRSet);
 
     // will fail if already set and not the same value.
-    record.set_data(Some(RData::A(A::new(101, 11, 101, 11))));
+    record.set_data(RData::A(A::new(101, 11, 101, 11)));
 
     let result = client.create(record, origin).expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::YXRRSet);
@@ -529,12 +527,11 @@ fn test_append() {
     let (client, origin) = create_sig0_ready_client(catalog);
 
     // append a record
-    let mut record = Record::with(
+    let mut record = Record::from_rdata(
         Name::from_str("new.example.com").unwrap(),
-        RecordType::A,
         Duration::minutes(5).whole_seconds() as u32,
+        RData::A(A::new(100, 10, 100, 10)),
     );
-    record.set_data(Some(RData::A(A::new(100, 10, 100, 10))));
 
     // first check the must_exist option
     let result = client
@@ -557,7 +554,7 @@ fn test_append() {
     assert_eq!(result.answers()[0], record);
 
     // will fail if already set and not the same value.
-    record.set_data(Some(RData::A(A::new(101, 11, 101, 11))));
+    record.set_data(RData::A(A::new(101, 11, 101, 11)));
 
     let result = client
         .append(record.clone(), origin.clone(), true)
@@ -573,7 +570,7 @@ fn test_append() {
     assert!(result
         .answers()
         .iter()
-        .any(|rr| if let RData::A(ip) = *rr.data().unwrap() {
+        .any(|rr| if let RData::A(ip) = *rr.data() {
             ip == A::new(100, 10, 100, 10)
         } else {
             false
@@ -581,7 +578,7 @@ fn test_append() {
     assert!(result
         .answers()
         .iter()
-        .any(|rr| if let RData::A(ip) = rr.data().unwrap() {
+        .any(|rr| if let RData::A(ip) = rr.data() {
             *ip == A::new(101, 11, 101, 11)
         } else {
             false
@@ -607,12 +604,11 @@ fn test_compare_and_swap() {
     let (client, origin) = create_sig0_ready_client(catalog);
 
     // create a record
-    let mut record = Record::with(
+    let record = Record::from_rdata(
         Name::from_str("new.example.com").unwrap(),
-        RecordType::A,
         Duration::minutes(5).whole_seconds() as u32,
+        RData::A(A::new(100, 10, 100, 10)),
     );
-    record.set_data(Some(RData::A(A::new(100, 10, 100, 10))));
 
     let result = client
         .create(record.clone(), origin.clone())
@@ -621,7 +617,7 @@ fn test_compare_and_swap() {
 
     let current = record;
     let mut new = current.clone();
-    new.set_data(Some(RData::A(A::new(101, 11, 101, 11))));
+    new.set_data(RData::A(A::new(101, 11, 101, 11)));
 
     let result = client
         .compare_and_swap(current.clone(), new.clone(), origin.clone())
@@ -636,14 +632,14 @@ fn test_compare_and_swap() {
     assert!(result
         .answers()
         .iter()
-        .any(|rr| if let RData::A(ip) = rr.data().unwrap() {
+        .any(|rr| if let RData::A(ip) = rr.data() {
             *ip == A::new(101, 11, 101, 11)
         } else {
             false
         }));
 
     // check the it fails if tried again.
-    new.set_data(Some(RData::A(A::new(102, 12, 102, 12))));
+    new.set_data(RData::A(A::new(102, 12, 102, 12)));
 
     let result = client
         .compare_and_swap(current, new.clone(), origin)
@@ -658,7 +654,7 @@ fn test_compare_and_swap() {
     assert!(result
         .answers()
         .iter()
-        .any(|rr| if let RData::A(ip) = rr.data().unwrap() {
+        .any(|rr| if let RData::A(ip) = rr.data() {
             *ip == A::new(101, 11, 101, 11)
         } else {
             false
@@ -672,12 +668,11 @@ fn test_delete_by_rdata() {
     let (client, origin) = create_sig0_ready_client(catalog);
 
     // append a record
-    let mut record = Record::with(
+    let mut record = Record::from_rdata(
         Name::from_str("new.example.com").unwrap(),
-        RecordType::A,
         Duration::minutes(5).whole_seconds() as u32,
+        RData::A(A::new(100, 10, 100, 10)),
     );
-    record.set_data(Some(RData::A(A::new(100, 10, 100, 10))));
 
     // first check the must_exist option
     let result = client
@@ -691,7 +686,7 @@ fn test_delete_by_rdata() {
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
-    record.set_data(Some(RData::A(A::new(101, 11, 101, 11))));
+    record.set_data(RData::A(A::new(101, 11, 101, 11)));
     let result = client
         .append(record.clone(), origin.clone(), true)
         .expect("create failed");
@@ -711,7 +706,7 @@ fn test_delete_by_rdata() {
     assert!(result
         .answers()
         .iter()
-        .any(|rr| if let RData::A(ip) = rr.data().unwrap() {
+        .any(|rr| if let RData::A(ip) = rr.data() {
             *ip == A::new(100, 10, 100, 10)
         } else {
             false
@@ -725,12 +720,11 @@ fn test_delete_rrset() {
     let (client, origin) = create_sig0_ready_client(catalog);
 
     // append a record
-    let mut record = Record::with(
+    let mut record = Record::from_rdata(
         Name::from_str("new.example.com").unwrap(),
-        RecordType::A,
         Duration::minutes(5).whole_seconds() as u32,
+        RData::A(A::new(100, 10, 100, 10)),
     );
-    record.set_data(Some(RData::A(A::new(100, 10, 100, 10))));
 
     // first check the must_exist option
     let result = client
@@ -744,7 +738,7 @@ fn test_delete_rrset() {
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
-    record.set_data(Some(RData::A(A::new(101, 11, 101, 11))));
+    record.set_data(RData::A(A::new(101, 11, 101, 11)));
     let result = client
         .append(record.clone(), origin.clone(), true)
         .expect("create failed");
@@ -772,12 +766,11 @@ fn test_delete_all() {
     let (client, origin) = create_sig0_ready_client(catalog);
 
     // append a record
-    let mut record = Record::with(
+    let mut record = Record::from_rdata(
         Name::from_str("new.example.com").unwrap(),
-        RecordType::A,
         Duration::minutes(5).whole_seconds() as u32,
+        RData::A(A::new(100, 10, 100, 10)),
     );
-    record.set_data(Some(RData::A(A::new(100, 10, 100, 10))));
 
     // first check the must_exist option
     let result = client
@@ -791,8 +784,7 @@ fn test_delete_all() {
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
-    record.set_record_type(RecordType::AAAA);
-    record.set_data(Some(RData::AAAA(AAAA::new(1, 2, 3, 4, 5, 6, 7, 8))));
+    record.set_data(RData::AAAA(AAAA::new(1, 2, 3, 4, 5, 6, 7, 8)));
     let result = client
         .create(record.clone(), origin.clone())
         .expect("create failed");

--- a/tests/integration-tests/tests/dnssec_client_handle_tests.rs
+++ b/tests/integration-tests/tests/dnssec_client_handle_tests.rs
@@ -64,7 +64,7 @@ where
     assert_eq!(record.dns_class(), DNSClass::IN);
     assert_eq!(record.proof(), Proof::Secure);
 
-    if let RData::A(ref address) = *record.data().unwrap() {
+    if let RData::A(ref address) = *record.data() {
         assert_eq!(address, &A::new(93, 184, 215, 14))
     } else {
         panic!();

--- a/tests/integration-tests/tests/lookup_tests.rs
+++ b/tests/integration-tests/tests/lookup_tests.rs
@@ -99,13 +99,13 @@ fn test_lookup_hosts() {
 fn create_ip_like_example() -> InMemoryAuthority {
     let mut authority = create_example();
     authority.upsert_mut(
-        Record::new()
-            .set_name(Name::from_str("1.2.3.4.example.com.").unwrap())
-            .set_ttl(86400)
-            .set_record_type(RecordType::A)
-            .set_dns_class(DNSClass::IN)
-            .set_data(Some(RData::A(A::new(198, 51, 100, 35))))
-            .clone(),
+        Record::from_rdata(
+            Name::from_str("1.2.3.4.example.com.").unwrap(),
+            86400,
+            RData::A(A::new(198, 51, 100, 35)),
+        )
+        .set_dns_class(DNSClass::IN)
+        .clone(),
         0,
     );
 
@@ -261,7 +261,7 @@ fn test_cname_lookup_preserve() {
     let lookup = io_loop.block_on(lookup).unwrap();
 
     let mut iter = lookup.iter();
-    assert_eq!(iter.next().unwrap(), cname_record.data().unwrap());
+    assert_eq!(iter.next().unwrap(), cname_record.data());
     assert_eq!(*iter.next().unwrap(), RData::A(A::new(93, 184, 215, 14)));
 }
 
@@ -341,7 +341,7 @@ fn test_chained_cname_lookup_preserve() {
     let lookup = io_loop.block_on(lookup).unwrap();
 
     let mut iter = lookup.iter();
-    assert_eq!(iter.next().unwrap(), cname_record.data().unwrap());
+    assert_eq!(iter.next().unwrap(), cname_record.data());
     assert_eq!(*iter.next().unwrap(), RData::A(A::new(93, 184, 215, 14)));
 }
 

--- a/tests/integration-tests/tests/server_future_tests.rs
+++ b/tests/integration-tests/tests/server_future_tests.rs
@@ -350,7 +350,7 @@ where
     assert_eq!(record.record_type(), RecordType::A);
     assert_eq!(record.dns_class(), DNSClass::IN);
 
-    if let RData::A(ref address) = *record.data().unwrap() {
+    if let RData::A(ref address) = *record.data() {
         assert_eq!(address, &A::new(93, 184, 215, 14))
     } else {
         panic!();

--- a/util/src/bin/recurse.rs
+++ b/util/src/bin/recurse.rs
@@ -179,18 +179,13 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for r in lookup.record_iter().filter(|r| r.record_type() == ty) {
         print!(
-            "\t{name} {ttl} {class} {ty}",
+            "\t{name} {ttl} {class} {ty} {rdata}",
             name = style(r.name()).blue(),
             ttl = style(r.ttl()).blue(),
             class = style(r.dns_class()).blue(),
             ty = style(r.record_type()).blue(),
+            rdata = r.data()
         );
-
-        if let Some(rdata) = r.data() {
-            println!(" {rdata}");
-        } else {
-            println!("NULL")
-        }
     }
 
     Ok(())

--- a/util/src/bin/resolve.rs
+++ b/util/src/bin/resolve.rs
@@ -148,17 +148,13 @@ struct Opts {
 
 fn print_record<D: RecordData, R: Deref<Target = Record<D>>>(r: &R) {
     print!(
-        "\t{name} {ttl} {class} {ty}",
+        "\t{name} {ttl} {class} {ty} {rdata}",
         name = style(r.name()).blue(),
         ttl = style(r.ttl()).blue(),
         class = style(r.dns_class()).blue(),
         ty = style(r.record_type()).blue(),
+        rdata = r.data(),
     );
-    if let Some(rdata) = r.data() {
-        println!(" {rdata}");
-    } else {
-        println!("NULL")
-    }
 }
 
 fn print_ok(lookup: Lookup) {


### PR DESCRIPTION
the `rr_type` field has been removed. this eliminates the possibility of setting `rdata` to a type that does not match `rr_type`. as a consequence, the `set_record_type` has also been removed

the `record_type` of the `Resource` is now derived from what's stored in the `rdata` field

`rdata` is no longer an `Option`. `rdata = None` was being used to represent update records. an `Update` variant has been added to the `RData` enum. this variant is used to represent update records, which have RDLENGTH set to 0.

the `Resource::{default,new}` constructors have been removed. they felt error prone as in most cases one wants to set the `rdata` and `name` fields since they have no sensible defaults. all uses of those constructors now use the pre-existing `from_rdata` constructor

the `Resource::with` constructor has also been removed. it was pretty similar to `from_rdata` but initialized `rr_type` and not `rdata`. all uses of `Record::with` has been changed to `from_rdata`

closes #2211 