### PR TITLE
Fix dns-over-openssl compilation and CI coverage

### DIFF
--- a/bin/tests/named_openssl_tests.rs
+++ b/bin/tests/named_openssl_tests.rs
@@ -18,6 +18,7 @@ use std::fs::File;
 use std::io::*;
 use std::net::*;
 
+use hickory_server::server::Protocol;
 use native_tls::Certificate;
 use tokio::net::TcpStream as TokioTcpStream;
 use tokio::runtime::Runtime;
@@ -39,8 +40,9 @@ fn test_example_tls_rustls_and_openssl_toml_startup() {
 }
 
 fn test_startup(toml: &'static str) {
-    named_test_harness(toml, move |_, _, tls_port, _, _| {
+    named_test_harness(toml, move |socket_ports| {
         let mut cert_der = vec![];
+        let tls_port = socket_ports.get_v4(Protocol::Tls);
         let server_path = env::var("TDNS_WORKSPACE_ROOT").unwrap_or_else(|_| "..".to_owned());
         println!("using server src path: {}", server_path);
 

--- a/justfile
+++ b/justfile
@@ -42,7 +42,7 @@ dns-over-h3: (default "--features=dns-over-h3" "--ignore=\\{async-std-resolver,h
 dns-over-native-tls: (default "--features=dns-over-native-tls" "--ignore=\\{async-std-resolver,hickory-compatibility,hickory-server,hickory-dns,hickory-util,hickory-integration\\}")
 
 # Check, build, and test all crates with dns-over-openssl enabled
-dns-over-openssl: (default "--features=dnssec-openssl" "--ignore=\\{async-std-resolver,hickory-compatibility\\}")
+dns-over-openssl: (default "--features=dns-over-openssl" "--ignore=\\{async-std-resolver,hickory-compatibility,hickory-util\\}")
 
 # Check, build, and test all crates with dnssec-openssl enabled
 dnssec-openssl: (default "--features=dnssec-openssl" "--ignore=\\{async-std-resolver,hickory-compatibility\\}")
@@ -228,7 +228,7 @@ e2e-tests-fmt:
 # runs all other ede-dot-com-* tasks
 ede-dot-com: (ede-dot-com-run) (ede-dot-com-ignored) (ede-dot-com-check)
 
-# runs hickory-specific end-to-end tests that use the dns-test framework
+# runs hickory-specific ede-dot-com tests that use the dns-test framework
 ede-dot-com-run filter='':
     bash -c '[[ -n "$(git status -s)" ]] && echo "WARNING: uncommited changes will NOT be tested" || true'
     DNS_TEST_VERBOSE_DOCKER_BUILD=1 cargo test --manifest-path tests/ede-dot-com/Cargo.toml -- {{filter}}

--- a/tests/integration-tests/src/example_authority.rs
+++ b/tests/integration-tests/src/example_authority.rs
@@ -3,7 +3,11 @@ use std::str::FromStr;
 use hickory_proto::rr::*;
 
 use hickory_server::authority::ZoneType;
-#[cfg(any(feature = "dnssec", feature = "dns-over-rustls"))]
+#[cfg(any(
+    feature = "dnssec",
+    feature = "dns-over-rustls",
+    feature = "dns-over-openssl"
+))]
 use hickory_server::config::dnssec::NxProofKind;
 use hickory_server::store::in_memory::InMemoryAuthority;
 
@@ -18,7 +22,11 @@ pub fn create_example() -> InMemoryAuthority {
         origin.clone(),
         ZoneType::Primary,
         false,
-        #[cfg(any(feature = "dnssec", feature = "dns-over-rustls"))]
+        #[cfg(any(
+            feature = "dnssec",
+            feature = "dns-over-rustls",
+            feature = "dns-over-openssl"
+        ))]
         Some(NxProofKind::Nsec),
     );
 

--- a/tests/integration-tests/tests/catalog_tests.rs
+++ b/tests/integration-tests/tests/catalog_tests.rs
@@ -5,7 +5,11 @@ use hickory_proto::{
     rr::{rdata::*, *},
     serialize::binary::{BinDecodable, BinEncodable},
 };
-#[cfg(any(feature = "dnssec", feature = "dns-over-rustls"))]
+#[cfg(any(
+    feature = "dnssec",
+    feature = "dns-over-rustls",
+    feature = "dns-over-openssl"
+))]
 use hickory_server::config::dnssec::NxProofKind;
 use hickory_server::{
     authority::{Authority, Catalog, MessageRequest, ZoneType},
@@ -23,7 +27,11 @@ pub fn create_test() -> InMemoryAuthority {
         origin.clone(),
         ZoneType::Primary,
         false,
-        #[cfg(any(feature = "dnssec", feature = "dns-over-rustls"))]
+        #[cfg(any(
+            feature = "dnssec",
+            feature = "dns-over-rustls",
+            feature = "dns-over-openssl"
+        ))]
         Some(NxProofKind::Nsec),
     );
 

--- a/tests/integration-tests/tests/truncation_tests.rs
+++ b/tests/integration-tests/tests/truncation_tests.rs
@@ -6,7 +6,11 @@ use hickory_proto::udp::UdpClientStream;
 use hickory_proto::xfer::FirstAnswer;
 use hickory_proto::DnsHandle;
 use hickory_server::authority::{Catalog, ZoneType};
-#[cfg(any(feature = "dnssec", feature = "dns-over-rustls"))]
+#[cfg(any(
+    feature = "dnssec",
+    feature = "dns-over-rustls",
+    feature = "dns-over-openssl"
+))]
 use hickory_server::config::dnssec::NxProofKind;
 use hickory_server::store::in_memory::InMemoryAuthority;
 use hickory_server::ServerFuture;
@@ -107,7 +111,11 @@ pub fn new_large_catalog(num_records: u32) -> Catalog {
         records,
         ZoneType::Primary,
         false,
-        #[cfg(any(feature = "dnssec", feature = "dns-over-rustls"))]
+        #[cfg(any(
+            feature = "dnssec",
+            feature = "dns-over-rustls",
+            feature = "dns-over-openssl"
+        ))]
         Some(NxProofKind::Nsec),
     )
     .unwrap();


### PR DESCRIPTION
I noticed that `just dns-over-openssl` was testing the wrong Cargo feature, thus `dns-over-openssl` hasn't had CI coverage for some time. I fixed that, along with various related bitrot problems.