### PR TITLE
Add test to check cache hit with DO bit

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2.rs
@@ -82,6 +82,36 @@ fn on_do_0_query_strips_dnssec_records_even_if_it_cached_a_previous_do_1_query()
     Ok(())
 }
 
+// this ensures that in the presence of a cached entry (answer), the dnssec records (answer+rrsig) are still
+// returned as per the RFC
+#[test]
+fn on_do_1_query_return_dnssec_records_even_if_it_cached_a_previous_do_0_query() -> Result<()> {
+    let network = &Network::new()?;
+    let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?
+        .sign()?
+        .start()?;
+    let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
+
+    let client = Client::new(network)?;
+    let settings = *DigSettings::default().recurse();
+    let resolver_addr = resolver.ipv4_addr();
+    let ans = client.dig(settings, resolver_addr, RecordType::SOA, &FQDN::ROOT)?;
+
+    let [answer] = ans.answer.try_into().unwrap();
+
+    assert!(matches!(answer, Record::SOA(_)));
+
+    let settings = *DigSettings::default().dnssec().recurse();
+    let ans = client.dig(settings, resolver_addr, RecordType::SOA, &FQDN::ROOT)?;
+
+    let [answer, rrsig] = ans.answer.try_into().unwrap();
+
+    assert!(matches!(answer, Record::SOA(_)));
+    assert!(matches!(rrsig, Record::RRSIG(_)));
+
+    Ok(())
+}
+
 #[test]
 fn if_do_bit_not_set_in_request_then_requested_dnssec_record_is_not_stripped() -> Result<()> {
     let network = &Network::new()?;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_5.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_5.rs
@@ -6,6 +6,7 @@ use dns_test::{
     Network, Resolver, Result, FQDN,
 };
 
+/// Two queries are sent with DNSSEC enabled, the second query should take the answer from the cache.
 #[test]
 fn caches_dnssec_records() -> Result<()> {
     let network = &Network::new()?;
@@ -32,6 +33,43 @@ fn caches_dnssec_records() -> Result<()> {
     }
 
     let mut tshark = tshark.unwrap();
+    tshark.wait_for_capture()?;
+
+    let captures = tshark.terminate()?;
+
+    // second query is cached so no communication between the resolver and the nameserver is
+    // expected
+    let ns_addr = ns.ipv4_addr();
+    for Capture { direction, .. } in captures {
+        assert_ne!(ns_addr, direction.peer_addr());
+    }
+
+    Ok(())
+}
+
+/// Two queries are sent, the first without DNSSEC enabled is put into the cache, the second query with
+/// DNSSEC enabled will fetch its result from the cache
+#[test]
+fn caches_query_without_dnssec_to_return_all_dnssec_records_in_subsequent_query() -> Result<()> {
+    let network = &Network::new()?;
+    let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?
+        .sign()?
+        .start()?;
+    let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
+
+    let client = Client::new(network)?;
+
+    // send first query without DNSSEC, fills cache
+    let settings = *DigSettings::default().recurse();
+    let dig = client.dig(settings, resolver.ipv4_addr(), RecordType::SOA, &FQDN::ROOT)?;
+    assert!(dig.status.is_noerror());
+
+    // send second query to fetch all DNSSEC records
+    let mut tshark = resolver.eavesdrop()?;
+    let settings = *DigSettings::default().dnssec().recurse();
+    let dig = client.dig(settings, resolver.ipv4_addr(), RecordType::SOA, &FQDN::ROOT)?;
+    assert!(dig.status.is_noerror());
+
     tshark.wait_for_capture()?;
 
     let captures = tshark.terminate()?;


### PR DESCRIPTION
This adds the companion test to check that a previously cached request with DO bit set to `0` followed by a second request with DO bit set to `1` returns all DNSSEC records, answer + RRSIG, hitting the cache.

* adding test to specifically check cache behaviour

Closes #2276