### PR TITLE
util: add a newline between records in resolve report

### DIFF
--- a/util/src/bin/resolve.rs
+++ b/util/src/bin/resolve.rs
@@ -147,7 +147,7 @@ struct Opts {
 }
 
 fn print_record<D: RecordData, R: Deref<Target = Record<D>>>(r: &R) {
-    print!(
+    println!(
         "\t{name} {ttl} {class} {ty} {rdata}",
         name = style(r.name()).blue(),
         ttl = style(r.ttl()).blue(),


### PR DESCRIPTION
It looks like in this PR, #1807,  the newlines on the records listed in the resolve CLI were removed, this adds a new line to the results back.