### PR TITLE
CI: also run hickory unit tests when only /conformance changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,14 +6,16 @@ on:
       - main
       - release/**
       - "*_dev"
-    paths-ignore:
-      - "conformance/**"
+    # does not work properly due to an issue in GitHub's branch protection
+    # rules: https://github.com/orgs/community/discussions/13690
+    # paths-ignore:
+    #   - "conformance/**"
   pull_request:
     branches:
       - main
       - release/**
-    paths-ignore:
-      - "conformance/**"
+    # paths-ignore:
+    #   - "conformance/**"
   schedule:
     - cron: "0 3 * * 4"
 


### PR DESCRIPTION
an issue in GitHub branch protecion rules prevents us from merging PRs that only change the /conformance directory with the current CI-time saving setup.

this commit works around the issue by *always* running all the tests

closes #2262