### PR TITLE
proto: change RecordSet::new() to take owned Name

### DIFF
--- a/crates/proto/src/rr/rr_set.rs
+++ b/crates/proto/src/rr/rr_set.rs
@@ -42,9 +42,9 @@ impl RecordSet {
     ///
     /// The newly created Resource Record Set
     /// TODO: make all cloned params pass by value
-    pub fn new(name: &Name, record_type: RecordType, serial: u32) -> Self {
+    pub fn new(name: Name, record_type: RecordType, serial: u32) -> Self {
         Self {
-            name: name.clone(),
+            name,
             record_type,
             dns_class: DNSClass::IN,
             ttl: 0,
@@ -623,7 +623,7 @@ mod test {
     fn test_insert() {
         let name = Name::from_str("www.example.com.").unwrap();
         let record_type = RecordType::A;
-        let mut rr_set = RecordSet::new(&name, record_type, 0);
+        let mut rr_set = RecordSet::new(name.clone(), record_type, 0);
 
         let insert = Record::from_rdata(
             name.clone(),
@@ -661,7 +661,7 @@ mod test {
     fn test_insert_soa() {
         let name = Name::from_str("example.com.").unwrap();
         let record_type = RecordType::SOA;
-        let mut rr_set = RecordSet::new(&name, record_type, 0);
+        let mut rr_set = RecordSet::new(name.clone(), record_type, 0);
 
         let insert = Record::from_rdata(
             name.clone(),
@@ -738,7 +738,7 @@ mod test {
         let new_cname = Name::from_str("w2.example.com.").unwrap();
 
         let record_type = RecordType::CNAME;
-        let mut rr_set = RecordSet::new(&name, record_type, 0);
+        let mut rr_set = RecordSet::new(name.clone(), record_type, 0);
 
         let insert = Record::from_rdata(name.clone(), 3600, RData::CNAME(CNAME(cname)))
             .set_dns_class(DNSClass::IN)
@@ -762,7 +762,7 @@ mod test {
     fn test_remove() {
         let name = Name::from_str("www.example.com.").unwrap();
         let record_type = RecordType::A;
-        let mut rr_set = RecordSet::new(&name, record_type, 0);
+        let mut rr_set = RecordSet::new(name.clone(), record_type, 0);
 
         let insert = Record::from_rdata(
             name.clone(),
@@ -793,7 +793,7 @@ mod test {
     fn test_remove_soa() {
         let name = Name::from_str("www.example.com.").unwrap();
         let record_type = RecordType::SOA;
-        let mut rr_set = RecordSet::new(&name, record_type, 0);
+        let mut rr_set = RecordSet::new(name.clone(), record_type, 0);
 
         let insert = Record::from_rdata(
             name,
@@ -820,7 +820,7 @@ mod test {
     fn test_remove_ns() {
         let name = Name::from_str("example.com.").unwrap();
         let record_type = RecordType::NS;
-        let mut rr_set = RecordSet::new(&name, record_type, 0);
+        let mut rr_set = RecordSet::new(name.clone(), record_type, 0);
 
         let ns1 = Record::from_rdata(
             name.clone(),

--- a/crates/proto/src/serialize/txt/zone.rs
+++ b/crates/proto/src/serialize/txt/zone.rs
@@ -416,9 +416,9 @@ impl<'a> Parser<'a> {
             }
             _ => {
                 // add a Vec if it's not there, then add the record to the list
-                let set = records
-                    .entry(key)
-                    .or_insert_with(|| RecordSet::new(record.name(), record.record_type(), 0));
+                let set = records.entry(key).or_insert_with(|| {
+                    RecordSet::new(record.name().clone(), record.record_type(), 0)
+                });
                 set.insert(record, 0);
             }
         }

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -651,7 +651,11 @@ impl InnerInMemory {
 
         let rr_key = RrKey::new(record.name().into(), record.record_type());
         let records: &mut Arc<RecordSet> = self.records.entry(rr_key).or_insert_with(|| {
-            Arc::new(RecordSet::new(record.name(), record.record_type(), serial))
+            Arc::new(RecordSet::new(
+                record.name().clone(),
+                record.record_type(),
+                serial,
+            ))
         });
 
         // because this is and Arc, we need to clone and then replace the entry
@@ -1271,7 +1275,8 @@ impl Authority for InMemoryAuthority {
                                 //   according to the rfc the ttl is from the ANAME
                                 //   TODO: technically we should take the min of the potential CNAME chain
                                 let ttl = answer.ttl().min(a_aaaa_ttl);
-                                let mut new_answer = RecordSet::new(answer.name(), query_type, ttl);
+                                let mut new_answer =
+                                    RecordSet::new(answer.name().clone(), query_type, ttl);
 
                                 for rdata in rdatas.into_iter().flatten() {
                                     new_answer.add_rdata(rdata);

--- a/tests/integration-tests/tests/integration/truncation_tests.rs
+++ b/tests/integration-tests/tests/integration/truncation_tests.rs
@@ -72,14 +72,14 @@ async fn test_truncation() {
 pub fn new_large_catalog(num_records: u32) -> Catalog {
     // Create a large record set.
     let name = large_name();
-    let mut record_set = RecordSet::new(&name, RecordType::A, 0);
+    let mut record_set = RecordSet::new(name.clone(), RecordType::A, 0);
     for i in 1..num_records + 1 {
         let ip = Ipv4Addr::from(i);
         let rdata = RData::A(A(ip));
         record_set.insert(Record::from_rdata(name.clone(), 86400, rdata), 0);
     }
 
-    let mut soa_record_set = RecordSet::new(&name, RecordType::SOA, 0);
+    let mut soa_record_set = RecordSet::new(name.clone(), RecordType::SOA, 0);
     soa_record_set.insert(
         Record::from_rdata(
             name.clone(),


### PR DESCRIPTION
Since it stores a `Name` internally anyway, better to make this explicit towards the caller.