### PR TITLE
conformance: DS of child's ZSK in parent zone

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
@@ -203,13 +203,13 @@ fn malformed_ds_fixture(leaf_zone: &FQDN, mutate: impl FnOnce(&mut DS)) -> Resul
     let nameservers_ns = nameservers_ns.sign(sign_settings.clone())?;
     let leaf_ns = leaf_ns.sign(sign_settings.clone())?;
 
-    tld_ns.add(nameservers_ns.ds().clone());
-    let mut ds = leaf_ns.ds().clone();
+    tld_ns.add(nameservers_ns.ds().ksk.clone());
+    let mut ds = leaf_ns.ds().ksk.clone();
     mutate(&mut ds);
     tld_ns.add(ds);
 
     let tld_ns = tld_ns.sign(sign_settings.clone())?;
-    root_ns.add(tld_ns.ds().clone());
+    root_ns.add(tld_ns.ds().ksk.clone());
 
     let mut trust_anchor = TrustAnchor::empty();
     let root_ns = root_ns.sign(sign_settings)?;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
@@ -112,10 +112,10 @@ fn no_rrsig_ksk() -> Result<()> {
                         if let Record::DNSKEY(dnskey) = record {
                             if dnskey.is_key_signing_key() {
                                 assert!(ksk_tag.is_none(), "more than one KSK");
-                                ksk_tag = Some(dnskey.calculate_key_tag());
+                                ksk_tag = Some(dnskey.rdata.calculate_key_tag());
                             } else {
                                 assert!(zsk_tag.is_none(), "more than one ZSK");
-                                zsk_tag = Some(dnskey.calculate_key_tag());
+                                zsk_tag = Some(dnskey.rdata.calculate_key_tag());
                             }
                         }
                     }

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/insecure.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/insecure.rs
@@ -38,10 +38,10 @@ fn unsigned_zone() -> Result<()> {
 
     let nameservers_ns = nameservers_ns.sign(sign_settings.clone())?;
 
-    tld_ns.add(nameservers_ns.ds().clone());
+    tld_ns.add(nameservers_ns.ds().ksk.clone());
     let tld_ns = tld_ns.sign(sign_settings.clone())?;
 
-    root_ns.add(tld_ns.ds().clone());
+    root_ns.add(tld_ns.ds().ksk.clone());
 
     let mut trust_anchor = TrustAnchor::empty();
     let root_ns = root_ns.sign(sign_settings)?;

--- a/conformance/packages/dns-test/src/trust_anchor.rs
+++ b/conformance/packages/dns-test/src/trust_anchor.rs
@@ -1,6 +1,9 @@
 use core::fmt;
 
-use crate::{record::DNSKEY, DEFAULT_TTL, FQDN};
+use crate::{
+    record::{DNSKEYRData, DNSKEY},
+    DEFAULT_TTL, FQDN,
+};
 
 pub struct TrustAnchor {
     keys: Vec<DNSKEY>,
@@ -16,18 +19,22 @@ impl TrustAnchor {
         anchors.add(DNSKEY {
             zone: FQDN::ROOT,
             ttl: DEFAULT_TTL,
-            flags: 256,
-            protocol: 3,
-            algorithm: 8,
-            public_key: "AwEAAbPwrxwtOMENWvblQbUFwBllR7ZtXsu9rg/LdyklKs9gU2GQTeOc59XjhuAPZ4WrT09z6YPL+vzIIJqnG3Hiru7hFUQ4pH0qsLNxrsuZrZYmXAKoVa9SXL1Ap0LygwrIugEk1G4v7Rk/Alt1jLUIE+ZymGtSEhIuGQdXrEmj3ffzXY13H42X4Ja3vJTn/WIQOXY7vwHXGDypSh9j0Tt0hknF1yVJCrIpfkhFWihMKNdMzMprD4bV+PDLRA5YSn3OPIeUnRn9qBUCN11LXQKb+W3Jg+m/5xQRQJzJ/qXgDh1+aN+Mc9AstP29Y/ZLFmF6cKtL2zoUMN5I5QymeSkJJzc=".to_string(),
+            rdata: DNSKEYRData {
+                flags: 256,
+                protocol: 3,
+                algorithm: 8,
+                public_key: "AwEAAbPwrxwtOMENWvblQbUFwBllR7ZtXsu9rg/LdyklKs9gU2GQTeOc59XjhuAPZ4WrT09z6YPL+vzIIJqnG3Hiru7hFUQ4pH0qsLNxrsuZrZYmXAKoVa9SXL1Ap0LygwrIugEk1G4v7Rk/Alt1jLUIE+ZymGtSEhIuGQdXrEmj3ffzXY13H42X4Ja3vJTn/WIQOXY7vwHXGDypSh9j0Tt0hknF1yVJCrIpfkhFWihMKNdMzMprD4bV+PDLRA5YSn3OPIeUnRn9qBUCN11LXQKb+W3Jg+m/5xQRQJzJ/qXgDh1+aN+Mc9AstP29Y/ZLFmF6cKtL2zoUMN5I5QymeSkJJzc=".to_string(),
+            }
         });
         anchors.add(DNSKEY {
             zone: FQDN::ROOT,
             ttl: DEFAULT_TTL,
-            flags: 257,
-            protocol: 3,
-            algorithm: 8,
-            public_key: "AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3+/4RgWOq7HrxRixHlFlExOLAJr5emLvN7SWXgnLh4+B5xQlNVz8Og8kvArMtNROxVQuCaSnIDdD5LKyWbRd2n9WGe2R8PzgCmr3EgVLrjyBxWezF0jLHwVN8efS3rCj/EWgvIWgb9tarpVUDK/b58Da+sqqls3eNbuv7pr+eoZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLYA4/ilBmSVIzuDWfdRUfhHdY6+cn8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6UwNR1AkUTV74bU=".to_string(),
+            rdata: DNSKEYRData {
+                flags: 257,
+                protocol: 3,
+                algorithm: 8,
+                public_key: "AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3+/4RgWOq7HrxRixHlFlExOLAJr5emLvN7SWXgnLh4+B5xQlNVz8Og8kvArMtNROxVQuCaSnIDdD5LKyWbRd2n9WGe2R8PzgCmr3EgVLrjyBxWezF0jLHwVN8efS3rCj/EWgvIWgb9tarpVUDK/b58Da+sqqls3eNbuv7pr+eoZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLYA4/ilBmSVIzuDWfdRUfhHdY6+cn8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6UwNR1AkUTV74bU=".to_string(),
+            }
         });
         anchors
     }

--- a/conformance/packages/dns-test/src/zone_file/mod.rs
+++ b/conformance/packages/dns-test/src/zone_file/mod.rs
@@ -153,6 +153,10 @@ impl DNSKEY {
 
         record::DNSKEY { zone, ttl, rdata }
     }
+
+    pub(crate) fn rdata(&self) -> &DNSKEYRData {
+        &self.rdata
+    }
 }
 
 impl FromStr for DNSKEY {

--- a/conformance/packages/dns-test/src/zone_file/mod.rs
+++ b/conformance/packages/dns-test/src/zone_file/mod.rs
@@ -9,7 +9,7 @@ use std::array;
 use std::net::Ipv4Addr;
 use std::str::FromStr;
 
-use crate::record::{self, Record, RecordType, RRSIG, SOA};
+use crate::record::{self, DNSKEYRData, Record, RecordType, RRSIG, SOA};
 use crate::{Error, Result, DEFAULT_TTL, FQDN};
 
 mod signer;
@@ -144,30 +144,14 @@ impl fmt::Display for Root {
 #[allow(clippy::upper_case_acronyms)]
 pub(crate) struct DNSKEY {
     zone: FQDN,
-    flags: u16,
-    protocol: u8,
-    algorithm: u8,
-    public_key: String,
+    rdata: DNSKEYRData,
 }
 
 impl DNSKEY {
     pub fn with_ttl(self, ttl: u32) -> record::DNSKEY {
-        let Self {
-            zone,
-            flags,
-            protocol,
-            algorithm,
-            public_key,
-        } = self;
+        let Self { zone, rdata } = self;
 
-        record::DNSKEY {
-            zone,
-            ttl,
-            flags,
-            protocol,
-            algorithm,
-            public_key,
-        }
+        record::DNSKEY { zone, ttl, rdata }
     }
 }
 
@@ -198,10 +182,12 @@ impl FromStr for DNSKEY {
 
         Ok(Self {
             zone: zone.parse()?,
-            flags: flags.parse()?,
-            protocol: protocol.parse()?,
-            algorithm: algorithm.parse()?,
-            public_key: public_key.to_string(),
+            rdata: DNSKEYRData {
+                flags: flags.parse()?,
+                protocol: protocol.parse()?,
+                algorithm: algorithm.parse()?,
+                public_key: public_key.to_string(),
+            },
         })
     }
 }
@@ -218,10 +204,13 @@ mod tests {
 
         let DNSKEY {
             zone,
-            flags,
-            protocol,
-            algorithm,
-            public_key,
+            rdata:
+                DNSKEYRData {
+                    flags,
+                    protocol,
+                    algorithm,
+                    public_key,
+                },
         } = input.parse()?;
 
         assert_eq!(FQDN::ROOT, zone);

--- a/conformance/packages/dns-test/src/zone_file/signer.rs
+++ b/conformance/packages/dns-test/src/zone_file/signer.rs
@@ -3,7 +3,12 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use crate::{container::Container, name_server::Signed, record::DS, FQDN};
+use crate::{
+    container::Container,
+    name_server::{Signed, DS2},
+    record::DS,
+    FQDN,
+};
 
 use super::{ZoneFile, DNSKEY};
 
@@ -149,8 +154,14 @@ impl<'a> Signer<'a> {
 
         // TODO do we want to make the hashing algorithm configurable?
         // -2 = use SHA256 for the DS hash
-        let key2ds = format!("cd {ZONES_DIR} && ldns-key2ds -n -2 {ZONE_FILENAME}.signed");
-        let ds: DS = self.container.stdout(&["sh", "-c", &key2ds])?.parse()?;
+        let key2ds = format!("cd {ZONES_DIR} && ldns-key2ds -f -n -2 {ZONE_FILENAME}.signed");
+        let dses = self
+            .container
+            .stdout(&["sh", "-c", &key2ds])?
+            .lines()
+            .map(|line| line.parse())
+            .collect::<Result<Vec<DS>, _>>()?;
+        let ds = DS2::classify(dses, &zsk, &ksk);
 
         let signed: ZoneFile = self
             .container


### PR DESCRIPTION
This is a new secure test that hickory fails ("false negative").

I came across this scenario trying to further investigate how much "ZSK vs KSK validation" happens in other resolvers. Although, resources in the internet recommend setting up auth name servers with two keys (ZSK + KSK); this scenario allows for single-key (only ZSK) deployments.

this PR depends on #2399 