### PR TITLE
dns-test: write logs to file

### DIFF
--- a/conformance/packages/dns-test/src/container.rs
+++ b/conformance/packages/dns-test/src/container.rs
@@ -1,6 +1,7 @@
 mod network;
 
 use core::{fmt, str};
+use std::ffi::OsStr;
 use std::net::Ipv4Addr;
 use std::process::{self, ChildStdout, ExitStatus};
 use std::process::{Command, Stdio};
@@ -231,7 +232,7 @@ impl Container {
         }
     }
 
-    pub fn spawn(&self, cmd: &[&str]) -> Result<Child> {
+    pub fn spawn(&self, cmd: &[impl AsRef<OsStr>]) -> Result<Child> {
         let mut command = Command::new("docker");
         command.stdout(Stdio::piped()).stderr(Stdio::piped());
         command.args(["exec", "-t", &self.inner.id]).args(cmd);

--- a/conformance/packages/dns-test/src/implementation.rs
+++ b/conformance/packages/dns-test/src/implementation.rs
@@ -151,11 +151,7 @@ impl Implementation {
     pub(crate) fn cmd_args(&self, role: Role) -> Vec<String> {
         let base = match self {
             Implementation::Bind => "named -g -d5",
-
-            Implementation::Hickory(_) => {
-                "echo $$ > /tmp/hickory.pid
-exec hickory-dns -d"
-            }
+            Implementation::Hickory(_) => "hickory-dns -d",
             Implementation::Unbound => match role {
                 Role::NameServer => "nsd -d",
                 Role::Resolver => "unbound -d",

--- a/tests/e2e-tests/src/resolver/dnssec/regression.rs
+++ b/tests/e2e-tests/src/resolver/dnssec/regression.rs
@@ -51,12 +51,10 @@ fn infinite_recursion_with_deprecated_algorithm() -> Result<()> {
     // we are not interested in the actual answer; just that the server does not crash
     assert!(res.is_ok(), "server did not answer query");
 
-    let res = resolver.terminate();
+    let logs = resolver.logs()?;
 
-    assert!(res.is_ok(), "server process not found");
-
-    let logs = res.unwrap();
     assert!(!logs.contains("stack overflow"));
+    assert!(!logs.contains("panicked"));
 
     Ok(())
 }


### PR DESCRIPTION
this removes the need for PID files and allows inspecting the logs of DNS implementation without terminating them first