### PR TITLE
dnssec: validate DS records

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
@@ -75,7 +75,6 @@ fn ds_bad_tag() -> Result<()> {
 
 // the algorithm field in the DS record does not match the algorithm field in the DNSKEY record
 #[test]
-#[ignore]
 fn ds_bad_key_algo() -> Result<()> {
     let output = malformed_ds_fixture(&FQDN::TEST_TLD.push_label("ds-bad-key-algo"), |ds| {
         assert_eq!(8, ds.algorithm, "number below may need to change");
@@ -84,10 +83,7 @@ fn ds_bad_key_algo() -> Result<()> {
 
     dbg!(&output);
 
-    assert!(
-        output.status.is_servfail()
-            || (output.status.is_noerror() && !output.flags.authenticated_data)
-    );
+    assert!(output.status.is_servfail());
 
     if dns_test::SUBJECT.is_unbound() {
         assert!(output.ede.iter().eq([&ExtendedDnsError::DnssecBogus]));

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
@@ -9,7 +9,6 @@ use dns_test::{
 };
 
 #[test]
-#[ignore]
 fn ds_unassigned_key_algo() -> Result<()> {
     let output =
         malformed_ds_fixture(&FQDN::TEST_TLD.push_label("ds-unassigned-key-algo"), |ds| {
@@ -18,6 +17,7 @@ fn ds_unassigned_key_algo() -> Result<()> {
 
     dbg!(&output);
 
+    // TODO change assert to only NOERROR+AD=0 when Hickory properly reports the Insecure outcome
     assert!(
         output.status.is_servfail()
             || (output.status.is_noerror() && !output.flags.authenticated_data)
@@ -31,7 +31,6 @@ fn ds_unassigned_key_algo() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn ds_reserved_key_algo() -> Result<()> {
     let output = malformed_ds_fixture(&FQDN::TEST_TLD.push_label("ds-reserved-key-algo"), |ds| {
         ds.algorithm = 200
@@ -39,6 +38,7 @@ fn ds_reserved_key_algo() -> Result<()> {
 
     dbg!(&output);
 
+    // TODO change assert to only NOERROR+AD=0 when Hickory properly reports the Insecure outcome
     assert!(
         output.status.is_servfail()
             || (output.status.is_noerror() && !output.flags.authenticated_data)

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
@@ -53,7 +53,6 @@ fn ds_reserved_key_algo() -> Result<()> {
 
 // the key tag in the DS record does not match the key tag in the DNSKEY record
 #[test]
-#[ignore]
 fn ds_bad_tag() -> Result<()> {
     let output = malformed_ds_fixture(&FQDN::TEST_TLD.push_label("ds-bad-tag"), |ds| {
         ds.key_tag = !ds.key_tag;
@@ -61,10 +60,7 @@ fn ds_bad_tag() -> Result<()> {
 
     dbg!(&output);
 
-    assert!(
-        output.status.is_servfail()
-            || (output.status.is_noerror() && !output.flags.authenticated_data)
-    );
+    assert!(output.status.is_servfail());
 
     if dns_test::SUBJECT.is_unbound() {
         assert!(output.ede.iter().eq([&ExtendedDnsError::DnssecBogus]));

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
@@ -1,1 +1,148 @@
 mod no_rrsig_dnskey;
+
+use dns_test::{
+    client::{Client, DigOutput, DigSettings, ExtendedDnsError},
+    name_server::NameServer,
+    record::{RecordType, DS},
+    zone_file::SignSettings,
+    Network, Resolver, Result, TrustAnchor, FQDN,
+};
+
+#[test]
+#[ignore]
+fn ds_unassigned_key_algo() -> Result<()> {
+    let output =
+        malformed_ds_fixture(&FQDN::TEST_TLD.push_label("ds-unassigned-key-algo"), |ds| {
+            ds.algorithm = 100
+        })?;
+
+    dbg!(&output);
+
+    assert!(
+        output.status.is_servfail()
+            || (output.status.is_noerror() && !output.flags.authenticated_data)
+    );
+
+    if dns_test::SUBJECT.is_unbound() {
+        assert!(output.ede.is_empty());
+    }
+
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn ds_reserved_key_algo() -> Result<()> {
+    let output = malformed_ds_fixture(&FQDN::TEST_TLD.push_label("ds-reserved-key-algo"), |ds| {
+        ds.algorithm = 200
+    })?;
+
+    dbg!(&output);
+
+    assert!(
+        output.status.is_servfail()
+            || (output.status.is_noerror() && !output.flags.authenticated_data)
+    );
+
+    if dns_test::SUBJECT.is_unbound() {
+        assert!(output.ede.is_empty());
+    }
+
+    Ok(())
+}
+
+// the key tag in the DS record does not match the key tag in the DNSKEY record
+#[test]
+#[ignore]
+fn ds_bad_tag() -> Result<()> {
+    let output = malformed_ds_fixture(&FQDN::TEST_TLD.push_label("ds-bad-tag"), |ds| {
+        ds.key_tag = !ds.key_tag;
+    })?;
+
+    dbg!(&output);
+
+    assert!(
+        output.status.is_servfail()
+            || (output.status.is_noerror() && !output.flags.authenticated_data)
+    );
+
+    if dns_test::SUBJECT.is_unbound() {
+        assert!(output.ede.iter().eq([&ExtendedDnsError::DnssecBogus]));
+    }
+
+    Ok(())
+}
+
+// the algorithm field in the DS record does not match the algorithm field in the DNSKEY record
+#[test]
+#[ignore]
+fn ds_bad_key_algo() -> Result<()> {
+    let output = malformed_ds_fixture(&FQDN::TEST_TLD.push_label("ds-bad-key-algo"), |ds| {
+        assert_eq!(8, ds.algorithm, "number below may need to change");
+        ds.algorithm = 7;
+    })?;
+
+    dbg!(&output);
+
+    assert!(
+        output.status.is_servfail()
+            || (output.status.is_noerror() && !output.flags.authenticated_data)
+    );
+
+    if dns_test::SUBJECT.is_unbound() {
+        assert!(output.ede.iter().eq([&ExtendedDnsError::DnssecBogus]));
+    }
+
+    Ok(())
+}
+
+fn malformed_ds_fixture(leaf_zone: &FQDN, mutate: impl FnOnce(&mut DS)) -> Result<DigOutput> {
+    let network = Network::new()?;
+    let sign_settings = SignSettings::default();
+
+    let peer = &dns_test::PEER;
+    let mut root_ns = NameServer::new(peer, FQDN::ROOT, &network)?;
+    let mut tld_ns = NameServer::new(peer, FQDN::TEST_TLD, &network)?;
+    let mut nameservers_ns = NameServer::new(peer, FQDN::TEST_DOMAIN, &network)?;
+    let leaf_ns = NameServer::new(peer, leaf_zone.clone(), &network)?;
+
+    root_ns.referral_nameserver(&tld_ns);
+    tld_ns.referral_nameserver(&nameservers_ns);
+    tld_ns.referral_nameserver(&leaf_ns);
+
+    nameservers_ns.add(root_ns.a());
+    nameservers_ns.add(tld_ns.a());
+
+    let nameservers_ns = nameservers_ns.sign(sign_settings.clone())?;
+    let leaf_ns = leaf_ns.sign(sign_settings.clone())?;
+
+    tld_ns.add(nameservers_ns.ds().clone());
+    let mut ds = leaf_ns.ds().clone();
+    mutate(&mut ds);
+    tld_ns.add(ds);
+
+    let tld_ns = tld_ns.sign(sign_settings.clone())?;
+    root_ns.add(tld_ns.ds().clone());
+
+    let mut trust_anchor = TrustAnchor::empty();
+    let root_ns = root_ns.sign(sign_settings)?;
+    trust_anchor.add(root_ns.key_signing_key().clone());
+    trust_anchor.add(root_ns.zone_signing_key().clone());
+
+    let root_hint = root_ns.root_hint();
+    let _root_ns = root_ns.start()?;
+    let _tld_ns = tld_ns.start()?;
+    let _nameservers_ns = nameservers_ns.start()?;
+    let _leaf_ns = leaf_ns.start()?;
+
+    let mut resolver = Resolver::new(&network, root_hint);
+    if dns_test::SUBJECT.is_unbound() {
+        resolver.extended_dns_errors();
+    }
+    let resolver = resolver.trust_anchor(&trust_anchor).start()?;
+
+    let client = Client::new(&network)?;
+    let settings = *DigSettings::default().recurse().authentic_data();
+
+    client.dig(settings, resolver.ipv4_addr(), RecordType::SOA, leaf_zone)
+}

--- a/crates/proto/src/xfer/dnssec_dns_handle.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle.rs
@@ -487,7 +487,6 @@ where
 
             // If all the keys are valid, then we are secure
             // FIXME: what if only some are invalid? we should return the good ones?
-            trace!("validated dnskey: {}", rrset.name());
             return Ok(false);
         }
     }

--- a/crates/proto/src/xfer/dnssec_dns_handle.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle.rs
@@ -448,7 +448,19 @@ where
             continue;
         };
 
+        let key_algorithm = key_rdata.algorithm();
         for r in ds_records.iter() {
+            if r.data().algorithm() != key_algorithm {
+                trace!(
+                    "skipping DS record due to algorithm mismatch, expected algorithm {}: ({}, {})",
+                    key_algorithm,
+                    r.name(),
+                    r.data(),
+                );
+
+                continue;
+            }
+
             if !r.data().covers(rrset.name(), key_rdata).unwrap_or(false) {
                 continue;
             }

--- a/crates/proto/src/xfer/dnssec_dns_handle.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle.rs
@@ -448,12 +448,25 @@ where
             continue;
         };
 
+        let Ok(key_tag) = key_rdata.calculate_key_tag() else {
+            continue;
+        };
         let key_algorithm = key_rdata.algorithm();
         for r in ds_records.iter() {
             if r.data().algorithm() != key_algorithm {
                 trace!(
                     "skipping DS record due to algorithm mismatch, expected algorithm {}: ({}, {})",
                     key_algorithm,
+                    r.name(),
+                    r.data(),
+                );
+
+                continue;
+            }
+
+            if r.data().key_tag() != key_tag {
+                trace!(
+                    "skipping DS record due to key tag mismatch, expected tag {key_tag}: ({}, {})",
                     r.name(),
                     r.data(),
                 );

--- a/crates/proto/src/xfer/dnssec_dns_handle.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle.rs
@@ -520,9 +520,14 @@ where
                 .take_answers()
                 .into_iter()
                 .filter_map(|r| Record::<DS>::try_from(r).ok())
+                .filter(|r| !matches!(r.data().algorithm(), Algorithm::Unknown(_)))
                 .collect::<Vec<_>>();
 
-            return Ok(ds_records);
+            if !ds_records.is_empty() {
+                return Ok(ds_records);
+            } else {
+                ProtoError::from(ProtoErrorKind::NoError)
+            }
         }
         Ok(_) => ProtoError::from(ProtoErrorKind::NoError),
         Err(error) => error,

--- a/tests/ede-dot-com/src/lib.rs
+++ b/tests/ede-dot-com/src/lib.rs
@@ -75,7 +75,6 @@ fn ds_bad_key_algo() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn ds_bad_tag() -> Result<()> {
     compare("ds-bad-tag").map(drop)
 }

--- a/tests/ede-dot-com/src/lib.rs
+++ b/tests/ede-dot-com/src/lib.rs
@@ -70,7 +70,6 @@ fn bad_zsk_algo() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn ds_bad_key_algo() -> Result<()> {
     compare("ds-bad-key-algo").map(drop)
 }


### PR DESCRIPTION
this PR ports 4 false positives scenarios from `ede-dot-com` into `conformance-tests`. Adds 3 DS checks to the DNSSEC validation code which fix all the newly added conformance tests.

Observably, this only fixes 2 `ede-dot-com` tests because the other 2 scenarios still fail due to  #2395 

~~this PR depends on #2392 so opening in draft state until that is merged~~