### PR TITLE
use a "test" TLD in conformance tests

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
@@ -12,7 +12,7 @@ fn can_resolve() -> Result<()> {
 
     let network = Network::new()?;
 
-    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;
+    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::TEST_DOMAIN, &network)?;
     leaf_ns.add(Record::a(needle_fqdn.clone(), expected_ipv4_addr));
 
     let Graph {
@@ -47,7 +47,7 @@ fn nxdomain() -> Result<()> {
 
     let network = Network::new()?;
 
-    let leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;
+    let leaf_ns = NameServer::new(&dns_test::PEER, FQDN::TEST_DOMAIN, &network)?;
 
     let Graph {
         nameservers: _nameservers,

--- a/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
@@ -8,7 +8,7 @@ use dns_test::{Network, Resolver, Result, FQDN};
 #[test]
 fn can_resolve() -> Result<()> {
     let expected_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
-    let needle_fqdn = FQDN("example.nameservers.com.")?;
+    let needle_fqdn = FQDN::EXAMPLE_SUBDOMAIN;
 
     let network = Network::new()?;
 

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/adhoc.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/adhoc.rs
@@ -13,7 +13,7 @@ use super::fixtures;
 
 #[test]
 fn empty_answer_section_on_failed_dnssec_validation_and_cd_flag_unset() -> Result<()> {
-    let leaf_fqdn = FQDN("example.nameservers.com.")?;
+    let leaf_fqdn = FQDN::EXAMPLE_SUBDOMAIN;
     let leaf_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
 
     let (resolver, _graph) =

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/fixtures.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/fixtures.rs
@@ -12,11 +12,11 @@ pub fn bad_signature_in_leaf_nameserver(
     leaf_fqdn: &FQDN,
     leaf_ipv4_addr: Ipv4Addr,
 ) -> Result<(Resolver, Graph)> {
-    assert_eq!(Some(FQDN::NAMESERVERS), leaf_fqdn.parent());
+    assert_eq!(Some(FQDN::TEST_DOMAIN), leaf_fqdn.parent());
 
     let network = Network::new()?;
 
-    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;
+    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::TEST_DOMAIN, &network)?;
     leaf_ns.add(Record::a(leaf_fqdn.clone(), leaf_ipv4_addr));
 
     let graph = Graph::build(
@@ -24,7 +24,7 @@ pub fn bad_signature_in_leaf_nameserver(
         Sign::AndAmend {
             settings: SignSettings::default(),
             mutate: &|zone, records| {
-                if zone == &FQDN::NAMESERVERS {
+                if zone == &FQDN::TEST_DOMAIN {
                     let mut modified = 0;
                     for record in records {
                         if let Record::RRSIG(rrsig) = record {
@@ -58,11 +58,11 @@ pub fn minimally_secure(
     leaf_fqdn: FQDN,
     leaf_ipv4_addr: Ipv4Addr,
 ) -> Result<(Resolver, Vec<NameServer<Running>>, TrustAnchor)> {
-    assert_eq!(Some(FQDN::NAMESERVERS), leaf_fqdn.parent());
+    assert_eq!(Some(FQDN::TEST_DOMAIN), leaf_fqdn.parent());
 
     let network = Network::new()?;
 
-    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;
+    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::TEST_DOMAIN, &network)?;
     leaf_ns.add(Record::a(leaf_fqdn.clone(), leaf_ipv4_addr));
 
     let Graph {

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/regression.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/regression.rs
@@ -11,7 +11,7 @@ use dns_test::{
 #[test]
 fn includes_rrsig_record_in_ns_query() -> Result<()> {
     let network = Network::new()?;
-    let leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;
+    let leaf_ns = NameServer::new(&dns_test::PEER, FQDN::TEST_DOMAIN, &network)?;
 
     let Graph {
         nameservers: _nameservers,
@@ -35,7 +35,7 @@ fn includes_rrsig_record_in_ns_query() -> Result<()> {
         *DigSettings::default().dnssec().recurse(),
         resolver_addr,
         RecordType::NS,
-        &FQDN::NAMESERVERS,
+        &FQDN::TEST_DOMAIN,
     )?;
 
     assert!(output.status.is_noerror());
@@ -55,7 +55,7 @@ fn includes_rrsig_record_in_ns_query() -> Result<()> {
 #[test]
 fn can_validate_ns_query() -> Result<()> {
     let network = Network::new()?;
-    let leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;
+    let leaf_ns = NameServer::new(&dns_test::PEER, FQDN::TEST_DOMAIN, &network)?;
 
     let Graph {
         nameservers: _nameservers,
@@ -81,7 +81,7 @@ fn can_validate_ns_query() -> Result<()> {
         *DigSettings::default().authentic_data().recurse(),
         resolver_addr,
         RecordType::NS,
-        &FQDN::NAMESERVERS,
+        &FQDN::TEST_DOMAIN,
     )?;
 
     // bug: this returned SERVFAIL instead of NOERROR with AD=1

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
@@ -11,7 +11,7 @@ use dns_test::{
 fn on_clients_ds_query_it_queries_the_parent_zone() -> Result<()> {
     let network = Network::new()?;
 
-    let leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;
+    let leaf_ns = NameServer::new(&dns_test::PEER, FQDN::TEST_DOMAIN, &network)?;
 
     let Graph {
         nameservers,
@@ -43,7 +43,7 @@ fn on_clients_ds_query_it_queries_the_parent_zone() -> Result<()> {
 
     let client = Client::new(&network)?;
     let settings = *DigSettings::default().recurse();
-    let output = client.dig(settings, resolver_addr, RecordType::DS, &FQDN::NAMESERVERS)?;
+    let output = client.dig(settings, resolver_addr, RecordType::DS, &FQDN::TEST_DOMAIN)?;
 
     tshark.wait_for_capture()?;
 
@@ -53,7 +53,7 @@ fn on_clients_ds_query_it_queries_the_parent_zone() -> Result<()> {
     assert!(output.status.is_noerror());
     let [record] = output.answer.try_into().unwrap();
     let ds = record.try_into_ds().unwrap();
-    assert_eq!(ds.zone, FQDN::NAMESERVERS);
+    assert_eq!(ds.zone, FQDN::TEST_DOMAIN);
 
     // check that DS query was forwarded to the `com.` (parent zone) nameserver
     let client_addr = client.ipv4_addr();

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
@@ -26,7 +26,7 @@ fn on_clients_ds_query_it_queries_the_parent_zone() -> Result<()> {
 
     let mut com_ns_addr = None;
     for nameserver in &nameservers {
-        if nameserver.zone() == &FQDN::COM {
+        if nameserver.zone() == &FQDN::TEST_TLD {
             com_ns_addr = Some(nameserver.ipv4_addr());
         }
     }
@@ -66,7 +66,11 @@ fn on_clients_ds_query_it_queries_the_parent_zone() -> Result<()> {
                     .expect("expected Object");
                 for query in queries.keys() {
                     if query.contains("type DS") {
-                        assert!(query.contains("nameservers.com"));
+                        // the domain name in the query omits the last `.` so strip it from
+                        // FQDN::TEST_DOMAIN
+                        let test_domain = FQDN::TEST_DOMAIN.as_str();
+                        let test_domain = test_domain.strip_suffix('.').unwrap_or(test_domain);
+                        assert!(query.contains(test_domain));
                         assert_eq!(com_ns_addr, destination);
 
                         outgoing_ds_query_count += 1;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2/section_3_2_2.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_2/section_3_2_2.rs
@@ -26,7 +26,7 @@ fn copies_cd_bit_from_query_to_response() -> Result<()> {
 
 #[test]
 fn if_cd_bit_is_set_then_respond_with_data_that_fails_authentication() -> Result<()> {
-    let needle_fqdn = FQDN("example.nameservers.com.")?;
+    let needle_fqdn = FQDN::EXAMPLE_SUBDOMAIN;
     let needle_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
 
     let (resolver, _graph) =
@@ -56,7 +56,7 @@ fn if_cd_bit_is_set_then_respond_with_data_that_fails_authentication() -> Result
 
 #[test]
 fn if_cd_bit_is_clear_and_data_is_not_authentic_then_respond_with_servfail() -> Result<()> {
-    let needle_fqdn = FQDN("example.nameservers.com.")?;
+    let needle_fqdn = FQDN::EXAMPLE_SUBDOMAIN;
     let needle_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
 
     let (resolver, _graph) =

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_5.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_5.rs
@@ -96,7 +96,7 @@ fn caches_query_without_dnssec_to_return_all_dnssec_records_in_subsequent_query(
 /// Therefore, a second query for a record like `DS com.` should be a cache hit.
 #[test]
 fn caches_intermediate_records() -> Result<()> {
-    let leaf_fqdn = FQDN("example.nameservers.com.")?;
+    let leaf_fqdn = FQDN::EXAMPLE_SUBDOMAIN;
     let leaf_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
     let (resolver, nameservers, _trust_anchor) =
         fixtures::minimally_secure(leaf_fqdn.clone(), leaf_ipv4_addr)?;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_5.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_5.rs
@@ -119,7 +119,7 @@ fn caches_intermediate_records() -> Result<()> {
 
     let mut tshark = resolver.eavesdrop()?;
 
-    let output = client.dig(settings, resolver_addr, RecordType::DS, &FQDN::COM)?;
+    let output = client.dig(settings, resolver_addr, RecordType::DS, &FQDN::TEST_TLD)?;
 
     assert!(output.status.is_noerror());
     assert!(output.flags.authenticated_data);

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_6.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_6.rs
@@ -12,7 +12,7 @@ use crate::resolver::dnssec::fixtures;
 #[test]
 fn clears_ad_bit_in_outgoing_queries() -> Result<()> {
     let leaf_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
-    let leaf_fqdn = FQDN("example.nameservers.com.")?;
+    let leaf_fqdn = FQDN::EXAMPLE_SUBDOMAIN;
 
     let (resolver, nameservers, _trust_anchor) =
         fixtures::minimally_secure(leaf_fqdn.clone(), leaf_ipv4_addr)?;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
@@ -12,7 +12,7 @@ fn dnskey_missing() -> Result<()> {
     fixture(
         ExtendedDnsError::DnskeyMissing,
         |_needle_fqdn, zone, records| {
-            if zone == &FQDN::NAMESERVERS {
+            if zone == &FQDN::TEST_DOMAIN {
                 // remove the DNSKEY record that contains the ZSK
                 let mut remove_count = 0;
                 *records = records
@@ -43,7 +43,7 @@ fn rrsigs_missing() -> Result<()> {
     fixture(
         ExtendedDnsError::RrsigsMissing,
         |needle_fqdn, zone, records| {
-            if zone == &FQDN::NAMESERVERS {
+            if zone == &FQDN::TEST_DOMAIN {
                 // remove the RRSIG records that covers the needle record
                 let mut remove_count = 0;
                 *records = records
@@ -74,7 +74,7 @@ fn unsupported_dnskey_algorithm() -> Result<()> {
     fixture(
         ExtendedDnsError::UnsupportedDnskeyAlgorithm,
         |needle_fqdn, zone, records| {
-            if zone == &FQDN::NAMESERVERS {
+            if zone == &FQDN::TEST_DOMAIN {
                 // lie about the algorithm that was used to sign the needle record
                 let mut modified_count = 0;
                 for record in records {
@@ -98,7 +98,7 @@ fn dnssec_bogus() -> Result<()> {
     fixture(
         ExtendedDnsError::DnssecBogus,
         |needle_fqdn, zone, records| {
-            if zone == &FQDN::NAMESERVERS {
+            if zone == &FQDN::TEST_DOMAIN {
                 // corrupt the RRSIG record that covers the needle record
                 let mut modified_count = 0;
                 for record in records {
@@ -133,7 +133,7 @@ fn fixture(
     let needle_fqdn = FQDN::EXAMPLE_SUBDOMAIN;
 
     let network = Network::new()?;
-    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;
+    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::TEST_DOMAIN, &network)?;
     leaf_ns.add(Record::a(needle_fqdn.clone(), expected_ipv4_addr));
 
     let Graph {

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
@@ -130,7 +130,7 @@ fn fixture(
     let supports_ede = subject.supports_ede();
 
     let expected_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
-    let needle_fqdn = FQDN("example.nameservers.com.")?;
+    let needle_fqdn = FQDN::EXAMPLE_SUBDOMAIN;
 
     let network = Network::new()?;
     let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::NAMESERVERS, &network)?;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
@@ -45,7 +45,7 @@ fn can_validate_without_delegation() -> Result<()> {
 #[test]
 fn can_validate_with_delegation() -> Result<()> {
     let expected_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
-    let needle_fqdn = FQDN("example.nameservers.com.")?;
+    let needle_fqdn = FQDN::EXAMPLE_SUBDOMAIN;
 
     let (resolver, _nameservers, _trust_anchor) =
         fixtures::minimally_secure(needle_fqdn.clone(), expected_ipv4_addr)?;
@@ -74,7 +74,7 @@ fn can_validate_with_delegation() -> Result<()> {
 #[test]
 fn also_secure_when_do_is_set() -> Result<()> {
     let expected_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
-    let needle_fqdn = FQDN("example.nameservers.com.")?;
+    let needle_fqdn = FQDN::EXAMPLE_SUBDOMAIN;
 
     let (resolver, _nameservers, _trust_anchor) =
         fixtures::minimally_secure(needle_fqdn.clone(), expected_ipv4_addr)?;
@@ -109,7 +109,7 @@ fn also_secure_when_do_is_set() -> Result<()> {
 #[test]
 fn caches_answer() -> Result<()> {
     let expected_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
-    let needle_fqdn = FQDN("example.nameservers.com.")?;
+    let needle_fqdn = FQDN::EXAMPLE_SUBDOMAIN;
 
     let (resolver, nameservers, _trust_anchor) =
         fixtures::minimally_secure(needle_fqdn.clone(), expected_ipv4_addr)?;

--- a/conformance/packages/dns-test/src/fqdn.rs
+++ b/conformance/packages/dns-test/src/fqdn.rs
@@ -30,16 +30,16 @@ impl FQDN {
         inner: Cow::Borrowed("."),
     };
 
-    pub const COM: FQDN = FQDN {
-        inner: Cow::Borrowed("com."),
+    pub const TEST_TLD: FQDN = FQDN {
+        inner: Cow::Borrowed("testing."),
     };
 
     pub const TEST_DOMAIN: FQDN = FQDN {
-        inner: Cow::Borrowed("nameservers.com."),
+        inner: Cow::Borrowed("hickory-dns.testing."),
     };
 
     pub const EXAMPLE_SUBDOMAIN: FQDN = FQDN {
-        inner: Cow::Borrowed("example.nameservers.com."),
+        inner: Cow::Borrowed("example.hickory-dns.testing."),
     };
 
     pub fn is_root(&self) -> bool {
@@ -123,7 +123,7 @@ mod tests {
         assert_eq!(2, fqdn.num_labels());
 
         let parent = fqdn.parent();
-        assert_eq!(Some(FQDN::COM), parent);
+        assert_eq!(Some(FQDN::TEST_TLD), parent);
         fqdn = parent.unwrap();
         assert_eq!(1, fqdn.num_labels());
 

--- a/conformance/packages/dns-test/src/fqdn.rs
+++ b/conformance/packages/dns-test/src/fqdn.rs
@@ -38,6 +38,10 @@ impl FQDN {
         inner: Cow::Borrowed("nameservers.com."),
     };
 
+    pub const EXAMPLE_SUBDOMAIN: FQDN = FQDN {
+        inner: Cow::Borrowed("example.nameservers.com."),
+    };
+
     pub fn is_root(&self) -> bool {
         self.inner == "."
     }
@@ -110,7 +114,7 @@ mod tests {
 
     #[test]
     fn parent() -> Result<()> {
-        let mut fqdn = FQDN("example.nameservers.com.")?;
+        let mut fqdn = FQDN::EXAMPLE_SUBDOMAIN;
         assert_eq!(3, fqdn.num_labels());
 
         let parent = fqdn.parent();

--- a/conformance/packages/dns-test/src/fqdn.rs
+++ b/conformance/packages/dns-test/src/fqdn.rs
@@ -34,7 +34,7 @@ impl FQDN {
         inner: Cow::Borrowed("com."),
     };
 
-    pub const NAMESERVERS: FQDN = FQDN {
+    pub const TEST_DOMAIN: FQDN = FQDN {
         inner: Cow::Borrowed("nameservers.com."),
     };
 
@@ -118,10 +118,7 @@ mod tests {
         assert_eq!(3, fqdn.num_labels());
 
         let parent = fqdn.parent();
-        assert_eq!(
-            Some("nameservers.com."),
-            parent.as_ref().map(|fqdn| fqdn.as_str())
-        );
+        assert_eq!(Some(FQDN::TEST_DOMAIN), parent);
         fqdn = parent.unwrap();
         assert_eq!(2, fqdn.num_labels());
 

--- a/conformance/packages/dns-test/src/name_server.rs
+++ b/conformance/packages/dns-test/src/name_server.rs
@@ -49,8 +49,8 @@ impl Graph {
         let network = leaf.container.network().clone();
         let implementation = leaf.implementation.clone();
 
-        let (mut nameservers_ns, leaf) = if leaf.zone() != &FQDN::NAMESERVERS {
-            let nameservers_ns = NameServer::new(&implementation, FQDN::NAMESERVERS, &network)?;
+        let (mut nameservers_ns, leaf) = if leaf.zone() != &FQDN::TEST_DOMAIN {
+            let nameservers_ns = NameServer::new(&implementation, FQDN::TEST_DOMAIN, &network)?;
             (nameservers_ns, Some(leaf))
         } else {
             (leaf, None)

--- a/conformance/packages/dns-test/src/record.rs
+++ b/conformance/packages/dns-test/src/record.rs
@@ -882,7 +882,7 @@ mod tests {
             digest,
         } = &DS_INPUT.parse()?;
 
-        assert_eq!(FQDN::COM, *zone);
+        assert_eq!(FQDN("com.")?, *zone);
         assert_eq!(7612, *ttl);
         assert_eq!(19718, *key_tag);
         assert_eq!(13, *algorithm);
@@ -977,7 +977,7 @@ mod tests {
             iterations,
         } = &NSEC3PARAM_INPUT.parse()?;
 
-        assert_eq!(FQDN::COM, *zone);
+        assert_eq!(FQDN("com.")?, *zone);
         assert_eq!(86238, *ttl);
         assert_eq!(1, *hash_alg);
         assert_eq!(0, *flags);

--- a/conformance/packages/dns-test/src/tshark.rs
+++ b/conformance/packages/dns-test/src/tshark.rs
@@ -329,10 +329,10 @@ mod tests {
     fn resolver() -> Result<()> {
         let network = &Network::new()?;
         let mut root_ns = NameServer::new(&Implementation::Unbound, FQDN::ROOT, network)?;
-        let mut com_ns = NameServer::new(&Implementation::Unbound, FQDN::COM, network)?;
+        let mut com_ns = NameServer::new(&Implementation::Unbound, FQDN::TEST_TLD, network)?;
 
         let mut nameservers_ns =
-            NameServer::new(&Implementation::Unbound, FQDN("nameservers.com.")?, network)?;
+            NameServer::new(&Implementation::Unbound, FQDN::TEST_DOMAIN, network)?;
         nameservers_ns.add(root_ns.a()).add(com_ns.a());
         let nameservers_ns = nameservers_ns.start()?;
 

--- a/tests/e2e-tests/src/resolver/dnssec/regression.rs
+++ b/tests/e2e-tests/src/resolver/dnssec/regression.rs
@@ -11,7 +11,7 @@ use dns_test::{
 /// regression test for https://github.com/hickory-dns/hickory-dns/issues/2252
 #[test]
 fn infinite_recursion_with_deprecated_algorithm() -> Result<()> {
-    let needle_fqdn = FQDN("example.nameservers.com.")?;
+    let needle_fqdn = FQDN::EXAMPLE_SUBDOMAIN;
     let expected_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
     let network = Network::new()?;
 

--- a/tests/e2e-tests/src/resolver/dnssec/regression.rs
+++ b/tests/e2e-tests/src/resolver/dnssec/regression.rs
@@ -15,7 +15,7 @@ fn infinite_recursion_with_deprecated_algorithm() -> Result<()> {
     let expected_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
     let network = Network::new()?;
 
-    let mut leaf_ns = NameServer::new(&Implementation::test_peer(), FQDN::NAMESERVERS, &network)?;
+    let mut leaf_ns = NameServer::new(&Implementation::test_peer(), FQDN::TEST_DOMAIN, &network)?;
     leaf_ns.add(Record::a(needle_fqdn.clone(), expected_ipv4_addr));
 
     let Graph {


### PR DESCRIPTION
This is to make it clearer, when discussing bugs in the issue tracker, that DNS queries happen within a test DNS environment.

`example.hickory-dns.testing.` is clearly not a public domain and `*.hickory-dns.testing.` domains won't overlap with existing public domains (hopefully)

Note that we do NOT use the `test.` TLD which is a reserved TLD in the DNS specification because RFC6761 lets DNS implementations diverge from the DNS specification when dealing with that TLD.

Namely, `unbound` appears to make use of that allowance (RFC6761) because it behaves differently when dealing  with `**.test.` domains and that leads to over 16 conformance test failures. In contrast, BIND passes all conformance tests when the `test.` TLD is used.

also see this thread https://github.com/hickory-dns/hickory-dns/issues/2192#issuecomment-2119013440