### PR TITLE
Ignore escaped dots when determining FQDN status

### DIFF
--- a/crates/proto/src/rr/domain/name.rs
+++ b/crates/proto/src/rr/domain/name.rs
@@ -632,7 +632,8 @@ impl Name {
             name = name.append_label(E::to_label(&label)?)?;
         }
 
-        if local.ends_with('.') {
+        // Check if the last character processed was an unescaped `.`
+        if label.is_empty() && !local.is_empty() {
             name.set_fqdn(true);
         } else if let Some(other) = origin {
             return name.append_domain(other);
@@ -2092,5 +2093,20 @@ mod tests {
             }
             _ => 0.0,
         }
+    }
+
+    #[test]
+    fn test_fqdn_escaped_dot() {
+        let name = Name::from_utf8("test.").unwrap();
+        assert!(name.is_fqdn());
+
+        let name = Name::from_utf8("test\\.").unwrap();
+        assert!(!name.is_fqdn());
+
+        let name = Name::from_utf8("").unwrap();
+        assert!(!name.is_fqdn());
+
+        let name = Name::from_utf8(".").unwrap();
+        assert!(name.is_fqdn());
     }
 }


### PR DESCRIPTION
This fixes another oddity I noticed while reducing a test case for #2419. If a name ends with `\.`, then `Name::from_encoded_str()` both adds a dot to the last label, due to escape decoding rules, and sets the flag that the name is an FQDN, because that check is unaware of escapes. As a result, encoding the name again will produce an extra dot at the end. This PR fixes the check by instead looking at whether the `label` local variable has just been cleared.