### PR TITLE
NSEC3 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,6 +1048,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "cfg-if",
+ "data-encoding",
  "enum-as-inner",
  "futures-executor",
  "futures-util",

--- a/bin/src/hickory-dns.rs
+++ b/bin/src/hickory-dns.rs
@@ -181,6 +181,8 @@ async fn load_zone(
                 is_dnssec_enabled,
                 Some(zone_dir),
                 config,
+                #[cfg(feature = "dnssec")]
+                zone_config.nsec3.clone(),
             )
             .await?;
 
@@ -199,6 +201,8 @@ async fn load_zone(
                 is_axfr_allowed,
                 Some(zone_dir),
                 config,
+                #[cfg(feature = "dnssec")]
+                zone_config.nsec3.clone(),
             )?;
 
             // load any keys for the Zone, if it is a dynamic update zone, then keys are required
@@ -244,6 +248,8 @@ async fn load_zone(
                 is_dnssec_enabled,
                 Some(zone_dir),
                 &config,
+                #[cfg(feature = "dnssec")]
+                zone_config.nsec3.clone(),
             )
             .await?;
 
@@ -262,6 +268,8 @@ async fn load_zone(
                 is_axfr_allowed,
                 Some(zone_dir),
                 &config,
+                #[cfg(feature = "dnssec")]
+                zone_config.nsec3.clone(),
             )?;
 
             // load any keys for the Zone, if it is a dynamic update zone, then keys are required

--- a/bin/src/hickory-dns.rs
+++ b/bin/src/hickory-dns.rs
@@ -181,6 +181,7 @@ async fn load_zone(
                 is_dnssec_enabled,
                 Some(zone_dir),
                 config,
+                zone_config.nx_proof,
                 #[cfg(feature = "dnssec")]
                 zone_config.nsec3.clone(),
             )
@@ -201,6 +202,7 @@ async fn load_zone(
                 is_axfr_allowed,
                 Some(zone_dir),
                 config,
+                zone_config.nx_proof,
                 #[cfg(feature = "dnssec")]
                 zone_config.nsec3.clone(),
             )?;
@@ -248,6 +250,7 @@ async fn load_zone(
                 is_dnssec_enabled,
                 Some(zone_dir),
                 &config,
+                zone_config.nx_proof,
                 #[cfg(feature = "dnssec")]
                 zone_config.nsec3.clone(),
             )
@@ -268,6 +271,7 @@ async fn load_zone(
                 is_axfr_allowed,
                 Some(zone_dir),
                 &config,
+                zone_config.nx_proof,
                 #[cfg(feature = "dnssec")]
                 zone_config.nsec3.clone(),
             )?;

--- a/crates/proto/src/rr/dnssec/nsec3.rs
+++ b/crates/proto/src/rr/dnssec/nsec3.rs
@@ -103,8 +103,9 @@ use crate::serialize::binary::{BinEncodable, BinEncoder};
 ///    requires IETF Standards Action [RFC2434].
 /// ```
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Default)]
 pub enum Nsec3HashAlgorithm {
+    #[default]
     /// Hash for the Nsec3 records
     SHA1,
 }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -109,6 +109,7 @@ async-trait.workspace = true
 toml = { workspace = true, optional = true }
 bytes.workspace = true
 cfg-if.workspace = true
+data-encoding.workspace = true
 enum-as-inner.workspace = true
 futures-util = { workspace = true, default-features = false, features = ["std"] }
 h2 = { workspace = true, features = ["stream"], optional = true }

--- a/crates/server/src/authority/authority.rs
+++ b/crates/server/src/authority/authority.rs
@@ -202,6 +202,9 @@ pub trait Authority: Send + Sync {
         self.lookup(self.origin(), RecordType::SOA, lookup_options)
             .await
     }
+    
+    /// Whether NSEC3 should be used instead of NSEC
+    fn is_nsec3_enabled(&self) -> bool;
 }
 
 /// Extension to Authority to allow for DNSSEC features

--- a/crates/server/src/authority/authority.rs
+++ b/crates/server/src/authority/authority.rs
@@ -15,7 +15,10 @@ use crate::proto::rr::{
     Name,
 };
 use crate::{
-    authority::{LookupError, MessageRequest, UpdateResult, ZoneType}, config::NxProof, proto::rr::{LowerName, RecordSet, RecordType, RrsetRecords}, server::RequestInfo
+    authority::{LookupError, MessageRequest, UpdateResult, ZoneType},
+    config::NxProof,
+    proto::rr::{LowerName, RecordSet, RecordType, RrsetRecords},
+    server::RequestInfo,
 };
 
 /// LookupOptions that specify different options from the client to include or exclude various records in the response.
@@ -200,7 +203,7 @@ pub trait Authority: Send + Sync {
             .await
     }
 
-    /// What kind of non-existence proof should be provided 
+    /// What kind of non-existence proof should be provided
     fn nx_proof(&self) -> NxProof;
 }
 

--- a/crates/server/src/authority/authority.rs
+++ b/crates/server/src/authority/authority.rs
@@ -15,9 +15,7 @@ use crate::proto::rr::{
     Name,
 };
 use crate::{
-    authority::{LookupError, MessageRequest, UpdateResult, ZoneType},
-    proto::rr::{LowerName, RecordSet, RecordType, RrsetRecords},
-    server::RequestInfo,
+    authority::{LookupError, MessageRequest, UpdateResult, ZoneType}, config::NxProof, proto::rr::{LowerName, RecordSet, RecordType, RrsetRecords}, server::RequestInfo
 };
 
 /// LookupOptions that specify different options from the client to include or exclude various records in the response.
@@ -202,8 +200,8 @@ pub trait Authority: Send + Sync {
             .await
     }
 
-    /// Whether NSEC3 should be used instead of NSEC
-    fn is_nsec3_enabled(&self) -> bool;
+    /// What kind of non-existence proof should be provided 
+    fn nx_proof(&self) -> NxProof;
 }
 
 /// Extension to Authority to allow for DNSSEC features

--- a/crates/server/src/authority/authority.rs
+++ b/crates/server/src/authority/authority.rs
@@ -183,6 +183,7 @@ pub trait Authority: Send + Sync {
     async fn get_nsec3_records(
         &self,
         name: &LowerName,
+        query_type: RecordType,
         lookup_options: LookupOptions,
     ) -> Result<Self::Lookup, LookupError>;
 

--- a/crates/server/src/authority/authority.rs
+++ b/crates/server/src/authority/authority.rs
@@ -172,6 +172,20 @@ pub trait Authority: Send + Sync {
         lookup_options: LookupOptions,
     ) -> Result<Self::Lookup, LookupError>;
 
+
+    /// Return the NSEC3 records based on the given name
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - given this name (i.e. the lookup name), return the NSEC record that is less than
+    ///            this
+    /// * `is_secure` - if true then it will return RRSIG records as well
+    async fn get_nsec3_records(
+        &self,
+        name: &LowerName,
+        lookup_options: LookupOptions,
+    ) -> Result<Self::Lookup, LookupError>;
+
     /// Returns the SOA of the authority.
     ///
     /// *Note*: This will only return the SOA, if this is fulfilling a request, a standard lookup

--- a/crates/server/src/authority/authority.rs
+++ b/crates/server/src/authority/authority.rs
@@ -172,7 +172,6 @@ pub trait Authority: Send + Sync {
         lookup_options: LookupOptions,
     ) -> Result<Self::Lookup, LookupError>;
 
-
     /// Return the NSEC3 records based on the given name
     ///
     /// # Arguments
@@ -202,7 +201,7 @@ pub trait Authority: Send + Sync {
         self.lookup(self.origin(), RecordType::SOA, lookup_options)
             .await
     }
-    
+
     /// Whether NSEC3 should be used instead of NSEC
     fn is_nsec3_enabled(&self) -> bool;
 }

