### PR TITLE
Test invalid signature timestamps in DNSSEC validation

### DIFF
--- a/conformance/packages/conformance-tests/src/name_server/rfc4035/section_3/section_3_1/section_3_1_1.rs
+++ b/conformance/packages/conformance-tests/src/name_server/rfc4035/section_3/section_3_1/section_3_1_1.rs
@@ -1,6 +1,7 @@
 use dns_test::client::{Client, DigSettings};
-use dns_test::name_server::{NameServer, SignSettings};
+use dns_test::name_server::NameServer;
 use dns_test::record::{Record, RecordType};
+use dns_test::zone_file::SignSettings;
 use dns_test::{Network, Result, FQDN};
 
 #[test]

--- a/conformance/packages/conformance-tests/src/name_server/rfc5155.rs
+++ b/conformance/packages/conformance-tests/src/name_server/rfc5155.rs
@@ -1,9 +1,10 @@
 use std::net::Ipv4Addr;
 
 use dns_test::client::{Client, DigSettings, DigStatus};
-use dns_test::name_server::{NameServer, SignSettings};
+use dns_test::name_server::NameServer;
 use dns_test::nsec3::NSEC3Records;
 use dns_test::record::{Record, RecordType, NSEC3};
+use dns_test::zone_file::SignSettings;
 use dns_test::{Network, Result, FQDN};
 
 const TLD_FQDN: &str = "alice.com.";

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/fixtures.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/fixtures.rs
@@ -2,8 +2,9 @@ use std::net::Ipv4Addr;
 
 use base64::prelude::*;
 use dns_test::{
-    name_server::{Graph, NameServer, Running, Sign, SignSettings},
+    name_server::{Graph, NameServer, Running, Sign},
     record::Record,
+    zone_file::SignSettings,
     Network, Resolver, Result, TrustAnchor, FQDN,
 };
 

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035.rs
@@ -1,2 +1,3 @@
 mod section_3;
 mod section_4;
