### PR TITLE
Use u32 internally when randomizing case of labels

### DIFF
--- a/crates/proto/src/rr/domain/name.rs
+++ b/crates/proto/src/rr/domain/name.rs
@@ -61,13 +61,13 @@ impl Name {
         use rand::distributions::{Distribution, Standard};
         let mut rand = rand::thread_rng();
 
-        // 16 bits should be enough to cover *most* queries without making another call to the RNG.
-        // Using u16 here resulted in repeated cases of the most-significant bit always being zero
-        let mut rand_bits: i16 = 0;
+        // Generate randomness 32 bits at a time, because this is the smallest unit on which the
+        // `rand` crate operates. One RNG call should be enough for most queries.
+        let mut rand_bits: u32 = 0;
 
         for (i, b) in self.label_data.iter_mut().enumerate() {
-            // Generate fresh random bits on the zeroth and then every 16th iteration.
-            if i % 16 == 0 {
+            // Generate fresh random bits on the zeroth and then every 32nd iteration.
+            if i % 32 == 0 {
                 rand_bits = Standard.sample(&mut rand);
             }
 


### PR DESCRIPTION
This is a follow-up to #2403 that changes how the case of labels is randomized. The temporary variable holding to-be-used random bits is changed from an `i16` to an `u32`, and the update part of the loop is changed to match.

I changed from 16 to 32 bits because the `rand` crate's RNGs primarily deal in either `u32`s or `u64`s. The implementation of `Distribution<u16> for Standard` just calls `rng.next_u32()` and truncates, so this change will cut RNG calls in half for longer names.

I changed from a signed integer to an unsigned integer, and deleted the associated comment, because I could not reproduce this issue. My best guess is that there was an off-by-one issue in an earlier version of the code. Plus, I'd rather that the shift operation use zero extension, rather than sign extension, because our tests can catch a character that's never randomized, but they can't currently catch correlation between the case of two characters, which is just as bad for entropy.