### PR TITLE
add DNSSEC validation to the recursive resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,15 +345,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
-name = "basic-toml"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,7 +1061,6 @@ name = "hickory-server"
 version = "0.25.0-alpha.1"
 dependencies = [
  "async-trait",
- "basic-toml",
  "bytes",
  "cfg-if",
  "enum-as-inner",
@@ -1095,6 +1085,7 @@ dependencies = [
  "tokio-openssl",
  "tokio-rustls",
  "tokio-util",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1962,6 +1953,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2213,6 +2213,40 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2618,6 +2652,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winnow"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,6 @@ http = "1.1"
 
 # others
 backtrace = "0.3.50"
-basic-toml = "0.1"
 bitflags = "2.4.1"
 bytes = "1"
 cfg-if = "1"
@@ -104,6 +103,7 @@ smallvec = "1.6"
 socket2 = "0.5"
 time = "0.3"
 tinyvec = "1.1.1"
+toml = "0.8.14"
 url = "2.4.0"
 wasm-bindgen-crate = { version = "0.2.58", package = "wasm-bindgen" }
 

--- a/bin/tests/named_test_rsa_dnssec.rs
+++ b/bin/tests/named_test_rsa_dnssec.rs
@@ -8,6 +8,7 @@ use std::fs::File;
 use std::io::Read;
 use std::net::*;
 use std::path::Path;
+use std::sync::Arc;
 
 use hickory_server::server::Protocol;
 use tokio::net::TcpStream as TokioTcpStream;
@@ -37,7 +38,11 @@ fn confg_toml() -> &'static str {
     "all_supported_dnssec.toml"
 }
 
-fn trust_anchor(public_key_path: &Path, format: KeyFormat, algorithm: Algorithm) -> TrustAnchor {
+fn trust_anchor(
+    public_key_path: &Path,
+    format: KeyFormat,
+    algorithm: Algorithm,
+) -> Arc<TrustAnchor> {
     let mut file = File::open(public_key_path).expect("key not found");
     let mut buf = Vec::<u8>::new();
 
@@ -50,7 +55,7 @@ fn trust_anchor(public_key_path: &Path, format: KeyFormat, algorithm: Algorithm)
     let mut trust_anchor = TrustAnchor::new();
 
     trust_anchor.insert_trust_anchor(&public_key);
-    trust_anchor
+    Arc::new(trust_anchor)
 }
 
 #[allow(clippy::type_complexity)]

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
@@ -8,7 +8,6 @@ use dns_test::{Network, Resolver, Result, TrustAnchor, FQDN};
 use crate::resolver::dnssec::fixtures;
 
 // no DS records are involved; this is a single-link chain of trust
-#[ignore]
 #[test]
 fn can_validate_without_delegation() -> Result<()> {
     let network = Network::new()?;
@@ -44,7 +43,6 @@ fn can_validate_without_delegation() -> Result<()> {
     Ok(())
 }
 
-#[ignore]
 #[test]
 fn can_validate_with_delegation() -> Result<()> {
     let expected_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);

--- a/conformance/packages/dns-test/src/templates/hickory.resolver.toml.jinja
+++ b/conformance/packages/dns-test/src/templates/hickory.resolver.toml.jinja
@@ -1,5 +1,4 @@
 [[zones]]
 zone = "."
 zone_type = "Hint"
-stores = { type = "recursor", roots = "/etc/root.hints", security_aware = true }
-enable_dnssec = {{ use_dnssec }}
+stores = { type = "recursor" , roots = "/etc/root.hints" {% if use_dnssec %}, dnssec_policy.ValidateWithStaticKey.path = "/etc/trusted-key.key" {% else %}, dnssec_policy = "ValidationDisabled" {% endif %}  }

--- a/crates/client/src/client/async_secure_client.rs
+++ b/crates/client/src/client/async_secure_client.rs
@@ -7,6 +7,7 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
 
 use futures_util::stream::Stream;
 
@@ -51,7 +52,7 @@ impl AsyncDnssecClient {
         Self::builder(connect_future).build().await
     }
 
-    fn from_client(client: AsyncClient, trust_anchor: TrustAnchor) -> Self {
+    fn from_client(client: AsyncClient, trust_anchor: Arc<TrustAnchor>) -> Self {
         Self {
             client: DnssecDnsHandle::with_trust_anchor(client, trust_anchor),
         }
@@ -107,7 +108,7 @@ where
     pub async fn build(
         mut self,
     ) -> Result<(AsyncDnssecClient, DnsExchangeBackground<S, TokioTime>), ProtoError> {
-        let trust_anchor = self.trust_anchor.take().unwrap_or_default();
+        let trust_anchor = Arc::new(self.trust_anchor.take().unwrap_or_default());
         let result = AsyncClient::connect(self.connect_future).await;
 
         result.map(|(client, bg)| (AsyncDnssecClient::from_client(client, trust_anchor), bg))

--- a/crates/proto/src/xfer/dnssec_dns_handle.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle.rs
@@ -71,7 +71,7 @@ where
     /// # Arguments
     /// * `handle` - handle to use for all connections to a remote server.
     pub fn new(handle: H) -> Self {
-        Self::with_trust_anchor(handle, TrustAnchor::default())
+        Self::with_trust_anchor(handle, Arc::new(TrustAnchor::default()))
     }
 
     /// Create a new DnssecDnsHandle wrapping the specified handle.
@@ -81,10 +81,10 @@ where
     /// # Arguments
     /// * `handle` - handle to use for all connections to a remote server.
     /// * `trust_anchor` - custom DNSKEYs that will be trusted, can be used to pin trusted keys.
-    pub fn with_trust_anchor(handle: H, trust_anchor: TrustAnchor) -> Self {
+    pub fn with_trust_anchor(handle: H, trust_anchor: Arc<TrustAnchor>) -> Self {
         Self {
             handle,
-            trust_anchor: Arc::new(trust_anchor),
+            trust_anchor,
             request_depth: 0,
             minimum_key_len: 0,
             minimum_algorithm: Algorithm::RSASHA256,

--- a/crates/recursor/src/lib.rs
+++ b/crates/recursor/src/lib.rs
@@ -28,6 +28,7 @@
 
 pub mod error;
 mod recursor;
+mod recursor_dns_handle;
 pub(crate) mod recursor_pool;
 
 use std::time::Instant;

--- a/crates/recursor/src/lib.rs
+++ b/crates/recursor/src/lib.rs
@@ -37,6 +37,8 @@ pub use error::{Error, ErrorKind};
 pub use hickory_proto as proto;
 pub use hickory_resolver as resolver;
 pub use hickory_resolver::config::NameServerConfig;
+#[cfg(feature = "dnssec")]
+use proto::rr::dnssec::TrustAnchor;
 use proto::{op::Query, xfer::DnsResponse};
 pub use recursor::{Recursor, RecursorBuilder};
 use resolver::{dns_lru::DnsLru, lookup::Lookup, Name};
@@ -54,6 +56,15 @@ pub enum DnssecPolicy {
     /// DNSSEC validation is disabled; DNSSEC records will be requested and processed
     #[cfg(feature = "dnssec")]
     ValidationDisabled,
+
+    /// DNSSEC validation is enabled and will use the chosen `trust_anchor` set of keys
+    #[cfg(feature = "dnssec")]
+    ValidateWithStaticKey {
+        /// set to `None` to use built-in trust anchor
+        trust_anchor: Option<TrustAnchor>,
+    },
+    // TODO RFC5011
+    // ValidateWithInitialKey { ..  },}
 }
 
 impl DnssecPolicy {

--- a/crates/recursor/src/lib.rs
+++ b/crates/recursor/src/lib.rs
@@ -31,6 +31,8 @@ mod recursor;
 mod recursor_dns_handle;
 pub(crate) mod recursor_pool;
 
+#[cfg(feature = "dnssec")]
+use std::sync::Arc;
 use std::time::Instant;
 
 pub use error::{Error, ErrorKind};
@@ -61,7 +63,7 @@ pub enum DnssecPolicy {
     #[cfg(feature = "dnssec")]
     ValidateWithStaticKey {
         /// set to `None` to use built-in trust anchor
-        trust_anchor: Option<TrustAnchor>,
+        trust_anchor: Option<Arc<TrustAnchor>>,
     },
     // TODO RFC5011
     // ValidateWithInitialKey { ..  },}

--- a/crates/recursor/src/lib.rs
+++ b/crates/recursor/src/lib.rs
@@ -35,3 +35,90 @@ pub use hickory_proto as proto;
 pub use hickory_resolver as resolver;
 pub use hickory_resolver::config::NameServerConfig;
 pub use recursor::{Recursor, RecursorBuilder};
+use resolver::Name;
+
+/// Bailiwick/sub zone checking.
+///
+/// # Overview
+///
+/// This function checks that two host names have a parent/child relationship, but does so more strictly than elsewhere in the libraries
+/// (see implementation notes.)
+///
+/// A resolver should not return answers outside of its delegated authority -- if we receive a delegation from the root servers for
+/// "example.com", that server should only return answers related to example.com or a sub-domain thereof.  Note that record data may point
+/// to out-of-bailwick records (e.g., example.com could return a CNAME record for www.example.com that points to example.cdnprovider.net,)
+/// but it should not return a record name that is out-of-bailiwick (e.g., we ask for www.example.com and it returns www.otherdomain.com.)
+///
+/// Out-of-bailiwick responses have been used in cache poisoning attacks.
+///
+/// ## Examples
+///
+/// | Parent       | Child                | Expected Result                                                  |
+/// |--------------|----------------------|------------------------------------------------------------------|
+/// | .            | com.                 | In-bailiwick (true)                                              |
+/// | com.         | example.net.         | Out-of-bailiwick (false)                                         |
+/// | example.com. | www.example.com.     | In-bailiwick (true)                                              |
+/// | example.com. | www.otherdomain.com. | Out-of-bailiwick (false)                                         |
+/// | example.com  | www.example.com.     | Out-of-bailiwick (false, note the parent is not fully qualified) |
+///
+/// # Implementation Notes
+///
+/// * This function is nominally a wrapper around Name::zone_of, with two additional checks:
+/// * If the caller doesn't provide a parent at all, we'll return false.
+/// * If the domains have mixed qualification -- that is, if one is fully-qualified and the other partially-qualified, we'll return
+///    false.
+///
+/// # References
+///
+/// * [RFC 8499](https://datatracker.ietf.org/doc/html/rfc8499) -- DNS Terminology (see page 25)
+/// * [The Hitchiker's Guide to DNS Cache Poisoning](https://www.cs.utexas.edu/%7Eshmat/shmat_securecomm10.pdf) -- for a more in-depth
+///   discussion of DNS cache poisoning attacks, see section 4, specifically, for a discussion of the Bailiwick rule.
+fn is_subzone(parent: Name, child: Name) -> bool {
+    if parent.is_empty() {
+        return false;
+    }
+
+    if (parent.is_fqdn() && !child.is_fqdn()) || (!parent.is_fqdn() && child.is_fqdn()) {
+        return false;
+    }
+
+    parent.zone_of(&child)
+}
+
+#[test]
+fn is_subzone_test() {
+    use core::str::FromStr;
+
+    assert!(is_subzone(
+        Name::from_str(".").unwrap(),
+        Name::from_str("com.").unwrap()
+    ));
+    assert!(is_subzone(
+        Name::from_str("com.").unwrap(),
+        Name::from_str("example.com.").unwrap()
+    ));
+    assert!(is_subzone(
+        Name::from_str("example.com.").unwrap(),
+        Name::from_str("host.example.com.").unwrap()
+    ));
+    assert!(is_subzone(
+        Name::from_str("example.com.").unwrap(),
+        Name::from_str("host.multilevel.example.com.").unwrap()
+    ));
+    assert!(!is_subzone(
+        Name::from_str("").unwrap(),
+        Name::from_str("example.com.").unwrap()
+    ));
+    assert!(!is_subzone(
+        Name::from_str("com.").unwrap(),
+        Name::from_str("example.net.").unwrap()
+    ));
+    assert!(!is_subzone(
+        Name::from_str("example.com.").unwrap(),
+        Name::from_str("otherdomain.com.").unwrap()
+    ));
+    assert!(!is_subzone(
+        Name::from_str("com").unwrap(),
+        Name::from_str("example.com.").unwrap()
+    ));
+}

--- a/crates/recursor/src/lib.rs
+++ b/crates/recursor/src/lib.rs
@@ -42,6 +42,26 @@ pub use recursor::{Recursor, RecursorBuilder};
 use resolver::{dns_lru::DnsLru, lookup::Lookup, Name};
 use tracing::{info, warn};
 
+/// `Recursor`'s DNSSEC policy
+// `Copy` can only be implemented when `dnssec` is disabled we don't want to remove a trait
+// implementation when a feature is enabled as features are meant to be additive
+#[allow(missing_copy_implementations)]
+#[derive(Clone)]
+pub enum DnssecPolicy {
+    /// security unaware; DNSSEC records will not be requested nor processed
+    SecurityUnaware,
+
+    /// DNSSEC validation is disabled; DNSSEC records will be requested and processed
+    #[cfg(feature = "dnssec")]
+    ValidationDisabled,
+}
+
+impl DnssecPolicy {
+    pub(crate) fn is_security_aware(&self) -> bool {
+        !matches!(self, Self::SecurityUnaware)
+    }
+}
+
 /// caches the `response` to `query` in `record_cache`
 ///
 /// `now` indicates when the `response` was obtained

--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -14,9 +14,6 @@ use lru_cache::LruCache;
 use parking_lot::Mutex;
 use tracing::{debug, info, warn};
 
-#[cfg(test)]
-use std::str::FromStr;
-
 use crate::{
     proto::{
         op::Query,
@@ -391,7 +388,7 @@ impl Recursor {
                     .chain(r.take_name_servers())
                     .chain(r.take_additionals())
                     .filter(|x| {
-                        if !is_subzone(ns.zone().clone(), x.name().clone()) {
+                        if !super::is_subzone(ns.zone().clone(), x.name().clone()) {
                             warn!(
                                 "Dropping out of bailiwick record {x} for zone {}",
                                 ns.zone().clone()
@@ -457,7 +454,7 @@ impl Recursor {
                 //     .filter_map(Record::data)
                 //     .filter_map(RData::to_ip_addr);
 
-                if !is_subzone(zone.base_name().clone(), zns.name().clone()) {
+                if !super::is_subzone(zone.base_name().clone(), zns.name().clone()) {
                     warn!(
                         "Dropping out of bailiwick record for {:?} with parent {:?}",
                         zns.name().clone(),
@@ -589,90 +586,6 @@ fn recursor_opts() -> ResolverOpts {
     options.num_concurrent_reqs = 1;
 
     options
-}
-
-/// Bailiwick/sub zone checking.
-///
-/// # Overview
-///
-/// This function checks that two host names have a parent/child relationship, but does so more strictly than elsewhere in the libraries
-/// (see implementation notes.)
-///
-/// A resolver should not return answers outside of its delegated authority -- if we receive a delegation from the root servers for
-/// "example.com", that server should only return answers related to example.com or a sub-domain thereof.  Note that record data may point
-/// to out-of-bailwick records (e.g., example.com could return a CNAME record for www.example.com that points to example.cdnprovider.net,)
-/// but it should not return a record name that is out-of-bailiwick (e.g., we ask for www.example.com and it returns www.otherdomain.com.)
-///
-/// Out-of-bailiwick responses have been used in cache poisoning attacks.
-///
-/// ## Examples
-///
-/// | Parent       | Child                | Expected Result                                                  |
-/// |--------------|----------------------|------------------------------------------------------------------|
-/// | .            | com.                 | In-bailiwick (true)                                              |
-/// | com.         | example.net.         | Out-of-bailiwick (false)                                         |
-/// | example.com. | www.example.com.     | In-bailiwick (true)                                              |
-/// | example.com. | www.otherdomain.com. | Out-of-bailiwick (false)                                         |
-/// | example.com  | www.example.com.     | Out-of-bailiwick (false, note the parent is not fully qualified) |
-///
-/// # Implementation Notes
-///
-/// * This function is nominally a wrapper around Name::zone_of, with two additional checks:
-/// * If the caller doesn't provide a parent at all, we'll return false.
-/// * If the domains have mixed qualification -- that is, if one is fully-qualified and the other partially-qualified, we'll return
-///    false.
-///
-/// # References
-///
-/// * [RFC 8499](https://datatracker.ietf.org/doc/html/rfc8499) -- DNS Terminology (see page 25)
-/// * [The Hitchiker's Guide to DNS Cache Poisoning](https://www.cs.utexas.edu/%7Eshmat/shmat_securecomm10.pdf) -- for a more in-depth
-///   discussion of DNS cache poisoning attacks, see section 4, specifically, for a discussion of the Bailiwick rule.
-fn is_subzone(parent: Name, child: Name) -> bool {
-    if parent.is_empty() {
-        return false;
-    }
-
-    if (parent.is_fqdn() && !child.is_fqdn()) || (!parent.is_fqdn() && child.is_fqdn()) {
-        return false;
-    }
-
-    parent.zone_of(&child)
-}
-
-#[test]
-fn is_subzone_test() {
-    assert!(is_subzone(
-        Name::from_str(".").unwrap(),
-        Name::from_str("com.").unwrap()
-    ));
-    assert!(is_subzone(
-        Name::from_str("com.").unwrap(),
-        Name::from_str("example.com.").unwrap()
-    ));
-    assert!(is_subzone(
-        Name::from_str("example.com.").unwrap(),
-        Name::from_str("host.example.com.").unwrap()
-    ));
-    assert!(is_subzone(
-        Name::from_str("example.com.").unwrap(),
-        Name::from_str("host.multilevel.example.com.").unwrap()
-    ));
-    assert!(!is_subzone(
-        Name::from_str("").unwrap(),
-        Name::from_str("example.com.").unwrap()
-    ));
-    assert!(!is_subzone(
-        Name::from_str("com.").unwrap(),
-        Name::from_str("example.net.").unwrap()
-    ));
-    assert!(!is_subzone(
-        Name::from_str("example.com.").unwrap(),
-        Name::from_str("otherdomain.com.").unwrap()
-    ));
-    assert!(!is_subzone(
-        Name::from_str("com").unwrap(),
-        Name::from_str("example.com.").unwrap()
-    ));
 }
 
 #[tokio::test]

--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -5,34 +5,14 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::{net::SocketAddr, time::Instant};
-
-use async_recursion::async_recursion;
-use futures_util::{future::select_all, FutureExt};
-use hickory_resolver::name_server::TokioConnectionProvider;
-use lru_cache::LruCache;
-use parking_lot::Mutex;
-use tracing::{debug, warn};
+use std::time::Instant;
 
 use crate::{
-    proto::{
-        op::Query,
-        rr::{RData, RecordType},
-    },
-    recursor_pool::RecursorPool,
-    resolver::{
-        config::{NameServerConfig, NameServerConfigGroup, Protocol, ResolverOpts},
-        dns_lru::{DnsLru, TtlConfig},
-        error::ResolveError,
-        lookup::Lookup,
-        name_server::{GenericNameServerPool, TokioRuntimeProvider},
-        Name,
-    },
-    Error, ErrorKind,
+    proto::op::Query,
+    recursor_dns_handle::RecursorDnsHandle,
+    resolver::{config::NameServerConfigGroup, error::ResolveError, lookup::Lookup},
+    Error,
 };
-
-/// Set of nameservers by the zone name
-type NameServerCache<P> = LruCache<Name, RecursorPool<P>>;
 
 /// A `Recursor` builder
 #[derive(Clone, Copy)]
@@ -98,10 +78,7 @@ impl RecursorBuilder {
 ///
 /// This is the well known root nodes, referred to as hints in RFCs. See the IANA [Root Servers](https://www.iana.org/domains/root/servers) list.
 pub struct Recursor {
-    roots: RecursorPool<TokioRuntimeProvider>,
-    name_server_cache: Mutex<NameServerCache<TokioRuntimeProvider>>,
-    record_cache: DnsLru,
-    security_aware: bool,
+    handle: RecursorDnsHandle,
 }
 
 impl Recursor {
@@ -116,25 +93,8 @@ impl Recursor {
         record_cache_size: usize,
         security_aware: bool,
     ) -> Result<Self, ResolveError> {
-        // configure the hickory-resolver
-        let roots: NameServerConfigGroup = roots.into();
-
-        assert!(!roots.is_empty(), "roots must not be empty");
-
-        debug!("Using cache sizes {}/{}", ns_cache_size, record_cache_size);
-        let opts = recursor_opts();
-        let roots =
-            GenericNameServerPool::from_config(roots, opts, TokioConnectionProvider::default());
-        let roots = RecursorPool::from(Name::root(), roots);
-        let name_server_cache = Mutex::new(NameServerCache::new(ns_cache_size));
-        let record_cache = DnsLru::new(record_cache_size, TtlConfig::default());
-
-        Ok(Self {
-            roots,
-            name_server_cache,
-            record_cache,
-            security_aware,
-        })
+        RecursorDnsHandle::new(roots, ns_cache_size, record_cache_size, security_aware)
+            .map(|handle| Self { handle })
     }
 
     /// Perform a recursive resolution
@@ -308,245 +268,16 @@ impl Recursor {
             return Err(Error::from("query's domain name must be fully qualified"));
         }
 
-        if let Some(lookup) = self.record_cache.get(&query, request_time) {
-            let lookup = super::maybe_strip_dnssec_records(query_has_dnssec_ok, lookup?, query);
-
-            return Ok(lookup);
-        }
-
-        // not in cache, let's look for an ns record for lookup
-        let zone = match query.query_type() {
-            // (RFC4035 section 3.1.4.1) the DS record needs to be queried in the parent zone
-            RecordType::NS | RecordType::DS => query.name().base_name(),
-            // look for the NS records "inside" the zone
-            _ => query.name().clone(),
-        };
-
-        let mut zone = zone;
-        let mut ns = None;
-
-        // max number of forwarding processes
-        'max_forward: for _ in 0..20 {
-            match self.ns_pool_for_zone(zone.clone(), request_time).await {
-                Ok(found) => {
-                    // found the nameserver
-                    ns = Some(found);
-                    break 'max_forward;
-                }
-                Err(e) => match e.kind() {
-                    ErrorKind::Forward(name) => {
-                        // if we already had this name, don't try again
-                        if &zone == name {
-                            debug!("zone previously searched for {}", name);
-                            break 'max_forward;
-                        };
-
-                        debug!("ns forwarded to {}", name);
-                        zone = name.clone();
-                    }
-                    _ => return Err(e),
-                },
-            }
-        }
-
-        let ns = ns.ok_or_else(|| Error::from(format!("no nameserver found for {zone}")))?;
-        debug!("found zone {} for {}", ns.zone(), query);
-
-        let response = self.lookup(query.clone(), ns, request_time).await?;
-
-        // RFC 4035 section 3.2.1 if DO bit not set, strip DNSSEC records unless
-        // explicitly requested
-        let lookup = super::maybe_strip_dnssec_records(query_has_dnssec_ok, response, query);
-
-        Ok(lookup)
+        self.handle
+            .resolve(query, request_time, query_has_dnssec_ok)
+            .await
     }
-
-    async fn lookup(
-        &self,
-        query: Query,
-        ns: RecursorPool<TokioRuntimeProvider>,
-        now: Instant,
-    ) -> Result<Lookup, Error> {
-        if let Some(lookup) = self.record_cache.get(&query, now) {
-            debug!("cached data {lookup:?}");
-            return lookup.map_err(Into::into);
-        }
-
-        let response = ns.lookup(query.clone(), self.security_aware);
-
-        // TODO: we are only expecting one response
-        // TODO: should we change DnsHandle to always be a single response? And build a totally custom handler for other situations?
-        // TODO: check if data is "authentic"
-        match response.await {
-            Ok(r) => super::cache_response(r, Some(ns.zone()), &self.record_cache, query, now),
-            Err(e) => {
-                warn!("lookup error: {e}");
-                Err(Error::from(e))
-            }
-        }
-    }
-
-    #[async_recursion]
-    async fn ns_pool_for_zone(
-        &self,
-        zone: Name,
-        request_time: Instant,
-    ) -> Result<RecursorPool<TokioRuntimeProvider>, Error> {
-        // TODO: need to check TTLs here.
-        if let Some(ns) = self.name_server_cache.lock().get_mut(&zone) {
-            return Ok(ns.clone());
-        };
-
-        let parent_zone = zone.base_name();
-
-        let nameserver_pool = if parent_zone.is_root() {
-            debug!("using roots for {zone} nameservers");
-            self.roots.clone()
-        } else {
-            self.ns_pool_for_zone(parent_zone, request_time).await?
-        };
-
-        // TODO: check for cached ns pool for this zone
-
-        let lookup = Query::query(zone.clone(), RecordType::NS);
-        let response = self
-            .lookup(lookup.clone(), nameserver_pool.clone(), request_time)
-            .await?;
-
-        // let zone_nameservers = response.name_servers();
-        // let glue = response.additionals();
-
-        // TODO: grab TTL and use for cache
-        // get all the NS records and glue
-        let mut config_group = NameServerConfigGroup::new();
-        let mut need_ips_for_names = Vec::new();
-
-        // unpack all glued records
-        for zns in response.record_iter() {
-            if let Some(ns_data) = zns.data().as_ns() {
-                // let glue_ips = glue
-                //     .iter()
-                //     .filter(|g| g.name() == ns_data)
-                //     .filter_map(Record::data)
-                //     .filter_map(RData::to_ip_addr);
-
-                if !super::is_subzone(zone.base_name().clone(), zns.name().clone()) {
-                    warn!(
-                        "Dropping out of bailiwick record for {:?} with parent {:?}",
-                        zns.name().clone(),
-                        zone.base_name().clone()
-                    );
-                    continue;
-                }
-
-                let cached_a = self.record_cache.get(
-                    &Query::query(ns_data.0.clone(), RecordType::A),
-                    request_time,
-                );
-                let cached_aaaa = self.record_cache.get(
-                    &Query::query(ns_data.0.clone(), RecordType::AAAA),
-                    request_time,
-                );
-
-                let cached_a = cached_a.and_then(Result::ok).map(Lookup::into_iter);
-                let cached_aaaa = cached_aaaa.and_then(Result::ok).map(Lookup::into_iter);
-
-                let glue_ips = cached_a
-                    .into_iter()
-                    .flatten()
-                    .chain(cached_aaaa.into_iter().flatten())
-                    .filter_map(|r| RData::ip_addr(&r));
-
-                let mut had_glue = false;
-                for ip in glue_ips {
-                    let mut udp = NameServerConfig::new(SocketAddr::from((ip, 53)), Protocol::Udp);
-                    let mut tcp = NameServerConfig::new(SocketAddr::from((ip, 53)), Protocol::Tcp);
-
-                    udp.trust_negative_responses = true;
-                    tcp.trust_negative_responses = true;
-
-                    config_group.push(udp);
-                    config_group.push(tcp);
-                    had_glue = true;
-                }
-
-                if !had_glue {
-                    debug!("glue not found for {}", ns_data);
-                    need_ips_for_names.push(ns_data);
-                }
-            }
-        }
-
-        // collect missing IP addresses, select over them all, get the addresses
-        // make it configurable to query for all records?
-        if config_group.is_empty() && !need_ips_for_names.is_empty() {
-            debug!("need glue for {}", zone);
-            let a_resolves = need_ips_for_names.iter().take(1).map(|name| {
-                let a_query = Query::query(name.0.clone(), RecordType::A);
-                self.resolve(a_query, request_time, false).boxed()
-            });
-
-            let aaaa_resolves = need_ips_for_names.iter().take(1).map(|name| {
-                let aaaa_query = Query::query(name.0.clone(), RecordType::AAAA);
-                self.resolve(aaaa_query, request_time, false).boxed()
-            });
-
-            let mut a_resolves: Vec<_> = a_resolves.chain(aaaa_resolves).collect();
-            while !a_resolves.is_empty() {
-                let (next, _, rest) = select_all(a_resolves).await;
-                a_resolves = rest;
-
-                match next {
-                    Ok(response) => {
-                        debug!("A or AAAA response: {:?}", response);
-                        let ips = response.iter().filter_map(RData::ip_addr);
-
-                        for ip in ips {
-                            let udp =
-                                NameServerConfig::new(SocketAddr::from((ip, 53)), Protocol::Udp);
-                            let tcp =
-                                NameServerConfig::new(SocketAddr::from((ip, 53)), Protocol::Tcp);
-
-                            config_group.push(udp);
-                            config_group.push(tcp);
-                        }
-                    }
-                    Err(e) => {
-                        warn!("resolve failed {}", e);
-                    }
-                }
-            }
-        }
-
-        // now construct a namesever pool based off the NS and glue records
-        let ns = GenericNameServerPool::from_config(
-            config_group,
-            recursor_opts(),
-            TokioConnectionProvider::default(),
-        );
-        let ns = RecursorPool::from(zone.clone(), ns);
-
-        // store in cache for future usage
-        debug!("found nameservers for {}", zone);
-        self.name_server_cache.lock().insert(zone, ns.clone());
-        Ok(ns)
-    }
-}
-
-fn recursor_opts() -> ResolverOpts {
-    let mut options = ResolverOpts::default();
-    options.ndots = 0;
-    options.edns0 = true;
-    options.validate = false; // we'll need to do any dnssec validation differently in a recursor (top-down rather than bottom-up)
-    options.preserve_intermediates = true;
-    options.recursion_desired = false;
-    options.num_concurrent_reqs = 1;
-
-    options
 }
 
 #[tokio::test]
 async fn not_fully_qualified_domain_name_in_query() -> Result<(), Error> {
+    use crate::{proto::rr::RecordType, resolver::Name};
+
     let recursor = Recursor::builder().build(NameServerConfigGroup::cloudflare())?;
     let name = Name::from_ascii("example.com")?;
     assert!(!name.is_fqdn());

--- a/crates/recursor/src/recursor_dns_handle.rs
+++ b/crates/recursor/src/recursor_dns_handle.rs
@@ -1,0 +1,306 @@
+use std::net::SocketAddr;
+use std::time::Instant;
+
+use async_recursion::async_recursion;
+use futures_util::{future::select_all, FutureExt};
+use lru_cache::LruCache;
+use parking_lot::Mutex;
+use tracing::{debug, warn};
+
+use crate::{
+    proto::{
+        op::Query,
+        rr::{RData, RecordType},
+    },
+    recursor_pool::RecursorPool,
+    resolver::{
+        config::{NameServerConfig, NameServerConfigGroup, Protocol, ResolverOpts},
+        dns_lru::{DnsLru, TtlConfig},
+        error::ResolveError,
+        lookup::Lookup,
+        name_server::{GenericNameServerPool, TokioConnectionProvider, TokioRuntimeProvider},
+        Name,
+    },
+    Error, ErrorKind,
+};
+
+/// Set of nameservers by the zone name
+type NameServerCache<P> = LruCache<Name, RecursorPool<P>>;
+
+pub(crate) struct RecursorDnsHandle {
+    roots: RecursorPool<TokioRuntimeProvider>,
+    name_server_cache: Mutex<NameServerCache<TokioRuntimeProvider>>,
+    record_cache: DnsLru,
+    security_aware: bool,
+}
+
+impl RecursorDnsHandle {
+    pub(crate) fn new(
+        roots: impl Into<NameServerConfigGroup>,
+        ns_cache_size: usize,
+        record_cache_size: usize,
+        security_aware: bool,
+    ) -> Result<Self, ResolveError> {
+        // configure the hickory-resolver
+        let roots: NameServerConfigGroup = roots.into();
+
+        assert!(!roots.is_empty(), "roots must not be empty");
+
+        debug!("Using cache sizes {}/{}", ns_cache_size, record_cache_size);
+        let opts = recursor_opts();
+        let roots =
+            GenericNameServerPool::from_config(roots, opts, TokioConnectionProvider::default());
+        let roots = RecursorPool::from(Name::root(), roots);
+        let name_server_cache = Mutex::new(NameServerCache::new(ns_cache_size));
+        let record_cache = DnsLru::new(record_cache_size, TtlConfig::default());
+
+        Ok(Self {
+            roots,
+            name_server_cache,
+            record_cache,
+            security_aware,
+        })
+    }
+
+    pub(crate) async fn resolve(
+        &self,
+        query: Query,
+        request_time: Instant,
+        query_has_dnssec_ok: bool,
+    ) -> Result<Lookup, Error> {
+        if let Some(lookup) = self.record_cache.get(&query, request_time) {
+            let lookup = super::maybe_strip_dnssec_records(query_has_dnssec_ok, lookup?, query);
+
+            return Ok(lookup);
+        }
+
+        // not in cache, let's look for an ns record for lookup
+        let zone = match query.query_type() {
+            // (RFC4035 section 3.1.4.1) the DS record needs to be queried in the parent zone
+            RecordType::NS | RecordType::DS => query.name().base_name(),
+            // look for the NS records "inside" the zone
+            _ => query.name().clone(),
+        };
+
+        let mut zone = zone;
+        let mut ns = None;
+
+        // max number of forwarding processes
+        'max_forward: for _ in 0..20 {
+            match self.ns_pool_for_zone(zone.clone(), request_time).await {
+                Ok(found) => {
+                    // found the nameserver
+                    ns = Some(found);
+                    break 'max_forward;
+                }
+                Err(e) => match e.kind() {
+                    ErrorKind::Forward(name) => {
+                        // if we already had this name, don't try again
+                        if &zone == name {
+                            debug!("zone previously searched for {}", name);
+                            break 'max_forward;
+                        };
+
+                        debug!("ns forwarded to {}", name);
+                        zone = name.clone();
+                    }
+                    _ => return Err(e),
+                },
+            }
+        }
+
+        let ns = ns.ok_or_else(|| Error::from(format!("no nameserver found for {zone}")))?;
+        debug!("found zone {} for {}", ns.zone(), query);
+
+        let response = self.lookup(query.clone(), ns, request_time).await?;
+
+        // RFC 4035 section 3.2.1 if DO bit not set, strip DNSSEC records unless
+        // explicitly requested
+        let lookup = super::maybe_strip_dnssec_records(query_has_dnssec_ok, response, query);
+
+        Ok(lookup)
+    }
+
+    async fn lookup(
+        &self,
+        query: Query,
+        ns: RecursorPool<TokioRuntimeProvider>,
+        now: Instant,
+    ) -> Result<Lookup, Error> {
+        if let Some(lookup) = self.record_cache.get(&query, now) {
+            debug!("cached data {lookup:?}");
+            return lookup.map_err(Into::into);
+        }
+
+        let response = ns.lookup(query.clone(), self.security_aware);
+
+        // TODO: we are only expecting one response
+        // TODO: should we change DnsHandle to always be a single response? And build a totally custom handler for other situations?
+        // TODO: check if data is "authentic"
+        match response.await {
+            Ok(r) => super::cache_response(r, Some(ns.zone()), &self.record_cache, query, now),
+            Err(e) => {
+                warn!("lookup error: {e}");
+                Err(Error::from(e))
+            }
+        }
+    }
+
+    #[async_recursion]
+    async fn ns_pool_for_zone(
+        &self,
+        zone: Name,
+        request_time: Instant,
+    ) -> Result<RecursorPool<TokioRuntimeProvider>, Error> {
+        // TODO: need to check TTLs here.
+        if let Some(ns) = self.name_server_cache.lock().get_mut(&zone) {
+            return Ok(ns.clone());
+        };
+
+        let parent_zone = zone.base_name();
+
+        let nameserver_pool = if parent_zone.is_root() {
+            debug!("using roots for {zone} nameservers");
+            self.roots.clone()
+        } else {
+            self.ns_pool_for_zone(parent_zone, request_time).await?
+        };
+
+        // TODO: check for cached ns pool for this zone
+
+        let lookup = Query::query(zone.clone(), RecordType::NS);
+        let response = self
+            .lookup(lookup.clone(), nameserver_pool.clone(), request_time)
+            .await?;
+
+        // let zone_nameservers = response.name_servers();
+        // let glue = response.additionals();
+
+        // TODO: grab TTL and use for cache
+        // get all the NS records and glue
+        let mut config_group = NameServerConfigGroup::new();
+        let mut need_ips_for_names = Vec::new();
+
+        // unpack all glued records
+        for zns in response.record_iter() {
+            if let Some(ns_data) = zns.data().as_ns() {
+                // let glue_ips = glue
+                //     .iter()
+                //     .filter(|g| g.name() == ns_data)
+                //     .filter_map(Record::data)
+                //     .filter_map(RData::to_ip_addr);
+
+                if !super::is_subzone(zone.base_name().clone(), zns.name().clone()) {
+                    warn!(
+                        "Dropping out of bailiwick record for {:?} with parent {:?}",
+                        zns.name().clone(),
+                        zone.base_name().clone()
+                    );
+                    continue;
+                }
+
+                let cached_a = self.record_cache.get(
+                    &Query::query(ns_data.0.clone(), RecordType::A),
+                    request_time,
+                );
+                let cached_aaaa = self.record_cache.get(
+                    &Query::query(ns_data.0.clone(), RecordType::AAAA),
+                    request_time,
+                );
+
+                let cached_a = cached_a.and_then(Result::ok).map(Lookup::into_iter);
+                let cached_aaaa = cached_aaaa.and_then(Result::ok).map(Lookup::into_iter);
+
+                let glue_ips = cached_a
+                    .into_iter()
+                    .flatten()
+                    .chain(cached_aaaa.into_iter().flatten())
+                    .filter_map(|r| RData::ip_addr(&r));
+
+                let mut had_glue = false;
+                for ip in glue_ips {
+                    let mut udp = NameServerConfig::new(SocketAddr::from((ip, 53)), Protocol::Udp);
+                    let mut tcp = NameServerConfig::new(SocketAddr::from((ip, 53)), Protocol::Tcp);
+
+                    udp.trust_negative_responses = true;
+                    tcp.trust_negative_responses = true;
+
+                    config_group.push(udp);
+                    config_group.push(tcp);
+                    had_glue = true;
+                }
+
+                if !had_glue {
+                    debug!("glue not found for {}", ns_data);
+                    need_ips_for_names.push(ns_data);
+                }
+            }
+        }
+
+        // collect missing IP addresses, select over them all, get the addresses
+        // make it configurable to query for all records?
+        if config_group.is_empty() && !need_ips_for_names.is_empty() {
+            debug!("need glue for {}", zone);
+            let a_resolves = need_ips_for_names.iter().take(1).map(|name| {
+                let a_query = Query::query(name.0.clone(), RecordType::A);
+                self.resolve(a_query, request_time, false).boxed()
+            });
+
+            let aaaa_resolves = need_ips_for_names.iter().take(1).map(|name| {
+                let aaaa_query = Query::query(name.0.clone(), RecordType::AAAA);
+                self.resolve(aaaa_query, request_time, false).boxed()
+            });
+
+            let mut a_resolves: Vec<_> = a_resolves.chain(aaaa_resolves).collect();
+            while !a_resolves.is_empty() {
+                let (next, _, rest) = select_all(a_resolves).await;
+                a_resolves = rest;
+
+                match next {
+                    Ok(response) => {
+                        debug!("A or AAAA response: {:?}", response);
+                        let ips = response.iter().filter_map(RData::ip_addr);
+
+                        for ip in ips {
+                            let udp =
+                                NameServerConfig::new(SocketAddr::from((ip, 53)), Protocol::Udp);
+                            let tcp =
+                                NameServerConfig::new(SocketAddr::from((ip, 53)), Protocol::Tcp);
+
+                            config_group.push(udp);
+                            config_group.push(tcp);
+                        }
+                    }
+                    Err(e) => {
+                        warn!("resolve failed {}", e);
+                    }
+                }
+            }
+        }
+
+        // now construct a namesever pool based off the NS and glue records
+        let ns = GenericNameServerPool::from_config(
+            config_group,
+            recursor_opts(),
+            TokioConnectionProvider::default(),
+        );
+        let ns = RecursorPool::from(zone.clone(), ns);
+
+        // store in cache for future usage
+        debug!("found nameservers for {}", zone);
+        self.name_server_cache.lock().insert(zone, ns.clone());
+        Ok(ns)
+    }
+}
+
+fn recursor_opts() -> ResolverOpts {
+    let mut options = ResolverOpts::default();
+    options.ndots = 0;
+    options.edns0 = true;
+    options.validate = false; // we'll need to do any dnssec validation differently in a recursor (top-down rather than bottom-up)
+    options.preserve_intermediates = true;
+    options.recursion_desired = false;
+    options.num_concurrent_reqs = 1;
+
+    options
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -53,7 +53,7 @@ dnssec = ["hickory-recursor?/dnssec"]
 recursor = ["hickory-recursor"]
 resolver = ["hickory-resolver"]
 sqlite = ["rusqlite"]
-toml = ["dep:basic-toml"]
+toml = ["dep:toml"]
 
 # TODO: Need to figure out how to be consistent with ring/openssl usage...
 # dns-over-https-openssl = ["dns-over-openssl", "hickory-client/dns-over-https-openssl", "dns-over-https"]
@@ -111,7 +111,7 @@ path = "src/lib.rs"
 
 [dependencies]
 async-trait.workspace = true
-basic-toml = { workspace = true, optional = true }
+toml = { workspace = true, optional = true }
 bytes.workspace = true
 cfg-if.workspace = true
 enum-as-inner.workspace = true

--- a/crates/server/src/authority/authority_object.rs
+++ b/crates/server/src/authority/authority_object.rs
@@ -221,6 +221,11 @@ pub trait LookupObject: Send {
     ///
     /// it is acceptable for this to return None after the first call.
     fn take_additionals(&mut self) -> Option<Box<dyn LookupObject>>;
+
+    /// Whether the records have been DNSSEC validated or not
+    fn dnssec_validated(&self) -> bool {
+        false
+    }
 }
 
 /// A lookup that returns no records

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -646,6 +646,8 @@ async fn send_forwarded_response(
         }
     };
 
+    response_header.set_authentic_data(answers.dnssec_validated());
+
     LookupSections {
         answers,
         ns: Box::<AuthLookup>::default(),

--- a/crates/server/src/config/mod.rs
+++ b/crates/server/src/config/mod.rs
@@ -100,7 +100,7 @@ impl Config {
     /// Read a [`Config`] from the given TOML string.
     #[cfg(feature = "toml")]
     pub fn from_toml(toml: &str) -> ConfigResult<Self> {
-        Ok(basic_toml::from_str(toml)?)
+        Ok(toml::from_str(toml)?)
     }
 
     /// set of listening ipv4 addresses (for TCP and UDP)

--- a/crates/server/src/error/config_error.rs
+++ b/crates/server/src/error/config_error.rs
@@ -27,7 +27,7 @@ pub enum ErrorKind {
     /// An error occurred while decoding toml data
     #[cfg(feature = "toml")]
     #[error("toml decode error: {0}")]
-    TomlDecode(#[from] basic_toml::Error),
+    TomlDecode(#[from] toml::de::Error),
 
     /// An error occurred while parsing a zone file
     #[error("failed to parse the zone file: {0}")]

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -9,8 +9,6 @@ use std::{io, path::Path, time::Instant};
 
 use tracing::{debug, info};
 
-#[cfg(feature = "dnssec")]
-use crate::recursor::DnssecPolicy;
 use crate::{
     authority::{
         Authority, LookupError, LookupObject, LookupOptions, MessageRequest, UpdateResult, ZoneType,
@@ -78,11 +76,8 @@ impl RecursiveAuthority {
         let mut recursor = Recursor::builder();
         recursor
             .ns_cache_size(config.ns_cache_size)
-            .record_cache_size(config.record_cache_size);
-        #[cfg(feature = "dnssec")]
-        if config.security_aware {
-            recursor.dnssec_policy(DnssecPolicy::ValidationDisabled);
-        }
+            .record_cache_size(config.record_cache_size)
+            .dnssec_policy(config.dnssec_policy.load()?);
         let recursor = recursor
             .build(roots)
             .map_err(|e| format!("failed to initialize recursor: {e}"))?;

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -174,4 +174,13 @@ impl LookupObject for RecursiveLookup {
     fn take_additionals(&mut self) -> Option<Box<dyn LookupObject>> {
         None
     }
+
+    fn dnssec_validated(&self) -> bool {
+        // TODO research what spec / other impls do when the answer section is empty, DNSSEC
+        // validation is enabled but nameservers provided no NSEC3 records
+        self.0
+            .records()
+            .iter()
+            .all(|record| record.proof().is_secure())
+    }
 }

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -9,6 +9,8 @@ use std::{io, path::Path, time::Instant};
 
 use tracing::{debug, info};
 
+#[cfg(feature = "dnssec")]
+use crate::recursor::DnssecPolicy;
 use crate::{
     authority::{
         Authority, LookupError, LookupObject, LookupOptions, MessageRequest, UpdateResult, ZoneType,
@@ -78,7 +80,9 @@ impl RecursiveAuthority {
             .ns_cache_size(config.ns_cache_size)
             .record_cache_size(config.record_cache_size);
         #[cfg(feature = "dnssec")]
-        recursor.security_aware(config.security_aware);
+        if config.security_aware {
+            recursor.dnssec_policy(DnssecPolicy::ValidationDisabled);
+        }
         let recursor = recursor
             .build(roots)
             .map_err(|e| format!("failed to initialize recursor: {e}"))?;

--- a/crates/server/src/store/recursor/config.rs
+++ b/crates/server/src/store/recursor/config.rs
@@ -21,6 +21,8 @@ use crate::proto::{
     serialize::txt::Parser,
 };
 use crate::resolver::Name;
+#[cfg(feature = "dnssec")]
+use crate::{proto::rr::dnssec::TrustAnchor, recursor::DnssecPolicy};
 
 /// Configuration for file based zones
 #[derive(Clone, Deserialize, Eq, PartialEq, Debug)]
@@ -37,10 +39,10 @@ pub struct RecursiveConfig {
     #[serde(default = "record_cache_size_default")]
     pub record_cache_size: usize,
 
-    /// Whether the recursor is security-aware (RFC4035 section 3.2)
+    /// DNSSEC policy
     #[cfg(feature = "dnssec")]
     #[serde(default)]
-    pub security_aware: bool,
+    pub dnssec_policy: DnssecPolicyConfig,
 }
 
 impl RecursiveConfig {
@@ -77,4 +79,101 @@ fn ns_cache_size_default() -> usize {
 }
 fn record_cache_size_default() -> usize {
     1048576
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
+pub enum DnssecPolicyConfig {
+    /// security unaware; DNSSEC records will not be requested nor processed
+    #[default]
+    SecurityUnaware,
+
+    /// DNSSEC validation is disabled; DNSSEC records will be requested and processed
+    #[cfg(feature = "dnssec")]
+    ValidationDisabled,
+
+    /// DNSSEC validation is enabled and will use the chosen `trust_anchor` set of keys
+    #[cfg(feature = "dnssec")]
+    ValidateWithStaticKey {
+        /// set to `None` to use built-in trust anchor
+        path: Option<PathBuf>,
+    },
+}
+
+impl DnssecPolicyConfig {
+    pub(crate) fn load(&self) -> Result<DnssecPolicy, String> {
+        Ok(match self {
+            Self::SecurityUnaware => DnssecPolicy::SecurityUnaware,
+            #[cfg(feature = "dnssec")]
+            Self::ValidationDisabled => DnssecPolicy::ValidationDisabled,
+            #[cfg(feature = "dnssec")]
+            Self::ValidateWithStaticKey { path } => DnssecPolicy::ValidateWithStaticKey {
+                trust_anchor: path
+                    .as_ref()
+                    .map(|path| read_trust_anchor(path))
+                    .transpose()?,
+            },
+        })
+    }
+}
+
+#[cfg(feature = "dnssec")]
+fn read_trust_anchor(path: &Path) -> Result<TrustAnchor, String> {
+    use std::fs;
+
+    let contents = fs::read_to_string(path).map_err(|e| e.to_string())?;
+
+    parse_trust_anchor(&contents)
+}
+
+#[cfg(feature = "dnssec")]
+fn parse_trust_anchor(input: &str) -> Result<TrustAnchor, String> {
+    use crate::proto::{
+        rr::dnssec::PublicKeyEnum,
+        serialize::txt::trust_anchor::{self, Entry},
+    };
+
+    let parser = trust_anchor::Parser::new(input);
+    let entries = parser.parse().map_err(|e| e.to_string())?;
+
+    let mut trust_anchor = TrustAnchor::new();
+    for entry in entries {
+        if let Entry::DNSKEY(record) = entry {
+            let dnskey = record.data();
+            // XXX should we filter based on `dnskey.flags()`?
+            let key = PublicKeyEnum::from_public_bytes(dnskey.public_key(), dnskey.algorithm())
+                .map_err(|e| e.to_string())?;
+            trust_anchor.insert_trust_anchor(&key);
+        }
+    }
+
+    Ok(trust_anchor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "dnssec")]
+    #[test]
+    fn can_load_trust_anchor_file() {
+        let input = include_str!("../../../../proto/tests/test-data/root.key");
+
+        let trust_anchor = parse_trust_anchor(input).unwrap();
+        assert_eq!(3, trust_anchor.len());
+    }
+
+    #[cfg(all(feature = "dnssec", feature = "toml"))]
+    #[test]
+    fn can_parse_recursive_config() {
+        let input = r#"roots = "/etc/root.hints"
+dnssec_policy.ValidateWithStaticKey.path = "/etc/trusted-key.key""#;
+
+        let config: RecursiveConfig = toml::from_str(input).unwrap();
+
+        if let DnssecPolicyConfig::ValidateWithStaticKey { path } = config.dnssec_policy {
+            assert_eq!(Some(Path::new("/etc/trusted-key.key")), path.as_deref());
+        } else {
+            unreachable!()
+        }
+    }
 }

--- a/crates/server/src/store/recursor/config.rs
+++ b/crates/server/src/store/recursor/config.rs
@@ -5,6 +5,8 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+#[cfg(feature = "dnssec")]
+use std::sync::Arc;
 use std::{
     borrow::Cow,
     fs::File,
@@ -110,7 +112,8 @@ impl DnssecPolicyConfig {
                 trust_anchor: path
                     .as_ref()
                     .map(|path| read_trust_anchor(path))
-                    .transpose()?,
+                    .transpose()?
+                    .map(Arc::new),
             },
         })
     }

--- a/tests/integration-tests/tests/dnssec_client_handle_tests.rs
+++ b/tests/integration-tests/tests/dnssec_client_handle_tests.rs
@@ -229,7 +229,7 @@ where
         let mut trust_anchor = TrustAnchor::new();
         trust_anchor.insert_trust_anchor(&public_key);
 
-        trust_anchor
+        Arc::new(trust_anchor)
     };
 
     let mut catalog = Catalog::new();


### PR DESCRIPTION
this is an initial implementation of DNSSEC validation that maximally reuses the existing `DnssecDnsHandle` logic. 

it passes the "happy path" conformance tests but there's more work to be done to pass the tests that exercise the failure modes. namely, fixing the bug reported in #2252 . also, handling the CD (Checking Disabled) bit has not yet been implemented

~~this PR depends on #2245 so I have set that PR's branch as the base for this PR.~~

~~this PR depends on PRs #2257 , #2258 and #2268~~ all those PRs have been merged

~~to avoid this being merged into the wrong branch I'm opening this as a *draft PR* but **it is ready for review**~~ this is now ready to be merged

closes #2194 
closes #2234