### PR TITLE
Manifest cleanup

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -94,27 +94,15 @@ path = "src/hickory-dns.rs"
 
 [dependencies]
 # clap features:
-# - suggestion for advanced help with error in cli
-# - derive for clap derive api
-# - help to generate --help
-clap = { workspace = true, default-features = false, features = [
-    "std",
-    "cargo",
-    "help",
-    "derive",
-    "suggestions",
-] }
-futures-util = { workspace = true, default-features = false, features = [
-    "std",
-] }
+# - `suggestions` for advanced help with error in cli
+# - `derive` for clap derive api
+# - `help` to generate --help
+clap = { workspace = true, default-features = false, features = ["cargo", "derive", "help", "std", "suggestions"] }
+futures-util = { workspace = true, default-features = false, features = ["std"] }
 rustls = { workspace = true, optional = true }
 time.workspace = true
 tracing.workspace = true
-tracing-subscriber = { workspace = true, features = [
-    "std",
-    "fmt",
-    "env-filter",
-] }
+tracing-subscriber = { workspace = true, features = ["fmt", "env-filter", "std"] }
 tokio = { workspace = true, features = ["time", "rt"] }
 hickory-client.workspace = true
 hickory-proto.workspace = true
@@ -123,10 +111,7 @@ hickory-server = { workspace = true, features = ["toml"] }
 [dev-dependencies]
 native-tls.workspace = true
 regex.workspace = true
-hickory-proto = { workspace = true, features = [
-    "testing",
-    "dns-over-native-tls",
-] }
+hickory-proto = { workspace = true, features = ["dns-over-native-tls", "testing"] }
 hickory-resolver.workspace = true
 webpki-roots.workspace = true
 

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -26,11 +26,6 @@ keywords.workspace = true
 categories.workspace = true
 license.workspace = true
 
-[badges]
-#github-actions = { repository = "bluejekyll/hickory", branch = "main", workflow = "test" }
-codecov = { repository = "hickory-dns/hickory-dns", branch = "main", service = "github" }
-maintenance = { status = "actively-developed" }
-
 [features]
 default = ["sqlite", "resolver", "native-certs", "ascii-art"]
 

--- a/crates/async-std-resolver/Cargo.toml
+++ b/crates/async-std-resolver/Cargo.toml
@@ -24,11 +24,6 @@ keywords.workspace = true
 categories.workspace = true
 license.workspace = true
 
-[badges]
-#github-actions = { repository = "bluejekyll/hickory", branch = "main", workflow = "test" }
-codecov = { repository = "hickory-dns/hickory-dns", branch = "main", service = "github" }
-maintenance = { status = "actively-developed" }
-
 [features]
 default = ["system-config"]
 

--- a/crates/async-std-resolver/Cargo.toml
+++ b/crates/async-std-resolver/Cargo.toml
@@ -56,18 +56,14 @@ path = "src/lib.rs"
 async-std = { workspace = true, features = ["unstable"] }
 async-trait.workspace = true
 futures-io = { workspace = true, default-features = false, features = ["std"] }
-futures-util = { workspace = true, default-features = false, features = [
-    "std",
-] }
+futures-util = { workspace = true, default-features = false, features = ["std"] }
 pin-utils.workspace = true
 hickory-resolver = { workspace = true, default-features = false }
 socket2.workspace = true
 
 [dev-dependencies]
 async-std = { workspace = true, features = ["attributes"] }
-hickory-resolver = { workspace = true, default-features = false, features = [
-    "testing",
-] }
+hickory-resolver = { workspace = true, default-features = false, features = ["testing"] }
 
 [lints]
 workspace = true

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -59,7 +59,7 @@ dnssec-openssl = ["dnssec", "hickory-proto/dnssec-openssl"]
 dnssec-ring = ["dnssec", "hickory-proto/dnssec-ring"]
 dnssec = ["hickory-proto/dnssec"]
 
-serde-config = ["dep:serde", "hickory-proto/serde-config"]
+serde = ["dep:serde", "hickory-proto/serde"]
 
 # enables experimental the mDNS (multicast) feature
 mdns = ["hickory-proto/mdns"]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -71,12 +71,8 @@ path = "src/lib.rs"
 [dependencies]
 cfg-if.workspace = true
 data-encoding.workspace = true
-futures-channel = { workspace = true, default-features = false, features = [
-    "std",
-] }
-futures-util = { workspace = true, default-features = false, features = [
-    "std",
-] }
+futures-channel = { workspace = true, default-features = false, features = ["std"] }
+futures-util = { workspace = true, default-features = false, features = ["std"] }
 once_cell.workspace = true
 radix_trie.workspace = true
 rand.workspace = true
@@ -85,22 +81,12 @@ serde = { workspace = true, features = ["derive"], optional = true }
 thiserror.workspace = true
 tracing.workspace = true
 tokio = { workspace = true, features = ["rt", "net"] }
-hickory-proto = { workspace = true, features = [
-    "text-parsing",
-    "tokio-runtime",
-] }
+hickory-proto = { workspace = true, features = ["text-parsing", "tokio-runtime"] }
 
 [dev-dependencies]
-futures = { workspace = true, default-features = false, features = [
-    "std",
-    "executor",
-] }
+futures = { workspace = true, default-features = false, features = ["std", "executor"] }
 tokio = { workspace = true, features = ["rt", "macros"] }
-tracing-subscriber = { workspace = true, features = [
-    "std",
-    "fmt",
-    "env-filter",
-] }
+tracing-subscriber = { workspace = true, features = ["fmt", "env-filter", "std"] }
 webpki-roots = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -29,11 +29,6 @@ keywords.workspace = true
 categories.workspace = true
 license.workspace = true
 
