### PR TITLE
server: avoid wrapping Arc in Box

### DIFF
--- a/tests/integration-tests/tests/integration/catalog_tests.rs
+++ b/tests/integration-tests/tests/integration/catalog_tests.rs
@@ -124,9 +124,9 @@ async fn test_catalog_lookup() {
     let origin = example.origin().clone();
     let test_origin = test.origin().clone();
 
-    let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(origin.clone(), Box::new(Arc::new(example)));
-    catalog.upsert(test_origin.clone(), Box::new(Arc::new(test)));
+    let mut catalog = Catalog::new();
+    catalog.upsert(origin.clone(), Arc::new(example));
+    catalog.upsert(test_origin.clone(), Arc::new(test));
 
     let mut question: Message = Message::new();
 
@@ -201,9 +201,9 @@ async fn test_catalog_lookup_soa() {
     let origin = example.origin().clone();
     let test_origin = test.origin().clone();
 
-    let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(origin.clone(), Box::new(Arc::new(example)));
-    catalog.upsert(test_origin, Box::new(Arc::new(test)));
+    let mut catalog = Catalog::new();
+    catalog.upsert(origin.clone(), Arc::new(example));
+    catalog.upsert(test_origin, Arc::new(test));
 
     let mut question: Message = Message::new();
 
@@ -268,8 +268,8 @@ async fn test_catalog_nx_soa() {
     let example = create_example();
     let origin = example.origin().clone();
 
-    let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(origin, Box::new(Arc::new(example)));
+    let mut catalog = Catalog::new();
+    catalog.upsert(origin, Arc::new(example));
 
     let mut question: Message = Message::new();
 
@@ -316,8 +316,8 @@ async fn test_non_authoritive_nx_refused() {
     let example = create_example();
     let origin = example.origin().clone();
 
-    let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(origin, Box::new(Arc::new(example)));
+    let mut catalog = Catalog::new();
+    catalog.upsert(origin, Arc::new(example));
 
     let mut question: Message = Message::new();
 
@@ -370,8 +370,8 @@ async fn test_axfr() {
     .set_dns_class(DNSClass::IN)
     .clone();
 
-    let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(origin.clone(), Box::new(Arc::new(test)));
+    let mut catalog = Catalog::new();
+    catalog.upsert(origin.clone(), Arc::new(test));
 
     let mut query: Query = Query::new();
     query.set_name(origin.clone().into());
@@ -486,8 +486,8 @@ async fn test_axfr_refused() {
 
     let origin = test.origin().clone();
 
-    let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(origin.clone(), Box::new(Arc::new(test)));
+    let mut catalog = Catalog::new();
+    catalog.upsert(origin.clone(), Arc::new(test));
 
     let mut query: Query = Query::new();
     query.set_name(origin.into());
@@ -525,8 +525,8 @@ async fn test_cname_additionals() {
     let example = create_example();
     let origin = example.origin().clone();
 
-    let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(origin, Box::new(Arc::new(example)));
+    let mut catalog = Catalog::new();
+    catalog.upsert(origin, Arc::new(example));
 
     let mut question: Message = Message::new();
 
@@ -572,8 +572,8 @@ async fn test_multiple_cname_additionals() {
     let example = create_example();
     let origin = example.origin().clone();
 
-    let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(origin, Box::new(Arc::new(example)));
+    let mut catalog = Catalog::new();
+    catalog.upsert(origin, Arc::new(example));
 
     let mut question: Message = Message::new();
 

--- a/tests/integration-tests/tests/integration/client_future_tests.rs
+++ b/tests/integration-tests/tests/integration/client_future_tests.rs
@@ -48,7 +48,7 @@ fn test_query_nonet() {
 
     let authority = create_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(authority.origin().clone(), Arc::new(authority));
 
     let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
@@ -257,7 +257,7 @@ fn test_notify() {
     let io_loop = Runtime::new().unwrap();
     let authority = create_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(authority.origin().clone(), Arc::new(authority));
 
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
     let client = AsyncClient::new(stream, sender, None);
@@ -317,7 +317,7 @@ async fn create_sig0_ready_client() -> (
 
     // setup the catalog
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(authority.origin().clone(), Arc::new(authority));
 
     let signer = Arc::new(signer.into());
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));

--- a/tests/integration-tests/tests/integration/client_tests.rs
+++ b/tests/integration-tests/tests/integration/client_tests.rs
@@ -63,7 +63,7 @@ impl ClientConnection for TestClientConnection {
 fn test_query_nonet() {
     let authority = create_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(authority.origin().clone(), Arc::new(authority));
 
     let client = SyncClient::new(TestClientConnection::new(catalog));
 
@@ -528,7 +528,7 @@ fn create_sig0_ready_client(mut catalog: Catalog) -> (SyncClient<TestClientConne
     );
     authority.upsert_mut(auth_key, 0);
 
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(authority.origin().clone(), Arc::new(authority));
     let client = SyncClient::with_signer(TestClientConnection::new(catalog), signer);
 
     (client, origin.into())

--- a/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
+++ b/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
@@ -232,7 +232,7 @@ where
     };
 
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(authority.origin().clone(), Arc::new(authority));
 
     let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));

--- a/tests/integration-tests/tests/integration/lookup_tests.rs
+++ b/tests/integration-tests/tests/integration/lookup_tests.rs
@@ -30,7 +30,7 @@ use hickory_integration::{example_authority::create_example, mock_client::*, Tes
 fn test_lookup() {
     let authority = create_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(authority.origin().clone(), Arc::new(authority));
 
     let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
@@ -58,7 +58,7 @@ fn test_lookup() {
 fn test_lookup_hosts() {
     let authority = create_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(authority.origin().clone(), Arc::new(authority));
 
     let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
@@ -116,7 +116,7 @@ fn create_ip_like_example() -> InMemoryAuthority {
 fn test_lookup_ipv4_like() {
     let authority = create_ip_like_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(authority.origin().clone(), Arc::new(authority));
 
     let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
@@ -146,7 +146,7 @@ fn test_lookup_ipv4_like() {
 fn test_lookup_ipv4_like_fall_through() {
     let authority = create_ip_like_example();
     let mut catalog = Catalog::new();
-    catalog.upsert(authority.origin().clone(), Box::new(Arc::new(authority)));
+    catalog.upsert(authority.origin().clone(), Arc::new(authority));
 
     let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));

--- a/tests/integration-tests/tests/integration/server_future_tests.rs
+++ b/tests/integration-tests/tests/integration/server_future_tests.rs
@@ -357,8 +357,8 @@ fn new_catalog() -> Catalog {
     let example = create_example();
     let origin = example.origin().clone();
 
-    let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(origin, Box::new(Arc::new(example)));
+    let mut catalog = Catalog::new();
+    catalog.upsert(origin, Arc::new(example));
     catalog
 }
 

--- a/tests/integration-tests/tests/integration/truncation_tests.rs
+++ b/tests/integration-tests/tests/integration/truncation_tests.rs
@@ -114,8 +114,8 @@ pub fn new_large_catalog(num_records: u32) -> Catalog {
     )
     .unwrap();
 
-    let mut catalog: Catalog = Catalog::new();
-    catalog.upsert(Name::root().into(), Box::new(Arc::new(authority)));
+    let mut catalog = Catalog::new();
+    catalog.upsert(Name::root().into(), Arc::new(authority));
     catalog
 }
 


### PR DESCRIPTION
Noticed this pre-existing issue while reviewing #2161. There doesn't seem to be a need to wrap `Arc` in `Box`, since the former already includes a heap allocation and can support trait objects directly.