### PR TITLE
Fix CI errors on coverage test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,8 +56,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2024-09-12
           components: llvm-tools-preview
 
       - uses: extractions/setup-just@v2

--- a/justfile
+++ b/justfile
@@ -4,6 +4,7 @@ export TDNS_BIND_PATH := join(TARGET_DIR, "bind")
 export TEST_DATA := join(join(justfile_directory(), "tests"), "test-data")
 
 NIGHTLY_DATE := "2024-05-23"
+COVERAGE_NIGHTLY_DATE := "2024-09-12"
 
 ## MSRV
 MSRV := env_var_or_default('MSRV', "")
@@ -111,13 +112,13 @@ coverage: init-llvm-cov
 
     echo $RUSTFLAGS
 
-    cargo +nightly llvm-cov clean
+    cargo +nightly-{{COVERAGE_NIGHTLY_DATE}} llvm-cov clean
     mkdir -p {{COV_CARGO_LLVM_COV_TARGET_DIR}}
 
-    cargo +nightly build --workspace --all-targets --all-features
-    cargo +nightly llvm-cov test --workspace --no-report --all-targets --all-features
-    cargo +nightly llvm-cov test --workspace --no-report --doc --doctests --all-features
-    cargo +nightly llvm-cov report --codecov --output-path {{join(COV_CARGO_LLVM_COV_TARGET_DIR, "hickory-dns-coverage.json")}}
+    cargo +nightly-{{COVERAGE_NIGHTLY_DATE}} build --workspace --all-targets --all-features
+    cargo +nightly-{{COVERAGE_NIGHTLY_DATE}} llvm-cov test --workspace --no-report --all-targets --all-features
+    cargo +nightly-{{COVERAGE_NIGHTLY_DATE}} llvm-cov test --workspace --no-report --doc --doctests --all-features
+    cargo +nightly-{{COVERAGE_NIGHTLY_DATE}} llvm-cov report --codecov --output-path {{join(COV_CARGO_LLVM_COV_TARGET_DIR, "hickory-dns-coverage.json")}}
 
 # Open the html view of the coverage report
 coverage-html: coverage
@@ -129,7 +130,7 @@ coverage-html: coverage
     export CARGO_LLVM_COV_TARGET_DIR={{COV_CARGO_LLVM_COV_TARGET_DIR}}
     export LLVM_PROFILE_FILE={{COV_LLVM_PROFILE_FILE}}
 
-    cargo +nightly llvm-cov report --html --open --output-dir {{COV_CARGO_LLVM_COV_TARGET_DIR}}
+    cargo +nightly-{{COVERAGE_NIGHTLY_DATE}} llvm-cov report --html --open --output-dir {{COV_CARGO_LLVM_COV_TARGET_DIR}}
 
 # (Re)generates Test Certificates, if tests are failing, this needs to be run yearly
 generate-test-certs: init-openssl


### PR DESCRIPTION
Manually set nightly toolchain version to 2024-09-12 to fix the CI errors with the 2024-09-13 release:

  rustup toolchain install nightly --component llvm-tools-preview --profile minimal --allow-downgrade --no-self-update
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    CARGO_WS_VERSION: 0.2.44
    CARGO_HOME: /home/runner/.cargo
info: syncing channel updates for 'nightly-x86_64-unknown-linux-gnu' info: latest update on 2024-09-13, rust version 1.83.0-nightly (adaff5368 2024-09-12) info: downloading component 'cargo'
info: downloading component 'llvm-tools'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: installing component 'cargo'
info: installing component 'llvm-tools'
info: installing component 'rust-std'
info: installing component 'rustc'
info: rolling back changes
error: failed to install component: 'rustc-x86_64-unknown-linux-gnu', detected conflict: 'lib/rustlib/x86_64-unknown-linux-gnu/bin/llc'