### PR TITLE
recursor: put tokio::test behind cfg attribute

### DIFF
--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -357,6 +357,7 @@ enum RecursorMode {
     },
 }
 
+#[cfg(test)]
 #[tokio::test]
 async fn not_fully_qualified_domain_name_in_query() -> Result<(), Error> {
     use crate::{proto::rr::RecordType, resolver::Name};


### PR DESCRIPTION
`tokio` is a dev-dependency so it's not available when building the code without `--cfg test` which is what `cargo doc` does. put the tokio test behind a `#[cfg(test)]` attribute to prevent the issue.

closes #2290 