### PR TITLE
DnssecDnsHandle: also update the RRSIG's proof

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
@@ -71,7 +71,6 @@ fn can_validate_with_delegation() -> Result<()> {
 
 // the inclusion of RRSIGs records in the answer should not change the outcome of validation
 // if the chain of trust was valid then the RRSIGs, which are part of the chain, must also be secure
-#[ignore]
 #[test]
 fn also_secure_when_do_is_set() -> Result<()> {
     let expected_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);


### PR DESCRIPTION
fixes #2274

the reason queries with DO=1 were getting an AD=0 response was that `DnssecDnsHandle` was update the `proof` fields of all records in the response except for the RRSIG records, which should inherit the result of the DNSSEC validation.

~~this PR depends on PR #2287 so leaving it in draft state for now to prevent it being merged into the wrong branch~~