### PR TITLE
Make sure Lookup futures are Sync

### DIFF
--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -364,7 +364,7 @@ impl<P: ConnectionProvider> AsyncResolver<P> {
         options: DnsRequestOptions,
     ) -> Result<L, ResolveError>
     where
-        L: From<Lookup> + Send + 'static,
+        L: From<Lookup> + Send + Sync + 'static,
     {
         let names = self.build_names(name);
         LookupFuture::lookup(names, record_type, options, self.client_cache.clone())


### PR DESCRIPTION
Running into some issues downstream where it seems like the compiler can't prove `Lookup` futures are `Sync` even though they should be in practice.