### PR TITLE
CI: Cache Unbound container

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -21,6 +21,23 @@ jobs:
           components: clippy, rustfmt
       - uses: extractions/setup-just@v2
 
+      - name: setup docker buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+          use: true
+          install: true
+      - name: build unbound
+        uses: docker/build-push-action@v6
+        with:
+          file: conformance/packages/dns-test/src/docker/unbound.Dockerfile
+          context: conformance/packages/dns-test/src/docker
+          tags: dns-test-unbound
+          push: false
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha
+
       - name: run test-framework tests
         run: just conformance-framework
 

--- a/conformance/packages/dns-test/src/container.rs
+++ b/conformance/packages/dns-test/src/container.rs
@@ -99,7 +99,7 @@ impl Container {
 
         let mut command = Command::new("docker");
         command
-            .args(["build", "-t"])
+            .args(["build", "--load", "-t"])
             .arg(&image_tag)
             .arg(docker_build_dir);
 


### PR DESCRIPTION
This switches from the `docker` buildx driver to `docker-container`, and then builds the Unbound container once with caching enabled before starting conformance tests. Since Unbound is being built from source now, this could shave ~90s off the conformance workflow.