### PR TITLE
Revert "Fix stdout handling during hickory startup"

### DIFF
--- a/conformance/packages/dns-test/src/container.rs
+++ b/conformance/packages/dns-test/src/container.rs
@@ -311,13 +311,6 @@ impl Child {
             .ok_or("could not retrieve child's stdout")?)
     }
 
-    /// Returns a reference to the child's stdout.
-    ///
-    /// This method will succeed multiple times.
-    pub fn stdout_ref(&mut self) -> Option<&mut ChildStdout> {
-        self.inner.as_mut().and_then(|child| child.stdout.as_mut())
-    }
-
     pub fn wait(mut self) -> Result<Output> {
         let output = self.inner.take().expect("unreachable").wait_with_output()?;
         output.try_into()


### PR DESCRIPTION
This reverts commit 3344d2150dfd1cfe959c959fbfd1f7d457b8acf6.

PR #2361 appears to have broken CI on `main` *after* being merged ([1](https://github.com/hickory-dns/hickory-dns/actions/runs/10523520502/job/29158365720), [2](https://github.com/hickory-dns/hickory-dns/actions/runs/10523528733/job/29158392769)) even though it passed CI when it was submitted as a PR ([3](https://github.com/hickory-dns/hickory-dns/actions/runs/10405968007/job/28851472972))

I guess another this another vote for enabling the merge queue as previously suggested here https://github.com/hickory-dns/hickory-dns/pull/2281#issuecomment-2208981820 cc @bluejekyll 