### PR TITLE
CI: fix conformance tests

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus/no_rrsig_dnskey.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus/no_rrsig_dnskey.rs
@@ -68,7 +68,7 @@ fn query_dnskey_record() -> Result<()> {
 
     if dns_test::SUBJECT.is_unbound() {
         // check that this failed for the right reason
-        assert_eq!(Some(ExtendedDnsError::RrsigsMissing), output.ede);
+        assert!(output.ede.iter().eq(&[ExtendedDnsError::RrsigsMissing]));
     }
 
     Ok(())
@@ -143,7 +143,7 @@ fn query_other_record() -> Result<()> {
 
     if dns_test::SUBJECT.is_unbound() {
         // check that this failed for the right reason
-        assert_eq!(Some(ExtendedDnsError::RrsigsMissing), output.ede);
+        assert!(output.ede.iter().eq(&[ExtendedDnsError::RrsigsMissing]));
     }
 
     Ok(())


### PR DESCRIPTION
these tests needed to be updated after the change in #2381 

I'm not sure why the merge queue merged the PR ... perhaps because the `conformance` job is not marked as "required"?