### PR TITLE
Fix stdout handling during hickory startup

### DIFF
--- a/conformance/packages/dns-test/src/container.rs
+++ b/conformance/packages/dns-test/src/container.rs
@@ -311,6 +311,13 @@ impl Child {
             .ok_or("could not retrieve child's stdout")?)
     }
 
+    /// Returns a reference to the child's stdout.
+    ///
+    /// This method will succeed multiple times.
+    pub fn stdout_ref(&mut self) -> Option<&mut ChildStdout> {
+        self.inner.as_mut().and_then(|child| child.stdout.as_mut())
+    }
+
     pub fn wait(mut self) -> Result<Output> {
         let output = self.inner.take().expect("unreachable").wait_with_output()?;
         output.try_into()

--- a/conformance/packages/dns-test/src/resolver.rs
+++ b/conformance/packages/dns-test/src/resolver.rs
@@ -1,5 +1,5 @@
 use core::fmt::Write;
-use std::io::{BufRead, BufReader};
+use std::io::Read;
 use std::net::Ipv4Addr;
 
 use crate::container::{Child, Container, Network};
@@ -135,11 +135,15 @@ impl ResolverSettings {
         // For HickoryDNS we need to wait until its start sequence finished. Only then the server is able
         // to accept connections. The start sequence logs are consumed here.
         if implementation.is_hickory() {
-            let stdout = child.stdout()?;
-            let lines = BufReader::new(stdout).lines();
+            let stdout = child.stdout_ref().expect("Failed to get stdout");
 
+            // read current available output
+            let mut output = Vec::new();
+            let _ = stdout.read(&mut output)?;
+            let output = std::str::from_utf8(&output[..])?;
+
+            let lines = output.lines();
             for line in lines {
-                let line = line?;
                 if line.contains("server starting up") {
                     break;
                 }
@@ -222,8 +226,7 @@ mod tests {
             .start_with_subject(&Implementation::hickory())?;
         let logs = resolver.terminate()?;
 
-        // Hickory-DNS start sequence log has been consumed in `ResolverSettings.start`.
-        assert!(logs.is_empty());
+        assert!(logs.contains("server starting up"));
 
         Ok(())
     }


### PR DESCRIPTION
During the startup sequence of hickory a specific output is expected. This startup sequence consumed the child's `stdout` instance.

The change does not take the stdout instance, but uses a reference to read the current output from. This means the output of hickory is also available in tests.

Closes #2345