-[badges]
-#github-actions = { repository = "bluejekyll/hickory", branch = "main", workflow = "test" }
-codecov = { repository = "hickory-dns/hickory-dns", branch = "main", service = "github" }
-maintenance = { status = "actively-developed" }
-
 [features]
 backtrace = ["hickory-proto/backtrace"]
 

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -24,11 +24,6 @@ keywords.workspace = true
 categories.workspace = true
 license.workspace = true
 
-[badges]
-#github-actions = { repository = "bluejekyll/hickory", branch = "main", workflow = "test" }
-codecov = { repository = "hickory-dns/hickory-dns", branch = "main", service = "github" }
-maintenance = { status = "actively-developed" }
-
 [features]
 dns-over-tls = []
 dns-over-rustls = [

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -85,13 +85,9 @@ bytes = { workspace = true, optional = true }
 cfg-if.workspace = true
 data-encoding.workspace = true
 enum-as-inner.workspace = true
-futures-channel = { workspace = true, default-features = false, features = [
-    "std",
-] }
+futures-channel = { workspace = true, default-features = false, features = ["std"] }
 futures-io = { workspace = true, default-features = false, features = ["std"] }
-futures-util = { workspace = true, default-features = false, features = [
-    "std",
-] }
+futures-util = { workspace = true, default-features = false, features = ["std"] }
 h2 = { workspace = true, features = ["stream"], optional = true }
 h3 = { workspace = true, optional = true }
 h3-quinn = { workspace = true, optional = true }
@@ -103,11 +99,7 @@ native-tls = { workspace = true, optional = true }
 once_cell.workspace = true
 openssl = { workspace = true, features = ["v102", "v110"], optional = true }
 pin-project-lite = { workspace = true, optional = true }
-quinn = { workspace = true, optional = true, features = [
-    "log",
-    "runtime-tokio",
-    "rustls",
-] }
+quinn = { workspace = true, optional = true, features = ["log", "runtime-tokio", "rustls"] }
 rand.workspace = true
 ring = { workspace = true, optional = true, features = ["std"] }
 rustls = { workspace = true, optional = true, default-features = false }
@@ -128,16 +120,10 @@ wasm-bindgen-crate = { workspace = true, optional = true }
 webpki-roots = { workspace = true, optional = true }
 
 [dev-dependencies]
-futures-executor = { workspace = true, default-features = false, features = [
-    "std",
-] }
+futures-executor = { workspace = true, default-features = false, features = ["std"] }
 openssl = { workspace = true, features = ["v102", "v110"] }
 tokio = { workspace = true, features = ["rt", "time", "macros"] }
-tracing-subscriber = { workspace = true, features = [
-    "std",
-    "fmt",
-    "env-filter",
-] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "std"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -63,7 +63,7 @@ text-parsing = []
 tokio-runtime = ["tokio/net", "tokio/rt", "tokio/time", "tokio/rt-multi-thread"]
 default = ["tokio-runtime"]
 
-serde-config = ["dep:serde", "url/serde"]
+serde = ["dep:serde", "url/serde"]
 
 # enables experimental the mDNS (multicast) feature
 mdns = ["socket2/all"]

--- a/crates/proto/src/rr/dns_class.rs
+++ b/crates/proto/src/rr/dns_class.rs
@@ -12,14 +12,14 @@ use std::cmp::Ordering;
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::error::*;
 use crate::serialize::binary::*;
 
 /// The DNS Record class
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
 #[allow(dead_code)]
 pub enum DNSClass {

--- a/crates/proto/src/rr/dnssec/algorithm.rs
+++ b/crates/proto/src/rr/dnssec/algorithm.rs
@@ -12,7 +12,7 @@
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::error::*;
@@ -99,7 +99,7 @@ use crate::serialize::binary::*;
 ///    This document cannot be updated, only made obsolete and replaced by a
 ///    successor document.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
 #[non_exhaustive]
 pub enum Algorithm {

--- a/crates/proto/src/rr/dnssec/digest_type.rs
+++ b/crates/proto/src/rr/dnssec/digest_type.rs
@@ -13,7 +13,7 @@ use openssl::hash;
 #[cfg(feature = "dnssec-ring")]
 use ring::digest;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::error::*;
@@ -33,7 +33,7 @@ use super::Digest;
 /// 5 ED25519 [RFC draft-ietf-curdle-dnskey-eddsa-03]
 /// 5-255 Unassigned -
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
 #[non_exhaustive]
 pub enum DigestType {

--- a/crates/proto/src/rr/dnssec/nsec3.rs
+++ b/crates/proto/src/rr/dnssec/nsec3.rs
@@ -18,7 +18,7 @@
 //! NSEC3 related record types
 #![allow(clippy::use_self)]
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(any(feature = "dnssec-openssl", feature = "dnssec-ring"))]
@@ -102,7 +102,7 @@ use crate::serialize::binary::{BinEncodable, BinEncoder};
 ///    Assignment of additional NSEC3 hash algorithms in this registry
 ///    requires IETF Standards Action [RFC2434].
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum Nsec3HashAlgorithm {
     /// Hash for the Nsec3 records

--- a/crates/proto/src/rr/dnssec/proof.rs
+++ b/crates/proto/src/rr/dnssec/proof.rs
@@ -10,7 +10,7 @@
 use std::{fmt, ops::BitOr};
 
 use bitflags::bitflags;
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -33,7 +33,7 @@ use super::Algorithm;
 ///   security-aware resolver must be able to distinguish between four
 ///   cases:
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[must_use = "Proof is a flag on Record data, it should be interrogated before using a record"]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
 #[repr(u8)]

--- a/crates/proto/src/rr/dnssec/rdata/cdnskey.rs
+++ b/crates/proto/src/rr/dnssec/rdata/cdnskey.rs
@@ -9,7 +9,7 @@
 
 use std::{fmt, ops::Deref};
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -21,7 +21,7 @@ use crate::{
 use super::{DNSSECRData, DNSKEY};
 
 /// RRSIG is really a derivation of the original SIG record data. See SIG for more documentation
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct CDNSKEY(DNSKEY);
 

--- a/crates/proto/src/rr/dnssec/rdata/cds.rs
+++ b/crates/proto/src/rr/dnssec/rdata/cds.rs
@@ -9,7 +9,7 @@
 
 use std::{fmt, ops::Deref};
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -21,7 +21,7 @@ use crate::{
 use super::{DNSSECRData, DS};
 
 /// RRSIG is really a derivation of the original SIG record data. See SIG for more documentation
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct CDS(DS);
 

--- a/crates/proto/src/rr/dnssec/rdata/dnskey.rs
+++ b/crates/proto/src/rr/dnssec/rdata/dnskey.rs
@@ -9,7 +9,7 @@
 
 use std::fmt;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -72,7 +72,7 @@ use super::DNSSECRData;
 ///    backward compatibility with early versions of the KEY record.
 ///
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct DNSKEY {
     zone_key: bool,

--- a/crates/proto/src/rr/dnssec/rdata/ds.rs
+++ b/crates/proto/src/rr/dnssec/rdata/ds.rs
@@ -9,7 +9,7 @@
 
 use std::fmt::{self, Display, Formatter};
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -66,7 +66,7 @@ use super::DNSSECRData;
 ///    hexadecimal digits.  Whitespace is allowed within the hexadecimal
 ///    text.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct DS {
     key_tag: u16,

--- a/crates/proto/src/rr/dnssec/rdata/key.rs
+++ b/crates/proto/src/rr/dnssec/rdata/key.rs
@@ -10,7 +10,7 @@
 
 use std::fmt;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -158,7 +158,7 @@ use super::DNSSECRData;
 ///               6 and 7 above) always have authority to sign any RRs in
 ///               the zone regardless of the value of the signatory field.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct KEY {
     key_trust: KeyTrust,
@@ -170,7 +170,7 @@ pub struct KEY {
 }
 
 /// Specifies in what contexts this key may be trusted for use
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum KeyTrust {
     /// Use of the key is prohibited for authentication
@@ -243,7 +243,7 @@ fn test_key_trust() {
 
 /// Declares what this key is for
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum KeyUsage {
     /// key associated with a "user" or "account" at an end entity, usually a host
     Host,
@@ -403,7 +403,7 @@ fn test_key_usage() {
 ///
 /// ```
 #[deprecated = "Deprecated by RFC3007"]
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct UpdateScope {
     /// this key is authorized to attach,
@@ -560,7 +560,7 @@ fn test_update_scope() {
 /// ```text
 /// All Protocol Octet values except DNSSEC (3) are eliminated
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum Protocol {
     /// Not in use

--- a/crates/proto/src/rr/dnssec/rdata/mod.rs
+++ b/crates/proto/src/rr/dnssec/rdata/mod.rs
@@ -9,7 +9,7 @@
 
 use std::fmt;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 // TODO: these should each be it's own struct, it would make parsing and decoding a little cleaner
@@ -54,7 +54,7 @@ pub use self::tsig::TSIG;
 pub type DNSSECRecordType = RecordType;
 
 /// Record data enum variants for DNSSEC-specific records.
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, EnumAsInner, PartialEq, Clone, Eq)]
 #[non_exhaustive]
 pub enum DNSSECRData {

--- a/crates/proto/src/rr/dnssec/rdata/nsec.rs
+++ b/crates/proto/src/rr/dnssec/rdata/nsec.rs
@@ -8,7 +8,7 @@
 //! NSEC record types
 use std::fmt;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::error::*;
@@ -42,7 +42,7 @@ use super::DNSSECRData;
 ///    expansion.  [RFC4035] describes the impact of wildcards on
 ///    authenticated denial of existence.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct NSEC {
     next_domain_name: Name,

--- a/crates/proto/src/rr/dnssec/rdata/nsec3.rs
+++ b/crates/proto/src/rr/dnssec/rdata/nsec3.rs
@@ -9,7 +9,7 @@
 
 use std::fmt;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -108,7 +108,7 @@ use super::DNSSECRData;
 ///  does not include the name of the containing zone.  The length of this
 ///  field is determined by the preceding Hash Length field.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct NSEC3 {
     hash_algorithm: Nsec3HashAlgorithm,

--- a/crates/proto/src/rr/dnssec/rdata/nsec3param.rs
+++ b/crates/proto/src/rr/dnssec/rdata/nsec3param.rs
@@ -9,7 +9,7 @@
 
 use std::fmt;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -76,7 +76,7 @@ use super::DNSSECRData;
 ///  length of this field is determined by the preceding Salt Length
 ///  field.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct NSEC3PARAM {
     hash_algorithm: Nsec3HashAlgorithm,

--- a/crates/proto/src/rr/dnssec/rdata/rrsig.rs
+++ b/crates/proto/src/rr/dnssec/rdata/rrsig.rs
@@ -9,7 +9,7 @@
 
 use std::{fmt, ops::Deref};
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -21,7 +21,7 @@ use crate::{
 use super::{DNSSECRData, SIG};
 
 /// RRSIG is really a derivation of the original SIG record data. See SIG for more documentation
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct RRSIG(SIG);
 

--- a/crates/proto/src/rr/dnssec/rdata/sig.rs
+++ b/crates/proto/src/rr/dnssec/rdata/sig.rs
@@ -8,7 +8,7 @@
 //! signature record for signing queries, updates, and responses
 use std::fmt;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -179,7 +179,7 @@ use super::DNSSECRData;
 ///    networks, this time bracket should not normally extend further than 5
 ///    minutes into the past and 5 minutes into the future.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct SIG {
     type_covered: RecordType,

--- a/crates/proto/src/rr/dnssec/rdata/tsig.rs
+++ b/crates/proto/src/rr/dnssec/rdata/tsig.rs
@@ -10,7 +10,7 @@
 
 use std::{convert::TryInto, fmt};
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -135,7 +135,7 @@ use crate::{
 ///      seconds (see Section 5.2.3).  This document assigns no meaning to
 ///      its contents in requests.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct TSIG {
     algorithm: TsigAlgorithm,
@@ -175,7 +175,7 @@ pub struct TSIG {
 ///      | hmac-sha512-256          | MAY            | MAY             |
 ///      +--------------------------+----------------+-----------------+
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum TsigAlgorithm {
     /// HMAC-MD5.SIG-ALG.REG.INT (not supported for cryptographic operations)

--- a/crates/proto/src/rr/dnssec/supported_algorithm.rs
+++ b/crates/proto/src/rr/dnssec/supported_algorithm.rs
@@ -18,7 +18,7 @@
 
 use std::fmt::{self, Display, Formatter};
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use tracing::warn;
@@ -28,7 +28,7 @@ use crate::rr::dnssec::Algorithm;
 use crate::serialize::binary::{BinEncodable, BinEncoder};
 
 /// Used to specify the set of SupportedAlgorithms between a client and server
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct SupportedAlgorithms {
     // right now the number of Algorithms supported are fewer than 16..

--- a/crates/proto/src/rr/domain/name.rs
+++ b/crates/proto/src/rr/domain/name.rs
@@ -19,7 +19,7 @@ use crate::rr::domain::label::{CaseInsensitive, CaseSensitive, IntoLabel, Label,
 use crate::rr::domain::usage::LOCALHOST as LOCALHOST_usage;
 use crate::serialize::binary::*;
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use tinyvec::TinyVec;
 
@@ -1328,7 +1328,7 @@ where
     }
 }
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 impl Serialize for Name {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -1338,7 +1338,7 @@ impl Serialize for Name {
     }
 }
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for Name {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/crates/proto/src/rr/lower_name.rs
+++ b/crates/proto/src/rr/lower_name.rs
@@ -14,7 +14,7 @@ use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 
 use crate::error::*;
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::rr::Name;
@@ -291,7 +291,7 @@ impl FromStr for LowerName {
     }
 }
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 impl Serialize for LowerName {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -301,7 +301,7 @@ impl Serialize for LowerName {
     }
 }
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for LowerName {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/crates/proto/src/rr/rdata/a.rs
+++ b/crates/proto/src/rr/rdata/a.rs
@@ -34,7 +34,7 @@
 pub use std::net::Ipv4Addr;
 use std::{fmt, net::AddrParseError, ops::Deref, str};
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -44,7 +44,7 @@ use crate::{
 };
 
 /// The DNS A record type, an IPv4 address
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct A(pub Ipv4Addr);
 

--- a/crates/proto/src/rr/rdata/aaaa.rs
+++ b/crates/proto/src/rr/rdata/aaaa.rs
@@ -26,7 +26,7 @@
 pub use std::net::Ipv6Addr;
 use std::{fmt, net::AddrParseError, ops::Deref, str};
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -36,7 +36,7 @@ use crate::{
 };
 
 /// The DNS AAAA record type, an IPv6 address
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct AAAA(pub Ipv6Addr);
 

--- a/crates/proto/src/rr/rdata/caa.rs
+++ b/crates/proto/src/rr/rdata/caa.rs
@@ -23,7 +23,7 @@
 
 use std::{fmt, str};
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -132,7 +132,7 @@ use crate::{
 /// domain will change between the time a certificate was issued and
 /// validation by a relying party.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct CAA {
     #[doc(hidden)]
@@ -220,7 +220,7 @@ impl CAA {
 }
 
 /// Specifies in what contexts this key may be trusted for use
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum Property {
     /// The issue property
@@ -301,7 +301,7 @@ impl From<String> for Property {
 /// `Issue` and `IssueWild` => `Issuer`,
 /// `Iodef` => `Url`,
 /// `Unknown` => `Unknown`,
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum Value {
     /// Issuer authorized to issue certs for this zone, and any associated parameters
@@ -630,7 +630,7 @@ pub fn read_iodef(url: &[u8]) -> ProtoResult<Url> {
 ///
 /// [RFC 8659, DNS Certification Authority Authorization, November 2019](https://www.rfc-editor.org/rfc/rfc8659#section-4.2)
 /// for more explanation.
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct KeyValue {
     key: String,

--- a/crates/proto/src/rr/rdata/csync.rs
+++ b/crates/proto/src/rr/rdata/csync.rs
@@ -9,7 +9,7 @@
 
 use std::fmt;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -40,7 +40,7 @@ use crate::{
 /// ```
 ///
 /// [rfc7477]: https://tools.ietf.org/html/rfc7477
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct CSYNC {
     soa_serial: u32,

--- a/crates/proto/src/rr/rdata/hinfo.rs
+++ b/crates/proto/src/rr/rdata/hinfo.rs
@@ -9,7 +9,7 @@
 
 use std::fmt;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -44,7 +44,7 @@ use crate::{
 /// ```
 ///
 /// [rfc1035]: https://tools.ietf.org/html/rfc1035
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct HINFO {
     cpu: Box<[u8]>,

--- a/crates/proto/src/rr/rdata/https.rs
+++ b/crates/proto/src/rr/rdata/https.rs
@@ -9,7 +9,7 @@
 
 use std::{fmt, ops::Deref};
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -21,7 +21,7 @@ use crate::{
 use super::SVCB;
 
 /// HTTPS is really a derivation of the original SVCB record data. See SVCB for more documentation
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct HTTPS(pub SVCB);
 

--- a/crates/proto/src/rr/rdata/mx.rs
+++ b/crates/proto/src/rr/rdata/mx.rs
@@ -9,7 +9,7 @@
 
 use std::fmt;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -35,7 +35,7 @@ use crate::{
 /// [RFC-974].
 ///
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct MX {
     preference: u16,

--- a/crates/proto/src/rr/rdata/name.rs
+++ b/crates/proto/src/rr/rdata/name.rs
@@ -32,7 +32,7 @@
 
 use std::{fmt, ops::Deref};
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -75,7 +75,7 @@ pub fn emit(encoder: &mut BinEncoder<'_>, name_data: &Name) -> ProtoResult<()> {
 macro_rules! name_rdata {
     ($name: ident) => {
         #[doc = stringify!(new type for the RecordData of $name)]
-        #[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+        #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
         #[derive(Debug, PartialEq, Eq, Hash, Clone)]
         pub struct $name(pub Name);
 

--- a/crates/proto/src/rr/rdata/naptr.rs
+++ b/crates/proto/src/rr/rdata/naptr.rs
@@ -9,7 +9,7 @@
 
 use std::fmt;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -47,7 +47,7 @@ use crate::{
 ///   <character-string> and <domain-name> as used here are defined in RFC
 ///   1035 [7].
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct NAPTR {
     order: u16,

--- a/crates/proto/src/rr/rdata/null.rs
+++ b/crates/proto/src/rr/rdata/null.rs
@@ -8,7 +8,7 @@
 //! null record type, generally not used except as an internal tool for representing null data
 use std::fmt;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -34,7 +34,7 @@ use crate::{
 /// allowed in Zone Files.  NULLs are used as placeholders in some
 /// experimental extensions of the DNS.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Default, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct NULL {
     anything: Vec<u8>,

--- a/crates/proto/src/rr/rdata/openpgpkey.rs
+++ b/crates/proto/src/rr/rdata/openpgpkey.rs
@@ -8,7 +8,7 @@
 //! OPENPGPKEY records for OpenPGP public keys
 use std::fmt;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -24,7 +24,7 @@ use crate::{
 /// value consisting of a Transferable Public Key formatted as specified
 /// in [RFC4880].
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct OPENPGPKEY {
     public_key: Vec<u8>,

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -12,7 +12,7 @@ use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use tracing::warn;
@@ -164,7 +164,7 @@ use crate::rr::dnssec::SupportedAlgorithms;
 ///       Set to zero by senders and ignored by receivers, unless modified
 ///       in a subsequent specification.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Default, Debug, Clone)]
 pub struct OPT {
     options: Vec<(EdnsCode, EdnsOption)>,
@@ -364,7 +364,7 @@ enum OptReadState {
 }
 
 /// The code of the EDNS data option
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Hash, Debug, Copy, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum EdnsCode {
@@ -461,7 +461,7 @@ impl From<EdnsCode> for u16 {
 /// `note: Not all EdnsOptions are supported at this time.`
 ///
 /// <https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-13>
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Hash)]
 #[non_exhaustive]
 pub enum EdnsOption {
@@ -605,7 +605,7 @@ impl<'a> From<&'a EdnsOption> for EdnsCode {
 ///    as a signal to the software developer making the request to fix
 ///    their implementation.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct ClientSubnet {
     address: IpAddr,

--- a/crates/proto/src/rr/rdata/soa.rs
+++ b/crates/proto/src/rr/rdata/soa.rs
@@ -9,7 +9,7 @@
 
 use std::fmt;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -62,7 +62,7 @@ use crate::{
 /// reason for this provision is to allow future dynamic update facilities to
 /// change the SOA RR with known semantics.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct SOA {
     mname: Name,

--- a/crates/proto/src/rr/rdata/srv.rs
+++ b/crates/proto/src/rr/rdata/srv.rs
@@ -8,7 +8,7 @@
 //! service records for identify port mapping for specific services on a host
 use std::fmt;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -77,7 +77,7 @@ use crate::{
 /// Class.
 ///
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct SRV {
     priority: u16,

--- a/crates/proto/src/rr/rdata/sshfp.rs
+++ b/crates/proto/src/rr/rdata/sshfp.rs
@@ -10,7 +10,7 @@
 
 use std::fmt;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use data_encoding::{Encoding, Specification};
@@ -58,7 +58,7 @@ pub static HEX: Lazy<Encoding> = Lazy::new(|| {
 ///    The message-digest algorithm is presumed to produce an opaque octet
 ///    string output, which is placed as-is in the RDATA fingerprint field.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct SSHFP {
     algorithm: Algorithm,
@@ -121,7 +121,7 @@ impl SSHFP {
 /// [RFC 6594](https://tools.ietf.org/html/rfc6594) and
 /// [RFC 7479](https://tools.ietf.org/html/rfc7479) and
 /// [RFC 8709](https://tools.ietf.org/html/rfc8709).
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum Algorithm {
     /// Reserved value
@@ -195,7 +195,7 @@ impl From<Algorithm> for u8 {
 ///
 /// The fingerprint type values have been updated in
 /// [RFC 6594](https://tools.ietf.org/html/rfc6594).
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum FingerprintType {
     /// Reserved value

--- a/crates/proto/src/rr/rdata/svcb.rs
+++ b/crates/proto/src/rr/rdata/svcb.rs
@@ -14,7 +14,7 @@ use std::{
     fmt,
 };
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use enum_as_inner::EnumAsInner;
@@ -70,7 +70,7 @@ use crate::{
 ///   If any RRs are malformed, the client MUST reject the entire RRSet and
 ///   fall back to non-SVCB connection establishment.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct SVCB {
     svc_priority: u16,
@@ -201,7 +201,7 @@ impl SVCB {
 ///   *  a 2 octet field containing the SvcParamKey as an integer in
 ///      network byte order.  (See Section 14.3.2 for the defined values.)
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum SvcParamKey {
     /// Mandatory keys in this RR
@@ -347,7 +347,7 @@ impl PartialOrd for SvcParamKey {
 ///   *  an octet string of this length whose contents are in a format
 ///      determined by the SvcParamKey.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, EnumAsInner)]
 pub enum SvcParamValue {
     ///    In a ServiceMode RR, a SvcParamKey is considered "mandatory" if the
@@ -565,7 +565,7 @@ impl fmt::Display for SvcParamValue {
 ///    SHOULD NOT appear in the list either.  (Including them wastes space
 ///    and otherwise has no effect.)
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 #[repr(transparent)]
 pub struct Mandatory(pub Vec<SvcParamKey>);
@@ -657,7 +657,7 @@ impl fmt::Display for Mandatory {
 ///   ALPN protocol identifier in the SVCB ALPN set indicates that this
 ///   service endpoint, described by TargetName and the other parameters
 ///   (e.g., "port"), offers service with the protocol suite associated
-///   with this ALPN identifier.  
+///   with this ALPN identifier.
 ///
 ///   Clients filter the set of ALPN identifiers to match the protocol suites
 ///   they support, and this informs the underlying transport protocol used
@@ -741,7 +741,7 @@ impl fmt::Display for Mandatory {
 ///   the default transports. This enables compatibility with the greatest
 ///   number of clients.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 #[repr(transparent)]
 pub struct Alpn(pub Vec<String>);
@@ -822,7 +822,7 @@ impl fmt::Display for Alpn {
 ///   with TLS server software. To enable simpler parsing, this SvcParam MUST NOT contain escape
 ///   sequences.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(PartialEq, Eq, Hash, Clone)]
 #[repr(transparent)]
 pub struct EchConfigList(pub Vec<u8>);
@@ -924,7 +924,7 @@ impl fmt::Debug for EchConfigList {
 ///   server operators SHOULD NOT include these hints, because they are
 ///   unlikely to convey any performance benefit.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 #[repr(transparent)]
 pub struct IpHint<T>(pub Vec<T>);
@@ -999,7 +999,7 @@ where
 ///   SvcParams in presentation format MAY appear in any order, but keys
 ///   MUST NOT be repeated.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 #[repr(transparent)]
 pub struct Unknown(pub Vec<u8>);

--- a/crates/proto/src/rr/rdata/tlsa.rs
+++ b/crates/proto/src/rr/rdata/tlsa.rs
@@ -10,7 +10,7 @@
 
 use std::fmt;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use super::sshfp;
@@ -40,7 +40,7 @@ use crate::{
 ///    /                                                               /
 ///    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct TLSA {
     cert_usage: CertUsage,
@@ -75,7 +75,7 @@ pub struct TLSA {
 ///    that accept other formats for certificates, those certificates will
 ///    need their own certificate usage values.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum CertUsage {
     /// ```text
@@ -186,7 +186,7 @@ impl From<CertUsage> for u8 {
 ///    unrelated to the use of "selector" in DomainKeys Identified Mail
 ///    (DKIM) [RFC6376].)
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum Selector {
     /// Full certificate: the Certificate binary structure as defined in [RFC5280](https://tools.ietf.org/html/rfc5280)
@@ -245,7 +245,7 @@ impl From<Selector> for u8 {
 ///    certificate (if possible) will assist clients that support a small
 ///    number of hash algorithms.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum Matching {
     /// Exact match on selected content

--- a/crates/proto/src/rr/rdata/txt.rs
+++ b/crates/proto/src/rr/rdata/txt.rs
@@ -9,7 +9,7 @@
 use std::fmt;
 use std::slice::Iter;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -31,7 +31,7 @@ use crate::{
 /// TXT RRs are used to hold descriptive text.  The semantics of the text
 /// depends on the domain where it is found.
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct TXT {
     txt_data: Box<[Box<[u8]>]>,

--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -12,7 +12,7 @@
 use std::convert::From;
 use std::{cmp::Ordering, fmt, net::IpAddr};
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use enum_as_inner::EnumAsInner;
@@ -55,7 +55,7 @@ use super::dnssec::rdata::DNSSECRData;
 /// is treated as binary information, and can be up to 256 characters in
 /// length (including the length octet).
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, EnumAsInner, PartialEq, Clone, Eq)]
 #[non_exhaustive]
 pub enum RData {

--- a/crates/proto/src/rr/record_type.rs
+++ b/crates/proto/src/rr/record_type.rs
@@ -12,7 +12,7 @@ use std::cmp::Ordering;
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::error::*;
@@ -25,7 +25,7 @@ use crate::serialize::binary::*;
 /// The type of the resource record.
 ///
 /// This specifies the type of data in the RData field of the Resource Record
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
 #[allow(dead_code)]
 #[non_exhaustive]

--- a/crates/proto/src/rr/resource.rs
+++ b/crates/proto/src/rr/resource.rs
@@ -9,7 +9,7 @@
 
 use std::{cmp::Ordering, convert::TryFrom, fmt};
 
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -70,7 +70,7 @@ const MDNS_ENABLE_CACHE_FLUSH: u16 = 1 << 15;
 ///     +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
 ///
 /// ```
-#[cfg_attr(feature = "serde-config", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Eq, Debug, Clone)]
 // TODO: make Record carry a lifetime for more efficient storage options in the future
 pub struct Record<R: RecordData = RData> {

--- a/crates/recursor/Cargo.toml
+++ b/crates/recursor/Cargo.toml
@@ -29,10 +29,6 @@ keywords.workspace = true
 categories.workspace = true
 license.workspace = true
 
-[badges]
-codecov = { repository = "hickory-dns/hickory-dns", branch = "main", service = "github" }
-maintenance = { status = "actively-developed" }
-
 [features]
 backtrace = ["dep:backtrace", "hickory-proto/backtrace", "hickory-resolver/backtrace"]
 

--- a/crates/recursor/Cargo.toml
+++ b/crates/recursor/Cargo.toml
@@ -87,10 +87,10 @@ dns-over-tls = []
 tls-openssl = ["dns-over-openssl"]
 tls = ["dns-over-openssl"]
 
-serde-config = [
+serde = [
     "dep:serde",
-    "hickory-proto/serde-config",
-    "hickory-resolver/serde-config",
+    "hickory-proto/serde",
+    "hickory-resolver/serde",
 ]
 
 testing = []

--- a/crates/recursor/Cargo.toml
+++ b/crates/recursor/Cargo.toml
@@ -106,9 +106,7 @@ backtrace = { version = "0.3.50", optional = true }
 bytes.workspace = true
 cfg-if.workspace = true
 enum-as-inner.workspace = true
-futures-util = { workspace = true, default-features = false, features = [
-    "std",
-] }
+futures-util = { workspace = true, default-features = false, features = ["std"] }
 lru-cache.workspace = true
 parking_lot.workspace = true
 serde = { workspace = true, features = ["derive"], optional = true }
@@ -120,11 +118,7 @@ hickory-resolver = { workspace = true, features = ["tokio-runtime"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
-tracing-subscriber = { workspace = true, features = [
-    "std",
-    "fmt",
-    "env-filter",
-] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "std"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -63,7 +63,7 @@ dnssec-openssl = ["dnssec", "hickory-proto/dnssec-openssl"]
 dnssec-ring = ["dnssec", "hickory-proto/dnssec-ring"]
 dnssec = []
 
-serde-config = ["dep:serde", "hickory-proto/serde-config"]
+serde = ["dep:serde", "hickory-proto/serde"]
 system-config = ["dep:ipconfig", "dep:resolv-conf"]
 
 testing = []

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -106,15 +106,9 @@ webpki-roots = { workspace = true, optional = true }
 ipconfig = { workspace = true, optional = true }
 
 [dev-dependencies]
-futures-executor = { workspace = true, default-features = false, features = [
-    "std",
-] }
+futures-executor = { workspace = true, default-features = false, features = ["std"] }
 tokio = { workspace = true, features = ["macros", "test-util"] }
-tracing-subscriber = { workspace = true, features = [
-    "std",
-    "fmt",
-    "env-filter",
-] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "std"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -24,11 +24,6 @@ keywords.workspace = true
 categories.workspace = true
 license.workspace = true
 
-[badges]
-#github-actions = { repository = "bluejekyll/hickory", branch = "main", workflow = "test" }
-codecov = { repository = "hickory-dns/hickory-dns", branch = "main", service = "github" }
-maintenance = { status = "actively-developed" }
-
 [features]
 default = ["system-config", "tokio-runtime"]
 backtrace = ["dep:backtrace", "hickory-proto/backtrace"]

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -20,7 +20,7 @@ use proto::rr::Name;
 #[cfg(feature = "dns-over-rustls")]
 use rustls::ClientConfig;
 
-#[cfg(all(feature = "serde-config", feature = "dns-over-rustls"))]
+#[cfg(all(feature = "serde", feature = "dns-over-rustls"))]
 use serde::{
     de::{Deserialize as DeserializeT, Deserializer},
     ser::{Serialize as SerializeT, Serializer},
@@ -28,13 +28,13 @@ use serde::{
 
 /// Configuration for the upstream nameservers to use for resolution
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde-config", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ResolverConfig {
     // base search domain
-    #[cfg_attr(feature = "serde-config", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     domain: Option<Name>,
     // search domains
-    #[cfg_attr(feature = "serde-config", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     search: Vec<Name>,
     // nameservers to use for resolution.
     name_servers: NameServerConfigGroup,
@@ -308,7 +308,7 @@ impl Default for ResolverConfig {
 /// The protocol on which a NameServer should be communicated with
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[cfg_attr(
-    feature = "serde-config",
+    feature = "serde",
     derive(Serialize, Deserialize),
     serde(rename_all = "lowercase")
 )]
@@ -428,15 +428,15 @@ impl std::fmt::Debug for TlsClientConfig {
 
 /// Configuration for the NameServer
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde-config", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NameServerConfig {
     /// The address which the DNS NameServer is registered at.
     pub socket_addr: SocketAddr,
     /// The protocol to use when communicating with the NameServer.
-    #[cfg_attr(feature = "serde-config", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub protocol: Protocol,
     /// SPKI name, only relevant for TLS connections
-    #[cfg_attr(feature = "serde-config", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub tls_dns_name: Option<String>,
     /// Whether to trust `NXDOMAIN` responses from upstream nameservers.
     ///
@@ -450,11 +450,11 @@ pub struct NameServerConfig {
     /// configuration setting.)
     ///
     /// Defaults to false.
-    #[cfg_attr(feature = "serde-config", serde(default))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub trust_negative_responses: bool,
     #[cfg(feature = "dns-over-rustls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-rustls")))]
-    #[cfg_attr(feature = "serde-config", serde(skip))]
+    #[cfg_attr(feature = "serde", serde(skip))]
     /// Optional configuration for the TLS client.
     ///
     /// The correct ALPN for the corresponding protocol is automatically
@@ -494,7 +494,7 @@ impl fmt::Display for NameServerConfig {
 /// A set of name_servers to associate with a [`ResolverConfig`].
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
-    all(feature = "serde-config", not(feature = "dns-over-rustls")),
+    all(feature = "serde", not(feature = "dns-over-rustls")),
     derive(Serialize, Deserialize)
 )]
 pub struct NameServerConfigGroup(
@@ -502,7 +502,7 @@ pub struct NameServerConfigGroup(
     #[cfg(feature = "dns-over-rustls")] Option<TlsClientConfig>,
 );
 
-#[cfg(all(feature = "serde-config", feature = "dns-over-rustls"))]
+#[cfg(all(feature = "serde", feature = "dns-over-rustls"))]
 impl SerializeT for NameServerConfigGroup {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -512,7 +512,7 @@ impl SerializeT for NameServerConfigGroup {
     }
 }
 
-#[cfg(all(feature = "serde-config", feature = "dns-over-rustls"))]
+#[cfg(all(feature = "serde", feature = "dns-over-rustls"))]
 impl<'de> DeserializeT<'de> for NameServerConfigGroup {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -846,7 +846,7 @@ impl From<Vec<NameServerConfig>> for NameServerConfigGroup {
 
 /// The lookup ip strategy
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "serde-config", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum LookupIpStrategy {
     /// Only query for A (Ipv4) records
     Ipv4Only,
@@ -869,7 +869,7 @@ impl Default for LookupIpStrategy {
 
 /// The strategy for establishing the query order of name servers in a pool.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "serde-config", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ServerOrderingStrategy {
     /// Servers are ordered based on collected query statistics. The ordering
     /// may vary over time.
@@ -888,11 +888,7 @@ impl Default for ServerOrderingStrategy {
 
 /// Configuration for the Resolver
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde-config",
-    derive(Serialize, Deserialize),
-    serde(default)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
 #[allow(missing_copy_implementations)]
 #[non_exhaustive]
 pub struct ResolverOpts {

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -248,7 +248,7 @@
 #[cfg(feature = "dns-over-tls")]
 #[macro_use]
 extern crate cfg_if;
-#[cfg(feature = "serde-config")]
+#[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;
 pub extern crate hickory_proto as proto;

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -129,8 +129,8 @@ tokio-openssl = { workspace = true, optional = true }
 tokio-rustls = { workspace = true, optional = true }
 tokio-util.workspace = true
 hickory-proto = { workspace = true, features = ["text-parsing", "tokio-runtime"] }
-hickory-recursor = { workspace = true, features = ["serde-config"], optional = true }
-hickory-resolver = { workspace = true, features = ["serde-config", "system-config", "tokio-runtime"], optional = true }
+hickory-recursor = { workspace = true, features = ["serde"], optional = true }
+hickory-resolver = { workspace = true, features = ["serde", "system-config", "tokio-runtime"], optional = true }
 
 [dev-dependencies]
 futures-executor = { workspace = true, default-features = false, features = ["std"] }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -30,11 +30,6 @@ keywords.workspace = true
 categories.workspace = true
 license.workspace = true
 
-[badges]
-#github-actions = { repository = "bluejekyll/hickory", branch = "main", workflow = "test" }
-codecov = { repository = "hickory-dns/hickory-dns", branch = "main", service = "github" }
-maintenance = { status = "actively-developed" }
-
 [features]
 backtrace = ["hickory-proto/backtrace"]
 dnssec-openssl = [

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -110,9 +110,7 @@ toml = { workspace = true, optional = true }
 bytes.workspace = true
 cfg-if.workspace = true
 enum-as-inner.workspace = true
-futures-util = { workspace = true, default-features = false, features = [
-    "std",
-] }
+futures-util = { workspace = true, default-features = false, features = ["std"] }
 h2 = { workspace = true, features = ["stream"], optional = true }
 h3 = { workspace = true, optional = true }
 h3-quinn = { workspace = true, optional = true }
@@ -130,29 +128,14 @@ tokio = { workspace = true, features = ["macros", "net", "sync"] }
 tokio-openssl = { workspace = true, optional = true }
 tokio-rustls = { workspace = true, optional = true }
 tokio-util.workspace = true
-hickory-proto = { workspace = true, features = [
-    "text-parsing",
-    "tokio-runtime",
-] }
-hickory-recursor = { workspace = true, features = [
-    "serde-config",
-], optional = true }
-hickory-resolver = { workspace = true, features = [
-    "serde-config",
-    "system-config",
-    "tokio-runtime",
-], optional = true }
+hickory-proto = { workspace = true, features = ["text-parsing", "tokio-runtime"] }
+hickory-recursor = { workspace = true, features = ["serde-config"], optional = true }
+hickory-resolver = { workspace = true, features = ["serde-config", "system-config", "tokio-runtime"], optional = true }
 
 [dev-dependencies]
-futures-executor = { workspace = true, default-features = false, features = [
-    "std",
-] }
+futures-executor = { workspace = true, default-features = false, features = ["std"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
-tracing-subscriber = { workspace = true, features = [
-    "std",
-    "fmt",
-    "env-filter",
-] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "std"] }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
* Badges are deprecated (and no longer displayed on crates.io), so remove them
* Spreading dependency features over multiple lines makes things harder to read IMO
* Now that the implicit serde feature is suppressed, we no longer need a verbosified feature name for `serde`