### PR TITLE
Refactor `start` method in Resolver

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
@@ -21,7 +21,7 @@ fn can_resolve() -> Result<()> {
         ..
     } = Graph::build(leaf_ns, Sign::No)?;
 
-    let resolver = Resolver::new(&network, root).start(&dns_test::SUBJECT)?;
+    let resolver = Resolver::new(&network, root).start()?;
     let resolver_ip_addr = resolver.ipv4_addr();
 
     let client = Client::new(&network)?;
@@ -55,7 +55,7 @@ fn nxdomain() -> Result<()> {
         ..
     } = Graph::build(leaf_ns, Sign::No)?;
 
-    let resolver = Resolver::new(&network, root).start(&dns_test::SUBJECT)?;
+    let resolver = Resolver::new(&network, root).start()?;
     let resolver_ip_addr = resolver.ipv4_addr();
 
     let client = Client::new(&network)?;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/fixtures.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/fixtures.rs
@@ -44,7 +44,7 @@ pub fn bad_signature_in_leaf_nameserver(
     let trust_anchor = graph.trust_anchor.as_ref().unwrap();
     let resolver = Resolver::new(&network, graph.root.clone())
         .trust_anchor(trust_anchor)
-        .start(&dns_test::SUBJECT)?;
+        .start()?;
 
     Ok((resolver, graph))
 }
@@ -69,7 +69,7 @@ pub fn minimally_secure(
     let trust_anchor = trust_anchor.unwrap();
     let resolver = Resolver::new(&network, root)
         .trust_anchor(&trust_anchor)
-        .start(&dns_test::SUBJECT)?;
+        .start()?;
 
     Ok((resolver, nameservers, trust_anchor))
 }

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
@@ -29,7 +29,7 @@ fn on_clients_ds_query_it_queries_the_parent_zone() -> Result<()> {
     let trust_anchor = &trust_anchor.unwrap();
     let resolver = Resolver::new(&network, root)
         .trust_anchor(trust_anchor)
-        .start(&dns_test::SUBJECT)?;
+        .start()?;
 
     let mut tshark = resolver.eavesdrop()?;
 

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2.rs
@@ -14,7 +14,7 @@ fn do_bit_not_set_in_request() -> Result<()> {
     let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?
         .sign()?
         .start()?;
-    let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
+    let resolver = Resolver::new(network, ns.root_hint()).start()?;
 
     let mut tshark = resolver.eavesdrop()?;
 
@@ -60,7 +60,7 @@ fn on_do_0_query_strips_dnssec_records_even_if_it_cached_a_previous_do_1_query()
     let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?
         .sign()?
         .start()?;
-    let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
+    let resolver = Resolver::new(network, ns.root_hint()).start()?;
 
     let client = Client::new(network)?;
     let settings = *DigSettings::default().dnssec().recurse();
@@ -90,7 +90,7 @@ fn on_do_1_query_return_dnssec_records_even_if_it_cached_a_previous_do_0_query()
     let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?
         .sign()?
         .start()?;
-    let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
+    let resolver = Resolver::new(network, ns.root_hint()).start()?;
 
     let client = Client::new(network)?;
     let settings = *DigSettings::default().recurse();
@@ -118,7 +118,7 @@ fn if_do_bit_not_set_in_request_then_requested_dnssec_record_is_not_stripped() -
     let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?
         .sign()?
         .start()?;
-    let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
+    let resolver = Resolver::new(network, ns.root_hint()).start()?;
 
     let client = Client::new(network)?;
     let settings = *DigSettings::default().recurse();
@@ -143,7 +143,7 @@ fn do_bit_set_in_request() -> Result<()> {
     let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?
         .sign()?
         .start()?;
-    let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
+    let resolver = Resolver::new(network, ns.root_hint()).start()?;
 
     let mut tshark = resolver.eavesdrop()?;
 

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2/section_3_2_2.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2/section_3_2_2.rs
@@ -13,7 +13,7 @@ use crate::resolver::dnssec::fixtures;
 fn copies_cd_bit_from_query_to_response() -> Result<()> {
     let network = &Network::new()?;
     let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?.start()?;
-    let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
+    let resolver = Resolver::new(network, ns.root_hint()).start()?;
 
     let client = Client::new(network)?;
     let settings = *DigSettings::default().checking_disabled().recurse();

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_1.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_1.rs
@@ -8,7 +8,7 @@ use dns_test::{Network, Resolver, Result, FQDN};
 fn edns_support() -> Result<()> {
     let network = &Network::new()?;
     let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?.start()?;
-    let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
+    let resolver = Resolver::new(network, ns.root_hint()).start()?;
 
     let mut tshark = resolver.eavesdrop()?;
 

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_5.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_5.rs
@@ -13,7 +13,7 @@ fn caches_dnssec_records() -> Result<()> {
     let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?
         .sign()?
         .start()?;
-    let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
+    let resolver = Resolver::new(network, ns.root_hint()).start()?;
 
     let client = Client::new(network)?;
     let settings = *DigSettings::default().dnssec().recurse();
@@ -55,7 +55,7 @@ fn caches_query_without_dnssec_to_return_all_dnssec_records_in_subsequent_query(
     let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?
         .sign()?
         .start()?;
-    let resolver = Resolver::new(network, ns.root_hint()).start(&dns_test::SUBJECT)?;
+    let resolver = Resolver::new(network, ns.root_hint()).start()?;
 
     let client = Client::new(network)?;
 

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
@@ -153,7 +153,7 @@ fn fixture(
     }
 
     let trust_anchor = &trust_anchor.unwrap();
-    let resolver = resolver.trust_anchor(trust_anchor).start(subject)?;
+    let resolver = resolver.trust_anchor(trust_anchor).start()?;
     let resolver_addr = resolver.ipv4_addr();
 
     let client = Client::new(&network)?;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
@@ -28,7 +28,7 @@ fn can_validate_without_delegation() -> Result<()> {
     let trust_anchor = &TrustAnchor::from_iter([root_ksk.clone(), root_zsk.clone()]);
     let resolver = Resolver::new(&network, ns.root_hint())
         .trust_anchor(trust_anchor)
-        .start(&dns_test::SUBJECT)?;
+        .start()?;
     let resolver_addr = resolver.ipv4_addr();
 
     let client = Client::new(&network)?;

--- a/conformance/packages/dns-test/examples/explore.rs
+++ b/conformance/packages/dns-test/examples/explore.rs
@@ -44,7 +44,7 @@ fn main() -> Result<()> {
     if let Some(trust_anchor) = trust_anchor {
         builder.trust_anchor(&trust_anchor);
     }
-    let resolver = builder.start(&dns_test::SUBJECT)?;
+    let resolver = builder.start()?;
     println!("DONE\n\n");
 
     let (tx, rx) = mpsc::channel();

--- a/conformance/packages/dns-test/src/tshark.rs
+++ b/conformance/packages/dns-test/src/tshark.rs
@@ -329,8 +329,8 @@ mod tests {
         root_ns.referral_nameserver(&com_ns);
         let root_ns = root_ns.start()?;
 
-        let resolver =
-            Resolver::new(network, root_ns.root_hint()).start(&Implementation::Unbound)?;
+        let resolver = Resolver::new(network, root_ns.root_hint())
+            .start_with_subject(&Implementation::Unbound)?;
         let mut tshark = resolver.eavesdrop()?;
         let resolver_addr = resolver.ipv4_addr();
 


### PR DESCRIPTION
In nearly all cases the passed argument is `SUBJECT`, therefore the change uses this as default. A separate method `start_with_subject` allows to provide passing in a specific `Implementation`.