### PR TITLE
ensure DNSKEY is validated with a KSK

### DIFF
--- a/conformance/Cargo.lock
+++ b/conformance/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,7 +85,7 @@ dependencies = [
 name = "conformance-tests"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "dns-test",
 ]
 
@@ -154,6 +160,7 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 name = "dns-test"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "ctrlc",
  "lazy_static",
  "minijinja",
@@ -466,7 +473,7 @@ version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "chrono",
  "hex",
  "indexmap 1.9.3",

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
@@ -91,7 +91,6 @@ fn ds_bad_key_algo() -> Result<()> {
 // the RRSIG covering the DNSKEYs generated using the KSK has been removed
 // but there's an RRSIG covering the DNSKEYs generated using the ZSK
 #[test]
-#[ignore]
 fn no_rrsig_ksk() -> Result<()> {
     let network = Network::new()?;
     let leaf_zone = FQDN::TEST_TLD.push_label("no-rrsig-ksk");

--- a/conformance/packages/dns-test/Cargo.toml
+++ b/conformance/packages/dns-test/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 version = "0.1.0"
 
 [dependencies]
+base64 = "0.22.1"
 lazy_static = "1.4.0"
 minijinja = "1.0.12"
 serde = { version = "1.0.196", features = ["derive"] }

--- a/conformance/packages/dns-test/src/zone_file/signer.rs
+++ b/conformance/packages/dns-test/src/zone_file/signer.rs
@@ -189,7 +189,7 @@ impl<'a> Signer<'a> {
     where
         T: Iterator<Item = String>,
     {
-        let mut args = vec![String::from("ldns-signzone")];
+        let mut args = vec![String::from("ldns-signzone"), "-A".to_string()];
 
         if let Some(expiration) = self.settings.expiration {
             args.push(format!("-e {}", expiration));

--- a/crates/proto/src/rr/dnssec/rdata/dnskey.rs
+++ b/crates/proto/src/rr/dnssec/rdata/dnskey.rs
@@ -152,6 +152,12 @@ impl DNSKEY {
         self.secure_entry_point
     }
 
+    /// A KSK has a `flags` value of `257`
+    pub fn is_key_signing_key(&self) -> bool {
+        // a flags value of 257
+        self.secure_entry_point() && self.zone_key() && !self.revoke()
+    }
+
     /// [RFC 5011, Trust Anchor Update, September 2007](https://tools.ietf.org/html/rfc5011#section-3)
     ///
     /// ```text

--- a/crates/proto/src/xfer/dnssec_dns_handle.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle.rs
@@ -664,6 +664,8 @@ where
                     .records()
                     .iter()
                     .filter_map(|r| r.try_borrow::<DNSKEY>())
+                    // DNSKEY must be signed using a KSK
+                    .filter(|r| r.data().is_key_signing_key())
                     .find_map(|dnskey| {
                         // If we had rrsigs to verify, then we want them to be secure, or the result is a Bogus proof
                         verify_rrset_with_dnskey(dnskey, *rrsig, &rrset, current_time).ok()

--- a/tests/ede-dot-com/Cargo.lock
+++ b/tests/ede-dot-com/Cargo.lock
@@ -124,6 +124,7 @@ dependencies = [
 name = "dns-test"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "lazy_static",
  "minijinja",
  "serde",

--- a/tests/ede-dot-com/src/lib.rs
+++ b/tests/ede-dot-com/src/lib.rs
@@ -54,7 +54,6 @@ fn bad_rrsig_dnskey() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn bad_rrsig_ksk() -> Result<()> {
     compare("bad-rrsig-ksk").map(drop)
 }
@@ -151,7 +150,6 @@ fn no_rrsig_dnskey() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn no_rrsig_ksk() -> Result<()> {
     compare("no-rrsig-ksk").map(drop)
 }


### PR DESCRIPTION
ports and fixes `no-rrsig-ksk` from `ede-dot-com`

this fixes the last two false positive scenarios in `ede-dot-com`

I think I spotted at least two more places where the lack of DNSKEY checks ("is this a ZSK?", "is this a KSK?") could cause issues. None of the remaining scenarios in `ede-dot-com` hits those paths so I'll try to write some tests first before I add any additional check to the DNSSEC validation code.

fixes #2389 

~~this PR depends on #2396 so opening as a draft PR until that gets merged~~