### PR TITLE
Use SerialNumber type for signature timestamps

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_5/section_5_3.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_5/section_5_3.rs
@@ -116,7 +116,7 @@ fn rrsig_rr_ttl_is_not_greater_than_duration_between_current_time_and_signature_
 /// Check that both RRSIG and RR use the same TTL, section 5.3.3 of RFC 4035 defines conditions how to adjust the TTL
 /// while section 2.2 states "The RRSIG RR's TTL is equal to the TTL of the RRset."
 #[test]
-fn rrsgig_and_rr_return_the_same_adjusted_ttl() -> Result<()> {
+fn rrsig_and_rr_return_the_same_adjusted_ttl() -> Result<()> {
     let ttl_delta = 4 * ONE_HOUR;
     let settings = SignSettings::default().expiration(SystemTime::now() + ttl_delta);
 
@@ -144,6 +144,75 @@ fn rrsgig_and_rr_return_the_same_adjusted_ttl() -> Result<()> {
 
     assert_eq!(soa.ttl, rrsig.ttl);
     assert!(soa.ttl <= ttl_delta.as_secs() as u32);
+
+    Ok(())
+}
+
+/// Check that Serial Number arithemtics support the case where the timesamp is `1 << 31` beyond UNIX_EPOCH.
+#[test]
+fn rrsig_rr_expiration_time_is_1_to_the_power_of_31_beyond_unix_epoch() -> Result<()> {
+    // The representation in the record uses format `YYYYMMDDhhmmss`
+    const MAX_UNIX_TIMESTAMP: u64 = 20380119031408;
+
+    let settings = SignSettings::default().expiration_from_u64(1 << 31);
+
+    let network = &Network::new()?;
+    let ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?
+        .sign(settings)?
+        .start()?;
+
+    let resolver = Resolver::new(network, ns.root_hint())
+        .trust_anchor(ns.trust_anchor().expect("Failed to get trust anchor"))
+        .start()?;
+
+    // Fetch RRSIG + RR
+    let client = Client::new(network)?;
+    let settings = *DigSettings::default().dnssec().recurse();
+
+    let resolver_addr = resolver.ipv4_addr();
+    let dig = client.dig(settings, resolver_addr, RecordType::SOA, &FQDN::ROOT)?;
+
+    // Validation should succeed
+    assert!(dig.status.is_noerror());
+
+    let [soa, rrsig] = dig.answer.try_into().unwrap();
+    let soa: SOA = soa.try_into_soa().unwrap();
+    let rrsig: RRSIG = rrsig.try_into_rrsig().unwrap();
+
+    assert_eq!(soa.ttl, rrsig.ttl);
+    assert_eq!(MAX_UNIX_TIMESTAMP, rrsig.signature_expiration);
+
+    Ok(())
+}
+
+/// Check that Serial Number arithmetics invalidate the case where the timestamp is `1 << 32` beyond UNIX_EPOCH.
+#[test]
+fn rrsig_rr_expiration_time_is_1_to_the_power_of_32_beyond_unix_epoch() -> Result<()> {
+    let settings = SignSettings::default();
+
+    let network = &Network::new()?;
+    let mut ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, network)?.sign(settings)?;
+
+    // `1 << 32` from Unix Epoch results in Sunday, February 7, 2106 6:28:16 AM
+    if let Some(rrsig) = ns.signed_zone_file_mut().rrsig_mut(RecordType::SOA) {
+        rrsig.signature_expiration = 21060207062816;
+    }
+
+    let ns = ns.start()?;
+
+    let resolver = Resolver::new(network, ns.root_hint())
+        .trust_anchor(ns.trust_anchor().expect("Failed to get trust anchor"))
+        .start()?;
+
+    // Fetch RRSIG + RR
+    let client = Client::new(network)?;
+    let settings = *DigSettings::default().dnssec().recurse();
+
+    let resolver_addr = resolver.ipv4_addr();
+    let dig = client.dig(settings, resolver_addr, RecordType::SOA, &FQDN::ROOT)?;
+
+    // Validation should fail
+    assert!(dig.status.is_servfail());
 
     Ok(())
 }

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_5/section_5_3.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_5/section_5_3.rs
@@ -136,6 +136,8 @@ fn rrsgig_and_rr_return_the_same_adjusted_ttl() -> Result<()> {
     let resolver_addr = resolver.ipv4_addr();
     let dig = client.dig(settings, resolver_addr, RecordType::SOA, &FQDN::ROOT)?;
 
+    assert!(dig.status.is_noerror());
+
     let [soa, rrsig] = dig.answer.try_into().unwrap();
     let soa: SOA = soa.try_into_soa().unwrap();
     let rrsig: RRSIG = rrsig.try_into_rrsig().unwrap();

--- a/conformance/packages/dns-test/src/zone_file/signer.rs
+++ b/conformance/packages/dns-test/src/zone_file/signer.rs
@@ -19,8 +19,8 @@ pub struct SignSettings {
     zsk_bits: u16,
     ksk_bits: u16,
     algorithm: Algorithm,
-    expiration: Option<SystemTime>,
-    inception: Option<SystemTime>,
+    expiration: Option<u64>,
+    inception: Option<u64>,
     nsec_salt: Option<String>,
 }
 
@@ -48,15 +48,21 @@ impl SignSettings {
         }
     }
 
+    /// Set the expiration parameter from a `u64`.
+    pub fn expiration_from_u64(mut self, timestamp: u64) -> Self {
+        self.expiration = Some(timestamp);
+        self
+    }
+
     /// Set the expiration parameter.
     pub fn expiration(mut self, expiraton: SystemTime) -> Self {
-        self.expiration = Some(expiraton);
+        self.expiration = Some(unix_timestamp(&expiraton));
         self
     }
 
     /// Set the inception parameter.
     pub fn inception(mut self, inception: SystemTime) -> Self {
-        self.inception = Some(inception);
+        self.inception = Some(unix_timestamp(&inception));
         self
     }
 
@@ -186,10 +192,10 @@ impl<'a> Signer<'a> {
         let mut args = vec![String::from("ldns-signzone")];
 
         if let Some(expiration) = self.settings.expiration {
-            args.push(format!("-e {}", unix_timestamp(&expiration)));
+            args.push(format!("-e {}", expiration));
         }
         if let Some(inception) = self.settings.inception {
-            args.push(format!("-i {}", unix_timestamp(&inception)));
+            args.push(format!("-i {}", inception));
         }
 
         // NSEC3 related options

--- a/crates/proto/src/rr/dnssec/rdata/rrsig.rs
+++ b/crates/proto/src/rr/dnssec/rdata/rrsig.rs
@@ -95,7 +95,7 @@ impl RRSIG {
         record
             .ttl()
             .min(self.original_ttl())
-            .min(self.sig_expiration().saturating_sub(current_time))
+            .min(self.sig_expiration().0.saturating_sub(current_time))
     }
 }
 

--- a/crates/proto/src/rr/dnssec/rdata/sig.rs
+++ b/crates/proto/src/rr/dnssec/rdata/sig.rs
@@ -371,7 +371,7 @@ impl SIG {
         self.sig_expiration
     }
 
-    /// see `get_sig_expiration`
+    /// see [`Self::sig_expiration`]
     pub fn sig_inception(&self) -> u32 {
         self.sig_inception
     }

--- a/crates/proto/src/rr/dnssec/rdata/sig.rs
+++ b/crates/proto/src/rr/dnssec/rdata/sig.rs
@@ -13,7 +13,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     error::*,
-    rr::{dnssec::Algorithm, Name, RData, RecordData, RecordDataDecodable, RecordType},
+    rr::{
+        dnssec::Algorithm, Name, RData, RecordData, RecordDataDecodable, RecordType, SerialNumber,
+    },
     serialize::binary::*,
 };
 
