### PR TITLE
do not retry NXDOMAIN over TCP when using `try_tcp_on_error`

### DIFF
--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -223,11 +223,12 @@ where
                             e.kind(),
                             ProtoErrorKind::NoRecordsFound {
                                 response_code: ResponseCode::NXDomain,
+                                trusted: true,
                                 ..
                             }
                         ) =>
                     {
-                        debug!("NoRecordsFound with NXDomain, not retrying over TCP");
+                        debug!("trusted NXDomain, not retrying over TCP");
                         return Err(e);
                     }
                     Err(e) if opts.try_tcp_on_error || e.is_no_connections() || e.is_io() => {

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -218,9 +218,9 @@ where
                         debug!("truncated response received, retrying over TCP");
                         Ok(response)
                     }
-                    Err(e) if matches!(e.kind(), ProtoErrorKind::NoRecordsFound{ response_code, .. } if *response_code == ResponseCode::NXDomain ) => {
+                    Err(e) if matches!(e.kind(), ProtoErrorKind::NoRecordsFound{ response_code: ResponseCode::NXDomain, .. }) => {
                         debug!("NoRecordsFound with NXDomain, not retrying over TCP");
-                        return Err(e).map_err(ProtoError::from)
+                        return Err(e)
                     }
                     Err(e) if opts.try_tcp_on_error || e.is_no_connections() || e.is_io() => {
                         debug!("error from UDP, retrying over TCP: {}", e);

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -218,9 +218,17 @@ where
                         debug!("truncated response received, retrying over TCP");
                         Ok(response)
                     }
-                    Err(e) if matches!(e.kind(), ProtoErrorKind::NoRecordsFound{ response_code: ResponseCode::NXDomain, .. }) => {
+                    Err(e)
+                        if matches!(
+                            e.kind(),
+                            ProtoErrorKind::NoRecordsFound {
+                                response_code: ResponseCode::NXDomain,
+                                ..
+                            }
+                        ) =>
+                    {
                         debug!("NoRecordsFound with NXDomain, not retrying over TCP");
-                        return Err(e)
+                        return Err(e);
                     }
                     Err(e) if opts.try_tcp_on_error || e.is_no_connections() || e.is_io() => {
                         debug!("error from UDP, retrying over TCP: {}", e);


### PR DESCRIPTION
All the background info is in #2228. At scale, retrying over TCP is adding quite a bit of latency.

The issue suggests changing to `if e.is_no_connections() || (opts.try_tcp_on_error  && e.is_io())` but I was wondering if it was too broad. Happy to put this behind a config flag to keep the existing behavior if needed.

Fixes: #2228 