### PR TITLE
Change domain name used in 'explore' example

### DIFF
--- a/conformance/packages/dns-test/examples/explore.rs
+++ b/conformance/packages/dns-test/examples/explore.rs
@@ -15,7 +15,7 @@ fn main() -> Result<()> {
     let peer = &dns_test::PEER;
 
     println!("building docker image...");
-    let leaf_ns = NameServer::new(peer, FQDN("mydomain.com.")?, &network)?;
+    let leaf_ns = NameServer::new(peer, FQDN::TEST_DOMAIN, &network)?;
     println!("DONE");
 
     println!("setting up name servers...");


### PR DESCRIPTION
This is a follow-up to #2359 to update the domain name used in the `explore` example. Currently this is failing on an assertion.