### PR TITLE
Fix SOA referrals

### DIFF
--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -26,7 +26,7 @@ use crate::op::{Header, Query, ResponseCode};
 
 #[cfg(feature = "dnssec")]
 use crate::rr::dnssec::{rdata::tsig::TsigAlgorithm, Proof};
-use crate::rr::{rdata::SOA, resource::RecordRef, Record};
+use crate::rr::{rdata::SOA, resource::RecordRef, Record, RecordType};
 use crate::serialize::binary::DecodeError;
 use crate::xfer::DnsResponse;
 
@@ -468,7 +468,7 @@ impl ProtoError {
 
                     // Collect any referral nameservers and associated glue records
                     let mut referral_name_servers = vec![];
-                    for ns in response.name_servers().iter() {
+                    for ns in response.name_servers().iter().filter(|ns| ns.record_type() == RecordType::NS) {
                         let glue = response
                             .additionals()
                             .iter()
@@ -483,7 +483,6 @@ impl ProtoError {
                                 None
                             })
                             .collect::<Vec<Record>>();
-
                         referral_name_servers.push(ForwardNSData { ns: Record::to_owned(ns), glue })
                     }
 

--- a/tests/integration-tests/src/mock_client.rs
+++ b/tests/integration-tests/src/mock_client.rs
@@ -15,7 +15,7 @@ use futures::stream::{once, Stream};
 use futures::{future, AsyncRead, AsyncWrite, Future};
 
 use hickory_client::op::{Message, Query};
-use hickory_client::rr::rdata::{CNAME, SOA};
+use hickory_client::rr::rdata::{CNAME, NS, SOA};
 use hickory_client::rr::{Name, RData, Record};
 use hickory_proto::error::ProtoError;
 use hickory_proto::tcp::DnsTcpStream;
@@ -185,6 +185,10 @@ impl<O: OnSend + Unpin> DnsHandle for MockClientHandle<O> {
             || error(ProtoError::from("Messages exhausted in MockClientHandle")),
         ))))
     }
+}
+
+pub fn ns_record(name: Name, nsname: Name) -> Record {
+    Record::from_rdata(name, 86400, RData::NS(NS(nsname)))
 }
 
 pub fn cname_record(name: Name, cname: Name) -> Record {


### PR DESCRIPTION
[PR #2325](https://github.com/hickory-dns/hickory-dns/pull/2325) broke SOA-based referrals by casting SOA records in the nameservers query response section into NS Records; this patch changes the logic in crates/proto/src/error.rs to only add records from the nameservers section of a non-responsive message to the nameserver list if the record type is NS, preserving the existing SOA-forwarding logic.

This was breaking certain NS referrals, notably SOA referals for cloudflare nameservers.