### PR TITLE
dns-test: bump unbound to 1.21.0

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
@@ -10,7 +10,7 @@ use dns_test::{Network, Resolver, Result, FQDN};
 #[test]
 fn dnskey_missing() -> Result<()> {
     fixture(
-        ExtendedDnsError::DnskeyMissing,
+        ExtendedDnsError::DnssecBogus,
         |_needle_fqdn, zone, records| {
             if zone == &FQDN::TEST_DOMAIN {
                 // remove the DNSKEY record that contains the ZSK

--- a/conformance/packages/dns-test/src/docker/unbound.Dockerfile
+++ b/conformance/packages/dns-test/src/docker/unbound.Dockerfile
@@ -1,9 +1,29 @@
 FROM debian:bookworm-slim
 
 # ldns-utils = ldns-{key2ds,keygen,signzone}
+# curl, etc. are used to build unbound from source
 RUN apt-get update && \
     apt-get install -y \
         ldnsutils \
         nsd \
         tshark \
-        unbound
+        curl \
+        gcc \
+        bison \
+        flex \
+        libssl-dev \
+        libexpat-dev \
+        make
+
+ENV UNBOUND_VERSION=1.21.0
+
+RUN curl -L https://github.com/NLnetLabs/unbound/archive/refs/tags/release-$UNBOUND_VERSION.tar.gz | tar xvz -C /tmp/ && \
+    cd /tmp/unbound-release-$UNBOUND_VERSION && \
+    ./configure \
+        --prefix=/usr \
+        --sysconfdir=/etc \
+        --localstatedir=/var \
+        --with-chroot-dir= && \
+    make -j$(nproc) && make install && \
+    rm -rf /tmp/unbound-release-$UNBOUND_VERSION
+RUN useradd --shell /usr/sbin/nologin --system --create-home --home-dir /var/lib/unbound unbound


### PR DESCRIPTION
from 1.17.1

as suggested in https://github.com/hickory-dns/hickory-dns/pull/2385#issuecomment-2311786032