### PR TITLE
Use container names, not IDs, in "explore" example

### DIFF
--- a/conformance/packages/dns-test/examples/explore.rs
+++ b/conformance/packages/dns-test/examples/explore.rs
@@ -62,7 +62,7 @@ fn main() -> Result<()> {
         println!("{} name server's IP address: {}", ns.zone(), ns.ipv4_addr());
         println!(
             "attach to this container with: `docker exec -it {} bash`\n",
-            ns.container_id()
+            ns.container_name()
         );
     }
 
@@ -70,13 +70,13 @@ fn main() -> Result<()> {
     println!("resolver's IP address: {resolver_addr}",);
     println!(
         "attach to this container with: `docker exec -it {} bash`\n",
-        resolver.container_id()
+        resolver.container_name()
     );
 
     println!("client's IP address: {}", client.ipv4_addr());
     println!(
         "attach to this container with: `docker exec -it {} bash`\n\n",
-        client.container_id()
+        client.container_name()
     );
 
     println!("example queries (run these in the client container):\n");

--- a/conformance/packages/dns-test/src/client.rs
+++ b/conformance/packages/dns-test/src/client.rs
@@ -21,6 +21,10 @@ impl Client {
         self.inner.id()
     }
 
+    pub fn container_name(&self) -> &str {
+        self.inner.name()
+    }
+
     pub fn ipv4_addr(&self) -> Ipv4Addr {
         self.inner.ipv4_addr()
     }

--- a/conformance/packages/dns-test/src/container.rs
+++ b/conformance/packages/dns-test/src/container.rs
@@ -254,6 +254,10 @@ impl Container {
     pub(crate) fn network(&self) -> &Network {
         &self.inner.network
     }
+
+    pub fn name(&self) -> &str {
+        &self.inner.name
+    }
 }
 
 fn verbose_docker_build() -> bool {

--- a/conformance/packages/dns-test/src/name_server.rs
+++ b/conformance/packages/dns-test/src/name_server.rs
@@ -393,6 +393,10 @@ impl<S> NameServer<S> {
         self.container.id()
     }
 
+    pub fn container_name(&self) -> &str {
+        self.container.name()
+    }
+
     pub fn ipv4_addr(&self) -> Ipv4Addr {
         self.container.ipv4_addr()
     }

--- a/conformance/packages/dns-test/src/resolver.rs
+++ b/conformance/packages/dns-test/src/resolver.rs
@@ -39,6 +39,10 @@ impl Resolver {
         self.container.id()
     }
 
+    pub fn container_name(&self) -> &str {
+        self.container.name()
+    }
+
     pub fn ipv4_addr(&self) -> Ipv4Addr {
         self.container.ipv4_addr()
     }


### PR DESCRIPTION
This changes the `explore` example to use container names instead of container IDs in the `docker` commands it prints out. I prefer using names here because they are shorter, more understandable, and easier to tab-complete.