### PR TITLE
NSEC3 validation

### DIFF
--- a/crates/proto/src/xfer/dnssec_dns_handle/nsec3_validation.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle/nsec3_validation.rs
@@ -79,7 +79,7 @@
 use crate::{
     op::{Query, ResponseCode},
     rr::{
-        dnssec::{rdata::NSEC3, Proof},
+        dnssec::{rdata::NSEC3, Nsec3HashAlgorithm, Proof},
         Name, Record, RecordType,
     },
 };
@@ -130,7 +130,26 @@ pub(super) fn verify_nsec3(
 
     // Basic sanity checks are done.
 
-    Proof::Secure
+    let query_name = query.name();
+
+    // From here on 4 big situations are possible:
+    // 1. No such name, and no servicing wildcard
+    // 2. Name exists but there's no record of this type
+    // 3. Name is serviced by wildcard that has a record of this type
+    // 4. Name is serviced by wildcard that doesn't have a record of this type
+
+    match response_code {
+        // Case 1:
+        ResponseCode::NXDomain => validate_nxdomain_response(query_name, soa_name, &nsec3s),
+
+        // RFC 5155: NoData
+        // Cases 2, 3, and 4:
+        ResponseCode::NoError => {
+            // TODO: Handle NoData responses
+            Proof::Secure
+        }
+        _ => Proof::Bogus,
+    }
 }
 
 struct Nsec3RecordPair<'a> {