@@ -367,13 +369,21 @@ impl SIG {
     ///  purposes not only when its data is updated but also when new SIG RRs
     ///  are inserted (ie, the zone or any part of it is re-signed).
     /// ```
-    pub fn sig_expiration(&self) -> u32 {
-        self.sig_expiration
+    ///
+    /// [RFC 2535](https://datatracker.ietf.org/doc/html/rfc2535#appendix-C), Appendix B: Changes from RFC 2065, 3.
+    ///
+    /// ```text
+    /// (3b) clarifying that signature expiration and inception use
+    /// serial number ring arithmetic
+    /// ```
+
+    pub fn sig_expiration(&self) -> SerialNumber {
+        SerialNumber(self.sig_expiration)
     }
 
     /// see [`Self::sig_expiration`]
-    pub fn sig_inception(&self) -> u32 {
-        self.sig_inception
+    pub fn sig_inception(&self) -> SerialNumber {
+        SerialNumber(self.sig_inception)
     }
 
     /// [RFC 2535](https://tools.ietf.org/html/rfc2535#section-4.1.6), Domain Name System Security Extensions, March 1999
@@ -474,8 +484,8 @@ impl BinEncodable for SIG {
         self.algorithm().emit(encoder)?;
         encoder.emit(self.num_labels())?;
         encoder.emit_u32(self.original_ttl())?;
-        encoder.emit_u32(self.sig_expiration())?;
-        encoder.emit_u32(self.sig_inception())?;
+        encoder.emit_u32(self.sig_expiration().0)?;
+        encoder.emit_u32(self.sig_inception().0)?;
         encoder.emit_u16(self.key_tag())?;
         self.signer_name()
             .emit_with_lowercase(encoder, is_canonical_names)?;
@@ -554,8 +564,8 @@ pub fn emit_pre_sig(
     algorithm: Algorithm,
     num_labels: u8,
     original_ttl: u32,
-    sig_expiration: u32,
-    sig_inception: u32,
+    sig_expiration: SerialNumber,
+    sig_inception: SerialNumber,
     key_tag: u16,
     signer_name: &Name,
 ) -> ProtoResult<()> {
@@ -563,8 +573,8 @@ pub fn emit_pre_sig(
     algorithm.emit(encoder)?;
     encoder.emit(num_labels)?;
     encoder.emit_u32(original_ttl)?;
-    encoder.emit_u32(sig_expiration)?;
-    encoder.emit_u32(sig_inception)?;
+    encoder.emit_u32(sig_expiration.0)?;
+    encoder.emit_u32(sig_inception.0)?;
     encoder.emit_u16(key_tag)?;
     signer_name.emit_as_canonical(encoder, true)?;
     Ok(())

--- a/crates/proto/src/rr/dnssec/tbs.rs
+++ b/crates/proto/src/rr/dnssec/tbs.rs
@@ -11,7 +11,7 @@ use std::borrow::Borrow;
 
 use crate::{
     error::*,
-    rr::{dnssec::Algorithm, DNSClass, Name, Record, RecordType},
+    rr::{dnssec::Algorithm, DNSClass, Name, Record, RecordType, SerialNumber},
     serialize::binary::{BinEncodable, BinEncoder, EncodeMode},
 };
 
@@ -93,8 +93,8 @@ pub fn rrset_tbs<B: Borrow<Record>>(
     type_covered: RecordType,
     algorithm: Algorithm,
     original_ttl: u32,
-    sig_expiration: u32,
-    sig_inception: u32,
+    sig_expiration: SerialNumber,
+    sig_inception: SerialNumber,
     key_tag: u16,
     signer_name: &Name,
     records: &[B],

--- a/crates/proto/src/rr/mod.rs
+++ b/crates/proto/src/rr/mod.rs
@@ -20,6 +20,7 @@ pub mod record_type;
 pub mod resource;
 mod rr_key;
 mod rr_set;
+pub mod serial_number;
 pub mod type_bit_map;
 
 use std::fmt::{Debug, Display};

--- a/crates/proto/src/rr/mod.rs
+++ b/crates/proto/src/rr/mod.rs
@@ -41,6 +41,7 @@ pub use self::rr_set::RecordSet;
 pub use self::rr_set::RrsetRecords;
 pub use lower_name::LowerName;
 pub use rr_key::RrKey;
+pub use serial_number::SerialNumber;
 
 /// RecordData that is stored in a DNS Record.
 ///

--- a/crates/proto/src/rr/serial_number.rs
+++ b/crates/proto/src/rr/serial_number.rs
@@ -6,7 +6,7 @@ use std::{cmp::Ordering, ops::Add};
 /// in RFC 1982. The signaure fields (expireation, inception) defined in RFC 4034, section 3.1.5
 /// are serial numbers.
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub(crate) struct SerialNumber(pub(crate) u32);
+pub struct SerialNumber(pub u32);
 
 /// Serial Number Addition, see RFC 1982, section 3.1
 ///

--- a/crates/proto/src/rr/serial_number.rs
+++ b/crates/proto/src/rr/serial_number.rs
@@ -6,7 +6,19 @@ use std::{cmp::Ordering, ops::Add};
 /// in RFC 1982. The signaure fields (expireation, inception) defined in RFC 4034, section 3.1.5
 /// are serial numbers.
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct SerialNumber(pub u32);
+pub struct SerialNumber(pub(crate) u32);
+
+impl SerialNumber {
+    /// Constructs a new [`SerialNumber`]
+    pub fn new(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// Returns internal value
+    pub fn get(&self) -> u32 {
+        self.0
+    }
+}
 
 /// Serial Number Addition, see RFC 1982, section 3.1
 ///

--- a/crates/proto/src/rr/serial_number.rs
+++ b/crates/proto/src/rr/serial_number.rs
@@ -1,0 +1,44 @@
+//! Number type to support Serial Number Arithmetics
+
+use std::{cmp::Ordering, ops::Add};
+
+/// Wrapper type to support Serial Number Arithmetics as defined
+/// in RFC 1982. The signaure fields (expireation, inception) defined in RFC 4034, section 3.1.5
+/// are serial numbers.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub(crate) struct SerialNumber(pub(crate) u32);
+
+/// Serial Number Addition, see RFC 1982, section 3.1
+///
+/// The result is a wrapping add.
+impl Add for SerialNumber {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0.wrapping_add(rhs.0))
+    }
+}
+
+/// Serial Number Comparison, see RFC 1982, section 3.2
+impl PartialOrd for SerialNumber {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        const SERIAL_BITS_HALF: u32 = 1 << (u32::BITS - 1);
+
+        let i1 = self.0;
+        let i2 = other.0;
+
+        if i1 == i2 {
+            Some(Ordering::Equal)
+        } else if (i1 < i2 && (i2 - i1) < SERIAL_BITS_HALF)
+            || (i1 > i2 && (i1 - i2) > SERIAL_BITS_HALF)
+        {
+            Some(Ordering::Less)
+        } else if (i1 < i2 && (i2 - i1) > SERIAL_BITS_HALF)
+            || (i1 > i2 && (i1 - i2) < SERIAL_BITS_HALF)
+        {
+            Some(Ordering::Greater)
+        } else {
+            None
+        }
+    }
+}

--- a/crates/proto/src/xfer/dnssec_dns_handle.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle.rs
@@ -31,8 +31,7 @@ use crate::{
             Algorithm, Proof, ProofError, ProofErrorKind, SupportedAlgorithms, TrustAnchor,
         },
         rdata::opt::EdnsOption,
-        serial_number::SerialNumber,
-        Name, RData, Record, RecordData, RecordType,
+        Name, RData, Record, RecordData, RecordType, SerialNumber,
     },
     xfer::{dns_handle::DnsHandle, DnsRequest, DnsRequestOptions, DnsResponse, FirstAnswer},
 };
@@ -818,8 +817,8 @@ fn check_rrsig_validity(
     current_time: u32,
 ) -> RrsigValidity {
     let current_time = SerialNumber(current_time);
-    let expiration = SerialNumber(rrsig.data().sig_expiration());
-    let inception = SerialNumber(rrsig.data().sig_inception());
+    let expiration = rrsig.data().sig_expiration();
+    let inception = rrsig.data().sig_inception();
 
     let Ok(dnskey_key_tag) = dnskey.data().calculate_key_tag() else {
         return RrsigValidity::WrongDnskey;

--- a/crates/proto/src/xfer/dnssec_dns_handle.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle.rs
@@ -31,6 +31,7 @@ use crate::{
             Algorithm, Proof, ProofError, ProofErrorKind, SupportedAlgorithms, TrustAnchor,
         },
         rdata::opt::EdnsOption,
+        serial_number::SerialNumber,
         Name, RData, Record, RecordData, RecordType,
     },
     xfer::{dns_handle::DnsHandle, DnsRequest, DnsRequestOptions, DnsResponse, FirstAnswer},
@@ -816,6 +817,10 @@ fn check_rrsig_validity(
     dnskey: RecordRef<'_, DNSKEY>,
     current_time: u32,
 ) -> RrsigValidity {
+    let current_time = SerialNumber(current_time);
+    let expiration = SerialNumber(rrsig.data().sig_expiration());
+    let inception = SerialNumber(rrsig.data().sig_inception());
+
     let Ok(dnskey_key_tag) = dnskey.data().calculate_key_tag() else {
         return RrsigValidity::WrongDnskey;
     };
@@ -838,16 +843,16 @@ fn check_rrsig_validity(
         return RrsigValidity::WrongRrsig;
     }
 
-    // TODO section 3.1.5 of RFC4034 states that 'all comparisons involving these fields MUST use
+    // Section 3.1.5 of RFC4034 states that 'all comparisons involving these fields MUST use
     // "Serial number arithmetic", as defined in RFC1982'
     if !(
         // "The validator's notion of the current time MUST be less than or equal to the time listed
         // in the RRSIG RR's Expiration field"
-        current_time <= rrsig.data().sig_expiration() &&
+        current_time <= expiration &&
 
         // "The validator's notion of the current time MUST be greater than or equal to the time
         // listed in the RRSIG RR's Inception field"
-        current_time >= rrsig.data().sig_inception()
+        current_time >= inception
     ) {
         return RrsigValidity::ExpiredRrsig;
     }

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -766,8 +766,8 @@ impl InnerInMemory {
                 rr_set.record_type(),
                 signer.algorithm(),
                 rr_set.ttl(),
-                SerialNumber(expiration.unix_timestamp() as u32),
-                SerialNumber(inception.unix_timestamp() as u32),
+                SerialNumber::new(expiration.unix_timestamp() as u32),
+                SerialNumber::new(inception.unix_timestamp() as u32),
                 signer.calculate_key_tag()?,
                 signer.signer_name(),
                 // TODO: this is a nasty clone... the issue is that the vec

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -739,6 +739,8 @@ impl InnerInMemory {
         zone_ttl: u32,
         zone_class: DNSClass,
     ) -> DnsSecResult<()> {
+        use hickory_proto::rr::SerialNumber;
+
         use crate::proto::rr::dnssec::rdata::RRSIG;
 
         let inception = OffsetDateTime::now_utc();
@@ -764,8 +766,8 @@ impl InnerInMemory {
                 rr_set.record_type(),
                 signer.algorithm(),
                 rr_set.ttl(),
-                expiration.unix_timestamp() as u32,
-                inception.unix_timestamp() as u32,
+                SerialNumber(expiration.unix_timestamp() as u32),
+                SerialNumber(inception.unix_timestamp() as u32),
                 signer.calculate_key_tag()?,
                 signer.signer_name(),
                 // TODO: this is a nasty clone... the issue is that the vec


### PR DESCRIPTION
This PR adds the `SerialNumber` NewType to support Serial Number Arithmetics as defined in [RFC 1982](https://www.rfc-editor.org/rfc/rfc1982). The RRSIG signature timestamps `inception` & `expiration` apply arithmetics for comparisons (see [RFC 4034, Section 3.1.5](https://datatracker.ietf.org/doc/html/rfc4034#section-3.1.5)).

Closes #2312 