### PR TITLE
Simplify TBS construction API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,6 +977,7 @@ dependencies = [
  "serde",
  "socket2 0.5.7",
  "thiserror",
+ "time",
  "tinyvec",
  "tokio",
  "tokio-native-tls",

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -122,6 +122,7 @@ rustls-pemfile = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 socket2 = { workspace = true, optional = true }
 thiserror.workspace = true
+time.workspace = true
 tinyvec = { workspace = true, features = ["alloc"] }
 tracing.workspace = true
 tokio = { workspace = true, features = ["io-util", "macros"], optional = true }

--- a/crates/proto/src/rr/dnssec/signer.rs
+++ b/crates/proto/src/rr/dnssec/signer.rs
@@ -705,7 +705,7 @@ mod tests {
             .clone(),
         ];
 
-        let tbs = tbs::rrset_tbs_with_rrsig(&rrsig, &rrset).unwrap();
+        let tbs = TBS::from_rrsig(&rrsig, &rrset).unwrap();
         let sig = signer.sign(&tbs).unwrap();
 
         let pub_key = signer.key().to_public_bytes().unwrap();
@@ -789,7 +789,6 @@ MC0CAQACBQC+L6pNAgMBAAECBQCYj0ZNAgMA9CsCAwDHZwICeEUCAnE/AgMA3u0=
         use openssl::rsa::Rsa;
 
         use crate::rr::dnssec::rdata::RRSIG;
-        use crate::rr::dnssec::tbs::*;
         use crate::rr::dnssec::*;
         use crate::rr::rdata::{CNAME, NS};
         use crate::rr::*;
@@ -834,7 +833,7 @@ MC0CAQACBQC+L6pNAgMBAAECBQCYj0ZNAgMA9CsCAwDHZwICeEUCAnE/AgMA3u0=
                 .clone(),
             ];
 
-            let tbs = rrset_tbs_with_rrsig(&rrsig, &rrset).unwrap();
+            let tbs = TBS::from_rrsig(&rrsig, &rrset).unwrap();
             assert!(!tbs.as_ref().is_empty());
 
             let rrset = vec![
@@ -875,7 +874,7 @@ MC0CAQACBQC+L6pNAgMBAAECBQCYj0ZNAgMA9CsCAwDHZwICeEUCAnE/AgMA3u0=
                 .clone(),
             ];
 
-            let filtered_tbs = rrset_tbs_with_rrsig(&rrsig, &rrset).unwrap();
+            let filtered_tbs = TBS::from_rrsig(&rrsig, &rrset).unwrap();
             assert!(!filtered_tbs.as_ref().is_empty());
             assert_eq!(tbs.as_ref(), filtered_tbs.as_ref());
         }

--- a/crates/proto/src/rr/dnssec/signer.rs
+++ b/crates/proto/src/rr/dnssec/signer.rs
@@ -705,7 +705,7 @@ mod tests {
             .clone(),
         ];
 
-        let tbs = TBS::from_rrsig(&rrsig, &rrset).unwrap();
+        let tbs = TBS::from_rrsig(&rrsig, rrset.iter()).unwrap();
         let sig = signer.sign(&tbs).unwrap();
 
         let pub_key = signer.key().to_public_bytes().unwrap();
@@ -833,7 +833,7 @@ MC0CAQACBQC+L6pNAgMBAAECBQCYj0ZNAgMA9CsCAwDHZwICeEUCAnE/AgMA3u0=
                 .clone(),
             ];
 
-            let tbs = TBS::from_rrsig(&rrsig, &rrset).unwrap();
+            let tbs = TBS::from_rrsig(&rrsig, rrset.iter()).unwrap();
             assert!(!tbs.as_ref().is_empty());
 
             let rrset = vec![
@@ -874,7 +874,7 @@ MC0CAQACBQC+L6pNAgMBAAECBQCYj0ZNAgMA9CsCAwDHZwICeEUCAnE/AgMA3u0=
                 .clone(),
             ];
 
-            let filtered_tbs = TBS::from_rrsig(&rrsig, &rrset).unwrap();
+            let filtered_tbs = TBS::from_rrsig(&rrsig, rrset.iter()).unwrap();
             assert!(!filtered_tbs.as_ref().is_empty());
             assert_eq!(tbs.as_ref(), filtered_tbs.as_ref());
         }

--- a/crates/proto/src/rr/dnssec/verifier.rs
+++ b/crates/proto/src/rr/dnssec/verifier.rs
@@ -19,6 +19,8 @@ use crate::{
     serialize::binary::BinEncodable,
 };
 
+use super::TBS;
+
 /// Types which are able to verify DNS based signatures
 pub trait Verifier {
     /// Return the algorithm which this Verifier covers
@@ -77,7 +79,7 @@ pub trait Verifier {
         sig: &RRSIG,
         records: &[&Record],
     ) -> ProtoResult<()> {
-        let rrset_tbs = tbs::rrset_tbs_with_sig(name, dns_class, sig, records)?;
+        let rrset_tbs = TBS::from_sig(name, dns_class, sig, records)?;
         self.verify(rrset_tbs.as_ref(), sig.sig())
     }
 }