--- a/crates/server/src/authority/authority_object.rs
+++ b/crates/server/src/authority/authority_object.rs
@@ -130,6 +130,9 @@ pub trait AuthorityObject: Send + Sync {
         self.lookup(self.origin(), RecordType::SOA, lookup_options)
             .await
     }
+
+    /// Whether NSEC3 should be used instead of NSEC
+    fn is_nsec3_enabled(&self) -> bool;
 }
 
 #[async_trait::async_trait]
@@ -238,6 +241,10 @@ where
         let lookup =
             Authority::get_nsec3_records(self.as_ref(), name, query_type, lookup_options).await;
         lookup.map(|l| Box::new(l) as Box<dyn LookupObject>)
+    }
+
+    fn is_nsec3_enabled(&self) -> bool {
+        Authority::is_nsec3_enabled(self.as_ref())
     }
 }
 

--- a/crates/server/src/authority/authority_object.rs
+++ b/crates/server/src/authority/authority_object.rs
@@ -108,6 +108,7 @@ pub trait AuthorityObject: Send + Sync {
     async fn get_nsec3_records(
         &self,
         name: &LowerName,
+        query_type: RecordType,
         lookup_options: LookupOptions,
     ) -> Result<Box<dyn LookupObject>, LookupError>;
 
@@ -231,11 +232,12 @@ where
     async fn get_nsec3_records(
         &self,
         name: &LowerName,
+        query_type: RecordType,
         lookup_options: LookupOptions,
     ) -> Result<Box<dyn LookupObject>, LookupError> {
-        let lookup = Authority::get_nsec3_records(self.as_ref(), name, lookup_options).await;
+        let lookup =
+            Authority::get_nsec3_records(self.as_ref(), name, query_type, lookup_options).await;
         lookup.map(|l| Box::new(l) as Box<dyn LookupObject>)
-
     }
 }
 

--- a/crates/server/src/authority/authority_object.rs
+++ b/crates/server/src/authority/authority_object.rs
@@ -12,9 +12,7 @@ use std::sync::Arc;
 use tracing::debug;
 
 use crate::{
-    authority::{Authority, LookupError, LookupOptions, MessageRequest, UpdateResult, ZoneType},
-    proto::rr::{LowerName, Record, RecordType},
-    server::RequestInfo,
+    authority::{Authority, LookupError, LookupOptions, MessageRequest, UpdateResult, ZoneType}, config::NxProof, proto::rr::{LowerName, Record, RecordType}, server::RequestInfo
 };
 
 /// An Object safe Authority
@@ -131,8 +129,8 @@ pub trait AuthorityObject: Send + Sync {
             .await
     }
 
-    /// Whether NSEC3 should be used instead of NSEC
-    fn is_nsec3_enabled(&self) -> bool;
+    /// What kind of non-existence proof should be provided
+    fn nx_proof(&self) -> NxProof;
 }
 
 #[async_trait::async_trait]
@@ -243,8 +241,8 @@ where
         lookup.map(|l| Box::new(l) as Box<dyn LookupObject>)
     }
 
-    fn is_nsec3_enabled(&self) -> bool {
-        Authority::is_nsec3_enabled(self.as_ref())
+    fn nx_proof(&self) -> NxProof {
+        Authority::nx_proof(self.as_ref())
     }
 }
 

--- a/crates/server/src/authority/authority_object.rs
+++ b/crates/server/src/authority/authority_object.rs
@@ -12,7 +12,10 @@ use std::sync::Arc;
 use tracing::debug;
 
 use crate::{
-    authority::{Authority, LookupError, LookupOptions, MessageRequest, UpdateResult, ZoneType}, config::NxProof, proto::rr::{LowerName, Record, RecordType}, server::RequestInfo
+    authority::{Authority, LookupError, LookupOptions, MessageRequest, UpdateResult, ZoneType},
+    config::NxProof,
+    proto::rr::{LowerName, Record, RecordType},
+    server::RequestInfo,
 };
 
 /// An Object safe Authority

--- a/crates/server/src/authority/authority_object.rs
+++ b/crates/server/src/authority/authority_object.rs
@@ -98,6 +98,19 @@ pub trait AuthorityObject: Send + Sync {
         lookup_options: LookupOptions,
     ) -> Result<Box<dyn LookupObject>, LookupError>;
 
+    /// Return the NSEC3 records based on the given name
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - given this name (i.e. the lookup name), return the NSEC record that is less than
+    ///            this
+    /// * `is_secure` - if true then it will return RRSIG records as well
+    async fn get_nsec3_records(
+        &self,
+        name: &LowerName,
+        lookup_options: LookupOptions,
+    ) -> Result<Box<dyn LookupObject>, LookupError>;
+
     /// Returns the SOA of the authority.
     ///
     /// *Note*: This will only return the SOA, if this is fulfilling a request, a standard lookup
