### PR TITLE
Fix corruption of signature expiration in flaky test

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -44,6 +44,8 @@ $ DNS_TEST_SUBJECT="hickory https://github.com/hickory-dns/hickory-dns" cargo ru
   
 - `DNS_TEST_VERBOSE_DOCKER_BUILD`. Setting this variable prints the output of the `docker build` invocations that the framework does to the console. This is useful to verify that image caching is working; for example if you set `DNS_TEST_SUBJECT` to a local `hickory-dns` repository then consecutively running the `explore` example and/or `conformance-tests` test suite **must** not rebuild `hickory-dns` provided that you have not *committed* any new change to the local repository.
 
+- `DNS_TEST_SKIP_DOCKER_BUILD`. Setting this variable skips running `docker build`. This should only be used if containers have been built recently.
+
 ### Automatic clean-up
 
 `dns-test` has been designed to clean up, that is remove, the Docker containers and Docker networks that it creates.

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
@@ -168,7 +168,11 @@ fn fixture(
     assert!(output.status.is_servfail());
 
     if supports_ede {
-        assert!(output.ede.into_iter().eq([expected]));
+        assert!(
+            output.ede.iter().eq([&expected]),
+            "output: {:?}, expected: {expected:?}",
+            &output.ede
+        );
     }
 
     Ok(())

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
@@ -104,7 +104,10 @@ fn dnssec_bogus() -> Result<()> {
                 for record in records {
                     if let Record::RRSIG(rrsig) = record {
                         if rrsig.type_covered == RecordType::A && rrsig.fqdn == *needle_fqdn {
-                            rrsig.signature_expiration = rrsig.signature_inception - 1;
+                            let seconds = rrsig.signature_inception % 100;
+                            let rest = rrsig.signature_inception - seconds;
+                            let modified_seconds = (seconds + 59).rem_euclid(60);
+                            rrsig.signature_expiration = rest + modified_seconds;
                             modified_count += 1;
                         }
                     }


### PR DESCRIPTION
This test has a 1 in 60 chance of corrupting the signature expiration field of `RRSIG` records to have `99` in the seconds place. This causes BIND to report "out of range" when loading the zone file, and skip the file. This in turn causes a test failure because Unbound can't fetch the corrupted signature, and it reports a different error code.

This PR fixes the issue by extracting the seconds field, and then subtracting 1 mod 60. (This still has a chance of being in the future, not the past, but it should still make the signature bogus no matter what) Closes #2421. I also added an environment variable to skip `docker build`, so I could get better throughput when running this one test in a bash loop.