### PR TITLE
dns-test: let the caller pick the NameServer's FQDN

### DIFF
--- a/conformance/packages/conformance-tests/src/name_server/rfc4035/section_3/section_3_1/section_3_1_1.rs
+++ b/conformance/packages/conformance-tests/src/name_server/rfc4035/section_3/section_3_1/section_3_1_1.rs
@@ -8,7 +8,7 @@ use dns_test::{Network, Result, FQDN};
 fn rrsig_in_answer_section() -> Result<()> {
     let network = Network::new()?;
 
-    let ns = NameServer::new(&dns_test::SUBJECT, FQDN::ROOT, &network)?
+    let ns = NameServer::new(&dns_test::SUBJECT, FQDN::ROOT, &network, None)?
         .sign()?
         .start()?;
 
@@ -37,7 +37,7 @@ fn rrsig_in_answer_section() -> Result<()> {
 fn rrsig_in_authority_section() -> Result<()> {
     let network = Network::new()?;
 
-    let ns = NameServer::new(&dns_test::SUBJECT, FQDN::ROOT, &network)?
+    let ns = NameServer::new(&dns_test::SUBJECT, FQDN::ROOT, &network, None)?
         .sign()?
         .start()?;
 

--- a/conformance/packages/conformance-tests/src/name_server/scenarios.rs
+++ b/conformance/packages/conformance-tests/src/name_server/scenarios.rs
@@ -6,7 +6,7 @@ use dns_test::{Network, Result, FQDN};
 #[test]
 fn authoritative_answer() -> Result<()> {
     let network = &Network::new()?;
-    let ns = NameServer::new(&dns_test::SUBJECT, FQDN::ROOT, network)?.start()?;
+    let ns = NameServer::new(&dns_test::SUBJECT, FQDN::ROOT, network, None)?.start()?;
 
     let client = Client::new(network)?;
     let ans = client.dig(

--- a/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
@@ -12,7 +12,7 @@ fn can_resolve() -> Result<()> {
 
     let network = Network::new()?;
 
-    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;
+    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network, None)?;
     leaf_ns.add(Record::a(needle_fqdn.clone(), expected_ipv4_addr));
 
     let Graph {
@@ -47,7 +47,7 @@ fn nxdomain() -> Result<()> {
 
     let network = Network::new()?;
 
-    let leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;
+    let leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network, None)?;
 
     let Graph {
         nameservers: _nameservers,

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/fixtures.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/fixtures.rs
@@ -15,7 +15,7 @@ pub fn bad_signature_in_leaf_nameserver(
 
     let network = Network::new()?;
 
-    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;
+    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network, None)?;
     leaf_ns.add(Record::a(leaf_fqdn.clone(), leaf_ipv4_addr));
 
     let graph = Graph::build(
@@ -57,7 +57,7 @@ pub fn minimally_secure(
 
     let network = Network::new()?;
 
-    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;
+    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network, None)?;
     leaf_ns.add(Record::a(leaf_fqdn.clone(), leaf_ipv4_addr));
 
     let Graph {

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
@@ -10,7 +10,7 @@ use dns_test::{
 fn on_clients_ds_query_it_queries_the_parent_zone() -> Result<()> {
     let network = Network::new()?;
 
-    let leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;
+    let leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network, None)?;
 
     let Graph {
         nameservers,

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2.rs
@@ -11,7 +11,7 @@ use dns_test::{
 #[test]
 fn do_bit_not_set_in_request() -> Result<()> {
     let network = &Network::new()?;
-    let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?
+    let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network, None)?
         .sign()?
         .start()?;
     let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
@@ -55,7 +55,7 @@ fn do_bit_not_set_in_request() -> Result<()> {
 #[test]
 fn if_do_bit_not_set_in_request_then_requested_dnssec_record_is_not_stripped() -> Result<()> {
     let network = &Network::new()?;
-    let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?
+    let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network, None)?
         .sign()?
         .start()?;
     let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
@@ -80,7 +80,7 @@ fn if_do_bit_not_set_in_request_then_requested_dnssec_record_is_not_stripped() -
 #[test]
 fn do_bit_set_in_request() -> Result<()> {
     let network = &Network::new()?;
-    let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?
+    let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network, None)?
         .sign()?
         .start()?;
     let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2/section_3_2_2.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2/section_3_2_2.rs
@@ -12,7 +12,7 @@ use crate::resolver::dnssec::fixtures;
 #[test]
 fn copies_cd_bit_from_query_to_response() -> Result<()> {
     let network = &Network::new()?;
-    let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?.start()?;
+    let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network, None)?.start()?;
     let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
 
     let client = Client::new(network)?;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_1.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_1.rs
@@ -7,7 +7,7 @@ use dns_test::{Network, Resolver, Result, FQDN};
 #[test]
 fn edns_support() -> Result<()> {
     let network = &Network::new()?;
-    let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?.start()?;
+    let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network, None)?.start()?;
     let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
 
     let mut tshark = resolver.eavesdrop()?;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
@@ -132,7 +132,7 @@ fn fixture(
     let needle_fqdn = FQDN("example.nameservers.com.")?;
 
     let network = Network::new()?;
-    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;
+    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network, None)?;
     leaf_ns.add(Record::a(needle_fqdn.clone(), expected_ipv4_addr));
 
     let Graph {

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
@@ -12,7 +12,7 @@ use crate::resolver::dnssec::fixtures;
 #[test]
 fn can_validate_without_delegation() -> Result<()> {
     let network = Network::new()?;
-    let mut ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, &network)?;
+    let mut ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, &network, None)?;
     ns.add(ns.a());
     let ns = ns.sign()?;
 

--- a/conformance/packages/dns-test/examples/explore.rs
+++ b/conformance/packages/dns-test/examples/explore.rs
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
     let peer = &dns_test::PEER;
 
     println!("building docker image...");
-    let leaf_ns = NameServer::new(peer, FQDN("mydomain.com.")?, &network)?;
+    let leaf_ns = NameServer::new(peer, FQDN("mydomain.com.")?, &network, None)?;
     println!("DONE");
 
     println!("setting up name servers...");

--- a/conformance/packages/dns-test/src/record.rs
+++ b/conformance/packages/dns-test/src/record.rs
@@ -150,6 +150,14 @@ impl Record {
             Err(self)
         }
     }
+
+    pub fn try_into_soa(self) -> CoreResult<SOA, Self> {
+        if let Self::SOA(v) = self {
+            Ok(v)
+        } else {
+            Err(self)
+        }
+    }
 }
 
 impl FromStr for Record {

--- a/conformance/packages/dns-test/src/resolver.rs
+++ b/conformance/packages/dns-test/src/resolver.rs
@@ -182,7 +182,7 @@ mod tests {
     #[test]
     fn terminate_unbound_works() -> Result<()> {
         let network = Network::new()?;
-        let ns = NameServer::new(&Implementation::Unbound, FQDN::ROOT, &network)?.start()?;
+        let ns = NameServer::new(&Implementation::Unbound, FQDN::ROOT, &network, None)?.start()?;
         let resolver = Resolver::new(&network, ns.root_hint()).start(&Implementation::Unbound)?;
         let logs = resolver.terminate()?;
 
@@ -195,7 +195,7 @@ mod tests {
     #[test]
     fn terminate_bind_works() -> Result<()> {
         let network = Network::new()?;
-        let ns = NameServer::new(&Implementation::Unbound, FQDN::ROOT, &network)?.start()?;
+        let ns = NameServer::new(&Implementation::Unbound, FQDN::ROOT, &network, None)?.start()?;
         let resolver = Resolver::new(&network, ns.root_hint()).start(&Implementation::Bind)?;
         let logs = resolver.terminate()?;
 
@@ -208,7 +208,7 @@ mod tests {
     #[test]
     fn terminate_hickory_works() -> Result<()> {
         let network = Network::new()?;
-        let ns = NameServer::new(&Implementation::Unbound, FQDN::ROOT, &network)?.start()?;
+        let ns = NameServer::new(&Implementation::Unbound, FQDN::ROOT, &network, None)?.start()?;
         let resolver = Resolver::new(&network, ns.root_hint()).start(&Implementation::Hickory(
             Repository("https://github.com/hickory-dns/hickory-dns"),
         ))?;

--- a/conformance/packages/dns-test/src/tshark.rs
+++ b/conformance/packages/dns-test/src/tshark.rs
@@ -272,7 +272,7 @@ mod tests {
     #[test]
     fn nameserver() -> Result<()> {
         let network = &Network::new()?;
-        let ns = NameServer::new(&Implementation::Unbound, FQDN::ROOT, network)?.start()?;
+        let ns = NameServer::new(&Implementation::Unbound, FQDN::ROOT, network, None)?.start()?;
         let mut tshark = ns.eavesdrop()?;
 
         let client = Client::new(network)?;
@@ -307,11 +307,15 @@ mod tests {
     #[test]
     fn resolver() -> Result<()> {
         let network = &Network::new()?;
-        let mut root_ns = NameServer::new(&Implementation::Unbound, FQDN::ROOT, network)?;
-        let mut com_ns = NameServer::new(&Implementation::Unbound, FQDN::COM, network)?;
+        let mut root_ns = NameServer::new(&Implementation::Unbound, FQDN::ROOT, network, None)?;
+        let mut com_ns = NameServer::new(&Implementation::Unbound, FQDN::COM, network, None)?;
 
-        let mut nameservers_ns =
-            NameServer::new(&Implementation::Unbound, FQDN("nameservers.com.")?, network)?;
+        let mut nameservers_ns = NameServer::new(
+            &Implementation::Unbound,
+            FQDN("nameservers.com.")?,
+            network,
+            None,
+        )?;
         nameservers_ns.add(root_ns.a()).add(com_ns.a());
         let nameservers_ns = nameservers_ns.start()?;
 


### PR DESCRIPTION
so far, the FQDN of the NameServer has been automatically generated based on a monotonically increasing counter.

to test NSEC3 functionality is preferable to fix the domain name to a known value. this is because the NSEC3 algorithm sorts records by their *hashed* domain names; and a name that's generated on the fly and changes on each invocation of the test will affect the order of the NSEC3 records.

if #2235 is not good enough we can land this more invasive change. until I heard back from @pvdrz I'm going to leave this as a draft