### PR TITLE
resolver: Make QuicSocketBinder as public as RuntimeProvider

### DIFF
--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -100,6 +100,8 @@ pub trait RuntimeProvider: Clone + Send + Sync + Unpin + 'static {
 #[cfg(not(any(feature = "dns-over-quic", feature = "dns-over-h3")))]
 pub trait QuicSocketBinder {}
 
+/// Create a UDP socket for QUIC usage.
+/// This trait is designed for customization.
 #[cfg(any(feature = "dns-over-quic", feature = "dns-over-h3"))]
 pub trait QuicSocketBinder {
     /// Create a UDP socket for QUIC usage.

--- a/crates/resolver/src/name_server/mod.rs
+++ b/crates/resolver/src/name_server/mod.rs
@@ -14,6 +14,8 @@ mod name_server_pool;
 mod name_server_state;
 mod name_server_stats;
 
+#[cfg(any(feature = "dns-over-quic", feature = "dns-over-h3"))]
+pub use self::connection_provider::QuicSocketBinder;
 pub use self::connection_provider::{ConnectionProvider, RuntimeProvider, Spawn};
 pub use self::connection_provider::{GenericConnection, GenericConnector};
 pub use self::name_server::{GenericNameServer, NameServer};


### PR DESCRIPTION
This is so that the quic_binder can be overridden externally.

```rs
#[cfg(any(feature = "dns-over-quic", feature = "dns-over-h3"))]
fn quic_binder(&self) -> Option<&dyn QuicSocketBinder> {
    Some(&TokioQuicSocketBinder)
}

```