@@ -142,4 +161,305 @@ fn split_first_label(name: &Name) -> Option<(&[u8], Name)> {
     let first_label = name.iter().next()?;
     let base = name.base_name();
     Some((first_label, base))
+}
+
+fn nsec3hash(name: &Name, salt: &[u8], iterations: u16) -> Vec<u8> {
+    Nsec3HashAlgorithm::SHA1
+        .hash(salt, name, iterations)
+        // We only compute hashes of names between `query_name` and `soa_name`
+        // and wildcards between `*.query_name.base_name()` and `*.soa_name`.
+        // All of them are guaranteed to be valid names.
+        .unwrap()
+        .as_ref()
+        .to_vec()
+}
+
+// NSEC3 records use a base32 hashed name as a record name component.
+// But within the record body the hash is stored as a binary blob.
+// Thus we need both for comparisons.
+struct HashedNameInfo {
+    name: Name,
+    hashed_name: Vec<u8>,
+    base32_hashed_name: String,
+}
+
+fn find_covering_record<'a>(
+    nsec3s: &'a [Nsec3RecordPair<'a>],
+    target_hashed_name: &[u8],
+    // Strictly speaking we don't need this parameter, we can calculate
+    // base32(target_hashed_name) inside the function.
+    // However, we already have it available at call sites, may as well use
+    // it and save on repeated base32 encodings.
+    target_base32_hashed_name: &str,
+) -> Option<&'a Nsec3RecordPair<'a>> {
+    nsec3s.iter().find(|record| {
+        record.base32_hashed_name < target_base32_hashed_name.as_bytes()
+            && target_hashed_name < record.nsec3_data.next_hashed_owner_name()
+    })
+}
+
+/// There is no such `query_name` in the zone and there's no wildcard that
+/// can be expanded to service this `query_name`.
+///
+/// Expecting the following records:
+/// * closest encloser - *matching* NSEC3 record
+/// * next closer - *covering* NSEC3 record
+/// * wildcard of closest encloser - *covering* NSEC3 record
+fn validate_nxdomain_response(
+    query_name: &Name,
+    soa_name: &Name,
+    nsec3s: &[Nsec3RecordPair<'_>],
+) -> Proof {
+    debug_assert!(!nsec3s.is_empty());
+    let salt = nsec3s[0].nsec3_data.salt();
+    let iterations = nsec3s[0].nsec3_data.iterations();
+
+    let hashed_query_name = nsec3hash(query_name, salt, iterations);
+    let base32_hased_query_name = data_encoding::BASE32_DNSSEC.encode(&hashed_query_name);
+
+    // The response is NXDomain but there's a record for query_name
+    if nsec3s
+        .iter()
+        .any(|r| r.base32_hashed_name == base32_hased_query_name.as_bytes())
+    {
+        return Proof::Bogus;
+    }
+
+    let (closest_encloser_proof_info, early_proof) =
+        closest_encloser_proof(query_name, soa_name, nsec3s);
+
+    if let Some(proof) = early_proof {
+        return proof;
+    }
+
+    // Note that the three fields may hold references to the same NSEC3
+    // record, because the interval of base32_hashed_name
+    // and next_hashed_owner_name happen to match / cover all three components
+    // of closest encloser proof.
+    let ClosestEncloserProofInfo {
+        closest_encloser,
+        next_closer,
+        closest_encloser_wildcard,
+    } = closest_encloser_proof_info;
+
+    match (closest_encloser, next_closer, closest_encloser_wildcard) {
+        // Got all three components - we proved that there's no `query_name`
+        // in the zone
+        (Some(_), Some(_), Some(_)) => Proof::Secure,
+        // `query_name`'s parent is the `soa_name` itself, so there's no need
+        // to send `soa_name`'s NSEC3 record. Still we have to show that
+        // both `query_name` doesn't exist and there's no wildcard to service it
+        (None, Some(_), Some(_)) if &query_name.base_name() == soa_name => Proof::Secure,
+        _ => Proof::Bogus,
+    }
+}
+
+struct ClosestEncloserProofInfo<'a> {
+    closest_encloser: Option<(HashedNameInfo, &'a Nsec3RecordPair<'a>)>,
+    next_closer: Option<(HashedNameInfo, &'a Nsec3RecordPair<'a>)>,
+    closest_encloser_wildcard: Option<(HashedNameInfo, &'a Nsec3RecordPair<'a>)>,
+}
+
+/// For each intermediary name from `query_name` to `soa_name` this function
+/// constructs a triplet of (Name, HashedName, Base32EncodedHashedName)
+///
+/// For `a.b.c.soa.name` it will generate:
+/// [
+///     (a.b.c.soa.name, h(a.b.c.soa.name), b32h(a.b.c.soa.name)),
+///     (b.c.soa.name, h(b.c.soa.name), b32h(b.c.soa.name)),
+///     (c.soa.name, h(c.soa.name), b32h(c.soa.name)),
+///     (soa.name, h(soa.name), b32h(soa.name)),
+/// ]
+///
+/// The list *starts* with `query_name` and *ends* with `soa_name`. Other
+/// code in this module exploits this invariant.
+///
+/// In simplest situations when `query_name` is `label.soa_name` it itself
+/// will act as "next closer"
+fn build_encloser_candidates_list(
+    query_name: &Name,
+    soa_name: &Name,
+    salt: &[u8],
+    iterations: u16,
+) -> Vec<HashedNameInfo> {
+    let mut candidates = Vec::with_capacity(query_name.num_labels() as usize);
+
+    // `query_name` is our first candidate
+    let mut name = query_name.clone();
+    loop {
+        let hashed_name = nsec3hash(&name, salt, iterations);
+        let base32_hashed_name = data_encoding::BASE32_DNSSEC.encode(&hashed_name);
+        candidates.push(HashedNameInfo {
+            name: name.clone(),
+            hashed_name,
+            base32_hashed_name,
+        });
+        if &name == soa_name {
+            // `soa_name` is the final candidate, we already added it.
+            return candidates;
+        }
+        name = name.base_name();
+        // TODO: can `query_name` *not* be a sub-name of `soa_name`?
+        debug_assert_ne!(name, Name::root());
+    }
+}
+
+/// Expecting the following records:
+/// * closest encloser - *matching* NSEC3 record
+/// * next closer - *covering* NSEC3 record
+/// * wildcard of closest encloser - *covering* NSEC3 record
+fn closest_encloser_proof<'a>(
+    query_name: &Name,
+    soa_name: &Name,
+    nsec3s: &'a [Nsec3RecordPair<'a>],
+) -> (ClosestEncloserProofInfo<'a>, Option<Proof>) {
+    debug_assert!(!nsec3s.is_empty());
+    let salt = nsec3s[0].nsec3_data.salt();
+    let iterations = nsec3s[0].nsec3_data.iterations();
+
+    let mut closest_encloser_candidates =
+        build_encloser_candidates_list(query_name, soa_name, salt, iterations);
+
+    // Search for *matching* closing encloser record, i.e.
+    // An NSEC3 record those name matches one of the names in
+    // candidate list
+    let closest_encloser_in_candidates = closest_encloser_candidates.iter().enumerate().find_map(
+        |(candidate_index, candidate_name_info)| {
+            let nsec3 = nsec3s.iter().find(|r| {
+                r.base32_hashed_name == candidate_name_info.base32_hashed_name.as_bytes()
+            });
+            nsec3.map(|record| (candidate_index, record))
+        },
+    );
+
+    match closest_encloser_in_candidates {
+        // General flow - there's a record for closest encloser
+        Some((closest_encloser_index, closest_encloser_record)) if closest_encloser_index > 0 => {
+            let closest_encloser_hash_info =
+                closest_encloser_candidates.swap_remove(closest_encloser_index);
+            let closest_encloser_wildcard_name = Name::new()
+                .append_label("*")
+                .unwrap()
+                .append_name(&closest_encloser_hash_info.name)
+                .expect("closest encloser name exists in the zone");
+            let closest_encloser = Some((closest_encloser_hash_info, closest_encloser_record));
+
+            let next_closer_hash_info =
+                closest_encloser_candidates.swap_remove(closest_encloser_index - 1);
+            let next_closer = find_covering_record(
+                nsec3s,
+                &next_closer_hash_info.hashed_name,
+                &next_closer_hash_info.base32_hashed_name,
+            )
+            .map(|record| (next_closer_hash_info, record));
+
+            let closest_encloser_wildcard_hashed_name =
+                nsec3hash(&closest_encloser_wildcard_name, salt, iterations);
+            let closest_encloser_wildcard_base32_hashed_name =
+                data_encoding::BASE32_DNSSEC.encode(&closest_encloser_wildcard_hashed_name);
+            let wildcard_name_info = HashedNameInfo {
+                name: closest_encloser_wildcard_name,
+                hashed_name: closest_encloser_wildcard_hashed_name,
+                base32_hashed_name: closest_encloser_wildcard_base32_hashed_name,
+            };
+            let wildcard = find_covering_record(
+                nsec3s,
+                &wildcard_name_info.hashed_name,
+                &wildcard_name_info.base32_hashed_name,
+            )
+            .map(|record| (wildcard_name_info, record));
+
+            (
+                ClosestEncloserProofInfo {
+                    closest_encloser,
+                    next_closer,
+                    closest_encloser_wildcard: wildcard,
+                },
+                None,
+            )
+        }
+        Some((0, _)) => {
+            // Closest encloser at index 0 corresponds to an NSEC3 record
+            // with the key = base32(hash(`query_name`)), which should not be
+            // possible because that would mean `query_name` exists in the zone,
+            // but the response code is NXDomain.
+            (
+                ClosestEncloserProofInfo {
+                    closest_encloser: None,
+                    next_closer: None,
+                    closest_encloser_wildcard: None,
+                },
+                Some(Proof::Bogus),
+            )
+        }
+        Some(_) => unreachable!(
+            "the compiler is convinced the first two cases don't match all Some(_)s possible"
+        ),
+        None if &query_name.base_name() == soa_name => {
+            // There's no record for closest encloser.
+            // It may not be present since the encloser is `soa_name` which
+            // is *known to exist*.
+            //
+            // Next closer *is* `query_name`, hence index 0
+            let next_encloser_hash_info = closest_encloser_candidates.swap_remove(0);
+            let next_closer = find_covering_record(
+                nsec3s,
+                &next_encloser_hash_info.hashed_name,
+                &next_encloser_hash_info.base32_hashed_name,
+            )
+            .map(|record| (next_encloser_hash_info, record));
+
+            // Additionally there should be an NSEC3 record *covering*
+            // `*.soa_name` wildcard.
+            // If the wildcard existed then the response code would be NoError
+            // but we received `NXDomain`
+            let closest_encloser_wildcard_name = Name::new()
+                .append_label("*")
+                .unwrap()
+                .append_name(soa_name)
+                .expect("`soa_name` is an existing domain with a valid name");
+            let closest_encloser_wildcard_hashed_name =
+                nsec3hash(&closest_encloser_wildcard_name, salt, iterations);
+            let closest_encloser_wildcard_base32_hashed_name =
+                data_encoding::BASE32_DNSSEC.encode(&closest_encloser_wildcard_hashed_name);
+            let wildcard_name_info = HashedNameInfo {
+                name: closest_encloser_wildcard_name,
+                hashed_name: closest_encloser_wildcard_hashed_name,
+                base32_hashed_name: closest_encloser_wildcard_base32_hashed_name,
+            };
+            let wildcard = find_covering_record(
+                nsec3s,
+                &wildcard_name_info.hashed_name,
+                &wildcard_name_info.base32_hashed_name,
+            )
+            .map(|record| (wildcard_name_info, record));
+
+            (
+                ClosestEncloserProofInfo {
+                    closest_encloser: None,
+                    next_closer,
+                    closest_encloser_wildcard: wildcard,
+                },
+                None,
+            )
+        }
+        None => {
+            // Problematic case: a.b.soa.name doesn't exist
+            // but there's no NSEC3 record for any of the ancestors
+            //
+            // If `b.soa.name` existed we should have its *matching* NSEC3 record
+            // and a record *covering* `a.b.soa.name` in `next_closer`
+            //
+            // If `b.soa.name` didn't exist we would get a record *covering* it
+            // in `next_closer`.
+            (
+                ClosestEncloserProofInfo {
+                    closest_encloser: None,
+                    next_closer: None,
+                    closest_encloser_wildcard: None,
+                },
+                Some(Proof::Bogus),
+            )
+        }
+    }
 }

