### PR TITLE
dns-test: make NameServer's FQDN more stable

### DIFF
--- a/conformance/packages/dns-test/src/name_server.rs
+++ b/conformance/packages/dns-test/src/name_server.rs
@@ -317,8 +317,10 @@ fn zone_file_path() -> String {
 }
 
 fn ns_count() -> usize {
-    static COUNT: AtomicUsize = AtomicUsize::new(0);
-    COUNT.fetch_add(1, atomic::Ordering::Relaxed)
+    thread_local! {
+        static COUNT: AtomicUsize = const { AtomicUsize::new(0) };
+    }
+    COUNT.with(|count| count.fetch_add(1, atomic::Ordering::Relaxed))
 }
 
 impl NameServer<Signed> {


### PR DESCRIPTION
previously, the FQDN of a NameServer was generated using a globally shared, monotonically increasing counter. that resulted in a unpredictable FQDN in the presence other tests running concurrently / in parallel

with this change, the presence of other test threads does not affect the FQDN automatically chosen for a NameServer. the FQDN becomes only a function of the order in which the NameServers are created *within a thread*

this should help write NSEC3 conformance tests cc @pvdrz 