### PR TITLE
Fix `nxdomain` conformance test for `hickory-recursor`

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
@@ -42,7 +42,6 @@ fn can_resolve() -> Result<()> {
     Ok(())
 }
 
-#[ignore]
 #[test]
 fn nxdomain() -> Result<()> {
     let needle_fqdn = FQDN::TEST_DOMAIN.push_label("unicorn");

--- a/crates/recursor/src/error.rs
+++ b/crates/recursor/src/error.rs
@@ -166,16 +166,10 @@ impl From<Error> for String {
 
 impl From<ResolveError> for Error {
     fn from(e: ResolveError) -> Self {
-        if let Some(ProtoErrorKind::NoRecordsFound { soa, ns, .. }) =
+        if let Some(ProtoErrorKind::NoRecordsFound { ns: Some(ns), .. }) =
             e.proto().map(ProtoError::kind)
         {
-            if let Some(ns) = ns {
-                ErrorKind::ForwardNS(ns.clone()).into()
-            } else if let Some(soa) = soa {
-                ErrorKind::Forward(soa.name().clone()).into()
-            } else {
-                ErrorKind::Resolve(e).into()
-            }
+            ErrorKind::ForwardNS(ns.clone()).into()
         } else {
             ErrorKind::Resolve(e).into()
         }


### PR DESCRIPTION
Fixes #2192