--- a/crates/proto/src/xfer/dnssec_dns_handle/nsec3_validation.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle/nsec3_validation.rs
@@ -1,0 +1,67 @@
+use crate::{
+    op::{Query, ResponseCode},
+    rr::{
+        dnssec::{rdata::NSEC3, Proof},
+        Name, Record, RecordType,
+    },
+};
+
+pub(super) fn verify_nsec3(
+    query: &Query,
+    soa_name: &Name,
+    response_code: ResponseCode,
+    answers: &[Record],
+    nsec3s: &[(&Name, &NSEC3)],
+) -> Proof {
+    debug_assert!(!nsec3s.is_empty());
+
+    // For every NSEC3 record that in text form looks like:
+    // <base32-hash>.soa.name NSEC3 <data>
+    // we extract (<base32-hash>, <data>) pair from deeply nested structures
+    let nsec3s: Option<Vec<Nsec3RecordPair<'_>>> = nsec3s
+        .iter()
+        .map(|(record_name, nsec3_data)| {
+            split_first_label(record_name)
+                .filter(|(_, base)| base == soa_name)
+                .map(|(base32_hashed_name, _)| Nsec3RecordPair {
+                    base32_hashed_name,
+                    nsec3_data,
+                })
+        })
+        .collect();
+
+    // Some of record names were NOT in a form of `<base32hash>.soa.name`
+    let Some(nsec3s) = nsec3s else {
+        return Proof::Bogus;
+    };
+
+    debug_assert!(!nsec3s.is_empty());
+
+    // RFC 5155 8.2 - all NSEC3 records share the same NSEC3 params
+    let first = &nsec3s[0];
+    let hash_algorithm = first.nsec3_data.hash_algorithm();
+    let salt = first.nsec3_data.salt();
+    let iterations = first.nsec3_data.iterations();
+    if nsec3s.iter().any(|r| {
+        r.nsec3_data.hash_algorithm() != hash_algorithm
+            || r.nsec3_data.salt() != salt
+            || r.nsec3_data.iterations() != iterations
+    }) {
+        return Proof::Bogus;
+    }
+
+    // Basic sanity checks are done.
+
+    Proof::Secure
+}
+
+struct Nsec3RecordPair<'a> {
+    base32_hashed_name: &'a [u8],
+    nsec3_data: &'a NSEC3,
+}
+
+fn split_first_label(name: &Name) -> Option<(&[u8], Name)> {
+    let first_label = name.iter().next()?;
+    let base = name.base_name();
+    Some((first_label, base))
+}

