### PR TITLE
Forwarder: fix NXDOMAIN status code and allow it to forward SOA records

### DIFF
--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -405,6 +405,33 @@ impl ProtoError {
         matches!(*self.kind, ProtoErrorKind::NoConnections)
     }
 
+    /// Returns true if the domain does not exist
+    #[inline]
+    pub fn is_nx_domain(&self) -> bool {
+        matches!(
+            *self.kind,
+            ProtoErrorKind::NoRecordsFound {
+                response_code: ResponseCode::NXDomain,
+                ..
+            }
+        )
+    }
+
+    /// Returns true if the error represents NoRecordsFound
+    #[inline]
+    pub fn is_no_records_found(&self) -> bool {
+        matches!(*self.kind, ProtoErrorKind::NoRecordsFound { .. })
+    }
+
+    /// Returns the SOA record, if the error contains one
+    #[inline]
+    pub fn into_soa(self) -> Option<Box<Record<SOA>>> {
+        match *self.kind {
+            ProtoErrorKind::NoRecordsFound { soa, .. } => soa,
+            _ => None,
+        }
+    }
+
     /// Returns true if this is a std::io::Error
     #[inline]
     pub fn is_io(&self) -> bool {

--- a/crates/recursor/src/error.rs
+++ b/crates/recursor/src/error.rs
@@ -17,6 +17,7 @@ use hickory_proto::error::ProtoErrorKind;
 use hickory_resolver::Name;
 use thiserror::Error;
 
+use crate::proto::rr::{rdata::SOA, Record};
 #[cfg(feature = "backtrace")]
 use crate::proto::{trace, ExtBacktrace};
 use crate::{proto::error::ProtoError, resolver::error::ResolveError};
@@ -74,6 +75,33 @@ impl Error {
     /// Get the kind of the error
     pub fn kind(&self) -> &ErrorKind {
         &self.kind
+    }
+
+    /// Returns true if the domain does not exist
+    pub fn is_nx_domain(&self) -> bool {
+        match &*self.kind {
+            ErrorKind::Proto(proto) => proto.is_nx_domain(),
+            ErrorKind::Resolve(err) => err.is_nx_domain(),
+            _ => false,
+        }
+    }
+
+    /// Returns true if no records were returned
+    pub fn is_no_records_found(&self) -> bool {
+        match &*self.kind {
+            ErrorKind::Proto(proto) => proto.is_no_records_found(),
+            ErrorKind::Resolve(err) => err.is_no_records_found(),
+            _ => false,
+        }
+    }
+
+    /// Returns the SOA record, if the error contains one
+    pub fn into_soa(self) -> Option<Box<Record<SOA>>> {
+        match *self.kind {
+            ErrorKind::Proto(proto) => proto.into_soa(),
+            ErrorKind::Resolve(err) => err.into_soa(),
+            _ => None,
+        }
     }
 }
 


### PR DESCRIPTION
Currently, the forwarder handles both NXDOMAIN and SOA forwarding rather poorly. The is_nx_domain() check is incomplete & did not consider NXDOMAIN in `ResolveError`s and `RecursiveError`s. SOA records were outright ignored.

This PR fixes those issues. Here's the result from `dig` when a nonexistent domain is queried:

```
; <<>> DiG 9.20.1 <<>> @127.0.0.1 -p 8553 nothing.example.com
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 19646
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags: do; udp: 1232
;; QUESTION SECTION:
;nothing.example.com.           IN      A

;; AUTHORITY SECTION:
example.com.            1800    IN      SOA     ns.icann.org. noc.dns.icann.org. 2024081402 7200 3600 1209600 3600

;; Query time: 203 msec
;; SERVER: 127.0.0.1#8553(127.0.0.1) (UDP)
;; WHEN: Fri Aug 23 21:53:56 +08 2024
;; MSG SIZE  rcvd: 115
```

Compared to the result before:

```
; <<>> DiG 9.20.1 <<>> @127.0.0.1 -p 8553 nothing.example.com
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 41628
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags: do; udp: 1232
; OPT=5: 08 0d 0e 0f ("....")
; OPT=6: 08 0d 0e 0f ("....")
;; QUESTION SECTION:
;nothing.example.com.           IN      A

;; Query time: 420 msec
;; SERVER: 127.0.0.1#8553(127.0.0.1) (UDP)
;; WHEN: Fri Aug 23 22:08:33 +08 2024
;; MSG SIZE  rcvd: 64
```

This closes #1891.