@@ -213,6 +226,16 @@ where
     ) -> Result<Box<dyn LookupObject>, LookupError> {
         let lookup = Authority::get_nsec_records(self.as_ref(), name, lookup_options).await;
         lookup.map(|l| Box::new(l) as Box<dyn LookupObject>)
+    }
+
+    async fn get_nsec3_records(
+        &self,
+        name: &LowerName,
+        lookup_options: LookupOptions,
+    ) -> Result<Box<dyn LookupObject>, LookupError> {
+        let lookup = Authority::get_nsec3_records(self.as_ref(), name, lookup_options).await;
+        lookup.map(|l| Box::new(l) as Box<dyn LookupObject>)
+
     }
 }
 

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -574,7 +574,7 @@ async fn send_authoritative_response(
             // in the dnssec case, nsec records should exist, we return NoError + NoData + NSec...
             debug!("request: {} non-existent adding nsecs", request_id);
             // run the nsec lookup future, and then transition to get soa
-            let future = authority.get_nsec_records(query.name(), lookup_options);
+            let future = authority.get_nsec3_records(query.name(), lookup_options);
             match future.await {
                 // run the soa lookup
                 Ok(nsecs) => Some(nsecs),

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -574,7 +574,7 @@ async fn send_authoritative_response(
             // in the dnssec case, nsec records should exist, we return NoError + NoData + NSec...
             debug!("request: {} non-existent adding nsecs", request_id);
             // run the nsec lookup future, and then transition to get soa
-            let future = authority.get_nsec3_records(query.name(), lookup_options);
+            let future = authority.get_nsec3_records(query.name(), query.query_type(), lookup_options);
             match future.await {
                 // run the soa lookup
                 Ok(nsecs) => Some(nsecs),

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -574,7 +574,12 @@ async fn send_authoritative_response(
             // in the dnssec case, nsec records should exist, we return NoError + NoData + NSec...
             debug!("request: {} non-existent adding nsecs", request_id);
             // run the nsec lookup future, and then transition to get soa
-            let future = authority.get_nsec3_records(query.name(), query.query_type(), lookup_options);
+            let future = if authority.is_nsec3_enabled() {
+                authority.get_nsec3_records(query.name(), query.query_type(), lookup_options)
+            } else {
+                authority.get_nsec_records(query.name(), lookup_options)
+            };
+
             match future.await {
                 // run the soa lookup
                 Ok(nsecs) => Some(nsecs),

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -583,9 +583,9 @@ async fn send_authoritative_response(
                 crate::config::NxProof::Nsec3 => {
                     authority.get_nsec3_records(query.name(), query.query_type(), lookup_options)
                 }
-                crate::config::NxProof::None => {
-                    Box::pin(async { Ok::<_, LookupError>(Box::new(EmptyLookup) as Box<dyn LookupObject>) })
-                }
+                crate::config::NxProof::None => Box::pin(async {
+                    Ok::<_, LookupError>(Box::new(EmptyLookup) as Box<dyn LookupObject>)
+                }),
             };
 
             match future.await {

--- a/crates/server/src/authority/error.rs
+++ b/crates/server/src/authority/error.rs
@@ -8,6 +8,7 @@
 use std::io;
 
 use enum_as_inner::EnumAsInner;
+use hickory_proto::error::ProtoError;
 use thiserror::Error;
 
 use crate::proto::op::ResponseCode;
@@ -39,6 +40,9 @@ pub enum LookupError {
     /// An underlying IO error occurred
     #[error("io error: {0}")]
     Io(io::Error),
+    /// An underlying serialization error ocurred
+    #[error("serialization error: {0}")]
+    Proto(#[from] ProtoError),
 }
 
 impl LookupError {

--- a/crates/server/src/config/mod.rs
+++ b/crates/server/src/config/mod.rs
@@ -352,6 +352,7 @@ pub struct Nsec3Config {
 
 /// The kind of non-existence proof provided by the server.
 #[derive(Debug, Default, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
 pub enum NxProof {
     #[cfg(feature = "dnssec")]
     #[cfg_attr(feature = "dnssec", default)]

--- a/crates/server/src/config/mod.rs
+++ b/crates/server/src/config/mod.rs
@@ -14,8 +14,6 @@ use std::fs::File;
 #[cfg(feature = "toml")]
 use std::io::Read;
 use std::net::{AddrParseError, Ipv4Addr, Ipv6Addr};
-#[cfg(feature = "dnssec")]
-use std::num::NonZeroU16;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::Duration;
@@ -339,7 +337,7 @@ impl ZoneConfig {
 
 #[cfg(feature = "dnssec")]
 /// NSEC3 related configuration.
-#[derive(Deserialize, PartialEq, Eq, Debug, Clone)]
+#[derive(Deserialize, PartialEq, Eq, Debug, Clone, Default)]
 pub struct Nsec3Config {
     /// Algorithm used to create the hashed NSEC3 owner names
     #[serde(default)]
@@ -348,24 +346,8 @@ pub struct Nsec3Config {
     #[serde(default)]
     pub salt: Vec<u8>,
     /// Number of iterations used to create the hashed NSEC3 owner names
-    #[serde(default = "default_iterations")]
-    pub iterations: NonZeroU16,
-}
-
-#[cfg(feature = "dnssec")]
-const fn default_iterations() -> NonZeroU16 {
-    NonZeroU16::MIN
-}
-
-#[cfg(feature = "dnssec")]
-impl Default for Nsec3Config {
-    fn default() -> Self {
-        Self {
-            hash_algorithm: Nsec3HashAlgorithm::default(),
-            salt: Vec::default(),
-            iterations: default_iterations(),
-        }
-    }
+    #[serde(default)]
+    pub iterations: u16,
 }
 
 /// The kind of non-existence proof provided by the server.

--- a/crates/server/src/config/mod.rs
+++ b/crates/server/src/config/mod.rs
@@ -258,6 +258,7 @@ impl ZoneConfig {
     /// * `enable_dnssec` - enable signing of the zone for DNSSEC
     /// * `nsec3` - NSEC3 Related configuration
     /// * `keys` - list of private and public keys used to sign a zone
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         zone: String,
         zone_type: ZoneType,
@@ -358,9 +359,9 @@ const fn default_iterations() -> NonZeroU16 {
 impl Default for Nsec3Config {
     fn default() -> Self {
         Self {
-            enable: Default::default(),
-            hash_algorithm: Default::default(),
-            salt: Default::default(),
+            enable: bool::default(),
+            hash_algorithm: Nsec3HashAlgorithm::default(),
+            salt: Vec::default(),
             iterations: default_iterations(),
         }
     }

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -24,8 +24,10 @@ use crate::{
 };
 use crate::{
     authority::{Authority, LookupError, LookupOptions, MessageRequest, UpdateResult, ZoneType},
-    proto::rr::{LowerName, Name, RecordSet, RecordType, RrKey},
-    proto::serialize::txt::Parser,
+    proto::{
+        rr::{LowerName, Name, RecordSet, RecordType, RrKey},
+        serialize::txt::Parser,
+    },
     server::RequestInfo,
     store::{file::FileConfig, in_memory::InMemoryAuthority},
 };
@@ -215,6 +217,14 @@ impl Authority for FileAuthority {
         lookup_options: LookupOptions,
     ) -> Result<Self::Lookup, LookupError> {
         self.0.get_nsec_records(name, lookup_options).await
+    }
+
+    async fn get_nsec3_records(
+        &self,
+        name: &LowerName,
+        lookup_options: LookupOptions,
+    ) -> Result<Self::Lookup, LookupError> {
+        self.0.get_nsec3_records(name, lookup_options).await
     }
 
     /// Returns the SOA of the authority.

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -222,9 +222,10 @@ impl Authority for FileAuthority {
     async fn get_nsec3_records(
         &self,
         name: &LowerName,
+        query_type: RecordType,
         lookup_options: LookupOptions,
     ) -> Result<Self::Lookup, LookupError> {
-        self.0.get_nsec3_records(name, lookup_options).await
+        self.0.get_nsec3_records(name, query_type, lookup_options).await
     }
 
     /// Returns the SOA of the authority.

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -240,6 +240,10 @@ impl Authority for FileAuthority {
     async fn soa_secure(&self, lookup_options: LookupOptions) -> Result<Self::Lookup, LookupError> {
         self.0.soa_secure(lookup_options).await
     }
+
+    fn is_nsec3_enabled(&self) -> bool {
+        self.0.is_nsec3_enabled()
+    }
 }
 
 #[cfg(feature = "dnssec")]

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -225,7 +225,9 @@ impl Authority for FileAuthority {
         query_type: RecordType,
         lookup_options: LookupOptions,
     ) -> Result<Self::Lookup, LookupError> {
-        self.0.get_nsec3_records(name, query_type, lookup_options).await
+        self.0
+            .get_nsec3_records(name, query_type, lookup_options)
+            .await
     }
 
     /// Returns the SOA of the authority.
@@ -293,6 +295,7 @@ mod tests {
             false,
             None,
             &config,
+            #[cfg(feature = "dnssec")]
             Nsec3Config::default(),
         )
         .expect("failed to load file");

--- a/crates/server/src/store/file/authority.rs
+++ b/crates/server/src/store/file/authority.rs
@@ -24,6 +24,7 @@ use crate::{
 };
 use crate::{
     authority::{Authority, LookupError, LookupOptions, MessageRequest, UpdateResult, ZoneType},
+    config::NxProof,
     proto::{
         rr::{LowerName, Name, RecordSet, RecordType, RrKey},
         serialize::txt::Parser,
@@ -59,6 +60,7 @@ impl FileAuthority {
         records: BTreeMap<RrKey, RecordSet>,
         zone_type: ZoneType,
         allow_axfr: bool,
+        nx_proof: NxProof,
         #[cfg(feature = "dnssec")] nsec3_config: Nsec3Config,
     ) -> Result<Self, String> {
         InMemoryAuthority::new(
@@ -66,6 +68,7 @@ impl FileAuthority {
             records,
             zone_type,
             allow_axfr,
+            nx_proof,
             #[cfg(feature = "dnssec")]
             nsec3_config,
         )
@@ -79,6 +82,7 @@ impl FileAuthority {
         allow_axfr: bool,
         root_dir: Option<&Path>,
         config: &FileConfig,
+        nx_proof: NxProof,
         #[cfg(feature = "dnssec")] nsec3_config: Nsec3Config,
     ) -> Result<Self, String> {
         let root_dir_path = root_dir.map(PathBuf::from).unwrap_or_default();
@@ -107,6 +111,7 @@ impl FileAuthority {
             records,
             zone_type,
             allow_axfr,
+            nx_proof,
             #[cfg(feature = "dnssec")]
             nsec3_config,
         )
@@ -243,8 +248,8 @@ impl Authority for FileAuthority {
         self.0.soa_secure(lookup_options).await
     }
 
-    fn is_nsec3_enabled(&self) -> bool {
-        self.0.is_nsec3_enabled()
+    fn nx_proof(&self) -> NxProof {
+        self.0.nx_proof()
     }
 }
 
@@ -295,6 +300,7 @@ mod tests {
             false,
             None,
             &config,
+            NxProof::None,
             #[cfg(feature = "dnssec")]
             Nsec3Config::default(),
         )

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -12,7 +12,7 @@ use tracing::{debug, info};
 
 use crate::{
     authority::{
-        Authority, LookupError, LookupObject, LookupOptions, MessageRequest, UpdateResult, ZoneType,
+        Authority, LookupError, LookupObject, LookupOptions, MessageRequest, UpdateResult, ZoneType
     },
     proto::{
         op::ResponseCode,
@@ -154,6 +154,17 @@ impl Authority for ForwardAuthority {
         Err(LookupError::from(io::Error::new(
             io::ErrorKind::Other,
             "Getting NSEC records is unimplemented for the forwarder",
+        )))
+    }
+
+    async fn get_nsec3_records(
+        &self,
+        _name: &LowerName,
+        _lookup_options: LookupOptions,
+    ) -> Result<Self::Lookup, LookupError> {
+        Err(LookupError::from(io::Error::new(
+            io::ErrorKind::Other,
+            "Getting NSEC3 records is unimplemented for the forwarder",
         )))
     }
 }

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -168,6 +168,10 @@ impl Authority for ForwardAuthority {
             "Getting NSEC3 records is unimplemented for the forwarder",
         )))
     }
+
+    fn is_nsec3_enabled(&self) -> bool {
+        false
+    }
 }
 
 /// A structure that holds the results of a forwarding lookup.

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -12,7 +12,7 @@ use tracing::{debug, info};
 
 use crate::{
     authority::{
-        Authority, LookupError, LookupObject, LookupOptions, MessageRequest, UpdateResult, ZoneType
+        Authority, LookupError, LookupObject, LookupOptions, MessageRequest, UpdateResult, ZoneType,
     },
     proto::{
         op::ResponseCode,

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -160,6 +160,7 @@ impl Authority for ForwardAuthority {
     async fn get_nsec3_records(
         &self,
         _name: &LowerName,
+        _query_type: RecordType,
         _lookup_options: LookupOptions,
     ) -> Result<Self::Lookup, LookupError> {
         Err(LookupError::from(io::Error::new(

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -13,10 +13,15 @@ use tracing::{debug, info};
 use crate::{
     authority::{
         Authority, LookupError, LookupObject, LookupOptions, MessageRequest, UpdateResult, ZoneType,
-    }, config::NxProof, proto::{
+    },
+    config::NxProof,
+    proto::{
         op::ResponseCode,
         rr::{LowerName, Name, Record, RecordType},
-    }, resolver::{config::ResolverConfig, lookup::Lookup as ResolverLookup, TokioAsyncResolver}, server::RequestInfo, store::forwarder::ForwardConfig
+    },
+    resolver::{config::ResolverConfig, lookup::Lookup as ResolverLookup, TokioAsyncResolver},
+    server::RequestInfo,
+    store::forwarder::ForwardConfig,
 };
 
 /// An authority that will forward resolutions to upstream resolvers.

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -13,14 +13,10 @@ use tracing::{debug, info};
 use crate::{
     authority::{
         Authority, LookupError, LookupObject, LookupOptions, MessageRequest, UpdateResult, ZoneType,
-    },
-    proto::{
+    }, config::NxProof, proto::{
         op::ResponseCode,
         rr::{LowerName, Name, Record, RecordType},
-    },
-    resolver::{config::ResolverConfig, lookup::Lookup as ResolverLookup, TokioAsyncResolver},
-    server::RequestInfo,
-    store::forwarder::ForwardConfig,
+    }, resolver::{config::ResolverConfig, lookup::Lookup as ResolverLookup, TokioAsyncResolver}, server::RequestInfo, store::forwarder::ForwardConfig
 };
 
 /// An authority that will forward resolutions to upstream resolvers.
@@ -169,8 +165,8 @@ impl Authority for ForwardAuthority {
         )))
     }
 
-    fn is_nsec3_enabled(&self) -> bool {
-        false
+    fn nx_proof(&self) -> NxProof {
+        NxProof::None
     }
 }
 

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -1581,6 +1581,16 @@ impl Authority for InMemoryAuthority {
     ) -> Result<Self::Lookup, LookupError> {
         Ok(AuthLookup::default())
     }
+
+    #[cfg(feature = "dnssec")]
+    fn is_nsec3_enabled(&self) -> bool {
+        self.nsec3_config.enable
+    }
+
+    #[cfg(not(feature = "dnssec"))]
+    fn is_nsec3_enabled(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(feature = "dnssec")]

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -692,7 +692,7 @@ impl InnerInMemory {
                     dns_class,
                     nsec3_config.hash_algorithm,
                     &nsec3_config.salt,
-                    nsec3_config.iterations.into(),
+                    nsec3_config.iterations,
                 );
             }
             NxProof::None => {}
@@ -1472,7 +1472,7 @@ impl Authority for InMemoryAuthority {
                 iterations,
                 ..
             } = self.nsec3_config;
-            hash_algorithm.hash(salt, name, iterations.into()).unwrap()
+            hash_algorithm.hash(salt, name, iterations).unwrap()
         };
 
         // Compute the hashed owner name from a given name. This is, the hash of the given name,

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -823,7 +823,7 @@ impl InnerInMemory {
         let mut record_types = record_types
             .into_iter()
             .map(|(name, type_bit_maps)| {
-                let hashed_name = hash_alg.hash(&salt, name.borrow(), iterations).unwrap();
+                let hashed_name = hash_alg.hash(salt, name.borrow(), iterations).unwrap();
                 (hashed_name, type_bit_maps)
             })
             .collect::<Vec<_>>();

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -1577,6 +1577,7 @@ impl Authority for InMemoryAuthority {
     async fn get_nsec3_records(
         &self,
         _name: &LowerName,
+        _query_type: RecordType,
         _lookup_options: LookupOptions,
     ) -> Result<Self::Lookup, LookupError> {
         Ok(AuthLookup::default())

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -10,6 +10,7 @@ use std::{io, path::Path, time::Instant};
 use tracing::{debug, info};
 
 use crate::{
+    config::NxProof,
     authority::{
         Authority, LookupError, LookupObject, LookupOptions, MessageRequest, UpdateResult, ZoneType,
     },
@@ -175,8 +176,8 @@ impl Authority for RecursiveAuthority {
         )))
     }
 
-    fn is_nsec3_enabled(&self) -> bool {
-        false
+    fn nx_proof(&self) -> NxProof {
+        NxProof::None
     }
 }
 

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -162,6 +162,17 @@ impl Authority for RecursiveAuthority {
             "Getting NSEC records is unimplemented for the recursor",
         )))
     }
+
+    async fn get_nsec3_records(
+        &self,
+        _name: &LowerName,
+        _lookup_options: LookupOptions,
+    ) -> Result<Self::Lookup, LookupError> {
+        Err(LookupError::from(io::Error::new(
+            io::ErrorKind::Other,
+            "Getting NSEC3 records is unimplemented for the recursor",
+        )))
+    }
 }
 
 pub struct RecursiveLookup(Lookup);

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -166,12 +166,17 @@ impl Authority for RecursiveAuthority {
     async fn get_nsec3_records(
         &self,
         _name: &LowerName,
+        _query_type: RecordType,
         _lookup_options: LookupOptions,
     ) -> Result<Self::Lookup, LookupError> {
         Err(LookupError::from(io::Error::new(
             io::ErrorKind::Other,
             "Getting NSEC3 records is unimplemented for the recursor",
         )))
+    }
+
+    fn is_nsec3_enabled(&self) -> bool {
+        false
     }
 }
 

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -10,10 +10,10 @@ use std::{io, path::Path, time::Instant};
 use tracing::{debug, info};
 
 use crate::{
-    config::NxProof,
     authority::{
         Authority, LookupError, LookupObject, LookupOptions, MessageRequest, UpdateResult, ZoneType,
     },
+    config::NxProof,
     proto::{
         op::{Query, ResponseCode},
         rr::{LowerName, Name, Record, RecordType},

--- a/crates/server/src/store/sqlite/authority.rs
+++ b/crates/server/src/store/sqlite/authority.rs
@@ -990,6 +990,14 @@ impl Authority for SqliteAuthority {
     ) -> Result<Self::Lookup, LookupError> {
         self.in_memory.get_nsec_records(name, lookup_options).await
     }
+
+    async fn get_nsec3_records(
+        &self,
+        name: &LowerName,
+        lookup_options: LookupOptions,
+    ) -> Result<Self::Lookup, LookupError> {
+        self.in_memory.get_nsec3_records(name, lookup_options).await
+    }
 }
 
 #[cfg(feature = "dnssec")]

--- a/crates/server/src/store/sqlite/authority.rs
+++ b/crates/server/src/store/sqlite/authority.rs
@@ -18,6 +18,7 @@ use tracing::{error, info, warn};
 
 use crate::{
     authority::{Authority, LookupError, LookupOptions, MessageRequest, UpdateResult, ZoneType},
+    config::NxProof,
     error::{PersistenceErrorKind, PersistenceResult},
     proto::{
         op::ResponseCode,
@@ -74,6 +75,7 @@ impl SqliteAuthority {
     }
 
     /// load the authority from the configuration
+    #[allow(clippy::too_many_arguments)]
     pub async fn try_from_config(
         origin: Name,
         zone_type: ZoneType,
@@ -81,6 +83,7 @@ impl SqliteAuthority {
         enable_dnssec: bool,
         root_dir: Option<&Path>,
         config: &SqliteConfig,
+        nx_proof: NxProof,
         #[cfg(feature = "dnssec")] nsec3_config: Nsec3Config,
     ) -> Result<Self, String> {
         use crate::store::file::{FileAuthority, FileConfig};
@@ -103,6 +106,7 @@ impl SqliteAuthority {
                 zone_name.clone(),
                 zone_type,
                 allow_axfr,
+                nx_proof,
                 #[cfg(feature = "dnssec")]
                 nsec3_config,
             );
@@ -131,6 +135,7 @@ impl SqliteAuthority {
                 allow_axfr,
                 root_dir,
                 &file_config,
+                nx_proof,
                 #[cfg(feature = "dnssec")]
                 nsec3_config,
             )?
@@ -1002,8 +1007,8 @@ impl Authority for SqliteAuthority {
             .await
     }
 
-    fn is_nsec3_enabled(&self) -> bool {
-        self.in_memory.is_nsec3_enabled()
+    fn nx_proof(&self) -> NxProof {
+        self.in_memory.nx_proof()
     }
 }
 

--- a/crates/server/src/store/sqlite/authority.rs
+++ b/crates/server/src/store/sqlite/authority.rs
@@ -997,7 +997,13 @@ impl Authority for SqliteAuthority {
         query_type: RecordType,
         lookup_options: LookupOptions,
     ) -> Result<Self::Lookup, LookupError> {
-        self.in_memory.get_nsec3_records(name, query_type, lookup_options).await
+        self.in_memory
+            .get_nsec3_records(name, query_type, lookup_options)
+            .await
+    }
+
+    fn is_nsec3_enabled(&self) -> bool {
+        self.in_memory.is_nsec3_enabled()
     }
 }
 

--- a/crates/server/src/store/sqlite/authority.rs
+++ b/crates/server/src/store/sqlite/authority.rs
@@ -994,9 +994,10 @@ impl Authority for SqliteAuthority {
     async fn get_nsec3_records(
         &self,
         name: &LowerName,
+        query_type: RecordType,
         lookup_options: LookupOptions,
     ) -> Result<Self::Lookup, LookupError> {
-        self.in_memory.get_nsec3_records(name, lookup_options).await
+        self.in_memory.get_nsec3_records(name, query_type, lookup_options).await
     }
 }
 

--- a/crates/server/tests/config_tests.rs
+++ b/crates/server/tests/config_tests.rs
@@ -53,6 +53,8 @@ fn test_read_config() {
                 None,
                 None,
                 None,
+                #[cfg(feature = "dnssec")]
+                None,
                 vec![],
             ),
             ZoneConfig::new(
@@ -61,6 +63,8 @@ fn test_read_config() {
                 "default/127.0.0.1.zone".into(),
                 None,
                 None,
+                None,
+                #[cfg(feature = "dnssec")]
                 None,
                 vec![],
             ),
@@ -73,6 +77,8 @@ fn test_read_config() {
                 None,
                 None,
                 None,
+                #[cfg(feature = "dnssec")]
+                None,
                 vec![],
             ),
             ZoneConfig::new(
@@ -81,6 +87,8 @@ fn test_read_config() {
                 "default/255.zone".into(),
                 None,
                 None,
+                None,
+                #[cfg(feature = "dnssec")]
                 None,
                 vec![],
             ),
@@ -91,6 +99,8 @@ fn test_read_config() {
                 None,
                 None,
                 None,
+                #[cfg(feature = "dnssec")]
+                None,
                 vec![],
             ),
             ZoneConfig::new(
@@ -99,6 +109,8 @@ fn test_read_config() {
                 "example.com.zone".into(),
                 None,
                 None,
+                None,
+                #[cfg(feature = "dnssec")]
                 None,
                 vec![],
             )

--- a/crates/server/tests/config_tests.rs
+++ b/crates/server/tests/config_tests.rs
@@ -53,6 +53,7 @@ fn test_read_config() {
                 None,
                 None,
                 None,
+                None,
                 #[cfg(feature = "dnssec")]
                 None,
                 vec![],
@@ -61,6 +62,7 @@ fn test_read_config() {
                 "0.0.127.in-addr.arpa".into(),
                 ZoneType::Primary,
                 "default/127.0.0.1.zone".into(),
+                None,
                 None,
                 None,
                 None,
@@ -77,6 +79,7 @@ fn test_read_config() {
                 None,
                 None,
                 None,
+                None,
                 #[cfg(feature = "dnssec")]
                 None,
                 vec![],
@@ -85,6 +88,7 @@ fn test_read_config() {
                 "255.in-addr.arpa".into(),
                 ZoneType::Primary,
                 "default/255.zone".into(),
+                None,
                 None,
                 None,
                 None,
@@ -99,6 +103,7 @@ fn test_read_config() {
                 None,
                 None,
                 None,
+                None,
                 #[cfg(feature = "dnssec")]
                 None,
                 vec![],
@@ -107,6 +112,7 @@ fn test_read_config() {
                 "example.com".into(),
                 ZoneType::Primary,
                 "example.com.zone".into(),
+                None,
                 None,
                 None,
                 None,

--- a/crates/server/tests/in_memory.rs
+++ b/crates/server/tests/in_memory.rs
@@ -6,8 +6,7 @@ use hickory_proto::rr::{rdata::CNAME, Name, RData, Record, RecordType};
 #[cfg(feature = "dnssec")]
 use hickory_server::config::Nsec3Config;
 use hickory_server::{
-    authority::{Authority, ZoneType},
-    store::in_memory::InMemoryAuthority,
+    authority::{Authority, ZoneType}, config::NxProof, store::in_memory::InMemoryAuthority
 };
 
 #[test]
@@ -17,6 +16,7 @@ fn test_cname_loop() {
         Name::from_str("example.com.").unwrap(),
         ZoneType::Primary,
         false,
+        NxProof::None,
         #[cfg(feature = "dnssec")]
         Nsec3Config::default(),
     );

--- a/crates/server/tests/in_memory.rs
+++ b/crates/server/tests/in_memory.rs
@@ -3,6 +3,8 @@ use std::str::FromStr;
 use tokio::runtime::Runtime;
 
 use hickory_proto::rr::{rdata::CNAME, Name, RData, Record, RecordType};
+#[cfg(feature = "dnssec")]
+use hickory_server::config::Nsec3Config;
 use hickory_server::{
     authority::{Authority, ZoneType},
     store::in_memory::InMemoryAuthority,
@@ -15,6 +17,8 @@ fn test_cname_loop() {
         Name::from_str("example.com.").unwrap(),
         ZoneType::Primary,
         false,
+        #[cfg(feature = "dnssec")]
+        Nsec3Config::default(),
     );
 
     auth.upsert_mut(

--- a/crates/server/tests/in_memory.rs
+++ b/crates/server/tests/in_memory.rs
@@ -6,7 +6,9 @@ use hickory_proto::rr::{rdata::CNAME, Name, RData, Record, RecordType};
 #[cfg(feature = "dnssec")]
 use hickory_server::config::Nsec3Config;
 use hickory_server::{
-    authority::{Authority, ZoneType}, config::NxProof, store::in_memory::InMemoryAuthority
+    authority::{Authority, ZoneType},
+    config::NxProof,
+    store::in_memory::InMemoryAuthority,
 };
 
 #[test]

--- a/crates/server/tests/store_file_tests.rs
+++ b/crates/server/tests/store_file_tests.rs
@@ -2,6 +2,8 @@ use std::str::FromStr;
 
 use hickory_proto::rr::{LowerName, Name, RecordType, RrKey};
 use hickory_server::authority::{Authority, LookupOptions, ZoneType};
+#[cfg(feature = "dnssec")]
+use hickory_server::config::Nsec3Config;
 use hickory_server::store::file::{FileAuthority, FileConfig};
 
 #[macro_use]
@@ -18,6 +20,8 @@ fn file(master_file_path: &str, _module: &str, _test_name: &str) -> FileAuthorit
         false,
         None,
         &config,
+        #[cfg(feature = "dnssec")]
+        Nsec3Config::default(),
     )
     .expect("failed to load file")
 }
@@ -38,6 +42,8 @@ fn test_all_lines_are_loaded() {
         false,
         None,
         &config,
+        #[cfg(feature = "dnssec")]
+        Nsec3Config::default(),
     )
     .expect("failed to load");
     let rrkey = RrKey {
@@ -59,6 +65,8 @@ fn test_implicit_in_class() {
         false,
         None,
         &config,
+        #[cfg(feature = "dnssec")]
+        Nsec3Config::default(),
     );
     assert!(authority.is_ok());
 }
@@ -76,6 +84,8 @@ async fn test_ttl_wilcard() {
         false,
         None,
         &config,
+        #[cfg(feature = "dnssec")]
+        Nsec3Config::default(),
     )
     .unwrap();
 

--- a/crates/server/tests/store_file_tests.rs
+++ b/crates/server/tests/store_file_tests.rs
@@ -1,10 +1,13 @@
 use std::str::FromStr;
 
 use hickory_proto::rr::{LowerName, Name, RecordType, RrKey};
-use hickory_server::{authority::{Authority, LookupOptions, ZoneType}, config::NxProof};
 #[cfg(feature = "dnssec")]
 use hickory_server::config::Nsec3Config;
 use hickory_server::store::file::{FileAuthority, FileConfig};
+use hickory_server::{
+    authority::{Authority, LookupOptions, ZoneType},
+    config::NxProof,
+};
 
 #[macro_use]
 mod authority_battery;

--- a/crates/server/tests/store_file_tests.rs
+++ b/crates/server/tests/store_file_tests.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use hickory_proto::rr::{LowerName, Name, RecordType, RrKey};
-use hickory_server::authority::{Authority, LookupOptions, ZoneType};
+use hickory_server::{authority::{Authority, LookupOptions, ZoneType}, config::NxProof};
 #[cfg(feature = "dnssec")]
 use hickory_server::config::Nsec3Config;
 use hickory_server::store::file::{FileAuthority, FileConfig};
@@ -20,6 +20,7 @@ fn file(master_file_path: &str, _module: &str, _test_name: &str) -> FileAuthorit
         false,
         None,
         &config,
+        NxProof::default(),
         #[cfg(feature = "dnssec")]
         Nsec3Config::default(),
     )
@@ -42,6 +43,7 @@ fn test_all_lines_are_loaded() {
         false,
         None,
         &config,
+        NxProof::default(),
         #[cfg(feature = "dnssec")]
         Nsec3Config::default(),
     )
@@ -65,6 +67,7 @@ fn test_implicit_in_class() {
         false,
         None,
         &config,
+        NxProof::default(),
         #[cfg(feature = "dnssec")]
         Nsec3Config::default(),
     );
@@ -84,6 +87,7 @@ async fn test_ttl_wilcard() {
         false,
         None,
         &config,
+        NxProof::default(),
         #[cfg(feature = "dnssec")]
         Nsec3Config::default(),
     )

--- a/crates/server/tests/store_sqlite_tests.rs
+++ b/crates/server/tests/store_sqlite_tests.rs
@@ -10,7 +10,9 @@ use hickory_proto::rr::Name;
 #[cfg(feature = "dnssec")]
 use hickory_server::config::Nsec3Config;
 use hickory_server::{
-    authority::ZoneType, config::NxProof, store::sqlite::{SqliteAuthority, SqliteConfig}
+    authority::ZoneType,
+    config::NxProof,
+    store::sqlite::{SqliteAuthority, SqliteConfig},
 };
 
 #[macro_use]

--- a/crates/server/tests/store_sqlite_tests.rs
+++ b/crates/server/tests/store_sqlite_tests.rs
@@ -10,8 +10,7 @@ use hickory_proto::rr::Name;
 #[cfg(feature = "dnssec")]
 use hickory_server::config::Nsec3Config;
 use hickory_server::{
-    authority::ZoneType,
-    store::sqlite::{SqliteAuthority, SqliteConfig},
+    authority::ZoneType, config::NxProof, store::sqlite::{SqliteAuthority, SqliteConfig}
 };
 
 #[macro_use]
@@ -40,6 +39,7 @@ fn sqlite(master_file_path: &str, module: &str, test_name: &str) -> SqliteAuthor
         true,
         None,
         &config,
+        NxProof::default(),
         #[cfg(feature = "dnssec")]
         Nsec3Config::default(),
     ))
@@ -70,6 +70,7 @@ fn sqlite_update(master_file_path: &str, module: &str, test_name: &str) -> Sqlit
         true,
         None,
         &config,
+        NxProof::default(),
         #[cfg(feature = "dnssec")]
         Nsec3Config::default(),
     ))

--- a/crates/server/tests/store_sqlite_tests.rs
+++ b/crates/server/tests/store_sqlite_tests.rs
@@ -7,6 +7,8 @@ use std::str::FromStr;
 use futures_executor::block_on;
 
 use hickory_proto::rr::Name;
+#[cfg(feature = "dnssec")]
+use hickory_server::config::Nsec3Config;
 use hickory_server::{
     authority::ZoneType,
     store::sqlite::{SqliteAuthority, SqliteConfig},
@@ -38,6 +40,8 @@ fn sqlite(master_file_path: &str, module: &str, test_name: &str) -> SqliteAuthor
         true,
         None,
         &config,
+        #[cfg(feature = "dnssec")]
+        Nsec3Config::default(),
     ))
     .expect("failed to load file")
 }
@@ -66,6 +70,8 @@ fn sqlite_update(master_file_path: &str, module: &str, test_name: &str) -> Sqlit
         true,
         None,
         &config,
+        #[cfg(feature = "dnssec")]
+        Nsec3Config::default(),
     ))
     .expect("failed to load file")
 }

--- a/crates/server/tests/txt_tests.rs
+++ b/crates/server/tests/txt_tests.rs
@@ -6,6 +6,8 @@ use hickory_proto::rr::rdata::{tlsa::*, A, AAAA};
 use hickory_proto::rr::*;
 use hickory_proto::serialize::txt::*;
 use hickory_server::authority::{Authority, LookupOptions, ZoneType};
+#[cfg(feature = "dnssec")]
+use hickory_server::config::Nsec3Config;
 use hickory_server::store::in_memory::InMemoryAuthority;
 
 // TODO: split this test up to test each thing separately
@@ -62,7 +64,15 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
 
     let (origin, records) = records.unwrap();
 
-    let authority = InMemoryAuthority::new(origin, records, ZoneType::Primary, false).unwrap();
+    let authority = InMemoryAuthority::new(
+        origin,
+        records,
+        ZoneType::Primary,
+        false,
+        #[cfg(feature = "dnssec")]
+        Nsec3Config::default(),
+    )
+    .unwrap();
 
     // not validating everything, just one of each...
 
@@ -424,7 +434,15 @@ a       A       127.0.0.1
 
     let (origin, records) = records.unwrap();
 
-    assert!(InMemoryAuthority::new(origin, records, ZoneType::Primary, false).is_err());
+    assert!(InMemoryAuthority::new(
+        origin,
+        records,
+        ZoneType::Primary,
+        false,
+        #[cfg(feature = "dnssec")]
+        Nsec3Config::default(),
+    )
+    .is_err());
 }
 
 #[test]
@@ -450,7 +468,15 @@ b       A       127.0.0.2
 
     let (origin, records) = records.unwrap();
 
-    assert!(InMemoryAuthority::new(origin, records, ZoneType::Primary, false).is_err());
+    assert!(InMemoryAuthority::new(
+        origin,
+        records,
+        ZoneType::Primary,
+        false,
+        #[cfg(feature = "dnssec")]
+        Nsec3Config::default(),
+    )
+    .is_err());
 }
 
 #[test]
@@ -475,7 +501,15 @@ a       A       127.0.0.1
 
     let (origin, records) = records.unwrap();
 
-    assert!(InMemoryAuthority::new(origin, records, ZoneType::Primary, false).is_ok());
+    assert!(InMemoryAuthority::new(
+        origin,
+        records,
+        ZoneType::Primary,
+        false,
+        #[cfg(feature = "dnssec")]
+        Nsec3Config::default(),
+    )
+    .is_ok());
 }
 
 #[test]

--- a/crates/server/tests/txt_tests.rs
+++ b/crates/server/tests/txt_tests.rs
@@ -8,6 +8,7 @@ use hickory_proto::serialize::txt::*;
 use hickory_server::authority::{Authority, LookupOptions, ZoneType};
 #[cfg(feature = "dnssec")]
 use hickory_server::config::Nsec3Config;
+use hickory_server::config::NxProof;
 use hickory_server::store::in_memory::InMemoryAuthority;
 
 // TODO: split this test up to test each thing separately
@@ -69,6 +70,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
         records,
         ZoneType::Primary,
         false,
+        NxProof::None,
         #[cfg(feature = "dnssec")]
         Nsec3Config::default(),
     )
@@ -439,6 +441,7 @@ a       A       127.0.0.1
         records,
         ZoneType::Primary,
         false,
+        NxProof::None,
         #[cfg(feature = "dnssec")]
         Nsec3Config::default(),
     )
@@ -473,6 +476,7 @@ b       A       127.0.0.2
         records,
         ZoneType::Primary,
         false,
+        NxProof::None,
         #[cfg(feature = "dnssec")]
         Nsec3Config::default(),
     )
@@ -506,6 +510,7 @@ a       A       127.0.0.1
         records,
         ZoneType::Primary,
         false,
+        NxProof::None,
         #[cfg(feature = "dnssec")]
         Nsec3Config::default(),
     )

--- a/tests/integration-tests/src/example_authority.rs
+++ b/tests/integration-tests/src/example_authority.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use hickory_proto::rr::*;
 
-use hickory_server::authority::ZoneType;
+use hickory_server::{authority::ZoneType, config::NxProof};
 #[cfg(any(feature = "dns-over-rustls", feature = "dnssec"))]
 use hickory_server::config::Nsec3Config;
 use hickory_server::store::in_memory::InMemoryAuthority;
@@ -18,6 +18,7 @@ pub fn create_example() -> InMemoryAuthority {
         origin.clone(),
         ZoneType::Primary,
         false,
+        NxProof::default(),
         #[cfg(any(feature = "dns-over-rustls", feature = "dnssec"))]
         Nsec3Config::default(),
     );

--- a/tests/integration-tests/src/example_authority.rs
+++ b/tests/integration-tests/src/example_authority.rs
@@ -3,6 +3,8 @@ use std::str::FromStr;
 use hickory_proto::rr::*;
 
 use hickory_server::authority::ZoneType;
+#[cfg(any(feature = "dns-over-rustls", feature = "dnssec"))]
+use hickory_server::config::Nsec3Config;
 use hickory_server::store::in_memory::InMemoryAuthority;
 
 #[allow(unused)]
@@ -12,7 +14,13 @@ pub fn create_example() -> InMemoryAuthority {
     use std::net::*;
 
     let origin: Name = Name::parse("example.com.", None).unwrap();
-    let mut records = InMemoryAuthority::empty(origin.clone(), ZoneType::Primary, false);
+    let mut records = InMemoryAuthority::empty(
+        origin.clone(),
+        ZoneType::Primary,
+        false,
+        #[cfg(any(feature = "dns-over-rustls", feature = "dnssec"))]
+        Nsec3Config::default(),
+    );
 
     // example.com.		3600	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082403 7200 3600 1209600 3600
     records.upsert_mut(

--- a/tests/integration-tests/src/example_authority.rs
+++ b/tests/integration-tests/src/example_authority.rs
@@ -2,10 +2,10 @@ use std::str::FromStr;
 
 use hickory_proto::rr::*;
 
-use hickory_server::{authority::ZoneType, config::NxProof};
 #[cfg(any(feature = "dns-over-rustls", feature = "dnssec"))]
 use hickory_server::config::Nsec3Config;
 use hickory_server::store::in_memory::InMemoryAuthority;
+use hickory_server::{authority::ZoneType, config::NxProof};
 
 #[allow(unused)]
 #[allow(clippy::unreadable_literal)]

--- a/tests/integration-tests/tests/catalog_tests.rs
+++ b/tests/integration-tests/tests/catalog_tests.rs
@@ -9,7 +9,10 @@ use hickory_client::{
 #[cfg(any(feature = "dns-over-rustls", feature = "dnssec"))]
 use hickory_server::config::Nsec3Config;
 use hickory_server::{
-    authority::{Authority, Catalog, MessageRequest, ZoneType}, config::NxProof, server::{Protocol, Request}, store::in_memory::InMemoryAuthority
+    authority::{Authority, Catalog, MessageRequest, ZoneType},
+    config::NxProof,
+    server::{Protocol, Request},
+    store::in_memory::InMemoryAuthority,
 };
 
 use hickory_integration::{example_authority::create_example, *};

--- a/tests/integration-tests/tests/catalog_tests.rs
+++ b/tests/integration-tests/tests/catalog_tests.rs
@@ -6,6 +6,8 @@ use hickory_client::{
     serialize::binary::{BinDecodable, BinEncodable},
 };
 
+#[cfg(any(feature = "dns-over-rustls", feature = "dnssec"))]
+use hickory_server::config::Nsec3Config;
 use hickory_server::{
     authority::{Authority, Catalog, MessageRequest, ZoneType},
     server::{Protocol, Request},
@@ -18,7 +20,13 @@ use hickory_integration::{example_authority::create_example, *};
 pub fn create_test() -> InMemoryAuthority {
     let origin: Name = Name::parse("test.com.", None).unwrap();
 
-    let mut records = InMemoryAuthority::empty(origin.clone(), ZoneType::Primary, false);
+    let mut records = InMemoryAuthority::empty(
+        origin.clone(),
+        ZoneType::Primary,
+        false,
+        #[cfg(any(feature = "dns-over-rustls", feature = "dnssec"))]
+        Nsec3Config::default(),
+    );
 
     records.upsert_mut(
         Record::from_rdata(

--- a/tests/integration-tests/tests/catalog_tests.rs
+++ b/tests/integration-tests/tests/catalog_tests.rs
@@ -9,9 +9,7 @@ use hickory_client::{
 #[cfg(any(feature = "dns-over-rustls", feature = "dnssec"))]
 use hickory_server::config::Nsec3Config;
 use hickory_server::{
-    authority::{Authority, Catalog, MessageRequest, ZoneType},
-    server::{Protocol, Request},
-    store::in_memory::InMemoryAuthority,
+    authority::{Authority, Catalog, MessageRequest, ZoneType}, config::NxProof, server::{Protocol, Request}, store::in_memory::InMemoryAuthority
 };
 
 use hickory_integration::{example_authority::create_example, *};
@@ -24,6 +22,7 @@ pub fn create_test() -> InMemoryAuthority {
         origin.clone(),
         ZoneType::Primary,
         false,
+        NxProof::default(),
         #[cfg(any(feature = "dns-over-rustls", feature = "dnssec"))]
         Nsec3Config::default(),
     );

--- a/tests/integration-tests/tests/sqlite_authority_tests.rs
+++ b/tests/integration-tests/tests/sqlite_authority_tests.rs
@@ -11,6 +11,8 @@ use hickory_proto::rr::*;
 
 use hickory_server::authority::LookupOptions;
 use hickory_server::authority::{Authority, ZoneType};
+#[cfg(feature = "dnssec")]
+use hickory_server::config::Nsec3Config;
 use hickory_server::server::Protocol;
 use hickory_server::server::RequestInfo;
 use hickory_server::store::in_memory::InMemoryAuthority;
@@ -924,8 +926,13 @@ async fn test_journal() {
     assert!(delete_rrset.was_empty());
 
     // that record should have been recorded... let's reload the journal and see if we get it.
-    let in_memory =
-        InMemoryAuthority::empty(authority.origin().clone().into(), ZoneType::Primary, false);
+    let in_memory = InMemoryAuthority::empty(
+        authority.origin().clone().into(),
+        ZoneType::Primary,
+        false,
+        #[cfg(feature = "dnssec")]
+        Nsec3Config::default(),
+    );
 
     let mut recovered_authority = SqliteAuthority::new(in_memory, false, false);
     recovered_authority
@@ -972,8 +979,13 @@ async fn test_recovery() {
     let journal = journal
         .as_ref()
         .expect("test should have associated journal");
-    let in_memory =
-        InMemoryAuthority::empty(authority.origin().clone().into(), ZoneType::Primary, false);
+    let in_memory = InMemoryAuthority::empty(
+        authority.origin().clone().into(),
+        ZoneType::Primary,
+        false,
+        #[cfg(feature = "dnssec")]
+        Nsec3Config::default(),
+    );
 
     let mut recovered_authority = SqliteAuthority::new(in_memory, false, false);
 

--- a/tests/integration-tests/tests/sqlite_authority_tests.rs
+++ b/tests/integration-tests/tests/sqlite_authority_tests.rs
@@ -13,6 +13,7 @@ use hickory_server::authority::LookupOptions;
 use hickory_server::authority::{Authority, ZoneType};
 #[cfg(feature = "dnssec")]
 use hickory_server::config::Nsec3Config;
+use hickory_server::config::NxProof;
 use hickory_server::server::Protocol;
 use hickory_server::server::RequestInfo;
 use hickory_server::store::in_memory::InMemoryAuthority;
@@ -930,6 +931,7 @@ async fn test_journal() {
         authority.origin().clone().into(),
         ZoneType::Primary,
         false,
+        NxProof::None,
         #[cfg(feature = "dnssec")]
         Nsec3Config::default(),
     );
@@ -983,6 +985,7 @@ async fn test_recovery() {
         authority.origin().clone().into(),
         ZoneType::Primary,
         false,
+        NxProof::None,
         #[cfg(feature = "dnssec")]
         Nsec3Config::default(),
     );

--- a/tests/integration-tests/tests/truncation_tests.rs
+++ b/tests/integration-tests/tests/truncation_tests.rs
@@ -8,6 +8,7 @@ use hickory_proto::DnsHandle;
 use hickory_server::authority::{Catalog, ZoneType};
 #[cfg(any(feature = "dns-over-rustls", feature = "dnssec"))]
 use hickory_server::config::Nsec3Config;
+use hickory_server::config::NxProof;
 use hickory_server::store::in_memory::InMemoryAuthority;
 use hickory_server::ServerFuture;
 use std::collections::BTreeMap;
@@ -107,6 +108,7 @@ pub fn new_large_catalog(num_records: u32) -> Catalog {
         records,
         ZoneType::Primary,
         false,
+        NxProof::default(),
         #[cfg(any(feature = "dns-over-rustls", feature = "dnssec"))]
         Nsec3Config::default(),
     )

--- a/tests/integration-tests/tests/truncation_tests.rs
+++ b/tests/integration-tests/tests/truncation_tests.rs
@@ -6,6 +6,8 @@ use hickory_proto::udp::UdpClientStream;
 use hickory_proto::xfer::FirstAnswer;
 use hickory_proto::DnsHandle;
 use hickory_server::authority::{Catalog, ZoneType};
+#[cfg(any(feature = "dns-over-rustls", feature = "dnssec"))]
+use hickory_server::config::Nsec3Config;
 use hickory_server::store::in_memory::InMemoryAuthority;
 use hickory_server::ServerFuture;
 use std::collections::BTreeMap;
@@ -100,8 +102,15 @@ pub fn new_large_catalog(num_records: u32) -> Catalog {
     let mut records = BTreeMap::new();
     records.insert(RrKey::new(name.clone().into(), RecordType::A), record_set);
     records.insert(RrKey::new(name.into(), RecordType::SOA), soa_record_set);
-    let authority =
-        InMemoryAuthority::new(Name::root(), records, ZoneType::Primary, false).unwrap();
+    let authority = InMemoryAuthority::new(
+        Name::root(),
+        records,
+        ZoneType::Primary,
+        false,
+        #[cfg(any(feature = "dns-over-rustls", feature = "dnssec"))]
+        Nsec3Config::default(),
+    )
+    .unwrap();
 
     let mut catalog: Catalog = Catalog::new();
     catalog.upsert(Name::root().into(), Box::new(Arc::new(authority)));


### PR DESCRIPTION
This PR implements RFC 5155 including zone signing and serving of NSEC3 records.

The only unimplemented feature of the RFC is opt-out support.