--- a/crates/proto/src/rr/dnssec/verifier.rs
+++ b/crates/proto/src/rr/dnssec/verifier.rs
@@ -72,12 +72,12 @@ pub trait Verifier {
     /// * `dns_class` - DNSClass of the records, generally IN
     /// * `sig` - signature record being validated
     /// * `records` - Records covered by SIG
-    fn verify_rrsig(
+    fn verify_rrsig<'a>(
         &self,
         name: &Name,
         dns_class: DNSClass,
         sig: &RRSIG,
-        records: &[&Record],
+        records: impl Iterator<Item = &'a Record>,
     ) -> ProtoResult<()> {
         let rrset_tbs = TBS::from_sig(name, dns_class, sig, records)?;
         self.verify(rrset_tbs.as_ref(), sig.sig())

--- a/crates/proto/src/rr/serial_number.rs
+++ b/crates/proto/src/rr/serial_number.rs
@@ -9,11 +9,6 @@ use std::{cmp::Ordering, ops::Add};
 pub struct SerialNumber(pub(crate) u32);
 
 impl SerialNumber {
-    /// Constructs a new [`SerialNumber`]
-    pub fn new(value: u32) -> Self {
-        Self(value)
-    }
-
     /// Returns internal value
     pub fn get(&self) -> u32 {
         self.0

--- a/crates/proto/src/xfer/dnssec_dns_handle.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle.rs
@@ -775,7 +775,7 @@ fn verify_rrset_with_dnskey(
             rrset.name(),
             rrset.record_class(),
             rrsig.data(),
-            rrset.records(),
+            rrset.records().iter().copied(),
         )
         .map(|_| {
             debug!(

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -739,7 +739,7 @@ impl InnerInMemory {
         zone_ttl: u32,
         zone_class: DNSClass,
     ) -> DnsSecResult<()> {
-        use hickory_proto::rr::{dnssec::TBS, SerialNumber};
+        use hickory_proto::rr::dnssec::TBS;
 
         use crate::proto::rr::dnssec::rdata::RRSIG;
 
@@ -758,20 +758,7 @@ impl InnerInMemory {
             );
 
             let expiration = inception + signer.sig_duration();
-
-            let tbs = TBS::new(
-                rr_set.name(),
-                zone_class,
-                rr_set.name().num_labels(),
-                rr_set.record_type(),
-                signer.algorithm(),
-                rr_set.ttl(),
-                SerialNumber::new(expiration.unix_timestamp() as u32),
-                SerialNumber::new(inception.unix_timestamp() as u32),
-                signer.calculate_key_tag()?,
-                signer.signer_name(),
-                rr_set.records_without_rrsigs(),
-            );
+            let tbs = TBS::from_rrset(rr_set, zone_class, inception, expiration, signer);
 
             // TODO, maybe chain these with some ETL operations instead?
             let tbs = match tbs {

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -30,7 +30,7 @@ use crate::{
     authority::DnssecAuthority,
     proto::rr::dnssec::{
         rdata::{key::KEY, DNSSECRData, NSEC},
-        {tbs, DnsSecResult, SigSigner, SupportedAlgorithms},
+        {DnsSecResult, SigSigner, SupportedAlgorithms},
     },
 };
 
@@ -739,7 +739,7 @@ impl InnerInMemory {
         zone_ttl: u32,
         zone_class: DNSClass,
     ) -> DnsSecResult<()> {
-        use hickory_proto::rr::SerialNumber;
+        use hickory_proto::rr::{dnssec::TBS, SerialNumber};
 
         use crate::proto::rr::dnssec::rdata::RRSIG;
 
@@ -759,7 +759,7 @@ impl InnerInMemory {
 
             let expiration = inception + signer.sig_duration();
 
-            let tbs = tbs::rrset_tbs(
+            let tbs = TBS::new(
                 rr_set.name(),
                 zone_class,
                 rr_set.name().num_labels(),

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -770,12 +770,7 @@ impl InnerInMemory {
                 SerialNumber::new(inception.unix_timestamp() as u32),
                 signer.calculate_key_tag()?,
                 signer.signer_name(),
-                // TODO: this is a nasty clone... the issue is that the vec
-                //  from records is of Vec<&R>, but we really want &[R]
-                &rr_set
-                    .records_without_rrsigs()
-                    .cloned()
-                    .collect::<Vec<Record>>(),
+                rr_set.records_without_rrsigs(),
             );
 
             // TODO, maybe chain these with some ETL operations instead?

--- a/crates/server/tests/authority_battery/dnssec.rs
+++ b/crates/server/tests/authority_battery/dnssec.rs
@@ -363,7 +363,7 @@ pub fn verify(records: &[&Record], rrsig_records: &[Record<RRSIG>], keys: &[DNSK
         .filter(|rrsig| rrsig.key_tag() == key.calculate_key_tag().unwrap())
         .filter(|rrsig| rrsig.type_covered() == record_type)
         .any(|rrsig| key
-            .verify_rrsig(record_name, DNSClass::IN, rrsig, records)
+            .verify_rrsig(record_name, DNSClass::IN, rrsig, records.iter().copied())
             .map_err(|e| println!("failed to verify: {e}"))
             .is_ok())));
 }


### PR DESCRIPTION
This then avoids constructing `SerialNumber` across crate boundaries, so we can remove its public constructor.

cc @justahero 