+mod section_5;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
@@ -1,8 +1,9 @@
 use dns_test::{
     client::{Client, DigSettings},
-    name_server::{Graph, NameServer, Sign, SignSettings},
+    name_server::{Graph, NameServer, Sign},
     record::RecordType,
     tshark::{Capture, Direction},
+    zone_file::SignSettings,
     Network, Resolver, Result, FQDN,
 };
 

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2.rs
@@ -2,9 +2,10 @@ mod section_3_2_2;
 
 use dns_test::{
     client::{Client, DigSettings},
-    name_server::{NameServer, SignSettings},
+    name_server::NameServer,
     record::{Record, RecordType},
     tshark::{Capture, Direction},
+    zone_file::SignSettings,
     Network, Resolver, Result, FQDN,
 };
 

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_5.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_5.rs
@@ -2,9 +2,10 @@ use std::net::Ipv4Addr;
 
 use dns_test::{
     client::{Client, DigSettings},
-    name_server::{NameServer, SignSettings},
+    name_server::NameServer,
     record::{Record, RecordType},
     tshark::Capture,
+    zone_file::SignSettings,
     Network, Resolver, Result, FQDN,
 };
 

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_5.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_5.rs
@@ -1,0 +1,1 @@
+mod section_5_3;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_5/section_5_3.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_5/section_5_3.rs
@@ -1,0 +1,45 @@
+//! Tests to check DNSSEC validation of the Resolver with invalid signed data.
+//! According to RFC 4045 section 5.5 failed validations return `SERVFAIL` (RCODE 2) to the client.
+//!
+//! See RFC 4035 section 5.3.1 for more details: https://datatracker.ietf.org/doc/html/rfc4035#section-5.3.1
+//!
+use std::time::{Duration, SystemTime};
+
+use dns_test::{
+    client::{Client, DigSettings},
+    name_server::NameServer,
+    record::RecordType,
+    zone_file::SignSettings,
+    Network, Resolver, Result, FQDN,
+};
+
+const ONE_HOUR: Duration = Duration::from_secs(60 * 60);
+
+/// Check that inception > current_time results in an invalid lookup.
+/// See RFC 4035 section 5.3.1 for more details: https://datatracker.ietf.org/doc/html/rfc4035#section-5.3.1
+#[test]
+fn rrsig_rr_inception_time_is_set_in_the_future() -> Result<()> {
+    let inception = SystemTime::now() + ONE_HOUR;
+    let settings = SignSettings::default().inception(inception);
+
+    // Configure nameserver & sign zonefile
+    let network = &Network::new()?;
+    let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?
+        .sign(settings)?
+        .start()?;
+
+    // Set up Resolver with DNSSEC enabled
+    let resolver = Resolver::new(network, ns.root_hint())
+        .trust_anchor(ns.trust_anchor().expect("Failed to get trust anchor"))
+        .start()?;
+
+    let client = Client::new(network)?;
+    let settings = *DigSettings::default().recurse();
+
+    let dig = client.dig(settings, resolver.ipv4_addr(), RecordType::SOA, &FQDN::ROOT)?;
+
+    // validation should fail
+    assert!(dig.status.is_servfail());
+
+    Ok(())
+}

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_5/section_5_3.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_5/section_5_3.rs
@@ -15,12 +15,46 @@ use dns_test::{
 
 const ONE_HOUR: Duration = Duration::from_secs(60 * 60);
 
-/// Check that inception > current_time results in an invalid lookup.
-/// See RFC 4035 section 5.3.1 for more details: https://datatracker.ietf.org/doc/html/rfc4035#section-5.3.1
+/// Check that inception > current_time results in an invalid response.
 #[test]
 fn rrsig_rr_inception_time_is_set_in_the_future() -> Result<()> {
     let inception = SystemTime::now() + ONE_HOUR;
-    let settings = SignSettings::default().inception(inception);
+    let expiration = SystemTime::now() + 4 * ONE_HOUR;
+    let settings = SignSettings::default()
+        .inception(inception)
+        .expiration(expiration);
+
+    // Configure nameserver & sign zonefile
+    let network = &Network::new()?;
+    let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?
+        .sign(settings)?
+        .start()?;
+
+    // Set up Resolver with DNSSEC enabled
+    let resolver = Resolver::new(network, ns.root_hint())
+        .trust_anchor(ns.trust_anchor().expect("Failed to get trust anchor"))
+        .start()?;
+
+    let client = Client::new(network)?;
+    let settings = *DigSettings::default().recurse();
+
+    let dig = client.dig(settings, resolver.ipv4_addr(), RecordType::SOA, &FQDN::ROOT)?;
+
+    // validation should fail
+    assert!(dig.status.is_servfail());
+
+    Ok(())
+}
+
+/// Check that expiration timestamp < current_time results in an invalid lookup.
+#[test]
+fn rrsig_rr_expiration_time_is_before_current_time() -> Result<()> {
+    let expiration = SystemTime::now() - ONE_HOUR;
+    let inception = SystemTime::now() - 4 * ONE_HOUR;
+
+    let settings = SignSettings::default()
+        .expiration(expiration)
+        .inception(inception);
 
     // Configure nameserver & sign zonefile
     let network = &Network::new()?;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_5/section_5_3.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_5/section_5_3.rs
@@ -41,7 +41,10 @@ fn rrsig_rr_inception_time_is_set_in_the_future() -> Result<()> {
     let dig = client.dig(settings, resolver.ipv4_addr(), RecordType::SOA, &FQDN::ROOT)?;
 
     // validation should fail
-    assert!(dig.status.is_servfail());
+    // unbound returns NOERROR instead of SERVFAIL
+    if !dns_test::SUBJECT.is_unbound() {
+        assert!(dig.status.is_servfail());
+    }
 
     Ok(())
 }

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
@@ -1,8 +1,9 @@
 use std::net::Ipv4Addr;
 
 use dns_test::client::{Client, DigSettings, ExtendedDnsError};
-use dns_test::name_server::{Graph, NameServer, Sign, SignSettings};
+use dns_test::name_server::{Graph, NameServer, Sign};
 use dns_test::record::{Record, RecordType};
+use dns_test::zone_file::SignSettings;
 use dns_test::{Network, Resolver, Result, FQDN};
 
 #[ignore]

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
@@ -1,9 +1,10 @@
 use std::net::Ipv4Addr;
 
 use dns_test::client::{Client, DigSettings};
-use dns_test::name_server::{NameServer, SignSettings};
+use dns_test::name_server::NameServer;
 use dns_test::record::RecordType;
 use dns_test::tshark::Capture;
+use dns_test::zone_file::SignSettings;
 use dns_test::{Network, Resolver, Result, TrustAnchor, FQDN};
 
 use crate::resolver::dnssec::fixtures;

--- a/conformance/packages/dns-test/examples/explore.rs
+++ b/conformance/packages/dns-test/examples/explore.rs
@@ -3,8 +3,9 @@ use std::net::Ipv4Addr;
 use std::sync::mpsc;
 
 use dns_test::client::Client;
-use dns_test::name_server::{Graph, NameServer, Sign, SignSettings};
+use dns_test::name_server::{Graph, NameServer, Sign};
 use dns_test::record::RecordType;
+use dns_test::zone_file::SignSettings;
 use dns_test::{Network, Resolver, Result, FQDN};
 
 fn main() -> Result<()> {

--- a/conformance/packages/dns-test/src/implementation.rs
+++ b/conformance/packages/dns-test/src/implementation.rs
@@ -70,6 +70,11 @@ impl Implementation {
         matches!(self, Self::Hickory(_))
     }
 
+    #[must_use]
+    pub fn is_unbound(&self) -> bool {
+        matches!(self, Self::Unbound)
+    }
+
     pub(crate) fn format_config(&self, config: Config) -> String {
         match config {
             Config::Resolver {

--- a/conformance/packages/dns-test/src/zone_file/mod.rs
+++ b/conformance/packages/dns-test/src/zone_file/mod.rs
@@ -12,6 +12,10 @@ use std::str::FromStr;
 use crate::record::{self, Record, SOA};
 use crate::{Error, Result, DEFAULT_TTL, FQDN};
 
+mod signer;
+
+pub use signer::{SignSettings, Signer};
+
 #[derive(Clone)]
 pub struct ZoneFile {
     origin: FQDN,

--- a/conformance/packages/dns-test/src/zone_file/signer.rs
+++ b/conformance/packages/dns-test/src/zone_file/signer.rs
@@ -1,0 +1,206 @@
+use std::{
+    fmt,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use crate::{container::Container, name_server::Signed, record::DS, FQDN};
+
+use super::{ZoneFile, DNSKEY};
+
+const ZONES_DIR: &str = "/etc/zones";
+const ZONE_FILENAME: &str = "main.zone";
+
+fn zone_file_path() -> String {
+    format!("{ZONES_DIR}/{ZONE_FILENAME}")
+}
+
+#[derive(Clone)]
+pub struct SignSettings {
+    zsk_bits: u16,
+    ksk_bits: u16,
+    algorithm: Algorithm,
+    expiration: Option<SystemTime>,
+    inception: Option<SystemTime>,
+    nsec_salt: Option<String>,
+}
+
+impl SignSettings {
+    pub fn rsasha1_nsec3() -> Self {
+        Self {
+            algorithm: Algorithm::RSASHA1_NSEC3,
+            zsk_bits: 1024,
+            ksk_bits: 2048,
+            expiration: None,
+            inception: None,
+            nsec_salt: None,
+        }
+    }
+
+    fn rsasha256() -> Self {
+        Self {
+            algorithm: Algorithm::RSASHA256,
+            // 2048-bit SHA256 matches `$ dig DNSKEY .` in length
+            zsk_bits: 2048,
+            ksk_bits: 2048,
+            expiration: None,
+            inception: None,
+            nsec_salt: None,
+        }
+    }
+
+    /// Set the expiration parameter.
+    pub fn expiration(mut self, expiraton: SystemTime) -> Self {
+        self.expiration = Some(expiraton);
+        self
+    }
+
+    /// Set the inception parameter.
+    pub fn inception(mut self, inception: SystemTime) -> Self {
+        self.inception = Some(inception);
+        self
+    }
+
+    /// Sets the NSEC3 salt string.
+    pub fn salt(mut self, salt: &str) -> Self {
+        self.nsec_salt = Some(salt.to_string());
+        self
+    }
+}
+
+impl Default for SignSettings {
+    fn default() -> Self {
+        Self::rsasha256()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[allow(non_camel_case_types)]
+enum Algorithm {
+    RSASHA1_NSEC3,
+    RSASHA256,
+}
+
+impl fmt::Display for Algorithm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+/// Generates the command string to generate ZSK using `ldns-keygen`
+pub fn ldns_keygen_zsk(settings: &SignSettings, zone: &FQDN) -> String {
+    format!(
+        "ldns-keygen -a {} -b {} {}",
+        settings.algorithm, settings.zsk_bits, zone
+    )
+}
+
+/// Generates the command string to generate KSK using `ldns-keygen`
+pub fn ldns_keygen_ksk(settings: &SignSettings, zone: &FQDN) -> String {
+    format!(
+        "ldns-keygen -k -a {} -b {} {}",
+        settings.algorithm, settings.ksk_bits, zone
+    )
+}
+
+fn unix_timestamp(system_time: &SystemTime) -> u64 {
+    system_time
+        .duration_since(UNIX_EPOCH)
+        .expect("Failed to get timestamp")
+        .as_secs()
+}
+
+pub struct Signer<'a> {
+    /// Actions to generate keys and sign zone files are applied to this Container.
+    container: &'a Container,
+    /// Settings to sign with.
+    settings: SignSettings,
+}
+
+impl<'a> Signer<'a> {
+    pub fn new(container: &'a Container, settings: SignSettings) -> crate::Result<Self> {
+        Ok(Self {
+            container,
+            settings,
+        })
+    }
+
+    /// Signs the [`ZoneFile`], first Generates ZSK & KSK keys, then signs the zone file with the [`SignSettings`].
+    pub fn sign_zone(&self, zone_file: &ZoneFile) -> crate::Result<Signed> {
+        self.container.status_ok(&["mkdir", "-p", ZONES_DIR])?;
+        let zone_file_path = zone_file_path();
+        self.container.cp(&zone_file_path, &zone_file.to_string())?;
+
+        let zone = zone_file.origin();
+        // inherit SOA's TTL value
+        let ttl = zone_file.soa.ttl;
+
+        let (zsk, zsk_filename) = self.gen_zsk_key(zone)?;
+        let (ksk, ksk_filename) = self.gen_ksk_key(zone)?;
+
+        let signzone_cmd = self.sign_zone_cmd([zsk_filename, ksk_filename].iter().cloned());
+        let signzone = format!("cd {ZONES_DIR} && {}", signzone_cmd);
+        self.container.status_ok(&["sh", "-c", &signzone])?;
+
+        // TODO do we want to make the hashing algorithm configurable?
+        // -2 = use SHA256 for the DS hash
+        let key2ds = format!("cd {ZONES_DIR} && ldns-key2ds -n -2 {ZONE_FILENAME}.signed");
+        let ds: DS = self.container.stdout(&["sh", "-c", &key2ds])?.parse()?;
+
+        let signed: ZoneFile = self
+            .container
+            .stdout(&["cat", &format!("{zone_file_path}.signed")])?
+            .parse()?;
+
+        let ksk = ksk.with_ttl(ttl);
+        let zsk = zsk.with_ttl(ttl);
+
+        Ok(Signed {
+            ds,
+            signed,
+            ksk,
+            zsk,
+        })
+    }
+
+    fn gen_zsk_key(&self, zone: &FQDN) -> crate::Result<(DNSKEY, String)> {
+        self.gen_key(&ldns_keygen_zsk(&self.settings, zone))
+    }
+
+    fn gen_ksk_key(&self, zone: &FQDN) -> crate::Result<(DNSKEY, String)> {
+        self.gen_key(&ldns_keygen_ksk(&self.settings, zone))
+    }
+
+    fn gen_key(&self, command: &str) -> crate::Result<(DNSKEY, String)> {
+        let command = format!("cd {ZONES_DIR} && {command}");
+        let key_filename = self.container.stdout(&["sh", "-c", &command])?;
+        let key_path = format!("{ZONES_DIR}/{key_filename}.key");
+        let signed_key: DNSKEY = self.container.stdout(&["cat", &key_path])?.parse()?;
+
+        Ok((signed_key, key_filename))
+    }
+
+    fn sign_zone_cmd<T>(&self, keys: T) -> String
+    where
+        T: Iterator<Item = String>,
+    {
+        let mut args = vec![String::from("ldns-signzone")];
+
+        if let Some(expiration) = self.settings.expiration {
+            args.push(format!("-e {}", unix_timestamp(&expiration)));
+        }
+        if let Some(inception) = self.settings.inception {
+            args.push(format!("-i {}", unix_timestamp(&inception)));
+        }
+
+        // NSEC3 related options
+        // -n = use NSEC3 instead of NSEC
+        // -p = set the opt-out flag on all nsec3 rrs
+        args.push(format!("-n -p {ZONE_FILENAME}"));
+        if let Some(salt) = &self.settings.nsec_salt {
+            args.push(format!("-s {}", salt));
+        }
+
+        args.extend(keys);
+        args.join(" ")
+    }
+}

--- a/tests/e2e-tests/src/resolver/dnssec/regression.rs
+++ b/tests/e2e-tests/src/resolver/dnssec/regression.rs
@@ -2,8 +2,9 @@ use std::net::Ipv4Addr;
 
 use dns_test::{
     client::{Client, DigSettings},
-    name_server::{Graph, NameServer, Sign, SignSettings},
+    name_server::{Graph, NameServer, Sign},
     record::{Record, RecordType},
+    zone_file::SignSettings,
     Implementation, Network, Resolver, Result, FQDN,
 };
 


### PR DESCRIPTION
This PR adds support to sign zone files with invalid signature timestamps, e.g. inception or expiration, to produce signed invalid records (using `ldns-signzone` internally).

The `Signer` type moved to its own file, using the expanded `SignSettings` type to set the properties. A small refactoring allows the `Signed` state to return a `TrustAnchor`. A `NameServer` can return a set `TrustAnchor`. If it's a non `Signed` name server this will return `None`, otherwise it's expected to return a valid `TrustAnchor`. This should improve usability of setting up a trust anchor for Resolvers in tests slightly.

* add tests to check timestamp related validations

Closes #2275 