### PR TITLE
Kill quad9 tests

### DIFF
--- a/crates/async-std-resolver/src/tests.rs
+++ b/crates/async-std-resolver/src/tests.rs
@@ -59,17 +59,6 @@ fn test_lookup_cloudflare() {
 }
 
 #[test]
-fn test_lookup_quad9() {
-    use testing::lookup_test;
-    let io_loop = AsyncStdConnectionProvider::new();
-    lookup_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
-        ResolverConfig::quad9(),
-        io_loop.clone(),
-        io_loop,
-    )
-}
-
-#[test]
 fn test_ip_lookup() {
     use testing::ip_lookup_test;
     let io_loop = AsyncStdConnectionProvider::new();

--- a/crates/resolver/src/async_resolver.rs
+++ b/crates/resolver/src/async_resolver.rs
@@ -1099,14 +1099,6 @@ mod tests {
     }
 
     #[test]
-    fn test_lookup_quad9() {
-        use super::testing::lookup_test;
-        let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        let handle = TokioConnectionProvider::default();
-        lookup_test::<Runtime, TokioConnectionProvider>(ResolverConfig::quad9(), io_loop, handle)
-    }
-
-    #[test]
     fn test_ip_lookup() {
         use super::testing::ip_lookup_test;
         let io_loop = Runtime::new().expect("failed to create tokio runtime");

--- a/crates/resolver/src/tls/mod.rs
+++ b/crates/resolver/src/tls/mod.rs
@@ -67,13 +67,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(windows))] // flakes on AppVeyor...
     fn test_google_tls() {
         tls_test(ResolverConfig::google_tls())
     }
 
     #[test]
-    #[cfg(not(windows))] // flakes on AppVeyor...
     fn test_cloudflare_tls() {
         tls_test(ResolverConfig::cloudflare_tls())
     }

--- a/crates/resolver/src/tls/mod.rs
+++ b/crates/resolver/src/tls/mod.rs
@@ -77,10 +77,4 @@ mod tests {
     fn test_cloudflare_tls() {
         tls_test(ResolverConfig::cloudflare_tls())
     }
-
-    #[test]
-    #[cfg(not(windows))] // flakes on AppVeyor...
-    fn test_quad9_tls() {
-        tls_test(ResolverConfig::quad9_tls())
-    }
 }


### PR DESCRIPTION
Recently the Quad9 tests have been breaking in CI a lot. Given that we already have tests for Google and Cloudflare, I feel like the incremental value these Quad9 tests provide is negligible, and so having these tests has become a net negative.