### PR TITLE
Adjust TTL of RRSIG + RR during validation

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_5/section_5_3.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_5/section_5_3.rs
@@ -81,7 +81,6 @@ fn rrsig_rr_expiration_time_is_before_current_time() -> Result<()> {
 
 /// Check that the validating resolver sets the TTL to a value between "now" and expiration time.
 /// See Github issue: https://github.com/hickory-dns/hickory-dns/issues/2292
-#[ignore]
 #[test]
 fn rrsig_rr_ttl_is_not_greater_than_duration_between_current_time_and_signature_expiration_timestamp(
 ) -> Result<()> {

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_5/section_5_3.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_5/section_5_3.rs
@@ -78,3 +78,38 @@ fn rrsig_rr_expiration_time_is_before_current_time() -> Result<()> {
 
     Ok(())
 }
+
+/// Check that the validating resolver sets the TTL to a value between "now" and expiration time.
+/// See Github issue: https://github.com/hickory-dns/hickory-dns/issues/2292
+#[ignore]
+#[test]
+fn rrsig_rr_ttl_is_not_greater_than_duration_between_current_time_and_signature_expiration_timestamp(
+) -> Result<()> {
+    let ttl_delta = 4 * ONE_HOUR;
+    let settings = SignSettings::default().expiration(SystemTime::now() + ttl_delta);
+
+    let network = &Network::new()?;
+    let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?
+        .sign(settings)?
+        .start()?;
+
+    let resolver = Resolver::new(network, ns.root_hint())
+        .trust_anchor(ns.trust_anchor().expect("Failed to get trust anchor"))
+        .start()?;
+
+    let client = Client::new(network)?;
+    let settings = *DigSettings::default().recurse();
+
+    let dig = client.dig(settings, resolver.ipv4_addr(), RecordType::SOA, &FQDN::ROOT)?;
+    assert!(dig.status.is_noerror());
+
+    let [answer] = dig.answer.try_into().unwrap();
+    assert!(answer.is_soa());
+
+    // get TTL from record
+    let soa_ttl = answer.try_into_soa().unwrap().ttl as u64;
+
+    assert!(soa_ttl <= ttl_delta.as_secs());
+
+    Ok(())
+}

--- a/conformance/packages/dns-test/src/record.rs
+++ b/conformance/packages/dns-test/src/record.rs
@@ -121,6 +121,14 @@ impl Record {
         }
     }
 
+    pub fn try_into_soa(self) -> CoreResult<SOA, Self> {
+        if let Self::SOA(soa) = self {
+            Ok(soa)
+        } else {
+            Err(self)
+        }
+    }
+
     pub fn is_soa(&self) -> bool {
         matches!(self, Self::SOA(..))
     }

--- a/conformance/packages/dns-test/src/templates/unbound.conf.jinja
+++ b/conformance/packages/dns-test/src/templates/unbound.conf.jinja
@@ -5,6 +5,7 @@ server:
     access-control: {{ netmask }} allow
     root-hints: /etc/root.hints
     pidfile: /tmp/unbound.pid
+    cache-max-ttl: 60
     ede: {% if ede %} yes {% else %} no {% endif %}
 {% if use_dnssec %}
     val-sig-skew-min: 3600

--- a/crates/proto/src/xfer/dnssec_dns_handle.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle.rs
@@ -349,7 +349,10 @@ where
         // The adjusted TTL is determined by RRSIG + RR record it covers.
         let (record_type, new_ttl) = if let RData::DNSSEC(DNSSECRData::RRSIG(rrsig)) = record.data()
         {
-            (rrsig.type_covered(), authenticated_ttl(rrsig, record, current_time))
+            (
+                rrsig.type_covered(),
+                rrsig.authenticated_ttl(record, current_time),
+            )
         } else {
             (record.record_type(), record.ttl())
         };
@@ -1014,34 +1017,6 @@ pub fn verify_nsec(query: &Query, soa_name: &Name, nsecs: &[&Record]) -> Proof {
             Proof::Bogus
         }
     }
-}
-
-/// Returns the authenticated TTL for RRSIG + RR.
-///
-/// ```text
-/// RFC 4035             DNSSEC Protocol Modifications            March 2005
-///
-/// If the resolver accepts the RRset as authentic, the validator MUST
-/// set the TTL of the RRSIG RR and each RR in the authenticated RRset to
-/// a value no greater than the minimum of:
-///
-///   o  the RRset's TTL as received in the response;
-///
-///   o  the RRSIG RR's TTL as received in the response;
-///
-///   o  the value in the RRSIG RR's Original TTL field; and
-///
-///   o  the difference of the RRSIG RR's Signature Expiration time and the
-///      current time.
-/// ```
-///
-/// See RFC 4035, section 5.3.3: https://datatracker.ietf.org/doc/html/rfc4035#section-5.3.3
-///
-fn authenticated_ttl(rrsig: &RRSIG, record: &Record, current_time: u32) -> u32 {
-    record
-        .ttl()
-        .min(rrsig.original_ttl())
-        .min(rrsig.sig_expiration().saturating_sub(current_time))
 }
 
 /// Returns the current system time as Unix timestamp in seconds.


### PR DESCRIPTION
This PR adjusts the TTL of RRSIG and its covering RR to conform to the last condition of [RFC 4035, section 5.3.3](https://datatracker.ietf.org/doc/html/rfc4035#section-5.3.3).

* add tests to check conditions

Closes #2292 