### PR TITLE
Allow to modify a RRSIG record before signing

### DIFF
--- a/conformance/packages/dns-test/src/record.rs
+++ b/conformance/packages/dns-test/src/record.rs
@@ -105,6 +105,14 @@ impl From<SOA> for Record {
 }
 
 impl Record {
+    pub fn as_rrsig_mut(&mut self) -> Option<&mut RRSIG> {
+        if let Self::RRSIG(rrsig) = self {
+            Some(rrsig)
+        } else {
+            None
+        }
+    }
+
     pub fn try_into_a(self) -> CoreResult<A, Self> {
         if let Self::A(v) = self {
             Ok(v)

--- a/conformance/packages/dns-test/src/zone_file/mod.rs
+++ b/conformance/packages/dns-test/src/zone_file/mod.rs
@@ -9,7 +9,7 @@ use std::array;
 use std::net::Ipv4Addr;
 use std::str::FromStr;
 
-use crate::record::{self, Record, SOA};
+use crate::record::{self, Record, RecordType, RRSIG, SOA};
 use crate::{Error, Result, DEFAULT_TTL, FQDN};
 
 mod signer;
@@ -36,6 +36,14 @@ impl ZoneFile {
     /// Adds the given `record` to the zone file
     pub fn add(&mut self, record: impl Into<Record>) {
         self.records.push(record.into())
+    }
+
+    /// Modify the RRSIG for the covered record type.
+    pub fn rrsig_mut(&mut self, covered_type: RecordType) -> Option<&mut RRSIG> {
+        self.records
+            .iter_mut()
+            .filter_map(|r| r.as_rrsig_mut())
+            .find(|rrsig| rrsig.type_covered == covered_type)
     }
 
     /// Shortcut method for adding a referral (NS + A record pair)


### PR DESCRIPTION
This PR adds support to modify a specific RRSIG record before starting a `NameServer<Signed>`.

An example on how to to use the logic in a conformance test.

```rust
let mut ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?.sign(settings)?;
ns.signed_zone_file_mut()
    .rrsig_mut(RecordType::SOA)
    .map(|rrsig| rrsig.signature_expiration = 21060207062816);
let ns = ns.start()?;
```

This is in preparation to set a timestamp (expiration, inception) to a value outside the supported range.

Builds upon #2316 