### PR TITLE
Explicitly limit H2 support to rustls

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -50,16 +50,12 @@ recursor = ["hickory-server/recursor"]
 resolver = ["hickory-server/resolver"]
 sqlite = ["hickory-server/sqlite"]
 
-# TODO: Need to figure out how to be consistent with ring/openssl usage...
-# dns-over-https-openssl = ["dns-over-openssl", "hickory-client/dns-over-https-openssl", "dns-over-https"]
 dns-over-https-rustls = [
-    "dns-over-https",
     "dns-over-rustls",
     "hickory-proto/dns-over-https-rustls",
     "hickory-client/dns-over-https-rustls",
     "hickory-server/dns-over-https-rustls",
 ]
-dns-over-https = ["hickory-server/dns-over-https"]
 dns-over-quic = ["dns-over-rustls", "hickory-server/dns-over-quic"]
 dns-over-h3 = ["dns-over-rustls", "hickory-server/dns-over-h3"]
 

--- a/bin/src/hickory-dns.rs
+++ b/bin/src/hickory-dns.rs
@@ -325,7 +325,7 @@ struct Cli {
 
     /// Listening port for DNS over HTTPS queries,
     /// overrides any value in config file
-    #[cfg(feature = "dns-over-https")]
+    #[cfg(feature = "dns-over-https-rustls")]
     #[clap(long = "https-port", value_name = "HTTPS-PORT")]
     pub(crate) https_port: Option<u16>,
 
@@ -353,7 +353,7 @@ struct Cli {
 
     /// Disable HTTPS protocol,
     /// overrides any value in config file
-    #[cfg(feature = "dns-over-https")]
+    #[cfg(feature = "dns-over-https-rustls")]
     #[clap(long = "disable-https", conflicts_with = "https_port")]
     pub(crate) disable_https: bool,
 
@@ -513,7 +513,7 @@ fn run() -> Result<(), String> {
 
     #[cfg(any(
         feature = "dns-over-tls",
-        feature = "dns-over-https",
+        feature = "dns-over-https-rustls",
         feature = "dns-over-quic"
     ))]
     if let Some(tls_cert_config) = config.get_tls_cert() {
@@ -533,7 +533,7 @@ fn run() -> Result<(), String> {
             info!("TLS protocol is disabled");
         }
 
-        #[cfg(feature = "dns-over-https")]
+        #[cfg(feature = "dns-over-https-rustls")]
         if !args.disable_https && !config.get_disable_https() {
             // setup HTTPS listeners
             config_https(
@@ -649,7 +649,7 @@ fn config_tls(
     Ok(())
 }
 
-#[cfg(feature = "dns-over-https")]
+#[cfg(feature = "dns-over-https-rustls")]
 fn config_https(
     args: &Cli,
     server: &mut ServerFuture<Catalog>,

--- a/bin/tests/named_https_tests.rs
+++ b/bin/tests/named_https_tests.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 #![cfg(not(windows))]
-#![cfg(feature = "dns-over-https")]
+#![cfg(feature = "dns-over-https-rustls")]
 
 mod server_harness;
 

--- a/bin/tests/server_harness/mod.rs
+++ b/bin/tests/server_harness/mod.rs
@@ -100,7 +100,7 @@ where
         .arg(&format!("--port={}", 0));
     #[cfg(feature = "dns-over-tls")]
     command.arg(&format!("--tls-port={}", 0));
-    #[cfg(feature = "dns-over-https")]
+    #[cfg(feature = "dns-over-https-rustls")]
     command.arg(&format!("--https-port={}", 0));
     #[cfg(feature = "dns-over-quic")]
     command.arg(&format!("--quic-port={}", 0));

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -32,15 +32,11 @@ license.workspace = true
 [features]
 backtrace = ["hickory-proto/backtrace"]
 
-dns-over-https-openssl = ["dns-over-https", "dns-over-openssl"]
 dns-over-https-rustls = [
-    "dns-over-https",
     "dns-over-rustls",
     "dep:rustls",
     "hickory-proto/dns-over-https-rustls",
 ]
-dns-over-https = ["hickory-proto/dns-over-https"]
-
 dns-over-quic = ["dns-over-rustls", "hickory-proto/dns-over-quic"]
 
 dns-over-native-tls = ["dns-over-tls", "hickory-proto/dns-over-native-tls"]

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -281,14 +281,14 @@ pub mod tcp;
 pub mod udp;
 
 // TODO: consider removing tcp/udp/https modules...
-#[cfg(feature = "dns-over-https")]
+#[cfg(feature = "dns-over-https-rustls")]
 mod h2_client_connection;
 
 pub use hickory_proto as proto;
 
 /// The https module which contains all https related connection types
-#[cfg(feature = "dns-over-https")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https")))]
+#[cfg(feature = "dns-over-https-rustls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https-rustls")))]
 pub mod h2 {
     pub use super::h2_client_connection::HttpsClientConnection;
 }

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -41,8 +41,7 @@ dns-over-native-tls = [
 ]
 dns-over-openssl = ["dns-over-tls", "dep:openssl", "dep:tokio-openssl", "tokio-runtime"]
 
-dns-over-https-rustls = ["dns-over-https"]
-dns-over-https = ["dep:bytes", "dep:h2", "dep:http", "dns-over-rustls", "tokio-runtime"]
+dns-over-https-rustls = ["dep:bytes", "dep:h2", "dep:http", "dns-over-rustls", "tokio-runtime"]
 dns-over-quic = [
     "dep:quinn",
     "dns-over-rustls",

--- a/crates/proto/src/http/error.rs
+++ b/crates/proto/src/http/error.rs
@@ -42,7 +42,7 @@ pub enum ErrorKind {
     ProtoError(#[from] ProtoError),
 
     #[error("h2: {0}")]
-    #[cfg(feature = "dns-over-https")]
+    #[cfg(feature = "dns-over-https-rustls")]
     H2(#[from] h2::Error),
 
     #[error("h3: {0}")]
@@ -122,7 +122,7 @@ impl From<ProtoError> for Error {
     }
 }
 
-#[cfg(feature = "dns-over-https")]
+#[cfg(feature = "dns-over-https-rustls")]
 impl From<h2::Error> for Error {
     fn from(msg: h2::Error) -> Self {
         ErrorKind::H2(msg).into()

--- a/crates/proto/src/http/mod.rs
+++ b/crates/proto/src/http/mod.rs
@@ -18,7 +18,7 @@ pub mod response;
 #[derive(Clone, Copy, Debug)]
 pub enum Version {
     /// HTTP/2 for DoH.
-    #[cfg(feature = "dns-over-https")]
+    #[cfg(feature = "dns-over-https-rustls")]
     Http2,
     /// HTTP/3 for DoH3.
     #[cfg(feature = "dns-over-h3")]
@@ -28,7 +28,7 @@ pub enum Version {
 impl Version {
     fn to_http(self) -> http::Version {
         match self {
-            #[cfg(feature = "dns-over-https")]
+            #[cfg(feature = "dns-over-https-rustls")]
             Self::Http2 => http::Version::HTTP_2,
             #[cfg(feature = "dns-over-h3")]
             Self::Http3 => http::Version::HTTP_3,

--- a/crates/proto/src/http/request.rs
+++ b/crates/proto/src/http/request.rs
@@ -132,7 +132,7 @@ pub fn verify<T>(version: Version, name_server: Option<&str>, request: &Request<
 
     if request.version() != version.to_http() {
         let message = match version {
-            #[cfg(feature = "dns-over-https")]
+            #[cfg(feature = "dns-over-https-rustls")]
             Version::Http2 => "only HTTP/2 supported",
             #[cfg(feature = "dns-over-h3")]
             Version::Http3 => "only HTTP/3 supported",
@@ -157,7 +157,7 @@ mod tests {
     use super::*;
 
     #[test]
-    #[cfg(feature = "dns-over-https")]
+    #[cfg(feature = "dns-over-https-rustls")]
     fn test_new_verify_h2() {
         let request = new(Version::Http2, "ns.example.com", 512).expect("error converting to http");
         assert!(verify(Version::Http2, Some("ns.example.com"), &request).is_ok());

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -62,16 +62,16 @@ pub fn spawn_bg<F: Future<Output = R> + Send + 'static, R: Send + 'static>(
 }
 
 pub mod error;
-#[cfg(feature = "dns-over-https")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https")))]
+#[cfg(feature = "dns-over-https-rustls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https-rustls")))]
 pub mod h2;
 #[cfg(feature = "dns-over-h3")]
 #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-h3")))]
 pub mod h3;
-#[cfg(any(feature = "dns-over-https", feature = "dns-over-h3"))]
+#[cfg(any(feature = "dns-over-https-rustls", feature = "dns-over-h3"))]
 #[cfg_attr(
     docsrs,
-    doc(cfg(any(feature = "dns-over-https", feature = "dns-over-h3")))
+    doc(cfg(any(feature = "dns-over-https-rustls", feature = "dns-over-h3")))
 )]
 pub mod http;
 #[cfg(feature = "mdns")]

--- a/crates/recursor/Cargo.toml
+++ b/crates/recursor/Cargo.toml
@@ -46,12 +46,10 @@ dnssec = []
 
 # TODO: Need to figure out how to be consistent with ring/openssl usage...
 dns-over-https-rustls = [
-    "dns-over-https",
     "hickory-proto/dns-over-https-rustls",
     "hickory-resolver/dns-over-https-rustls",
     "dns-over-rustls",
 ]
-dns-over-https = ["hickory-proto/dns-over-https"]
 dns-over-quic = [
     "dns-over-rustls",
     "hickory-proto/dns-over-quic",

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -50,9 +50,7 @@ dns-over-tls = ["tokio-runtime"]
 dns-over-https-rustls = [
     "hickory-proto/dns-over-https-rustls",
     "dns-over-rustls",
-    "dns-over-https",
 ]
-dns-over-https = ["hickory-proto/dns-over-https"]
 dns-over-quic = ["dep:quinn", "dns-over-rustls", "hickory-proto/dns-over-quic"]
 dns-over-h3 = ["dep:quinn", "dns-over-rustls", "hickory-proto/dns-over-h3"]
 

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -86,8 +86,8 @@ impl ResolverConfig {
     /// Please see Google's [privacy statement](https://developers.google.com/speed/public-dns/privacy) for important information about what they track, many ISP's track similar information in DNS. To use the system configuration see: `Resolver::from_system_conf` and `AsyncResolver::from_system_conf`
     ///
     /// NameServerConfigGroups can be combined to use a set of different providers, see `NameServerConfigGroup` and `ResolverConfig::from_parts`
-    #[cfg(feature = "dns-over-https")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https")))]
+    #[cfg(feature = "dns-over-https-rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https-rustls")))]
     pub fn google_https() -> Self {
         Self {
             // TODO: this should get the hostname and use the basename as the default
@@ -148,8 +148,8 @@ impl ResolverConfig {
     /// Please see: <https://www.cloudflare.com/dns/>
     ///
     /// NameServerConfigGroups can be combined to use a set of different providers, see `NameServerConfigGroup` and `ResolverConfig::from_parts`
-    #[cfg(feature = "dns-over-https")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https")))]
+    #[cfg(feature = "dns-over-https-rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https-rustls")))]
     pub fn cloudflare_https() -> Self {
         Self {
             // TODO: this should get the hostname and use the basename as the default
@@ -194,8 +194,8 @@ impl ResolverConfig {
     /// Please see: <https://www.quad9.net/faq/>
     ///
     /// NameServerConfigGroups can be combined to use a set of different providers, see `NameServerConfigGroup` and `ResolverConfig::from_parts`
-    #[cfg(feature = "dns-over-https")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https")))]
+    #[cfg(feature = "dns-over-https-rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https-rustls")))]
     pub fn quad9_https() -> Self {
         Self {
             // TODO: this should get the hostname and use the basename as the default
@@ -323,8 +323,8 @@ pub enum Protocol {
     #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-tls")))]
     Tls,
     /// Https for DNS over HTTPS
-    #[cfg(feature = "dns-over-https")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https")))]
+    #[cfg(feature = "dns-over-https-rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https-rustls")))]
     Https,
     /// QUIC for DNS over QUIC
     #[cfg(feature = "dns-over-quic")]
@@ -343,7 +343,7 @@ impl fmt::Display for Protocol {
             Self::Tcp => "tcp",
             #[cfg(feature = "dns-over-tls")]
             Self::Tls => "tls",
-            #[cfg(feature = "dns-over-https")]
+            #[cfg(feature = "dns-over-https-rustls")]
             Self::Https => "https",
             #[cfg(feature = "dns-over-quic")]
             Self::Quic => "quic",
@@ -363,7 +363,7 @@ impl Protocol {
             Self::Tcp => false,
             #[cfg(feature = "dns-over-tls")]
             Self::Tls => false,
-            #[cfg(feature = "dns-over-https")]
+            #[cfg(feature = "dns-over-https-rustls")]
             Self::Https => false,
             // TODO: if you squint, this is true...
             #[cfg(feature = "dns-over-quic")]
@@ -385,7 +385,7 @@ impl Protocol {
             Self::Tcp => false,
             #[cfg(feature = "dns-over-tls")]
             Self::Tls => true,
-            #[cfg(feature = "dns-over-https")]
+            #[cfg(feature = "dns-over-https-rustls")]
             Self::Https => true,
             #[cfg(feature = "dns-over-quic")]
             Self::Quic => true,
@@ -578,7 +578,7 @@ impl NameServerConfigGroup {
         name_servers
     }
 
-    #[cfg(any(feature = "dns-over-tls", feature = "dns-over-https"))]
+    #[cfg(any(feature = "dns-over-tls", feature = "dns-over-https-rustls"))]
     fn from_ips_encrypted(
         ips: &[IpAddr],
         port: u16,
@@ -630,8 +630,8 @@ impl NameServerConfigGroup {
     /// Configure a NameServer address and port for DNS-over-HTTPS
     ///
     /// This will create a HTTPS connections.
-    #[cfg(feature = "dns-over-https")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https")))]
+    #[cfg(feature = "dns-over-https-rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https-rustls")))]
     pub fn from_ips_https(
         ips: &[IpAddr],
         port: u16,
@@ -706,8 +706,8 @@ impl NameServerConfigGroup {
     /// Creates a default configuration, using `8.8.8.8`, `8.8.4.4` and `2001:4860:4860::8888`, `2001:4860:4860::8844` (thank you, Google). This limits the registered connections to just HTTPS lookups
     ///
     /// Please see Google's [privacy statement](https://developers.google.com/speed/public-dns/privacy) for important information about what they track, many ISP's track similar information in DNS. To use the system configuration see: `Resolver::from_system_conf` and `AsyncResolver::from_system_conf`
-    #[cfg(feature = "dns-over-https")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https")))]
+    #[cfg(feature = "dns-over-https-rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https-rustls")))]
     pub fn google_https() -> Self {
         Self::from_ips_https(GOOGLE_IPS, 443, "dns.google".to_string(), true)
     }
@@ -740,8 +740,8 @@ impl NameServerConfigGroup {
     /// Creates a configuration, using `1.1.1.1`, `1.0.0.1` and `2606:4700:4700::1111`, `2606:4700:4700::1001` (thank you, Cloudflare). This limits the registered connections to just HTTPS lookups
     ///
     /// Please see: <https://www.cloudflare.com/dns/>
-    #[cfg(feature = "dns-over-https")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https")))]
+    #[cfg(feature = "dns-over-https-rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https-rustls")))]
     pub fn cloudflare_https() -> Self {
         Self::from_ips_https(CLOUDFLARE_IPS, 443, "cloudflare-dns.com".to_string(), true)
     }
@@ -765,8 +765,8 @@ impl NameServerConfigGroup {
     /// Creates a configuration, using `9.9.9.9`, `149.112.112.112` and `2620:fe::fe`, `2620:fe::fe:9`, the "secure" variants of the quad9 settings. This limits the registered connections to just HTTPS lookups
     ///
     /// Please see: <https://www.quad9.net/faq/>
-    #[cfg(feature = "dns-over-https")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https")))]
+    #[cfg(feature = "dns-over-https-rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dns-over-https-rustls")))]
     pub fn quad9_https() -> Self {
         Self::from_ips_https(QUAD9_IPS, 443, "dns.quad9.net".to_string(), true)
     }

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -258,7 +258,7 @@ pub mod caching_client;
 pub mod config;
 pub mod dns_lru;
 pub mod error;
-#[cfg(feature = "dns-over-https")]
+#[cfg(feature = "dns-over-https-rustls")]
 mod h2;
 #[cfg(feature = "dns-over-h3")]
 mod h3;

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -50,16 +50,14 @@ resolver = ["hickory-resolver"]
 sqlite = ["rusqlite"]
 toml = ["dep:toml"]
 
-# TODO: Need to figure out how to be consistent with ring/openssl usage...
-# dns-over-https-openssl = ["dns-over-openssl", "hickory-client/dns-over-https-openssl", "dns-over-https"]
 dns-over-https-rustls = [
-    "dns-over-https",
     "hickory-proto/dns-over-https-rustls",
     "hickory-resolver/dns-over-https-rustls",
     "dns-over-rustls",
+    "dep:h2",
+    "dep:http",
     "dep:tokio-rustls",
 ]
-dns-over-https = ["h2", "http", "hickory-proto/dns-over-https"]
 
 # TODO: migrate all tls and tls-openssl features to dns-over-tls, et al
 dns-over-openssl = [

--- a/crates/server/src/server/mod.rs
+++ b/crates/server/src/server/mod.rs
@@ -7,7 +7,7 @@
 
 //! `Server` component for hosting a domain name servers operations.
 
-#[cfg(feature = "dns-over-https")]
+#[cfg(feature = "dns-over-https-rustls")]
 mod h2_handler;
 #[cfg(feature = "dns-over-h3")]
 mod h3_handler;

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -56,11 +56,9 @@ dnssec = ["dep:openssl"]
 dns-over-https-rustls = [
     "hickory-client/dns-over-https-rustls",
     "hickory-resolver/dns-over-https-rustls",
-    "dns-over-https",
     "dep:rustls",
     "dep:webpki-roots",
 ]
-dns-over-https = ["hickory-proto/dns-over-https"]
 dns-over-quic = [
     "dns-over-rustls",
     "hickory-proto/dns-over-quic",

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -37,16 +37,10 @@ dns-over-rustls = [
     "hickory-resolver/dns-over-rustls",
 ]
 dns-over-https-rustls = [
-    "dns-over-https",
     "dns-over-rustls",
     "hickory-proto/dns-over-https-rustls",
     "hickory-client/dns-over-https-rustls",
     "hickory-resolver/dns-over-https-rustls",
-]
-dns-over-https = [
-    "hickory-proto/dns-over-https",
-    "hickory-client/dns-over-https",
-    "hickory-resolver/dns-over-https",
 ]
 dns-over-quic = ["dns-over-rustls", "hickory-resolver/dns-over-quic"]
 dns-over-h3 = ["dns-over-rustls", "hickory-resolver/dns-over-h3"]

--- a/util/src/bin/dns.rs
+++ b/util/src/bin/dns.rs
@@ -308,12 +308,12 @@ async fn tls(opts: Opts) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg(not(feature = "dns-over-https"))]
+#[cfg(not(feature = "dns-over-https-rustls"))]
 async fn https(_opts: Opts) -> Result<(), Box<dyn std::error::Error>> {
     panic!("`dns-over-https` feature is required during compilation");
 }
 
-#[cfg(feature = "dns-over-https")]
+#[cfg(feature = "dns-over-https-rustls")]
 async fn https(opts: Opts) -> Result<(), Box<dyn std::error::Error>> {
     use hickory_proto::h2::HttpsClientStreamBuilder;
 


### PR DESCRIPTION
Although the Cargo features have suggested that H2 support was available ever since the seeming introduction of DoH (in #541, I think?), it looks like the H2 implementation consistently depends on rustls. Make this explicit by removing the `dns-over-https` features from all crates in favor of only supporting `dns-over-https-rustls`.

Fixes #2365.