--- a/crates/proto/src/xfer/dnssec_dns_handle/nsec3_validation.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle/nsec3_validation.rs
@@ -1,3 +1,81 @@
+//! Throughout this module several NSEC3 specific terms are used.
+//!
+//! "closest_encloser" - a name that is a longest parent / grandparent /
+//!     great-grandparent, etc. of a `query_name`, that DOES exist.
+//!
+//! "next_closer" - a name that is one level deeper in the hierarchy from
+//!     `closest_encloser`, that DOES NOT exist in the zone.
+//!
+//! "wildcard of closest encloser" - a name in a form of `*.closest_encloser`.
+//!     If it exists then `query_name` would be serviced by the wildcard.
+//!
+//! "covering NSEC3 record" - NSEC3 record name has a hash (`hashed_owner_name`),
+//!     and inside the record data there's `next_hashed_owner_name`.
+//!     If the hash of `query_name` fits between the two hashes then the record
+//!     "covers" `query_name`
+//!
+//! "matching NSEC3 record" - exists for *existing* names only.
+//!     The `hashed_owner_name` would match one of the names *exactly*.
+//!
+//! In general:
+//! * if a name exists we would expect to see its "matching" NSEC3 record,
+//! * if the name doesn't exist we would expect to see a "covering" NSEC3 record.
+//!
+//! A various combinations of matching and covering records for `closest_encloser`,
+//! `next_closer`, and `wildcard_encloser` can tell us whether `query_name`
+//! exists, whether `wildcard_encloser` exists, and whether its own or
+//! `wildcard_encloser`'s records have a record of a requested type.
+//!
+//! NOTE: A single NSEC3 record can in theory address multiple situations.
+//! Thus, the number of records is not important as long as all
+//! conditions are represented by them.
+//!
+//! NOTE: Normally, when there exist a wildcard that a given name fits into,
+//! it is said that the wildcard "covers" the name. But since the wording
+//! around NSEC3 records uses "cover" in a specific sense we use the word
+//! "service" instead:
+//! `*.w.soa.name` *services* `x.w.soa.name`
+//!
+//! In general, avoid using the word "cover" for anything not related to
+//! "covering NSEC3 record"
+//!
+//! ## Examples
+//!
+//! To explain them let's use the following example zone:
+//!
+//! soa.name
+//! *.w.soa.name
+//! c.e.soa.name
+//!
+//! if we request:
+//!     `query_name` = `x.y.z.nc.c.e.soa.name`
+//! then:
+//!     `closest_encloser` == `c.e.soa.name` (the first existing ancestor)
+//!     `next_closer`      == `nc.c.e.soa.name` (doesn't exist in the zone)
+//!     `wildcard_encloser` == `*.c.e.soa.name`
+//!
+//! if we request:
+//!     `query_name` = `x.y.z.nc.w.soa.name`
+//! then:
+//!     `closest_encloser` == `w.soa.name`
+//!     `next_closer`      == `nc.w.soa.name`
+//!     `wildcard_encloser` == `*.w.soa.name`
+//!
+//! if we request:
+//!     `query_name` = `x.soa.name`
+//! then:
+//!     `closest_encloser` == `soa.name`
+//!     `next_closer`      == `x.soa.name`
+//!     `wildcard_encloser` == `*.soa.name`
+//!
+//! if we request:
+//!     `query_name` = `e.soa.name`
+//! then:
+//!     `closest_encloser` == `e.soa.name`
+//!     `next_closer`      == doesn't exist
+//!     `wildcard_encloser` == `*.soa.name`
+//!
+
 use crate::{
     op::{Query, ResponseCode},
     rr::{

--- a/tests/integration-tests/tests/client_tests.rs
+++ b/tests/integration-tests/tests/client_tests.rs
@@ -417,6 +417,40 @@ fn test_nsec3_nxdomain() {
     assert_eq!(response.response_code(), ResponseCode::NXDomain);
 }
 
+#[test]
+#[cfg(feature = "dnssec")]
+fn test_nsec3_no_data() {
+    let name = Name::from_labels(vec!["www", "example", "com"]).unwrap();
+
+    let addr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
+    let conn = TcpClientConnection::new(addr).unwrap();
+    let client = SyncDnssecClient::new(conn).build();
+
+    let response = client
+        .query(&name, DNSClass::IN, RecordType::PTR)
+        .expect("Query failed");
+
+    // the name "www.example.com" exists but there's no PTR record on it
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+}
+
+#[test]
+#[cfg(feature = "dnssec")]
+fn test_nsec3_query_name_is_soa_name() {
+    let name = Name::from_labels("valid.extended-dns-errors.com".split(".")).unwrap();
+
+    let addr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
+    let conn = TcpClientConnection::new(addr).unwrap();
+    let client = SyncDnssecClient::new(conn).build();
+
+    let response = client
+        .query(&name, DNSClass::IN, RecordType::PTR)
+        .expect("Query failed");
+
+    // the name "valid.extended-dns-errors.com" exists but there's no PTR record on it
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+}
+
 // TODO: disabled until I decide what to do with NSEC3 see issue #10
 //
 // TODO these NSEC3 tests don't work, it seems that the zone is not signed properly.

--- a/tests/integration-tests/tests/client_tests.rs
+++ b/tests/integration-tests/tests/client_tests.rs
@@ -400,6 +400,23 @@ fn test_nsec_query_type() {
     assert!(response.answers().is_empty());
 }
 
+// NSEC3 tests
+#[test]
+#[cfg(feature = "dnssec")]
+fn test_nsec3_nxdomain() {
+    let name = Name::from_labels(vec!["a", "b", "c", "example", "com"]).unwrap();
+
+    let addr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
+    let conn = TcpClientConnection::new(addr).unwrap();
+    let client = SyncDnssecClient::new(conn).build();
+
+    let response = client
+        .query(&name, DNSClass::IN, RecordType::NS)
+        .expect("Query failed");
+
+    assert_eq!(response.response_code(), ResponseCode::NXDomain);
+}
+
 // TODO: disabled until I decide what to do with NSEC3 see issue #10
 //
 // TODO these NSEC3 tests don't work, it seems that the zone is not signed properly.


### PR DESCRIPTION
Adds support for NSEC3 records validation for the resolver

* [x] non-direct enclosers
* [x] wildcard enclosers
* [x] support NO_DATA responses

