### PR TITLE
dns-test: make unit tests use the checked out version of this repo

### DIFF
--- a/conformance/packages/dns-test/src/lib.rs
+++ b/conformance/packages/dns-test/src/lib.rs
@@ -70,6 +70,17 @@ fn parse_peer() -> Implementation {
 }
 
 #[cfg(test)]
+fn repo_root() -> String {
+    use std::path::PathBuf;
+
+    let mut repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")); // /conformance/packages/dns-test
+    repo_root.pop(); // /conformance/packages/
+    repo_root.pop(); // /conformance
+    repo_root.pop(); // /
+    repo_root.display().to_string()
+}
+
+#[cfg(test)]
 mod tests {
     use std::env;
 

--- a/conformance/packages/dns-test/src/name_server.rs
+++ b/conformance/packages/dns-test/src/name_server.rs
@@ -586,7 +586,7 @@ mod tests {
     fn terminate_hickory_works() -> Result<()> {
         let network = Network::new()?;
         let ns = NameServer::new(
-            &Implementation::Hickory(Repository("https://github.com/hickory-dns/hickory-dns")),
+            &Implementation::Hickory(Repository(crate::repo_root())),
             FQDN::ROOT,
             &network,
         )?

--- a/conformance/packages/dns-test/src/resolver.rs
+++ b/conformance/packages/dns-test/src/resolver.rs
@@ -209,9 +209,8 @@ mod tests {
     fn terminate_hickory_works() -> Result<()> {
         let network = Network::new()?;
         let ns = NameServer::new(&Implementation::Unbound, FQDN::ROOT, &network)?.start()?;
-        let resolver = Resolver::new(&network, ns.root_hint()).start(&Implementation::Hickory(
-            Repository("https://github.com/hickory-dns/hickory-dns"),
-        ))?;
+        let resolver = Resolver::new(&network, ns.root_hint())
+            .start(&Implementation::Hickory(Repository(crate::repo_root())))?;
         let logs = resolver.terminate()?;
 
         // Hickory-DNS start sequence log has been consumed in `ResolverSettings.start`.


### PR DESCRIPTION
instead of https://github.com/hickory-dns/hickory-dns

the GitHub URL won't include the changes being tested in CI and can make the tests fail due to it being an older version