### PR TITLE
Fix udp create immediate polling wrong

### DIFF
--- a/crates/proto/src/udp/udp_stream.rs
+++ b/crates/proto/src/udp/udp_stream.rs
@@ -217,7 +217,12 @@ pub(crate) struct NextRandomUdpSocket<S> {
     bind_address: SocketAddr,
     closure: UdpCreator<S>,
     marker: PhantomData<S>,
+    state: Option<(UdpSocketCreateAttempt, UdpSocketCreateFuture<S>)>,
 }
+
+type UdpSocketCreateAttempt = usize;
+
+type UdpSocketCreateFuture<S> = Pin<Box<dyn Send + Future<Output = io::Result<S>>>>;
 
 impl<S: UdpSocket + 'static> NextRandomUdpSocket<S> {
     /// Creates a future for randomly binding to a local socket address for client connections,
@@ -240,6 +245,7 @@ impl<S: UdpSocket + 'static> NextRandomUdpSocket<S> {
             bind_address,
             closure: Arc::new(|local_addr: _, _server_addr: _| S::bind(local_addr)),
             marker: PhantomData,
+            state: None,
         }
     }
 }
@@ -258,6 +264,7 @@ impl<S: DnsUdpSocket> NextRandomUdpSocket<S> {
             bind_address,
             closure: func,
             marker: PhantomData,
+            state: None,
         }
     }
 }
@@ -267,53 +274,79 @@ impl<S: DnsUdpSocket + Send> Future for NextRandomUdpSocket<S> {
 
     /// polls until there is an available next random UDP port,
     /// if no port has been specified in bind_addr.
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        if self.bind_address.port() == 0 {
-            // Per RFC 6056 Section 3.2:
-            //
-            // As mentioned in Section 2.1, the dynamic ports consist of the range
-            // 49152-65535.  However, ephemeral port selection algorithms should use
-            // the whole range 1024-65535.
-            let rand_port_range = Uniform::new_inclusive(1_024, u16::MAX);
-            let mut rand = rand::thread_rng();
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut attempt = 0;
+        loop {
+            let state = self.state.take();
 
-            for attempt in 0..10 {
-                let port = rand_port_range.sample(&mut rand);
-                let bind_addr = SocketAddr::new(self.bind_address.ip(), port);
+            match state {
+                None => {
+                    if self.bind_address.port() == 0 {
+                        if attempt < 10 {
+                            // Per RFC 6056 Section 3.2:
+                            //
+                            // As mentioned in Section 2.1, the dynamic ports consist of the range
+                            // 49152-65535.  However, ephemeral port selection algorithms should use
+                            // the whole range 1024-65535.
+                            let rand_port_range = Uniform::new_inclusive(1024_u16, u16::MAX);
+                            let mut rand = rand::thread_rng();
 
-                // TODO: allow TTL to be adjusted...
-                // TODO: this immediate poll might be wrong in some cases...
-                match (*self.closure)(bind_addr, self.name_server)
-                    .as_mut()
-                    .poll(cx)
-                {
-                    Poll::Ready(Ok(socket)) => {
-                        debug!("created socket successfully");
-                        return Poll::Ready(Ok(socket));
+                            let port = rand_port_range.sample(&mut rand);
+                            let bind_addr = SocketAddr::new(self.bind_address.ip(), port);
+
+                            // TODO: allow TTL to be adjusted...
+                            self.state =
+                                Some((attempt + 1, (*self.closure)(bind_addr, self.name_server)));
+                        } else {
+                            debug!("could not get next random port, falling back to OS assignment");
+                            // When no free port was found after 10 tries let the OS assign one.
+                            // This is needed in cases where almost all udp ports are in use on the host
+                            // so the chance of finding a free is very low and it could spam 1000s of bind
+                            // calls without finding a free one until the future is canceled.
+
+                            self.state = Some((
+                                UdpSocketCreateAttempt::MAX,
+                                (*self.closure)(self.bind_address, self.name_server),
+                            ));
+                        }
+                    } else {
+                        // Use port that was specified in bind address.
+                        self.state = Some((
+                            UdpSocketCreateAttempt::MAX,
+                            (*self.closure)(self.bind_address, self.name_server),
+                        ));
+                    };
+                }
+                Some((s, mut fut)) => {
+                    attempt = s;
+                    match fut.as_mut().poll(cx) {
+                        Poll::Ready(Ok(socket)) => {
+                            debug!("created socket successfully");
+                            return Poll::Ready(Ok(socket));
+                        }
+                        Poll::Ready(Err(err)) => match err.kind() {
+                            io::ErrorKind::AddrInUse
+                                if attempt > 0 && attempt != UdpSocketCreateAttempt::MAX =>
+                            {
+                                debug!("unable to bind port, attempt: {}: {}", attempt, err);
+
+                                // try next random port.
+                                continue;
+                            }
+                            _ => {
+                                debug!("failed to bind port: {}", err);
+                                return Poll::Ready(Err(err));
+                            }
+                        },
+                        Poll::Pending => {
+                            self.state = Some((attempt, fut));
+                            // returning NotReady here, perhaps the next poll there will be some more socket available.
+                            return Poll::Pending;
+                        }
                     }
-                    Poll::Ready(Err(err)) => match err.kind() {
-                        io::ErrorKind::AddrInUse => {
-                            debug!("unable to bind port, attempt: {}: {}", attempt, err);
-                        }
-                        _ => {
-                            debug!("failed to bind port: {}", err);
-                            return Poll::Ready(Err(err));
-                        }
-                    },
-                    Poll::Pending => debug!("unable to bind port, attempt: {}", attempt),
                 }
             }
-
-            debug!("could not get next random port, falling back to OS assignment");
-            // When no free port was found after 10 tries let the OS assign one.
-            // This is needed in cases where almost all udp ports are in use on the host
-            // so the chance of finding a free is very low and it could spam 1000s of bind
-            // calls without finding a free one until the future is canceled.
         }
-        // Use port that was specified in bind address.
-        (*self.closure)(self.bind_address, self.name_server)
-            .as_mut()
-            .poll(cx)
     }
 }
 


### PR DESCRIPTION
This PR fixes that `self.closure` is not immediately ready.