### PR TITLE
Set explicit version of tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,9 +2144,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2161,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ futures-executor = { version = "0.3.5", default-features = false }
 futures-io = { version = "0.3.5", default-features = false }
 futures-util = { version = "0.3.5", default-features = false }
 async-std = "1.6"
-tokio = "1.21"
+tokio = "= 1.38.1"
 tokio-native-tls = "0.3.0"
 tokio-openssl = "0.6.0"
 tokio-rustls = "0.24.0"


### PR DESCRIPTION
This is to ensure a new release of `tokio` does not affect any CI build. The latest release of tokio resulted in a massive bump of their MSRV from version `1.63.0` to `1.70.0`, therefore failing the `past-future (1.67.0)` CI job.

* set latest working version of `tokio` to `1.38.1`

Closes #2320