### PR TITLE
Allow changing URI paths for DNS-over-HTTPS

### DIFF
--- a/bin/src/hickory-dns.rs
+++ b/bin/src/hickory-dns.rs
@@ -674,6 +674,7 @@ fn config_https(
         .iter()
         .flat_map(|x| (*x, https_listen_port).to_socket_addrs().unwrap())
         .collect();
+    let endpoint_path = config.get_http_endpoint();
 
     if https_sockaddrs.is_empty() {
         warn!("a tls certificate was specified, but no HTTPS addresses configured to listen on");
@@ -713,6 +714,7 @@ fn config_https(
                 config.get_tcp_request_timeout(),
                 tls_cert,
                 tls_cert_config.get_endpoint_name().map(|s| s.to_string()),
+                endpoint_path.into(),
             )
             .map_err(|err| format!("failed to register HTTPS listener: {err}"))?;
     }

--- a/bin/tests/integration/named_https_tests.rs
+++ b/bin/tests/integration/named_https_tests.rs
@@ -71,7 +71,7 @@ fn test_example_https_toml_startup() {
 
         let provider = TokioRuntimeProvider::new();
         let https_builder = HttpsClientStreamBuilder::with_client_config(client_config, provider);
-        let mp = https_builder.build(addr, "ns.example.com".to_string());
+        let mp = https_builder.build(addr, "ns.example.com".to_string(), "/dns-query".to_string());
         let client = AsyncClient::connect(mp);
 
         // ipv4 should succeed

--- a/crates/proto/src/h2/h2_client_stream.rs
+++ b/crates/proto/src/h2/h2_client_stream.rs
@@ -773,7 +773,7 @@ mod tests {
         #[cfg(all(feature = "native-certs", not(feature = "webpki-roots")))]
         {
             let (added, ignored) = root_store
-                .add_parsable_certificates(&rustls_native_certs::load_native_certs().unwrap());
+                .add_parsable_certificates(rustls_native_certs::load_native_certs().unwrap());
 
             if ignored > 0 {
                 warn!(

--- a/crates/proto/src/http/mod.rs
+++ b/crates/proto/src/http/mod.rs
@@ -8,7 +8,9 @@
 //! HTTP protocol related components for DNS over HTTP/2 (DoH) and HTTP/3 (DoH3)
 
 pub(crate) const MIME_APPLICATION_DNS: &str = "application/dns-message";
-pub(crate) const DNS_QUERY_PATH: &str = "/dns-query";
+
+/// The default query path for DNS-over-HTTPS if none was given.
+pub const DEFAULT_DNS_QUERY_PATH: &str = "/dns-query";
 
 pub(crate) mod error;
 pub mod request;

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -442,6 +442,9 @@ pub struct NameServerConfig {
     /// SPKI name, only relevant for TLS connections
     #[cfg_attr(feature = "serde", serde(default))]
     pub tls_dns_name: Option<String>,
+    /// The HTTP endpoint where the DNS NameServer provides service. Only
+    /// relevant to DNS-over-HTTPS. Defaults to `/dns-query` if unspecified.
+    pub http_endpoint: Option<String>,
     /// Whether to trust `NXDOMAIN` responses from upstream nameservers.
     ///
     /// When this is `true`, and an empty `NXDOMAIN` response or `NOERROR`
@@ -476,6 +479,7 @@ impl NameServerConfig {
             protocol,
             trust_negative_responses: true,
             tls_dns_name: None,
+            http_endpoint: None,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
             bind_addr: None,
@@ -560,6 +564,7 @@ impl NameServerConfigGroup {
                 socket_addr,
                 protocol: Protocol::Udp,
                 tls_dns_name: None,
+                http_endpoint: None,
                 trust_negative_responses,
                 #[cfg(feature = "dns-over-rustls")]
                 tls_config: None,
@@ -569,6 +574,7 @@ impl NameServerConfigGroup {
                 socket_addr,
                 protocol: Protocol::Tcp,
                 tls_dns_name: None,
+                http_endpoint: None,
                 trust_negative_responses,
                 #[cfg(feature = "dns-over-rustls")]
                 tls_config: None,
@@ -599,6 +605,7 @@ impl NameServerConfigGroup {
                 socket_addr: SocketAddr::new(*ip, port),
                 protocol,
                 tls_dns_name: Some(tls_dns_name.clone()),
+                http_endpoint: None,
                 trust_negative_responses,
                 #[cfg(feature = "dns-over-rustls")]
                 tls_config: None,

--- a/crates/resolver/src/h2.rs
+++ b/crates/resolver/src/h2.rs
@@ -23,6 +23,7 @@ pub(crate) fn new_https_stream<P: RuntimeProvider>(
     socket_addr: SocketAddr,
     bind_addr: Option<SocketAddr>,
     dns_name: String,
+    http_endpoint: String,
     client_config: Option<TlsClientConfig>,
     provider: P,
 ) -> DnsExchangeConnect<HttpsClientConnect<P::Tcp>, HttpsClientStream, TokioTime> {
@@ -39,7 +40,7 @@ pub(crate) fn new_https_stream<P: RuntimeProvider>(
     if let Some(bind_addr) = bind_addr {
         https_builder.bind_addr(bind_addr);
     }
-    DnsExchange::connect(https_builder.build(socket_addr, dns_name))
+    DnsExchange::connect(https_builder.build(socket_addr, dns_name, http_endpoint))
 }
 
 #[allow(clippy::type_complexity)]
@@ -47,6 +48,7 @@ pub(crate) fn new_https_stream_with_future<S, F>(
     future: F,
     socket_addr: SocketAddr,
     dns_name: String,
+    http_endpoint: String,
     client_config: Option<TlsClientConfig>,
 ) -> DnsExchangeConnect<HttpsClientConnect<S>, HttpsClientStream, TokioTime>
 where
@@ -67,6 +69,7 @@ where
         client_config,
         socket_addr,
         dns_name,
+        http_endpoint,
     ))
 }
 

--- a/crates/resolver/src/h3.rs
+++ b/crates/resolver/src/h3.rs
@@ -23,6 +23,7 @@ pub(crate) fn new_h3_stream(
     socket_addr: SocketAddr,
     bind_addr: Option<SocketAddr>,
     dns_name: String,
+    http_endpoint: String,
     client_config: Option<TlsClientConfig>,
 ) -> DnsExchangeConnect<H3ClientConnect, H3ClientStream, TokioTime> {
     let client_config = if let Some(TlsClientConfig(client_config)) = client_config {
@@ -43,7 +44,7 @@ pub(crate) fn new_h3_stream(
     if let Some(bind_addr) = bind_addr {
         h3_builder.bind_addr(bind_addr);
     }
-    DnsExchange::connect(h3_builder.build(socket_addr, dns_name))
+    DnsExchange::connect(h3_builder.build(socket_addr, dns_name, http_endpoint))
 }
 
 #[allow(clippy::type_complexity)]
@@ -51,6 +52,7 @@ pub(crate) fn new_h3_stream_with_future(
     socket: Arc<dyn quinn::AsyncUdpSocket>,
     socket_addr: SocketAddr,
     dns_name: String,
+    http_endpoint: String,
     client_config: Option<TlsClientConfig>,
 ) -> DnsExchangeConnect<H3ClientConnect, H3ClientStream, TokioTime> {
     let client_config = if let Some(TlsClientConfig(client_config)) = client_config {
@@ -68,7 +70,7 @@ pub(crate) fn new_h3_stream_with_future(
     let crypto_config: CryptoConfig = (*client_config).clone();
 
     h3_builder.crypto_config(crypto_config);
-    DnsExchange::connect(h3_builder.build_with_future(socket, socket_addr, dns_name))
+    DnsExchange::connect(h3_builder.build_with_future(socket, socket_addr, dns_name, http_endpoint))
 }
 
 #[cfg(all(test, any(feature = "native-certs", feature = "webpki-roots")))]

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -295,6 +295,10 @@ impl<P: RuntimeProvider> ConnectionProvider for GenericConnector<P> {
             (Protocol::Https, _) => {
                 let socket_addr = config.socket_addr;
                 let tls_dns_name = config.tls_dns_name.clone().unwrap_or_default();
+                let http_endpoint = config
+                    .http_endpoint
+                    .clone()
+                    .unwrap_or_else(|| proto::http::DEFAULT_DNS_QUERY_PATH.to_owned());
                 #[cfg(feature = "dns-over-rustls")]
                 let client_config = config.tls_config.clone();
                 let tcp_future = self.runtime_provider.connect_tcp(socket_addr, None, None);
@@ -303,6 +307,7 @@ impl<P: RuntimeProvider> ConnectionProvider for GenericConnector<P> {
                     tcp_future,
                     socket_addr,
                     tls_dns_name,
+                    http_endpoint,
                     client_config,
                 );
                 ConnectionConnect::Https(exchange)
@@ -339,6 +344,10 @@ impl<P: RuntimeProvider> ConnectionProvider for GenericConnector<P> {
                     }
                 });
                 let tls_dns_name = config.tls_dns_name.clone().unwrap_or_default();
+                let http_endpoint = config
+                    .http_endpoint
+                    .clone()
+                    .unwrap_or_else(|| proto::http::DEFAULT_DNS_QUERY_PATH.to_owned());
                 let client_config = config.tls_config.clone();
                 let socket = binder.bind_quic(bind_addr, socket_addr)?;
 
@@ -346,6 +355,7 @@ impl<P: RuntimeProvider> ConnectionProvider for GenericConnector<P> {
                     socket,
                     socket_addr,
                     tls_dns_name,
+                    http_endpoint,
                     client_config,
                 );
                 ConnectionConnect::H3(exchange)

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -249,6 +249,7 @@ mod tests {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53),
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            http_endpoint: None,
             trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
@@ -287,6 +288,7 @@ mod tests {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 252)), 252),
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            http_endpoint: None,
             trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -427,6 +427,7 @@ mod tests {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 252)), 253),
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            http_endpoint: None,
             trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
@@ -437,6 +438,7 @@ mod tests {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53),
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            http_endpoint: None,
             trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
@@ -499,6 +501,7 @@ mod tests {
             socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 53),
             protocol: Protocol::Tcp,
             tls_dns_name: None,
+            http_endpoint: None,
             trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,

--- a/crates/resolver/src/system_conf/unix.rs
+++ b/crates/resolver/src/system_conf/unix.rs
@@ -69,6 +69,7 @@ fn into_resolver_config(
             socket_addr: SocketAddr::new(ip.into(), DEFAULT_PORT),
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            http_endpoint: None,
             trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
@@ -78,6 +79,7 @@ fn into_resolver_config(
             socket_addr: SocketAddr::new(ip.into(), DEFAULT_PORT),
             protocol: Protocol::Tcp,
             tls_dns_name: None,
+            http_endpoint: None,
             trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
@@ -138,6 +140,7 @@ mod tests {
                 socket_addr: addr,
                 protocol: Protocol::Udp,
                 tls_dns_name: None,
+                http_endpoint: None,
                 trust_negative_responses: false,
                 #[cfg(feature = "dns-over-rustls")]
                 tls_config: None,
@@ -147,6 +150,7 @@ mod tests {
                 socket_addr: addr,
                 protocol: Protocol::Tcp,
                 tls_dns_name: None,
+                http_endpoint: None,
                 trust_negative_responses: false,
                 #[cfg(feature = "dns-over-rustls")]
                 tls_config: None,

--- a/crates/resolver/src/system_conf/windows.rs
+++ b/crates/resolver/src/system_conf/windows.rs
@@ -32,6 +32,7 @@ fn get_name_servers() -> ResolveResult<Vec<NameServerConfig>> {
             socket_addr,
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            http_endpoint: None,
             trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
@@ -41,6 +42,7 @@ fn get_name_servers() -> ResolveResult<Vec<NameServerConfig>> {
             socket_addr,
             protocol: Protocol::Tcp,
             tls_dns_name: None,
+            http_endpoint: None,
             trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,

--- a/crates/server/src/config/mod.rs
+++ b/crates/server/src/config/mod.rs
@@ -80,6 +80,10 @@ pub struct Config {
     /// Certificate to associate to TLS connections (currently the same is used for HTTPS and TLS)
     #[cfg(feature = "dnssec")]
     tls_cert: Option<dnssec::TlsCertConfig>,
+    /// The HTTP endpoint where the DNS-over-HTTPS server provides service. Applicable
+    /// to both HTTP/2 and HTTP/3 servers. Typically `/dns-query`.
+    #[cfg(any(feature = "dns-over-https-rustls", feature = "dns-over-h3"))]
+    http_endpoint: Option<String>,
     /// Networks denied to access the server
     #[serde(default)]
     deny_networks: Vec<IpNet>,
@@ -202,6 +206,14 @@ impl Config {
                 None
             }
         }
+    }
+
+    /// the HTTP endpoint from where requests are received
+    #[cfg(any(feature = "dns-over-https-rustls", feature = "dns-over-h3"))]
+    pub fn get_http_endpoint(&self) -> &str {
+        self.http_endpoint
+            .as_deref()
+            .unwrap_or(hickory_proto::http::DEFAULT_DNS_QUERY_PATH)
     }
 
     /// get the networks denied access to this server

--- a/crates/server/src/server/server_future.rs
+++ b/crates/server/src/server/server_future.rs
@@ -611,6 +611,7 @@ impl<T: RequestHandler> ServerFuture<T> {
         _timeout: Duration,
         certificate_and_key: (Vec<CertificateDer<'static>>, PrivateKeyDer<'static>),
         dns_hostname: Option<String>,
+        http_endpoint: String,
     ) -> io::Result<()> {
         use tokio_rustls::TlsAcceptor;
 
@@ -618,6 +619,7 @@ impl<T: RequestHandler> ServerFuture<T> {
         use crate::server::h2_handler::h2_handler;
 
         let dns_hostname: Option<Arc<str>> = dns_hostname.map(|n| n.into());
+        let http_endpoint: Arc<str> = Arc::from(http_endpoint);
 
         let handler = self.handler.clone();
         let access = self.access.clone();
@@ -665,6 +667,7 @@ impl<T: RequestHandler> ServerFuture<T> {
                 let access = access.clone();
                 let tls_acceptor = tls_acceptor.clone();
                 let dns_hostname = dns_hostname.clone();
+                let http_endpoint = http_endpoint.clone();
 
                 inner_join_set.spawn(async move {
                     debug!("starting HTTPS request from: {src_addr}");
@@ -688,6 +691,7 @@ impl<T: RequestHandler> ServerFuture<T> {
                         tls_stream,
                         src_addr,
                         dns_hostname,
+                        http_endpoint,
                         shutdown.clone(),
                     )
                     .await;
@@ -1375,6 +1379,7 @@ mod tests {
                         Duration::from_secs(1),
                         cert_key,
                         None,
+                        "/dns-query".into(),
                     )
                     .unwrap();
             }

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -59,6 +59,7 @@ impl RecursiveAuthority {
                 socket_addr,
                 protocol: Protocol::Tcp,
                 tls_dns_name: None,
+                http_endpoint: None,
                 trust_negative_responses: false,
                 #[cfg(feature = "dns-over-rustls")]
                 tls_config: None,
@@ -69,6 +70,7 @@ impl RecursiveAuthority {
                 socket_addr,
                 protocol: Protocol::Udp,
                 tls_dns_name: None,
+                http_endpoint: None,
                 trust_negative_responses: false,
                 #[cfg(feature = "dns-over-rustls")]
                 tls_config: None,

--- a/tests/integration-tests/tests/integration/client_future_tests.rs
+++ b/tests/integration-tests/tests/integration/client_future_tests.rs
@@ -155,7 +155,11 @@ fn test_query_https() {
         Arc::new(client_config),
         TokioRuntimeProvider::new(),
     );
-    let client = AsyncClient::connect(https_builder.build(addr, "cloudflare-dns.com".to_string()));
+    let client = AsyncClient::connect(https_builder.build(
+        addr,
+        "cloudflare-dns.com".to_string(),
+        "/dns-query".to_string(),
+    ));
     let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
     hickory_proto::runtime::spawn_bg(&io_loop, bg);
 

--- a/tests/integration-tests/tests/integration/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/integration/name_server_pool_tests.rs
@@ -82,6 +82,7 @@ fn mock_nameserver_on_send_nx<O: OnSend + Unpin>(
             socket_addr: SocketAddr::new(addr, 0),
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            http_endpoint: None,
             trust_negative_responses,
             #[cfg(any(feature = "dns-over-rustls", feature = "dns-over-https-rustls"))]
             tls_config: None,

--- a/util/src/bin/recurse.rs
+++ b/util/src/bin/recurse.rs
@@ -125,6 +125,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             socket_addr: *socket_addr,
             protocol: Protocol::Tcp,
             tls_dns_name: None,
+            http_endpoint: None,
             trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
@@ -135,6 +136,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             socket_addr: *socket_addr,
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            http_endpoint: None,
             trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,

--- a/util/src/bin/resolve.rs
+++ b/util/src/bin/resolve.rs
@@ -275,6 +275,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             socket_addr: *socket_addr,
             protocol: Protocol::Tcp,
             tls_dns_name: None,
+            http_endpoint: None,
             trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,
@@ -285,6 +286,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             socket_addr: *socket_addr,
             protocol: Protocol::Udp,
             tls_dns_name: None,
+            http_endpoint: None,
             trust_negative_responses: false,
             #[cfg(feature = "dns-over-rustls")]
             tls_config: None,


### PR DESCRIPTION
This allows for instance `ns.example.com/foobar` to be used instead of `ns.example.com/dns-query`.

Fingers crossed I didn't miss anything.