### PR TITLE
Conformance test cleanup

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -1,13 +1,13 @@
-# `dnssec-tests`
+# Conformance tests
 
-This repository contains two packages:
+This workspace contains two packages:
 
 - `dns-test`. This is a test framework (library) for testing DNS implementations.
 - `conformance-tests`. This is a collection of DNS, mainly DNSSEC, tests.
 
 ## Requirements
 
-To use the code in this repository you need:
+To use the code in this workspace you need:
 
 - a stable Rust toolchain to build the code
 - a working Docker setup that can run *Linux* containers -- the host OS does not need to be Linux 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -40,7 +40,7 @@ $ DNS_TEST_SUBJECT="hickory https://github.com/hickory-dns/hickory-dns" cargo ru
 
 - `DNS_TEST_SUBJECT`. This variable controls what the `dns_test::subject` function returns. The variable can contain one of these values:
   - `unbound`
-  - `hickory $REPOSITORY`. where `$REPOSITORY` is a placeholder for git repository. Examples values for `$REPOSITORY`: `https://github.com/hickory-dns/hickory-dns`; `/home/user/git-repos/hickory-dns`. NOTE: when using a local repository, changes that have not been committed, regardless of whether they are staged or not, will **not** be included in the `hickory-dns` build.
+  - `hickory $REPOSITORY`. where `$REPOSITORY` is a placeholder for a git repository. Examples values for `$REPOSITORY`: `https://github.com/hickory-dns/hickory-dns`; `/home/user/git-repos/hickory-dns`. NOTE: when using a local repository, changes that have not been committed, regardless of whether they are staged or not, will **not** be included in the `hickory-dns` build.
   
 - `DNS_TEST_VERBOSE_DOCKER_BUILD`. Setting this variable prints the output of the `docker build` invocations that the framework does to the console. This is useful to verify that image caching is working; for example if you set `DNS_TEST_SUBJECT` to a local `hickory-dns` repository then consecutively running the `explore` example and/or `conformance-tests` test suite **must** not rebuild `hickory-dns` provided that you have not *committed* any new change to the local repository.
 

--- a/conformance/packages/dns-test/src/docker/hickory.Dockerfile
+++ b/conformance/packages/dns-test/src/docker/hickory.Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
 
 # `dns-test` will invoke `docker build` from a temporary directory that contains
 # a clone of the hickory repository. `./src` here refers to that clone; not to
-# any directory inside the `dns-test` repository
+# any directory inside the `hickory-dns` repository
 COPY ./src /usr/src/hickory
 RUN --mount=type=cache,target=/usr/src/hickory/target cargo build --manifest-path /usr/src/hickory/Cargo.toml -p hickory-dns --features recursor,dnssec-ring && \
     cp /usr/src/hickory/target/debug/hickory-dns /usr/bin/ && \

--- a/conformance/packages/dns-test/src/docker/hickory.Dockerfile
+++ b/conformance/packages/dns-test/src/docker/hickory.Dockerfile
@@ -11,6 +11,5 @@ RUN apt-get update && \
 # any directory inside the `hickory-dns` repository
 COPY ./src /usr/src/hickory
 RUN --mount=type=cache,target=/usr/src/hickory/target cargo build --manifest-path /usr/src/hickory/Cargo.toml -p hickory-dns --features recursor,dnssec-ring && \
-    cp /usr/src/hickory/target/debug/hickory-dns /usr/bin/ && \
-    mkdir /etc/hickory
+    cp /usr/src/hickory/target/debug/hickory-dns /usr/bin/
 ENV RUST_LOG=debug


### PR DESCRIPTION
This cleans up some old references to the separate dnssec-tests repository, before it was merged in. I also got rid of the `/etc/hickory` directory inside the Hickory container, because the configuration is placed in `/etc/named.toml` instead.