### PR TITLE
SignSettings: rm use_dnssec field

### DIFF
--- a/conformance/packages/conformance-tests/src/name_server/rfc5155.rs
+++ b/conformance/packages/conformance-tests/src/name_server/rfc5155.rs
@@ -301,11 +301,7 @@ fn query_nameserver(
         ns.add(record);
     }
 
-    let mut sign_settings = SignSettings::default();
-
-    if dns_test::SUBJECT.is_hickory() {
-        sign_settings = sign_settings.use_dnssec(true);
-    }
+    let sign_settings = SignSettings::default();
 
     let ns = ns.sign(sign_settings)?;
 

--- a/conformance/packages/dns-test/src/zone_file/signer.rs
+++ b/conformance/packages/dns-test/src/zone_file/signer.rs
@@ -27,7 +27,6 @@ pub struct SignSettings {
     expiration: Option<u64>,
     inception: Option<u64>,
     nsec_salt: Option<String>,
-    use_dnssec: bool,
 }
 
 impl SignSettings {
@@ -39,7 +38,6 @@ impl SignSettings {
             expiration: None,
             inception: None,
             nsec_salt: None,
-            use_dnssec: false,
         }
     }
 
@@ -51,7 +49,6 @@ impl SignSettings {
             expiration: None,
             inception: None,
             nsec_salt: None,
-            use_dnssec: false,
         }
     }
 
@@ -63,7 +60,6 @@ impl SignSettings {
             expiration: None,
             inception: None,
             nsec_salt: None,
-            use_dnssec: false,
         }
     }
 
@@ -76,7 +72,6 @@ impl SignSettings {
             expiration: None,
             inception: None,
             nsec_salt: None,
-            use_dnssec: false,
         }
     }
 
@@ -101,11 +96,6 @@ impl SignSettings {
     /// Sets the NSEC3 salt string.
     pub fn salt(mut self, salt: &str) -> Self {
         self.nsec_salt = Some(salt.to_string());
-        self
-    }
-
-    pub fn use_dnssec(mut self, doit: bool) -> Self {
-        self.use_dnssec = doit;
         self
     }
 }
@@ -211,7 +201,7 @@ impl<'a> Signer<'a> {
             signed,
             ksk,
             zsk,
-            use_dnssec: self.settings.use_dnssec,
+            use_dnssec: true,
         })
     }
 


### PR DESCRIPTION
if the zone is being signed then DNSSEC has to be enabled as RRSIG are DNSSEC records.

I understand that `Config::Nameserver.use_dnssec` is being used to enable runtime signing in hickory but *not* enabling that when `SignSettings` is used would lead to a situation where other `SUBJECT`s (e.g. unbound) are signing their zones and hickory is not which would be a wrongly set up test.

also, to me it seems that `Config::Nameserver.use_dnssec` should have type `Option<SignSettings>` (and be called something else) and that `Implementation::format_config` should panic if settings not supported by hickory are used, e.g. opt-out maybe?

r? @pvdrz 