### PR TITLE
Strict parsing of configuration files

### DIFF
--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -428,7 +428,11 @@ impl std::fmt::Debug for TlsClientConfig {
 
 /// Configuration for the NameServer
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(deny_unknown_fields)
+)]
 pub struct NameServerConfig {
     /// The address which the DNS NameServer is registered at.
     pub socket_addr: SocketAddr,
@@ -903,7 +907,11 @@ pub enum ResolveHosts {
 
 /// Configuration for the Resolver
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(default, deny_unknown_fields)
+)]
 #[allow(missing_copy_implementations)]
 #[non_exhaustive]
 pub struct ResolverOpts {

--- a/crates/server/src/config/dnssec.rs
+++ b/crates/server/src/config/dnssec.rs
@@ -25,6 +25,7 @@ use crate::proto::serialize::txt::ParseResult;
 
 /// Key pair configuration for DNSSEC keys for signing a zone
 #[derive(Deserialize, PartialEq, Eq, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct KeyConfig {
     /// file path to the key
     pub key_path: String,
@@ -202,6 +203,7 @@ impl Default for PrivateKeyType {
 
 /// Configuration for a TLS certificate
 #[derive(Deserialize, PartialEq, Eq, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct TlsCertConfig {
     path: String,
     endpoint_name: Option<String>,

--- a/crates/server/src/config/mod.rs
+++ b/crates/server/src/config/mod.rs
@@ -40,6 +40,7 @@ static DEFAULT_TCP_REQUEST_TIMEOUT: u64 = 5;
 
 /// Server configuration
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     /// The list of IPv4 addresses to listen on
     #[serde(default)]
@@ -216,6 +217,7 @@ impl Config {
 
 /// Configuration for a zone
 #[derive(Deserialize, PartialEq, Eq, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct ZoneConfig {
     /// name of the zone
     pub zone: String, // TODO: make Domain::Name decodable

--- a/crates/server/src/store/file/config.rs
+++ b/crates/server/src/store/file/config.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 
 /// Configuration for file based zones
 #[derive(Deserialize, PartialEq, Eq, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct FileConfig {
     /// path to the zone file
     pub zone_file_path: String,

--- a/crates/server/src/store/forwarder/config.rs
+++ b/crates/server/src/store/forwarder/config.rs
@@ -11,6 +11,7 @@ use crate::resolver::config::{NameServerConfigGroup, ResolverOpts};
 
 /// Configuration for file based zones
 #[derive(Clone, Deserialize, PartialEq, Eq, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct ForwardConfig {
     /// upstream name_server configurations
     pub name_servers: NameServerConfigGroup,

--- a/crates/server/src/store/recursor/config.rs
+++ b/crates/server/src/store/recursor/config.rs
@@ -84,6 +84,7 @@ fn record_cache_size_default() -> usize {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub enum DnssecPolicyConfig {
     /// security unaware; DNSSEC records will not be requested nor processed
     #[default]

--- a/crates/server/src/store/sqlite/config.rs
+++ b/crates/server/src/store/sqlite/config.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 
 /// Configuration for zone file for sqlite based zones
 #[derive(Deserialize, PartialEq, Eq, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct SqliteConfig {
     /// path to initial zone file
     pub zone_file_path: String,

--- a/tests/test-data/test_configs/example_forwarder.toml
+++ b/tests/test-data/test_configs/example_forwarder.toml
@@ -37,5 +37,5 @@ zone_type = "Forward"
 
 ## remember the port, defaults: 53 for Udp & Tcp, 853 for Tls and 443 for Https.
 ##   Tls and/or Https require features dns-over-tls and/or dns-over-https
-stores = { type = "forward", name_servers = [{ socket_addr = "8.8.8.8:53", protocol = "udp", trust_nx_responses = false },
-                                             { socket_addr = "8.8.8.8:53", protocol = "tcp", trust_nx_responses = false }] }
+stores = { type = "forward", name_servers = [{ socket_addr = "8.8.8.8:53", protocol = "udp", trust_negative_responses = false },
+                                             { socket_addr = "8.8.8.8:53", protocol = "tcp", trust_negative_responses = false }] }


### PR DESCRIPTION
This PR implements one half of #2195. I added `#[serde(deny_unknown_fields)]` to all configuration types, which will cause an error if there are any unexpected keys in a table. This turned up one issue in the example forwarder config file.

I also added a test that starts with all config files in `tests/test-data/test_configs`, mutates them by adding an extra key to each table in turn, and confirms that it gets an "unknown field" error when trying to parse each mutated input. Since `#[serde(deny_unknown_fields)]` is configured on a type-by-type basis, it can be easy to forget, so this test is intended to help maintain this behavior going forward. It can't discover new tables on its own, but so long as the example/test configuration files have good coverage, it should help.