### PR TITLE
add conformance to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,4 @@
 
 # Ferrous team can review changes to the E2E / integration tests
 /tests @japaric @justahero @listochkin @pvdrz
+/conformance @japaric @justahero @listochkin @pvdrz


### PR DESCRIPTION
when I was working on #2222 I initially put the conformance test suite inside the `tests` directory but ended up moving it to the root as that simplified the changes to the `justfile`. 

I then forgot to put that new `/conformance` directory in the CODEOWNERS file. this PR fixes that

thanks @justahero for spotting this