### PR TITLE
Update bytes to 1.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,9 +378,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cc"


### PR DESCRIPTION
Cargo audit is failing because bytes 1.6.0 has been yanked due to a bug:

    This release fixes a bug where `Bytes::is_unique` returns incorrect values when
    the `Bytes` originates from a shared `BytesMut`

Upstream discussion: https://github.com/tokio-rs/bytes/pull/718