### PR TITLE
recursor: strip dnssec records on cache hit

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2.rs
@@ -55,7 +55,6 @@ fn do_bit_not_set_in_request() -> Result<()> {
 // this ensures that even in the presence of a cached (answer+rrsig) we strip the dnssec records as
 // per the RFC
 #[test]
-#[ignore]
 fn on_do_0_query_strips_dnssec_records_even_if_it_cached_a_previous_do_1_query() -> Result<()> {
     let network = &Network::new()?;
     let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?

--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -307,11 +307,7 @@ impl Recursor {
         request_time: Instant,
         query_has_dnssec_ok: bool,
     ) -> Result<Lookup, Error> {
-        if self.security_aware {
-            // TODO RFC4035 section 4.5 recommends caching "each response as a single atomic entry
-            // containing the entire answer, including the named RRset and any associated DNSSEC
-            // RRs"
-        } else if let Some(lookup) = self.record_cache.get(&query, request_time) {
+        if let Some(lookup) = self.record_cache.get(&query, request_time) {
             return lookup.map_err(Into::into);
         }
 


### PR DESCRIPTION
this is triggered by a DO=1 query followed by the almost exact same query but with DO=0

this is best reviewed on a commit by commit basis