### PR TITLE
ci: trigger workflows for merge queue branches

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 
 jobs:
   everything:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ on:
       - release/**
     # paths-ignore:
     #   - "conformance/**"
+  merge_group:
   schedule:
     - cron: "0 3 * * 4"
 


### PR DESCRIPTION
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

Preparation for enabling the merge queue, as suggested in https://github.com/hickory-dns/hickory-dns/pull/2376#issue-2482769533.

cc @japaric 