### PR TITLE
Extract tracing-subscriber setup to new crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,8 +266,7 @@ dependencies = [
  "hickory-resolver",
  "pin-utils",
  "socket2",
- "tracing",
- "tracing-subscriber",
+ "test-support",
 ]
 
 [[package]]
@@ -854,6 +853,7 @@ dependencies = [
  "native-tls",
  "regex",
  "rustls",
+ "test-support",
  "time",
  "tokio",
  "tracing",
@@ -876,6 +876,7 @@ dependencies = [
  "rand",
  "rusqlite",
  "rustls",
+ "test-support",
  "time",
  "tokio",
  "tracing",
@@ -918,6 +919,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "socket2",
+ "test-support",
  "thiserror",
  "time",
  "tinyvec",
@@ -976,6 +978,7 @@ dependencies = [
  "rustls-native-certs",
  "serde",
  "smallvec",
+ "test-support",
  "thiserror",
  "tokio",
  "tokio-native-tls",
@@ -1010,6 +1013,7 @@ dependencies = [
  "rusqlite",
  "rustls",
  "serde",
+ "test-support",
  "thiserror",
  "time",
  "tokio",
@@ -1922,6 +1926,14 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "test-support"
+version = "0.25.0-alpha.2"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "util",
     "tests/compatibility-tests",
     "tests/integration-tests",
+    "tests/test-support",
 ]
 exclude = ["fuzz"]
 
@@ -33,6 +34,7 @@ hickory-recursor = { version = "0.25.0-alpha.2", path = "crates/recursor", defau
 hickory-resolver = { version = "0.25.0-alpha.2", path = "crates/resolver", default-features = false }
 hickory-server = { version = "0.25.0-alpha.2", path = "crates/server", default-features = false }
 hickory-proto = { version = "0.25.0-alpha.2", path = "crates/proto", default-features = false }
+test-support.path = "tests/test-support"
 
 
 # logging

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -76,6 +76,7 @@ native-tls.workspace = true
 regex.workspace = true
 hickory-proto = { workspace = true, features = ["dns-over-native-tls", "testing"] }
 hickory-resolver.workspace = true
+test-support.workspace = true
 webpki-roots.workspace = true
 
 [lints]

--- a/bin/tests/integration/main.rs
+++ b/bin/tests/integration/main.rs
@@ -1,5 +1,3 @@
-use std::sync::Once;
-
 mod named_https_tests;
 mod named_openssl_tests;
 mod named_quic_tests;
@@ -7,16 +5,3 @@ mod named_rustls_tests;
 mod named_test_rsa_dnssec;
 mod named_tests;
 mod server_harness;
-
-/// Registers a global default tracing subscriber when called for the first time. This is intended
-/// for use in tests.
-fn subscribe() {
-    static INSTALL_TRACING_SUBSCRIBER: Once = Once::new();
-    INSTALL_TRACING_SUBSCRIBER.call_once(|| {
-        let subscriber = tracing_subscriber::FmtSubscriber::builder()
-            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-            .with_test_writer()
-            .finish();
-        tracing::subscriber::set_global_default(subscriber).unwrap();
-    });
-}

--- a/bin/tests/integration/named_https_tests.rs
+++ b/bin/tests/integration/named_https_tests.rs
@@ -20,11 +20,11 @@ use hickory_proto::iocompat::AsyncIoTokioAsStd;
 use hickory_server::server::Protocol;
 use rustls::pki_types::CertificateDer;
 use rustls::{ClientConfig, RootCertStore};
+use test_support::subscribe;
 use tokio::net::TcpStream as TokioTcpStream;
 use tokio::runtime::Runtime;
 
 use crate::server_harness::{named_test_harness, query_a};
-use crate::subscribe;
 
 #[test]
 fn test_example_https_toml_startup() {

--- a/bin/tests/integration/named_quic_tests.rs
+++ b/bin/tests/integration/named_quic_tests.rs
@@ -14,12 +14,10 @@ use hickory_client::client::*;
 use hickory_proto::quic::QuicClientStream;
 use hickory_server::server::Protocol;
 use rustls::{pki_types::CertificateDer, ClientConfig, RootCertStore};
+use test_support::subscribe;
 use tokio::runtime::Runtime;
 
-use crate::{
-    server_harness::{named_test_harness, query_a},
-    subscribe,
-};
+use crate::server_harness::{named_test_harness, query_a};
 
 #[test]
 fn test_example_quic_toml_startup() {

--- a/bin/tests/integration/named_tests.rs
+++ b/bin/tests/integration/named_tests.rs
@@ -17,12 +17,12 @@ use hickory_proto::udp::UdpClientStream;
 
 use hickory_client::client::*;
 use hickory_server::server::Protocol;
+use test_support::subscribe;
 use tokio::net::TcpStream as TokioTcpStream;
 use tokio::net::UdpSocket as TokioUdpSocket;
 use tokio::runtime::Runtime;
 
 use crate::server_harness::{named_test_harness, query_a, query_a_refused};
-use crate::subscribe;
 
 #[test]
 fn test_example_toml_startup() {
@@ -286,7 +286,7 @@ fn test_server_continues_on_bad_data_tcp() {
 #[test]
 #[cfg(feature = "resolver")]
 fn test_forward() {
-    use crate::{server_harness::query_message, subscribe};
+    use crate::server_harness::query_message;
     use hickory_proto::rr::rdata::A;
 
     subscribe();

--- a/crates/async-std-resolver/Cargo.toml
+++ b/crates/async-std-resolver/Cargo.toml
@@ -64,8 +64,7 @@ socket2.workspace = true
 [dev-dependencies]
 async-std = { workspace = true, features = ["attributes"] }
 hickory-resolver = { workspace = true, default-features = false, features = ["testing"] }
-tracing.workspace = true
-tracing-subscriber.workspace = true
+test-support.workspace = true
 
 [lints]
 workspace = true

--- a/crates/async-std-resolver/src/tests.rs
+++ b/crates/async-std-resolver/src/tests.rs
@@ -1,9 +1,8 @@
 #![allow(clippy::extra_unused_type_parameters)]
 
-use std::sync::Once;
-
 use hickory_resolver::name_server::GenericConnection;
 use hickory_resolver::testing;
+use test_support::subscribe;
 
 use crate::config::{ResolverConfig, ResolverOpts};
 use crate::lookup::LookupFuture;
@@ -219,17 +218,4 @@ fn test_search_ipv6_name_parse_fails() {
         io_loop.clone(),
         io_loop,
     );
-}
-
-/// Registers a global default tracing subscriber when called for the first time. This is intended
-/// for use in tests.
-fn subscribe() {
-    static INSTALL_TRACING_SUBSCRIBER: Once = Once::new();
-    INSTALL_TRACING_SUBSCRIBER.call_once(|| {
-        let subscriber = tracing_subscriber::FmtSubscriber::builder()
-            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-            .with_test_writer()
-            .finish();
-        tracing::subscriber::set_global_default(subscriber).unwrap();
-    });
 }

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -121,6 +121,7 @@ webpki-roots = { workspace = true, optional = true }
 [dev-dependencies]
 futures-executor = { workspace = true, default-features = false, features = ["std"] }
 openssl = { workspace = true, features = ["v102", "v110"] }
+test-support.workspace = true
 tokio = { workspace = true, features = ["rt", "time", "macros"] }
 tracing-subscriber.workspace = true
 

--- a/crates/proto/src/h2/h2_client_stream.rs
+++ b/crates/proto/src/h2/h2_client_stream.rs
@@ -535,6 +535,7 @@ mod tests {
     use std::str::FromStr;
 
     use rustls::KeyLogFile;
+    use test_support::subscribe;
     use tokio::net::TcpStream as TokioTcpStream;
     use tokio::runtime::Runtime;
 
@@ -542,7 +543,6 @@ mod tests {
     use crate::op::{Message, Query, ResponseCode};
     use crate::rr::rdata::{A, AAAA};
     use crate::rr::{Name, RecordType};
-    use crate::tests::subscribe;
     use crate::xfer::{DnsRequestOptions, FirstAnswer};
 
     use super::*;

--- a/crates/proto/src/h3/h3_client_stream.rs
+++ b/crates/proto/src/h3/h3_client_stream.rs
@@ -460,13 +460,13 @@ mod tests {
     use std::str::FromStr;
 
     use rustls::KeyLogFile;
+    use test_support::subscribe;
     use tokio::runtime::Runtime;
     use tokio::task::JoinSet;
 
     use crate::op::{Message, Query, ResponseCode};
     use crate::rr::rdata::{A, AAAA};
     use crate::rr::{Name, RecordType};
-    use crate::tests::subscribe;
     use crate::xfer::{DnsRequestOptions, FirstAnswer};
 
     use super::*;

--- a/crates/proto/src/multicast/mdns_stream.rs
+++ b/crates/proto/src/multicast/mdns_stream.rs
@@ -427,8 +427,9 @@ pub(crate) mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
 
     use super::*;
-    use crate::{tests::subscribe, xfer::dns_handle::DnsStreamHandle};
+    use crate::xfer::dns_handle::DnsStreamHandle;
     use futures_util::future::Either;
+    use test_support::subscribe;
     use tokio::runtime;
 
     // TODO: is there a better way?

--- a/crates/proto/src/tests/mod.rs
+++ b/crates/proto/src/tests/mod.rs
@@ -10,20 +10,3 @@ pub use self::tcp::tcp_stream_test;
 pub use self::udp::next_random_socket_test;
 pub use self::udp::udp_client_stream_test;
 pub use self::udp::udp_stream_test;
-
-/// Registers a global default tracing subscriber when called for the first time. This is intended
-/// for use in tests.
-#[cfg(test)]
-#[allow(dead_code)]
-pub(crate) fn subscribe() {
-    use std::sync::Once;
-
-    static INSTALL_TRACING_SUBSCRIBER: Once = Once::new();
-    INSTALL_TRACING_SUBSCRIBER.call_once(|| {
-        let subscriber = tracing_subscriber::FmtSubscriber::builder()
-            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-            .with_test_writer()
-            .finish();
-        tracing::subscriber::set_global_default(subscriber).unwrap();
-    });
-}

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -416,8 +416,9 @@ async fn send_serial_message_inner<S: DnsUdpSocket + Send>(
 #[cfg(feature = "tokio-runtime")]
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
-    use crate::tests::{subscribe, udp_client_stream_test};
+    use crate::tests::udp_client_stream_test;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use test_support::subscribe;
     use tokio::{net::UdpSocket as TokioUdpSocket, runtime::Runtime};
 
     #[test]

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -105,6 +105,7 @@ ipconfig = { workspace = true, optional = true }
 
 [dev-dependencies]
 futures-executor = { workspace = true, default-features = false, features = ["std"] }
+test-support.workspace = true
 tokio = { workspace = true, features = ["macros", "test-util"] }
 tracing-subscriber.workspace = true
 

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -1039,22 +1039,6 @@ pub mod testing {
             IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0xc633, 0x6423))
         );
     }
-
-    /// Registers a global default tracing subscriber when called for the first time. This is intended
-    /// for use in tests.
-    #[cfg(test)]
-    pub(crate) fn subscribe() {
-        use std::sync::Once;
-
-        static INSTALL_TRACING_SUBSCRIBER: Once = Once::new();
-        INSTALL_TRACING_SUBSCRIBER.call_once(|| {
-            let subscriber = tracing_subscriber::FmtSubscriber::builder()
-                .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-                .with_test_writer()
-                .finish();
-            tracing::subscriber::set_global_default(subscriber).unwrap();
-        });
-    }
 }
 
 #[cfg(test)]
@@ -1062,6 +1046,7 @@ pub mod testing {
 #[allow(clippy::extra_unused_type_parameters)]
 mod tests {
     use proto::xfer::DnsRequest;
+    use test_support::subscribe;
     use tokio::runtime::Runtime;
 
     use crate::config::{ResolverConfig, ResolverOpts};
@@ -1139,7 +1124,8 @@ mod tests {
     #[test]
     #[cfg(feature = "dnssec")]
     fn test_sec_lookup() {
-        use super::testing::{sec_lookup_test, subscribe};
+        use super::testing::sec_lookup_test;
+        use test_support::subscribe;
         subscribe();
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
         let handle = TokioConnectionProvider::default();
@@ -1204,7 +1190,7 @@ mod tests {
 
     #[test]
     fn test_domain_search() {
-        use super::testing::{domain_search_test, subscribe};
+        use super::testing::domain_search_test;
         subscribe();
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
         let handle = TokioConnectionProvider::default();

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -230,6 +230,7 @@ mod tests {
     use std::time::Duration;
 
     use futures_util::{future, FutureExt};
+    use test_support::subscribe;
     use tokio::runtime::Runtime;
 
     use proto::op::{Query, ResponseCode};
@@ -237,7 +238,6 @@ mod tests {
     use proto::xfer::{DnsHandle, DnsRequestOptions, FirstAnswer};
 
     use super::*;
-    use crate::async_resolver::testing::subscribe;
     use crate::config::Protocol;
     use crate::name_server::TokioConnectionProvider;
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -131,6 +131,7 @@ hickory-resolver = { workspace = true, features = ["serde", "system-config", "to
 
 [dev-dependencies]
 futures-executor = { workspace = true, default-features = false, features = ["std"] }
+test-support.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 tracing-subscriber.workspace = true
 

--- a/crates/server/tests/integration/authority_battery/basic.rs
+++ b/crates/server/tests/integration/authority_battery/basic.rs
@@ -747,7 +747,7 @@ macro_rules! basic_battery {
         #[cfg(test)]
         mod basic {
             mod $name {
-                use crate::subscribe;
+                use test_support::subscribe;
 
                 define_basic_test!($new;
                     test_a_lookup,

--- a/crates/server/tests/integration/main.rs
+++ b/crates/server/tests/integration/main.rs
@@ -1,7 +1,5 @@
 #![recursion_limit = "128"]
 
-use std::sync::Once;
-
 #[macro_use]
 mod authority_battery;
 mod config_tests;
@@ -12,16 +10,3 @@ mod store_file_tests;
 mod store_sqlite_tests;
 mod timeout_stream_tests;
 mod txt_tests;
-
-/// Registers a global default tracing subscriber when called for the first time. This is intended
-/// for use in tests.
-fn subscribe() {
-    static INSTALL_TRACING_SUBSCRIBER: Once = Once::new();
-    INSTALL_TRACING_SUBSCRIBER.call_once(|| {
-        let subscriber = tracing_subscriber::FmtSubscriber::builder()
-            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-            .with_test_writer()
-            .finish();
-        tracing::subscriber::set_global_default(subscriber).unwrap();
-    });
-}

--- a/justfile
+++ b/justfile
@@ -27,28 +27,28 @@ all-features: (default "--all-features")
 no-default-features: (default "--no-default-features" "--ignore=\\{hickory-compatibility\\}")
 
 # Check, build, and test all crates with dns-over-rustls enabled
-dns-over-rustls: (default "--features=dns-over-rustls" "--ignore=\\{async-std-resolver,hickory-compatibility\\}")
+dns-over-rustls: (default "--features=dns-over-rustls" "--ignore=\\{async-std-resolver,hickory-compatibility,test-support\\}")
 
 # Check, build, and test all crates with dns-over-https-rustls enabled
-dns-over-https-rustls: (default "--features=dns-over-https-rustls" "--ignore=\\{async-std-resolver,hickory-compatibility\\}")
+dns-over-https-rustls: (default "--features=dns-over-https-rustls" "--ignore=\\{async-std-resolver,hickory-compatibility,test-support\\}")
 
 # Check, build, and test all crates with dns-over-quic enabled
-dns-over-quic: (default "--features=dns-over-quic" "--ignore=\\{async-std-resolver,hickory-compatibility\\}")
+dns-over-quic: (default "--features=dns-over-quic" "--ignore=\\{async-std-resolver,hickory-compatibility,test-support\\}")
 
 # Check, build, and test all crates with dns-over-h3 enabled
-dns-over-h3: (default "--features=dns-over-h3" "--ignore=\\{async-std-resolver,hickory-compatibility,hickory-client\\}")
+dns-over-h3: (default "--features=dns-over-h3" "--ignore=\\{async-std-resolver,hickory-compatibility,hickory-client,test-support\\}")
 
 # Check, build, and test all crates with dns-over-native-tls enabled
-dns-over-native-tls: (default "--features=dns-over-native-tls" "--ignore=\\{async-std-resolver,hickory-compatibility,hickory-server,hickory-dns,hickory-util,hickory-integration\\}")
+dns-over-native-tls: (default "--features=dns-over-native-tls" "--ignore=\\{async-std-resolver,hickory-compatibility,hickory-server,hickory-dns,hickory-util,hickory-integration,test-support\\}")
 
 # Check, build, and test all crates with dns-over-openssl enabled
-dns-over-openssl: (default "--features=dns-over-openssl" "--ignore=\\{async-std-resolver,hickory-compatibility,hickory-util\\}")
+dns-over-openssl: (default "--features=dns-over-openssl" "--ignore=\\{async-std-resolver,hickory-compatibility,hickory-util,test-support\\}")
 
 # Check, build, and test all crates with dnssec-openssl enabled
-dnssec-openssl: (default "--features=dnssec-openssl" "--ignore=\\{async-std-resolver,hickory-compatibility\\}")
+dnssec-openssl: (default "--features=dnssec-openssl" "--ignore=\\{async-std-resolver,hickory-compatibility,test-support\\}")
 
 # Check, build, and test all crates with dnssec-ring enabled
-dnssec-ring: (default "--features=dnssec-ring" "--ignore=\\{async-std-resolver,hickory-compatibility\\}")
+dnssec-ring: (default "--features=dnssec-ring" "--ignore=\\{async-std-resolver,hickory-compatibility,test-support\\}")
 
 # Run check on all projects in the workspace
 check feature='' ignore='':

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -109,4 +109,5 @@ webpki-roots = { workspace = true, optional = true }
 [dev-dependencies]
 futures = { workspace = true, features = ["thread-pool"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
+test-support.workspace = true
 tracing-subscriber.workspace = true

--- a/tests/integration-tests/tests/integration/client_future_tests.rs
+++ b/tests/integration-tests/tests/integration/client_future_tests.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use futures::{Future, FutureExt, TryFutureExt};
+use test_support::subscribe;
 #[cfg(feature = "dnssec")]
 use time::Duration;
 use tokio::{
@@ -44,8 +45,6 @@ use hickory_server::authority::{Authority, Catalog};
 use hickory_integration::{
     example_authority::create_example, NeverReturnsClientStream, TestClientStream,
 };
-
-use crate::subscribe;
 
 #[test]
 fn test_query_nonet() {

--- a/tests/integration-tests/tests/integration/client_tests.rs
+++ b/tests/integration-tests/tests/integration/client_tests.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex as StdMutex};
 
 use futures::Future;
+use test_support::subscribe;
 #[cfg(feature = "dnssec")]
 use time::Duration;
 
@@ -28,8 +29,6 @@ use hickory_proto::rr::Record;
 use hickory_proto::rr::{rdata::A, DNSClass, Name, RData, RecordType};
 use hickory_proto::xfer::{DnsMultiplexer, DnsMultiplexerConnect};
 use hickory_server::authority::{Authority, Catalog};
-
-use crate::subscribe;
 
 pub struct TestClientConnection {
     catalog: Arc<StdMutex<Catalog>>,

--- a/tests/integration-tests/tests/integration/main.rs
+++ b/tests/integration-tests/tests/integration/main.rs
@@ -1,5 +1,3 @@
-use std::sync::Once;
-
 mod catalog_tests;
 mod client_future_tests;
 mod client_tests;
@@ -10,16 +8,3 @@ mod retry_dns_handle_tests;
 mod server_future_tests;
 mod sqlite_authority_tests;
 mod truncation_tests;
-
-/// Registers a global default tracing subscriber when called for the first time. This is intended
-/// for use in tests.
-fn subscribe() {
-    static INSTALL_TRACING_SUBSCRIBER: Once = Once::new();
-    INSTALL_TRACING_SUBSCRIBER.call_once(|| {
-        let subscriber = tracing_subscriber::FmtSubscriber::builder()
-            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-            .with_test_writer()
-            .finish();
-        tracing::subscriber::set_global_default(subscriber).unwrap();
-    });
-}

--- a/tests/integration-tests/tests/integration/truncation_tests.rs
+++ b/tests/integration-tests/tests/integration/truncation_tests.rs
@@ -18,9 +18,8 @@ use std::collections::BTreeMap;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::str::FromStr;
 use std::sync::Arc;
+use test_support::subscribe;
 use tokio::net::UdpSocket;
-
-use crate::subscribe;
 
 #[tokio::test]
 async fn test_truncation() {

--- a/tests/test-support/Cargo.toml
+++ b/tests/test-support/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "test-support"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[lints]
+workspace = true

--- a/tests/test-support/src/lib.rs
+++ b/tests/test-support/src/lib.rs
@@ -1,0 +1,14 @@
+use std::sync::Once;
+
+/// Registers a global default tracing subscriber when called for the first time. This is intended
+/// for use in tests.
+pub fn subscribe() {
+    static INSTALL_TRACING_SUBSCRIBER: Once = Once::new();
+    INSTALL_TRACING_SUBSCRIBER.call_once(|| {
+        let subscriber = tracing_subscriber::FmtSubscriber::builder()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_test_writer()
+            .finish();
+        tracing::subscriber::set_global_default(subscriber).unwrap();
+    });
+}


### PR DESCRIPTION
This is a follow-up to #2453 to extract the duplicated setup function into a new test support crate.