### PR TITLE
treat zone as Insecure if all DNSKEY algorithms are unsupported

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/insecure/deprecated_algorithm.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/insecure/deprecated_algorithm.rs
@@ -28,7 +28,6 @@ fn sanity_check() -> Result<()> {
 }
 
 #[test]
-#[ignore = "hickory answers with SERVFAIL"]
 fn dsa() -> Result<()> {
     let output = fixture("dsa", SignSettings::dsa())?;
 
@@ -45,7 +44,6 @@ fn dsa() -> Result<()> {
 }
 
 #[test]
-#[ignore = "hickory answers with SERVFAIL"]
 fn rsamd5() -> Result<()> {
     let output = fixture("rsamd5", SignSettings::rsamd5())?;
 

--- a/crates/proto/src/rr/dnssec/algorithm.rs
+++ b/crates/proto/src/rr/dnssec/algorithm.rs
@@ -155,6 +155,22 @@ impl Algorithm {
         }
     }
 
+    /// Whether this algorithm is supported by hickory's build settings
+    pub fn is_supported(&self) -> bool {
+        match self {
+            #[cfg(any(feature = "dnssec-openssl", feature = "dnssec-ring"))]
+            Algorithm::ECDSAP256SHA256
+            | Algorithm::ECDSAP384SHA384
+            | Algorithm::RSASHA1
+            | Algorithm::RSASHA1NSEC3SHA1
+            | Algorithm::RSASHA256
+            | Algorithm::RSASHA512 => true,
+            #[cfg(feature = "dnssec-ring")]
+            Algorithm::ED25519 => true,
+            _ => false,
+        }
+    }
+
     /// length in bytes that the hash portion of this function will produce
     pub fn hash_len(self) -> Option<usize> {
         match self {

--- a/crates/proto/src/rr/dnssec/proof.rs
+++ b/crates/proto/src/rr/dnssec/proof.rs
@@ -287,9 +287,13 @@ pub enum ProofErrorKind {
         name: Name,
     },
 
-    /// Unsupported key algorithm
+    /// Unknown or reserved key algorithm
     #[error("unknown or reserved key algorithm")]
     UnknownKeyAlgorithm,
+
+    /// Unsupported key algorithms
+    #[error("unsupported key algorithms")]
+    UnsupportedKeyAlgorithm,
 }
 
 /// The error type for dnssec errors that get returned in the crate

--- a/crates/proto/src/rr/dnssec/public_key.rs
+++ b/crates/proto/src/rr/dnssec/public_key.rs
@@ -479,6 +479,9 @@ impl<'k> PublicKeyEnum<'k> {
     /// Converts the bytes into a PulbicKey of the specified algorithm
     #[allow(unused_variables, clippy::match_single_binding)]
     pub fn from_public_bytes(public_key: &'k [u8], algorithm: Algorithm) -> ProtoResult<Self> {
+        // try to keep this and `Algorithm::is_supported` in sync
+        debug_assert!(algorithm.is_supported());
+
         #[allow(deprecated)]
         match algorithm {
             #[cfg(any(feature = "dnssec-openssl", feature = "dnssec-ring"))]

--- a/tests/ede-dot-com/src/lib.rs
+++ b/tests/ede-dot-com/src/lib.rs
@@ -101,7 +101,6 @@ fn ds_unassigned_key_algo() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn dsa() -> Result<()> {
     compare("dsa").map(drop)
 }
@@ -224,7 +223,6 @@ fn rrsig_not_yet_all() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn rsamd5() -> Result<()> {
     compare("rsamd5").map(drop)
 }


### PR DESCRIPTION
this fixes the diagnostics of two more ede-dot-com tests

~~depends on #2438 so opening as a draft until that is merged~~