### PR TITLE
Set up tracing subscriber in various tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -131,9 +131,6 @@ updates:
   - dependency-name: h2
     versions:
     - 0.3.1
-  - dependency-name: env_logger
-    versions:
-    - 0.8.3
   - dependency-name: idna
     versions:
     - 0.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,8 @@ dependencies = [
  "hickory-resolver",
  "pin-utils",
  "socket2",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ hickory-proto = { version = "0.25.0-alpha.2", path = "crates/proto", default-fea
 
 # logging
 tracing = "0.1.30"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "std"] }
 thiserror = "1.0.20"
 
 

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -65,7 +65,7 @@ futures-util = { workspace = true, default-features = false, features = ["std"] 
 rustls = { workspace = true, optional = true }
 time.workspace = true
 tracing.workspace = true
-tracing-subscriber = { workspace = true, features = ["fmt", "env-filter", "std"] }
+tracing-subscriber.workspace = true
 tokio = { workspace = true, features = ["time", "rt"] }
 hickory-client.workspace = true
 hickory-proto.workspace = true

--- a/bin/tests/integration/main.rs
+++ b/bin/tests/integration/main.rs
@@ -1,3 +1,5 @@
+use std::sync::Once;
+
 mod named_https_tests;
 mod named_openssl_tests;
 mod named_quic_tests;
@@ -5,3 +7,16 @@ mod named_rustls_tests;
 mod named_test_rsa_dnssec;
 mod named_tests;
 mod server_harness;
+
+/// Registers a global default tracing subscriber when called for the first time. This is intended
+/// for use in tests.
+fn subscribe() {
+    static INSTALL_TRACING_SUBSCRIBER: Once = Once::new();
+    INSTALL_TRACING_SUBSCRIBER.call_once(|| {
+        let subscriber = tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_test_writer()
+            .finish();
+        tracing::subscriber::set_global_default(subscriber).unwrap();
+    });
+}

--- a/bin/tests/integration/named_https_tests.rs
+++ b/bin/tests/integration/named_https_tests.rs
@@ -24,10 +24,11 @@ use tokio::net::TcpStream as TokioTcpStream;
 use tokio::runtime::Runtime;
 
 use crate::server_harness::{named_test_harness, query_a};
+use crate::subscribe;
 
 #[test]
 fn test_example_https_toml_startup() {
-    // env_logger::try_init().ok();
+    subscribe();
 
     const ALPN_H2: &[u8] = b"h2";
 

--- a/bin/tests/integration/named_quic_tests.rs
+++ b/bin/tests/integration/named_quic_tests.rs
@@ -16,11 +16,14 @@ use hickory_server::server::Protocol;
 use rustls::{pki_types::CertificateDer, ClientConfig, RootCertStore};
 use tokio::runtime::Runtime;
 
-use crate::server_harness::{named_test_harness, query_a};
+use crate::{
+    server_harness::{named_test_harness, query_a},
+    subscribe,
+};
 
 #[test]
 fn test_example_quic_toml_startup() {
-    // env_logger::try_init().ok();
+    subscribe();
 
     named_test_harness("dns_over_quic.toml", move |socket_ports| {
         let mut cert_der = vec![];

--- a/bin/tests/integration/named_tests.rs
+++ b/bin/tests/integration/named_tests.rs
@@ -22,9 +22,12 @@ use tokio::net::UdpSocket as TokioUdpSocket;
 use tokio::runtime::Runtime;
 
 use crate::server_harness::{named_test_harness, query_a, query_a_refused};
+use crate::subscribe;
 
 #[test]
 fn test_example_toml_startup() {
+    subscribe();
+
     named_test_harness("example.toml", |socket_ports| {
         let mut io_loop = Runtime::new().unwrap();
         let tcp_port = socket_ports.get_v4(Protocol::Tcp);
@@ -283,10 +286,10 @@ fn test_server_continues_on_bad_data_tcp() {
 #[test]
 #[cfg(feature = "resolver")]
 fn test_forward() {
-    use crate::server_harness::query_message;
+    use crate::{server_harness::query_message, subscribe};
     use hickory_proto::rr::rdata::A;
 
-    //env_logger::init();
+    subscribe();
 
     named_test_harness("example_forwarder.toml", |socket_ports| {
         let mut io_loop = Runtime::new().unwrap();

--- a/crates/async-std-resolver/Cargo.toml
+++ b/crates/async-std-resolver/Cargo.toml
@@ -64,6 +64,8 @@ socket2.workspace = true
 [dev-dependencies]
 async-std = { workspace = true, features = ["attributes"] }
 hickory-resolver = { workspace = true, default-features = false, features = ["testing"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -82,7 +82,7 @@ hickory-proto = { workspace = true, features = ["text-parsing", "tokio-runtime"]
 [dev-dependencies]
 futures = { workspace = true, default-features = false, features = ["std", "executor"] }
 tokio = { workspace = true, features = ["rt", "macros"] }
-tracing-subscriber = { workspace = true, features = ["fmt", "env-filter", "std"] }
+tracing-subscriber.workspace = true
 webpki-roots = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -122,7 +122,7 @@ webpki-roots = { workspace = true, optional = true }
 futures-executor = { workspace = true, default-features = false, features = ["std"] }
 openssl = { workspace = true, features = ["v102", "v110"] }
 tokio = { workspace = true, features = ["rt", "time", "macros"] }
-tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "std"] }
+tracing-subscriber.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/proto/src/h2/h2_client_stream.rs
+++ b/crates/proto/src/h2/h2_client_stream.rs
@@ -542,13 +542,14 @@ mod tests {
     use crate::op::{Message, Query, ResponseCode};
     use crate::rr::rdata::{A, AAAA};
     use crate::rr::{Name, RecordType};
+    use crate::tests::subscribe;
     use crate::xfer::{DnsRequestOptions, FirstAnswer};
 
     use super::*;
 
     #[test]
     fn test_https_google() {
-        //env_logger::try_init().ok();
+        subscribe();
 
         let google = SocketAddr::from(([8, 8, 8, 8], 443));
         let mut request = Message::new();
@@ -610,7 +611,7 @@ mod tests {
 
     #[test]
     fn test_https_google_with_pure_ip_address_server() {
-        //env_logger::try_init().ok();
+        subscribe();
 
         let google = SocketAddr::from(([8, 8, 8, 8], 443));
         let mut request = Message::new();
@@ -673,7 +674,7 @@ mod tests {
     #[test]
     #[ignore] // cloudflare has been unreliable as a public test service.
     fn test_https_cloudflare() {
-        // self::env_logger::try_init().ok();
+        subscribe();
 
         let cloudflare = SocketAddr::from(([1, 1, 1, 1], 443));
         let mut request = Message::new();

--- a/crates/proto/src/h3/h3_client_stream.rs
+++ b/crates/proto/src/h3/h3_client_stream.rs
@@ -466,13 +466,14 @@ mod tests {
     use crate::op::{Message, Query, ResponseCode};
     use crate::rr::rdata::{A, AAAA};
     use crate::rr::{Name, RecordType};
+    use crate::tests::subscribe;
     use crate::xfer::{DnsRequestOptions, FirstAnswer};
 
     use super::*;
 
     #[test]
     fn test_h3_google() {
-        //env_logger::try_init().ok();
+        subscribe();
 
         let google = SocketAddr::from(([8, 8, 8, 8], 443));
         let mut request = Message::new();
@@ -534,7 +535,7 @@ mod tests {
 
     #[test]
     fn test_h3_google_with_pure_ip_address_server() {
-        //env_logger::try_init().ok();
+        subscribe();
 
         let google = SocketAddr::from(([8, 8, 8, 8], 443));
         let mut request = Message::new();
@@ -598,7 +599,7 @@ mod tests {
     #[test]
     #[ignore] // cloudflare has been unreliable as a public test service.
     fn test_h3_cloudflare() {
-        // self::env_logger::try_init().ok();
+        subscribe();
 
         let cloudflare = SocketAddr::from(([1, 1, 1, 1], 443));
         let mut request = Message::new();

--- a/crates/proto/src/multicast/mdns_stream.rs
+++ b/crates/proto/src/multicast/mdns_stream.rs
@@ -427,7 +427,7 @@ pub(crate) mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
 
     use super::*;
-    use crate::xfer::dns_handle::DnsStreamHandle;
+    use crate::{tests::subscribe, xfer::dns_handle::DnsStreamHandle};
     use futures_util::future::Either;
     use tokio::runtime;
 
@@ -443,8 +443,7 @@ pub(crate) mod tests {
     // one_shot tests are basically clones from the udp tests
     #[test]
     fn test_next_random_socket() {
-        // use env_logger;
-        // env_logger::init();
+        subscribe();
 
         let io_loop = runtime::Runtime::new().unwrap();
         let (stream, _) = MdnsStream::new(

--- a/crates/proto/src/tests/mod.rs
+++ b/crates/proto/src/tests/mod.rs
@@ -10,3 +10,20 @@ pub use self::tcp::tcp_stream_test;
 pub use self::udp::next_random_socket_test;
 pub use self::udp::udp_client_stream_test;
 pub use self::udp::udp_stream_test;
+
+/// Registers a global default tracing subscriber when called for the first time. This is intended
+/// for use in tests.
+#[cfg(test)]
+#[allow(dead_code)]
+pub(crate) fn subscribe() {
+    use std::sync::Once;
+
+    static INSTALL_TRACING_SUBSCRIBER: Once = Once::new();
+    INSTALL_TRACING_SUBSCRIBER.call_once(|| {
+        let subscriber = tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_test_writer()
+            .finish();
+        tracing::subscriber::set_global_default(subscriber).unwrap();
+    });
+}

--- a/crates/proto/src/tests/udp.rs
+++ b/crates/proto/src/tests/udp.rs
@@ -125,9 +125,6 @@ pub fn udp_client_stream_test<S: UdpSocket + Send + 'static, E: Executor>(
     use std::str::FromStr;
     use std::time::Duration;
 
-    // use env_logger;
-    // env_logger::try_init().ok();
-
     let succeeded = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let succeeded_clone = succeeded.clone();
     std::thread::Builder::new()

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -416,12 +416,13 @@ async fn send_serial_message_inner<S: DnsUdpSocket + Send>(
 #[cfg(feature = "tokio-runtime")]
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
-    use crate::tests::udp_client_stream_test;
+    use crate::tests::{subscribe, udp_client_stream_test};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use tokio::{net::UdpSocket as TokioUdpSocket, runtime::Runtime};
 
     #[test]
     fn test_udp_client_stream_ipv4() {
+        subscribe();
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
         udp_client_stream_test::<TokioUdpSocket, Runtime>(
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
@@ -431,6 +432,7 @@ mod tests {
 
     #[test]
     fn test_udp_client_stream_ipv6() {
+        subscribe();
         let io_loop = Runtime::new().expect("failed to create tokio runtime");
         udp_client_stream_test::<TokioUdpSocket, Runtime>(
             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),

--- a/crates/recursor/Cargo.toml
+++ b/crates/recursor/Cargo.toml
@@ -118,7 +118,7 @@ hickory-resolver = { workspace = true, features = ["tokio-runtime"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
-tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "std"] }
+tracing-subscriber.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -106,7 +106,7 @@ ipconfig = { workspace = true, optional = true }
 [dev-dependencies]
 futures-executor = { workspace = true, default-features = false, features = ["std"] }
 tokio = { workspace = true, features = ["macros", "test-util"] }
-tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "std"] }
+tracing-subscriber.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -237,12 +237,13 @@ mod tests {
     use proto::xfer::{DnsHandle, DnsRequestOptions, FirstAnswer};
 
     use super::*;
+    use crate::async_resolver::testing::subscribe;
     use crate::config::Protocol;
     use crate::name_server::TokioConnectionProvider;
 
     #[test]
     fn test_name_server() {
-        //env_logger::try_init().ok();
+        subscribe();
 
         let config = NameServerConfig {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53),

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -132,7 +132,7 @@ hickory-resolver = { workspace = true, features = ["serde", "system-config", "to
 [dev-dependencies]
 futures-executor = { workspace = true, default-features = false, features = ["std"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
-tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "std"] }
+tracing-subscriber.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/server/tests/integration/authority_battery/basic.rs
+++ b/crates/server/tests/integration/authority_battery/basic.rs
@@ -733,8 +733,7 @@ macro_rules! define_basic_test {
         $(
             #[test]
             fn $f () {
-                // Useful for getting debug logs
-                // env_logger::try_init().ok();
+                subscribe();
 
                 let authority = $new("../../tests/test-data/test_configs/example.com.zone", module_path!(), stringify!($f));
                 crate::authority_battery::basic::$f(authority);
@@ -748,6 +747,8 @@ macro_rules! basic_battery {
         #[cfg(test)]
         mod basic {
             mod $name {
+                use crate::subscribe;
+
                 define_basic_test!($new;
                     test_a_lookup,
                     test_soa,

--- a/crates/server/tests/integration/main.rs
+++ b/crates/server/tests/integration/main.rs
@@ -1,5 +1,7 @@
 #![recursion_limit = "128"]
 
+use std::sync::Once;
+
 #[macro_use]
 mod authority_battery;
 mod config_tests;
@@ -10,3 +12,16 @@ mod store_file_tests;
 mod store_sqlite_tests;
 mod timeout_stream_tests;
 mod txt_tests;
+
+/// Registers a global default tracing subscriber when called for the first time. This is intended
+/// for use in tests.
+fn subscribe() {
+    static INSTALL_TRACING_SUBSCRIBER: Once = Once::new();
+    INSTALL_TRACING_SUBSCRIBER.call_once(|| {
+        let subscriber = tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_test_writer()
+            .finish();
+        tracing::subscriber::set_global_default(subscriber).unwrap();
+    });
+}

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -109,8 +109,4 @@ webpki-roots = { workspace = true, optional = true }
 [dev-dependencies]
 futures = { workspace = true, features = ["thread-pool"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
-tracing-subscriber = { workspace = true, features = [
-    "std",
-    "fmt",
-    "env-filter",
-] }
+tracing-subscriber.workspace = true

--- a/tests/integration-tests/tests/integration/client_future_tests.rs
+++ b/tests/integration-tests/tests/integration/client_future_tests.rs
@@ -45,9 +45,11 @@ use hickory_integration::{
     example_authority::create_example, NeverReturnsClientStream, TestClientStream,
 };
 
+use crate::subscribe;
+
 #[test]
 fn test_query_nonet() {
-    // env_logger::init();
+    subscribe();
 
     let authority = create_example();
     let mut catalog = Catalog::new();
@@ -977,7 +979,7 @@ fn test_timeout_query(mut client: AsyncClient, io_loop: Runtime) {
 
 #[test]
 fn test_timeout_query_nonet() {
-    //env_logger::try_init().ok();
+    subscribe();
     let io_loop = Runtime::new().expect("failed to create Tokio Runtime");
     let (stream, sender) = NeverReturnsClientStream::new();
     let client =
@@ -990,7 +992,7 @@ fn test_timeout_query_nonet() {
 
 #[test]
 fn test_timeout_query_udp() {
-    //env_logger::try_init().ok();
+    subscribe();
     let io_loop = Runtime::new().unwrap();
 
     // this is a test network, it should NOT be in use
@@ -1011,7 +1013,7 @@ fn test_timeout_query_udp() {
 
 #[test]
 fn test_timeout_query_tcp() {
-    //env_logger::try_init().ok();
+    subscribe();
     let io_loop = Runtime::new().unwrap();
 
     // this is a test network, it should NOT be in use

--- a/tests/integration-tests/tests/integration/client_tests.rs
+++ b/tests/integration-tests/tests/integration/client_tests.rs
@@ -29,6 +29,8 @@ use hickory_proto::rr::{rdata::A, DNSClass, Name, RData, RecordType};
 use hickory_proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect};
 use hickory_server::authority::{Authority, Catalog};
 
+use crate::subscribe;
+
 pub struct TestClientConnection {
     catalog: Arc<StdMutex<Catalog>>,
 }
@@ -195,7 +197,7 @@ where
 #[allow(deprecated)]
 #[cfg(feature = "dnssec")]
 fn test_secure_query_example_udp() {
-    // env_logger::init();
+    subscribe();
 
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
     let conn = UdpClientConnection::new(addr).unwrap();
@@ -208,7 +210,7 @@ fn test_secure_query_example_udp() {
 #[allow(deprecated)]
 #[cfg(feature = "dnssec")]
 fn test_secure_query_example_tcp() {
-    // env_logger::init();
+    subscribe();
 
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
     let conn = TcpClientConnection::new(addr).unwrap();
@@ -222,7 +224,7 @@ fn test_secure_query_example<CC>(client: SyncDnssecClient<CC>)
 where
     CC: ClientConnection,
 {
-    // env_logger::try_init().ok();
+    subscribe();
 
     let name = Name::from_str("www.example.com").unwrap();
 
@@ -268,7 +270,7 @@ where
 
 #[test]
 fn test_timeout_query_nonet() {
-    // env_logger::try_init().ok();
+    subscribe();
     // TODO: need to add timeout length to SyncClient
     let client = SyncClient::new(NeverReturnsClientConnection::new().unwrap());
     test_timeout_query(client);

--- a/tests/integration-tests/tests/integration/main.rs
+++ b/tests/integration-tests/tests/integration/main.rs
@@ -1,3 +1,5 @@
+use std::sync::Once;
+
 mod catalog_tests;
 mod client_future_tests;
 mod client_tests;
@@ -8,3 +10,16 @@ mod retry_dns_handle_tests;
 mod server_future_tests;
 mod sqlite_authority_tests;
 mod truncation_tests;
+
+/// Registers a global default tracing subscriber when called for the first time. This is intended
+/// for use in tests.
+fn subscribe() {
+    static INSTALL_TRACING_SUBSCRIBER: Once = Once::new();
+    INSTALL_TRACING_SUBSCRIBER.call_once(|| {
+        let subscriber = tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_test_writer()
+            .finish();
+        tracing::subscriber::set_global_default(subscriber).unwrap();
+    });
+}

--- a/tests/integration-tests/tests/integration/truncation_tests.rs
+++ b/tests/integration-tests/tests/integration/truncation_tests.rs
@@ -20,9 +20,11 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tokio::net::UdpSocket;
 
+use crate::subscribe;
+
 #[tokio::test]
 async fn test_truncation() {
-    let _guard = subscribe();
+    subscribe();
 
     let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 0));
     let udp_socket = UdpSocket::bind(&addr).await.unwrap();
@@ -65,14 +67,6 @@ async fn test_truncation() {
     assert_eq!(max_payload, result.max_payload());
 
     server.shutdown_gracefully().await.unwrap();
-}
-
-// TODO: should we do this for all of the integration tests?
-fn subscribe() -> tracing::subscriber::DefaultGuard {
-    let sub = tracing_subscriber::FmtSubscriber::builder()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .finish();
-    tracing::subscriber::set_default(sub)
 }
 
 pub fn new_large_catalog(num_records: u32) -> Catalog {

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -101,11 +101,7 @@ openssl = { workspace = true, features = ["v102", "v110"], optional = true }
 rustls = { workspace = true, optional = true }
 rustls-native-certs = { workspace = true, optional = true }
 tracing.workspace = true
-tracing-subscriber = { workspace = true, features = [
-    "std",
-    "fmt",
-    "env-filter",
-] }
+tracing-subscriber. workspace = true
 hickory-client.workspace = true
 hickory-proto.workspace = true
 hickory-recursor.workspace = true


### PR DESCRIPTION
This PR sets up a tracing subscriber in various tests that currently have a commented-out `env_logger` initialization. The one existing use of tracing subscribers in a test is converted over to match, so it uses `tracing::subscriber::set_global_default()` instead of `tracing::subscriber::set_default()`, since the latter only works on the current thread. This closes #2445.