### PR TITLE
Escape dots inside IDNA labels

### DIFF
--- a/crates/proto/src/rr/domain/label.rs
+++ b/crates/proto/src/rr/domain/label.rs
@@ -245,11 +245,15 @@ impl Display for Label {
         if self.as_bytes().starts_with(IDNA_PREFIX) {
             // this should never be outside the ascii codes...
             let label = String::from_utf8_lossy(self.borrow());
-            let (label, e) = idna::Config::default()
+            let (mut label, e) = idna::Config::default()
                 .use_std3_ascii_rules(false)
                 .transitional_processing(false)
                 .verify_dns_length(false)
                 .to_unicode(&label);
+
+            if label.contains('.') {
+                label = label.replace('.', "\\.");
+            }
 
             if e.is_ok() {
                 return f.write_str(&label);

--- a/crates/proto/src/rr/domain/name.rs
+++ b/crates/proto/src/rr/domain/name.rs
@@ -1777,6 +1777,15 @@ mod tests {
     }
 
     #[test]
+    fn test_utf8_round_trip_escaped_dot() {
+        let name = Name::from_utf8("ben\\.fry").unwrap();
+        assert_eq!(name.to_utf8(), "ben\\.fry");
+
+        let name = Name::from_utf8("🦀ben\\.fry").unwrap();
+        assert_eq!(name.to_utf8(), "🦀ben\\.fry");
+    }
+
+    #[test]
     fn test_into_name() {
         let name = Name::from_utf8("www.example.com").unwrap();
         assert_eq!(Name::from_utf8("www.example.com").unwrap(), name);


### PR DESCRIPTION
This implements an idea I mentioned in #2419, escaping dots within labels when encoding them as UTF-8. I'm unfamiliar with applications where escaped dots are allowed in names, so I'm looking for feedback on whether this is the right approach.