### PR TITLE
conformance: use `push_label` API and update variable names

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
@@ -45,7 +45,7 @@ fn can_resolve() -> Result<()> {
 #[ignore]
 #[test]
 fn nxdomain() -> Result<()> {
-    let needle_fqdn = FQDN("unicorn.nameservers.com.")?;
+    let needle_fqdn = FQDN::TEST_DOMAIN.push_label("unicorn");
 
     let network = Network::new()?;
 

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
@@ -24,13 +24,13 @@ fn on_clients_ds_query_it_queries_the_parent_zone() -> Result<()> {
         },
     )?;
 
-    let mut com_ns_addr = None;
+    let mut tld_ns_addr = None;
     for nameserver in &nameservers {
         if nameserver.zone() == &FQDN::TEST_TLD {
-            com_ns_addr = Some(nameserver.ipv4_addr());
+            tld_ns_addr = Some(nameserver.ipv4_addr());
         }
     }
-    let com_ns_addr = com_ns_addr.expect("com. NS not found");
+    let tld_ns_addr = tld_ns_addr.expect("NS for TLD not found");
 
     let trust_anchor = &trust_anchor.unwrap();
     let resolver = Resolver::new(&network, root)
@@ -55,7 +55,7 @@ fn on_clients_ds_query_it_queries_the_parent_zone() -> Result<()> {
     let ds = record.try_into_ds().unwrap();
     assert_eq!(ds.zone, FQDN::TEST_DOMAIN);
 
-    // check that DS query was forwarded to the `com.` (parent zone) nameserver
+    // check that DS query was forwarded to the `testing.` (parent zone) nameserver
     let client_addr = client.ipv4_addr();
     let mut outgoing_ds_query_count = 0;
     for Capture { message, direction } in captures {
@@ -71,7 +71,7 @@ fn on_clients_ds_query_it_queries_the_parent_zone() -> Result<()> {
                         let test_domain = FQDN::TEST_DOMAIN.as_str();
                         let test_domain = test_domain.strip_suffix('.').unwrap_or(test_domain);
                         assert!(query.contains(test_domain));
-                        assert_eq!(com_ns_addr, destination);
+                        assert_eq!(tld_ns_addr, destination);
 
                         outgoing_ds_query_count += 1;
                     }

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_5.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_5.rs
@@ -89,11 +89,11 @@ fn caches_query_without_dnssec_to_return_all_dnssec_records_in_subsequent_query(
     Ok(())
 }
 
-/// The chain of trust used to validate `A example.nameservers.com.` includes records within the
-/// `nameservers.com.`, `com.` and `.` domains. Those records should be cached in the "Secure"
-/// cache as part of the validation of `A example.com.`.
+/// The chain of trust used to validate `A example.hickory-dns.testing.` includes records within the
+/// `hickory-dns.testing.`, `testing` and `.` zones. Those records should be cached in the "Secure"
+/// cache as part of the validation of `A example.hickory-dns.testing.`.
 ///
-/// Therefore, a second query for a record like `DS com.` should be a cache hit.
+/// Therefore, a second query for a record like `DS testing.` should be a cache hit.
 #[test]
 fn caches_intermediate_records() -> Result<()> {
     let leaf_fqdn = FQDN::EXAMPLE_SUBDOMAIN;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/insecure.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/insecure.rs
@@ -17,13 +17,13 @@ mod deprecated_algorithm;
 #[ignore]
 fn unsigned_zone() -> Result<()> {
     let expected_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
-    let needle_fqdn = FQDN("example.unsigned.testing.")?;
+    let unsigned_zone = FQDN::TEST_TLD.push_label("unsigned");
+    let needle_fqdn = unsigned_zone.push_label("example");
 
     let sign_settings = SignSettings::default();
     let network = Network::new()?;
 
-    let unsigned_fqdn = FQDN("unsigned.testing.")?;
-    let mut unsigned_ns = NameServer::new(&dns_test::PEER, unsigned_fqdn.clone(), &network)?;
+    let mut unsigned_ns = NameServer::new(&dns_test::PEER, unsigned_zone.clone(), &network)?;
     unsigned_ns.add(Record::a(needle_fqdn.clone(), expected_ipv4_addr));
     let mut nameservers_ns = NameServer::new(&dns_test::PEER, FQDN::TEST_DOMAIN, &network)?;
     let mut tld_ns = NameServer::new(&dns_test::PEER, FQDN::TEST_TLD, &network)?;


### PR DESCRIPTION
to no longer refer to the old `nameservers.com.`, and parent, domains