### PR TITLE
fix compilation failed

### DIFF
--- a/bin/src/hickory-dns.rs
+++ b/bin/src/hickory-dns.rs
@@ -167,7 +167,7 @@ async fn load_zone(
     }
 
     // load the zone
-    let authority = match zone_config.stores {
+    let authority: Arc<dyn AuthorityObject> = match zone_config.stores {
         #[cfg(feature = "sqlite")]
         Some(StoreConfig::Sqlite(ref config)) => {
             if zone_path.is_some() {
@@ -188,7 +188,7 @@ async fn load_zone(
 
             // load any keys for the Zone, if it is a dynamic update zone, then keys are required
             load_keys(&mut authority, zone_name_for_signer, zone_config).await?;
-            Arc::new(authority) as Arc<dyn AuthorityObject>
+            Arc::new(authority)
         }
         Some(StoreConfig::File(ref config)) => {
             if zone_path.is_some() {


### PR DESCRIPTION
build with rust 1.81.0, by running
```
cargo install -v --profile release --features "resolver,dns-over-https-rustls,dns-over-quic,dns-over-h3,native-certs,dnssec-ring,recursor" --no-default-features --path ./bin
```

```
error[E0308]: `match` arms have incompatible types
   --> bin/src/hickory-dns.rs:216:13
    |
170 |       let authority = match zone_config.stores {
    |  _____________________-
171 | |         #[cfg(feature = "sqlite")]
172 | |         Some(StoreConfig::Sqlite(ref config)) => {
173 | |             if zone_path.is_some() {
...   |
210 | |             Arc::new(authority)
    | |             ------------------- this is found to be of type `Arc<FileAuthority>`
...   |
216 | |             Arc::new(forwarder)
    | |             ^^^^^^^^^^^^^^^^^^^ expected `Arc<FileAuthority>`, found `Arc<ForwardAuthority>`
...   |
281 | |         }
282 | |     };
    | |_____- `match` arms have incompatible types
    |
    = note: expected struct `Arc<FileAuthority>`
               found struct `Arc<ForwardAuthority>`

For more information about this error, try `rustc --explain E0308`.
```