### PR TITLE
Fix Issue #2306 / infinite recursion in ns_pool_for_zone

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dnssec/regression.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/regression.rs
@@ -97,7 +97,6 @@ fn can_validate_ns_query() -> Result<()> {
 
 /// regression test for https://github.com/hickory-dns/hickory-dns/issues/2306
 #[test]
-#[ignore]
 fn single_node_dns_graph_with_bind_as_peer() -> Result<()> {
     let network = Network::new()?;
     let peer = Implementation::Bind;

--- a/crates/recursor/src/lib.rs
+++ b/crates/recursor/src/lib.rs
@@ -38,9 +38,10 @@ use std::time::Instant;
 pub use error::{Error, ErrorKind};
 pub use hickory_proto as proto;
 pub use hickory_resolver as resolver;
-pub use hickory_resolver::config::NameServerConfig;
+pub use hickory_resolver::config::{NameServerConfig, NameServerConfigGroup};
 #[cfg(feature = "dnssec")]
 use proto::rr::dnssec::TrustAnchor;
+
 use proto::{op::Query, xfer::DnsResponse};
 pub use recursor::{Recursor, RecursorBuilder};
 use resolver::{dns_lru::DnsLru, lookup::Lookup, Name};

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -796,6 +796,21 @@ impl NameServerConfigGroup {
         }
     }
 
+    /// Append nameservers to a NameServerConfigGroup.
+    pub fn append_ips(
+        &mut self,
+        nameserver_ips: impl Iterator<Item = IpAddr>,
+        trust_negative_response: bool,
+    ) {
+        for ip in nameserver_ips {
+            for proto in [Protocol::Udp, Protocol::Tcp] {
+                let mut config = NameServerConfig::new(SocketAddr::from((ip, 53)), proto);
+                config.trust_negative_responses = trust_negative_response;
+                self.push(config);
+            }
+        }
+    }
+
     /// add a [`rustls::ClientConfig`]
     #[cfg(feature = "dns-over-rustls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-rustls")))]


### PR DESCRIPTION
As described in [Issue #2306](https://github.com/hickory-dns/hickory-dns/issues/2306), it is possible to cause a Hickory server crash under certain conditions:

   1) There are no cached NS pools for a given zone with valid name servers
   2) Querying the parent DNS servers for a given zone only return child NS records. E.g.,
      querying IN NS for example.com only returns something like:

        example.com. IN NS ns1.example.com.
        example.com. IN NS ns2.example.com.

      with no non-child NS records. E.g.,

       example.com. IN NS ns1.someotherdomain.net.

   3) No glue records are returned with the NS records.

This will cause an infinite loop where ns_pool_for_zone calls resolve to get A/AAAA records for the NS records returned by the parent server, which since there is no pool for example.com will in turn call ns_pool_for_zone again, which triggers another call to resolve, and so on until the stack is exhausted.

This can be seen, as described in the issue if you configure BIND to act as a dummy root server for a hosted zone. It will only return glue records if those are present in its cache -- not the hosted zone.  So, if you send the BIND server an A query directly for the delegated nameserver prior to sending the recursive query through Hickory, this bug will not be triggered. If you empty caches on both servers and send a query for the hosted zone to Hickory first, the bug will be triggered.

This patch works by changing the logic in ns_pool_for_zone to only call resolve from within ns_pool_for_zone for non-child NS servers.  If, after querying for any non-child NS servers there still are not any NS servers to use for a zone, then queries for child NS servers will be sent to the parent zone of the zone being queried, but these queries are done with NameServerPool.lookup so as to avoid the possibility of infinite recursion.  The initial check for glue records is unchanged, so the overall order of priority within ns_pool_for_zone for identifying name servers to use for a pool is:

	1. Use glue records from the query to the parent zone
	2. Use resolve to query non-child nameservers returned without glue from the parent zone
	3. Use NameServerPool.lookup to try to directly resolve child nameserver records returned without glue from the parent zone nameserver.

