### PR TITLE
only retry I/O errors over TCP

### DIFF
--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -952,12 +952,6 @@ pub struct ResolverOpts {
     pub preserve_intermediates: bool,
     /// Try queries over TCP if they fail over UDP.
     pub try_tcp_on_error: bool,
-    /// Try queries over TCP for I/O errors only.
-    ///
-    /// Requires `try_tcp_on_error` to be `true` as well. When enabled, "errors" such as NXDomain
-    /// or NoError are not retried over TCP as they would result in the same response.
-    /// Defaults to false to preserve the existing behavior of retrying all errors.
-    pub try_tcp_on_io_error_only: bool,
     /// The server ordering strategy that the resolver should use.
     pub server_ordering_strategy: ServerOrderingStrategy,
     /// Request upstream recursive resolvers to not perform any recursion.
@@ -996,7 +990,6 @@ impl Default for ResolverOpts {
             preserve_intermediates: true,
 
             try_tcp_on_error: false,
-            try_tcp_on_io_error_only: false,
             server_ordering_strategy: ServerOrderingStrategy::default(),
             recursion_desired: true,
             authentic_data: false,

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -952,6 +952,12 @@ pub struct ResolverOpts {
     pub preserve_intermediates: bool,
     /// Try queries over TCP if they fail over UDP.
     pub try_tcp_on_error: bool,
+    /// Try queries over TCP for I/O errors only.
+    ///
+    /// Requires `try_tcp_on_error` to be `true` as well. When enabled, "errors" such as NXDomain
+    /// or NoError are not retried over TCP as they would result in the same response.
+    /// Defaults to false to preserve the existing behavior of retrying all errors.
+    pub try_tcp_on_io_error_only: bool,
     /// The server ordering strategy that the resolver should use.
     pub server_ordering_strategy: ServerOrderingStrategy,
     /// Request upstream recursive resolvers to not perform any recursion.
@@ -990,6 +996,7 @@ impl Default for ResolverOpts {
             preserve_intermediates: true,
 
             try_tcp_on_error: false,
+            try_tcp_on_io_error_only: false,
             server_ordering_strategy: ServerOrderingStrategy::default(),
             recursion_desired: true,
             authentic_data: false,

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -217,6 +217,15 @@ where
                         debug!("truncated response received, retrying over TCP");
                         Ok(response)
                     }
+                    Err(e)
+                        if opts.try_tcp_on_io_error_only
+                            && opts.try_tcp_on_error
+                            && !e.is_no_connections()
+                            && !e.is_io() =>
+                    {
+                        debug!("not an I/O error, not retrying over TCP: {}", e);
+                        return Err(e);
+                    }
                     Err(e) if opts.try_tcp_on_error || e.is_no_connections() || e.is_io() => {
                         debug!("error from UDP, retrying over TCP: {}", e);
                         Err(e)

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -217,16 +217,7 @@ where
                         debug!("truncated response received, retrying over TCP");
                         Ok(response)
                     }
-                    Err(e)
-                        if opts.try_tcp_on_io_error_only
-                            && opts.try_tcp_on_error
-                            && !e.is_no_connections()
-                            && !e.is_io() =>
-                    {
-                        debug!("not an I/O error, not retrying over TCP: {}", e);
-                        return Err(e);
-                    }
-                    Err(e) if opts.try_tcp_on_error || e.is_no_connections() || e.is_io() => {
+                    Err(e) if (opts.try_tcp_on_error && e.is_io()) || e.is_no_connections() => {
                         debug!("error from UDP, retrying over TCP: {}", e);
                         Err(e)
                     }

--- a/tests/integration-tests/tests/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/name_server_pool_tests.rs
@@ -306,7 +306,7 @@ fn test_tcp_fallback_only_on_truncated() {
 #[test]
 fn test_no_tcp_fallback_on_non_io_error() {
     // Lookup to UDP should fail with a non I/O error, and the resolver should not retry
-    // the query over TCP because `try_tcp_on_io_error_only` is set to true.
+    // the query over TCP when `try_tcp_on_error` is set to true.
 
     let query = Query::query(Name::from_str("www.example.com.").unwrap(), RecordType::A);
 
@@ -334,7 +334,6 @@ fn test_no_tcp_fallback_on_non_io_error() {
 
     let mut options = ResolverOpts::default();
     options.try_tcp_on_error = true;
-    options.try_tcp_on_io_error_only = true;
     let pool = mock_nameserver_pool(vec![udp_nameserver], vec![tcp_nameserver], None, options);
 
     let request = message(query, vec![], vec![], vec![]);
@@ -354,7 +353,7 @@ fn test_no_tcp_fallback_on_non_io_error() {
 #[test]
 fn test_tcp_fallback_on_io_error() {
     // Lookup to UDP should fail with an I/O error, and the resolver should then try
-    // the query over TCP when `try_tcp_on_io_error_only` is set to true.
+    // the query over TCP when `try_tcp_on_error` is set to true.
 
     let query = Query::query(Name::from_str("www.example.com.").unwrap(), RecordType::A);
 
@@ -376,7 +375,6 @@ fn test_tcp_fallback_on_io_error() {
 
     let mut options = ResolverOpts::default();
     options.try_tcp_on_error = true;
-    options.try_tcp_on_io_error_only = true;
     let pool = mock_nameserver_pool(vec![udp_nameserver], vec![tcp_nameserver], None, options);
 
     let request = message(query, vec![], vec![], vec![]);
@@ -396,7 +394,7 @@ fn test_tcp_fallback_on_io_error() {
 #[test]
 fn test_tcp_fallback_on_no_connections() {
     // Lookup to UDP should fail with a NoConnections error, and the resolver should then try
-    // the query over TCP when `try_tcp_on_io_error_only` is set to true.
+    // the query over TCP whether `try_tcp_on_error` is set to true or not.
 
     let query = Query::query(Name::from_str("www.example.com.").unwrap(), RecordType::A);
 
@@ -417,7 +415,6 @@ fn test_tcp_fallback_on_no_connections() {
 
     let mut options = ResolverOpts::default();
     options.try_tcp_on_error = true;
-    options.try_tcp_on_io_error_only = true;
     let pool = mock_nameserver_pool(vec![udp_nameserver], vec![tcp_nameserver], None, options);
 
     let request = message(query, vec![], vec![], vec![]);

--- a/tests/integration-tests/tests/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/name_server_pool_tests.rs
@@ -238,7 +238,8 @@ fn test_datagram_fails_to_stream() {
     let query = Query::query(Name::from_str("www.example.com.").unwrap(), RecordType::A);
 
     let tcp_record = v4_record(query.name().clone(), Ipv4Addr::new(127, 0, 0, 2));
-    let udp_message: Result<DnsResponse, _> = Err(ProtoError::from("Forced Testing Error"));
+    let io_error = std::io::Error::new(std::io::ErrorKind::Other, "Some I/O Error");
+    let udp_message: Result<DnsResponse, _> = Err(ProtoError::from(io_error));
 
     let tcp_message = message(query.clone(), vec![tcp_record.clone()], vec![], vec![]);
 


### PR DESCRIPTION
Alternative to #2333.

NXDOMAIN / NoError are not retried over TCP. This is behind a feature flag (`try_tcp_on_io_error_only`) to preserve the current behavior by default.

Fixes: #2228 