### PR TITLE
add hickory-server to the info and debug log line configs

### DIFF
--- a/bin/src/hickory-dns.rs
+++ b/bin/src/hickory-dns.rs
@@ -857,7 +857,7 @@ fn get_env() -> String {
 
 fn all_hickory_dns(level: impl ToString) -> String {
     format!(
-        "hickory_dns={level},{env}",
+        "hickory_dns={level},hickory_server={level},{env}",
         level = level.to_string().to_lowercase(),
         env = get_env()
     )


### PR DESCRIPTION
This makes sure that the `hickory-server` crate logs are output with the hickory binary, `hickory-dns` with the CLI flags. The default behavior is to output INFO level log lines, this PR adds this back to the default behavior:

```
1726853979:INFO:hickory_server::server::server_future:1017:request:27420 src:UDP://127.0.0.1#11151 QUERY:www.example.com.:A:IN qflags:RD response:NoError rr:1/0/0 rflags:RD,AA
```

The DEBUG level output with the `-d` or `--debug` flag is:

```
1726854074:DEBUG:hickory_server::server::server_future:110:received udp request from: 127.0.0.1:46992
1726854074:DEBUG:hickory_server::server::server_future:1070:request:20266 src:UDP://127.0.0.1#46992 type:QUERY dnssec:false QUERY:www.example.com.:A:IN qflags:RD
1726854074:DEBUG:hickory_server::authority::catalog:146:query received: 20266
1726854074:DEBUG:hickory_server::authority::catalog:397:searching authorities for: www.example.com.
1726854074:DEBUG:hickory_server::authority::catalog:397:searching authorities for: example.com.
1726854074:DEBUG:hickory_server::authority::catalog:430:request: 20266 found authority: example.com.; performing name: www.example.com. type: A class: IN
1726854074:DEBUG:hickory_server::authority::authority_object:210:performing name: www.example.com. type: A class: IN on example.com.
1726854074:DEBUG:hickory_server::store::in_memory::authority:1363:searching InMemoryAuthority for: name: www.example.com. type: A class: IN
1726854074:DEBUG:hickory_server::server::response_handler:106:response: 20266 response_code: No Error
1726854074:INFO:hickory_server::server::server_future:1017:request:20266 src:UDP://127.0.0.1#46992 QUERY:www.example.com.:A:IN qflags:RD response:NoError rr:1/0/0 rflags:RD,AA
```

the `-q` or `--quiet` still works properly by disabling all output. The environment variable configs can be used to override these behaviors. 