### PR TITLE
validating recursor: return answer from cache

### DIFF
--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -319,6 +319,23 @@ impl Recursor {
                 handle,
                 record_cache,
             } => {
+                if let Some(Ok(lookup)) = record_cache.get(&query, request_time) {
+                    let none_indeterminate = lookup
+                        .records()
+                        .iter()
+                        .all(|record| !record.proof().is_indeterminate());
+
+                    // if any cached record is indeterminate, fall through and perform
+                    // DNSSEC validation
+                    if none_indeterminate {
+                        return Ok(super::maybe_strip_dnssec_records(
+                            query_has_dnssec_ok,
+                            lookup,
+                            query,
+                        ));
+                    }
+                }
+
                 let mut options = DnsRequestOptions::default();
                 // a validating recursor must be security aware
                 options.use_edns = true;


### PR DESCRIPTION
if all its records have a non-indeterminate DNSSEC state

---

this PR partially addresses #2294. in particular, it fully addresses this comment https://github.com/hickory-dns/hickory-dns/issues/2294#issuecomment-2214926406

we cannot really test the caching behavior with a library-level unit test because `Recursor` requires an initial query, which result in network operations, to cache a result.

we also cannot observe that signature validation is not repeated on a subsequent query using `dns-test` because the signature validation is not visible at the network level; we do have `dns-test`-based tests that check that no network operation happens when a query is already in the cache -- those tests were already passing without this PR.

I can, however, observe that signature validation does not happen on a second query in the hickory-dns logs

this PR depends on PR #2293 so I'm leaving it in draft state until that's merged but this PR is ready for review