### PR TITLE
Listen on IPv6 by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,7 @@ dependencies = [
  "rusqlite",
  "rustls",
  "serde",
+ "socket2",
  "test-support",
  "time",
  "tokio",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -67,6 +67,7 @@ ipnet = { workspace = true, features = ["serde"] }
 # rusqlite is actually only needed for test situations, but we need an optional dependency
 # here so we can disable it for MSRV tests (rusqlite only supports latest stable)
 rusqlite = { workspace = true, features = ["bundled", "time"], optional = true }
+socket2.workspace = true
 rustls = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 time.workspace = true

--- a/bin/src/hickory-dns.rs
+++ b/bin/src/hickory-dns.rs
@@ -39,7 +39,7 @@
 use std::{
     env, fmt,
     io::Error,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -477,6 +477,7 @@ fn run() -> Result<(), String> {
 
     if listen_addrs.is_empty() {
         listen_addrs.push(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)));
+        listen_addrs.push(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)));
     }
 
     if args.validate {

--- a/bin/src/hickory-dns.rs
+++ b/bin/src/hickory-dns.rs
@@ -38,12 +38,14 @@
 
 use std::{
     env, fmt,
-    net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs},
+    io::Error,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
     path::{Path, PathBuf},
     sync::Arc,
 };
 
 use clap::Parser;
+use socket2::{Domain, Socket, Type};
 use time::OffsetDateTime;
 use tokio::{
     net::{TcpListener, UdpSocket},
@@ -476,10 +478,6 @@ fn run() -> Result<(), String> {
     if listen_addrs.is_empty() {
         listen_addrs.push(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)));
     }
-    let sockaddrs: Vec<SocketAddr> = listen_addrs
-        .iter()
-        .flat_map(|x| (*x, listen_port).to_socket_addrs().unwrap())
-        .collect();
 
     if args.validate {
         info!("configuration files are validated");
@@ -494,15 +492,15 @@ fn run() -> Result<(), String> {
     #[cfg_attr(not(feature = "dns-over-tls"), allow(unused_mut))]
     let mut server = ServerFuture::with_access(catalog, deny_networks, allow_networks);
 
+    let _guard = runtime.enter();
+
     if !args.disable_udp && !config.disable_udp() {
         // load all udp listeners
-        for udp_socket in &sockaddrs {
-            info!("binding UDP to {:?}", udp_socket);
-            let udp_socket = runtime
-                .block_on(UdpSocket::bind(udp_socket))
-                .map_err(|err| {
-                    format!("failed to bind to UDP socket address {udp_socket:?}: {err}")
-                })?;
+        for addr in &listen_addrs {
+            info!("binding UDP to {addr:?}");
+
+            let udp_socket = build_udp_socket(*addr, listen_port)
+                .map_err(|err| format!("failed to bind to UDP socket address {addr:?}: {err}"))?;
 
             info!(
                 "listening for UDP on {:?}",
@@ -511,7 +509,6 @@ fn run() -> Result<(), String> {
                     .map_err(|err| format!("failed to lookup local address: {err}"))?
             );
 
-            let _guard = runtime.enter();
             server.register_socket(udp_socket);
         }
     } else {
@@ -520,14 +517,11 @@ fn run() -> Result<(), String> {
 
     if !args.disable_tcp && !config.disable_tcp() {
         // load all tcp listeners
-        for tcp_listener in &sockaddrs {
-            info!("binding TCP to {:?}", tcp_listener);
-            let tcp_listener =
-                runtime
-                    .block_on(TcpListener::bind(tcp_listener))
-                    .map_err(|err| {
-                        format!("failed to bind to TCP socket address {tcp_listener:?}: {err}")
-                    })?;
+        for addr in &listen_addrs {
+            info!("binding TCP to {addr:?}");
+
+            let tcp_listener = build_tcp_listener(*addr, listen_port)
+                .map_err(|err| format!("failed to bind to TCP socket address {addr:?}: {err}"))?;
 
             info!(
                 "listening for TCP on {:?}",
@@ -536,7 +530,6 @@ fn run() -> Result<(), String> {
                     .map_err(|err| format!("failed to lookup local address: {err}"))?
             );
 
-            let _guard = runtime.enter();
             server.register_listener(tcp_listener, tcp_request_timeout);
         }
     } else {
@@ -559,7 +552,6 @@ fn run() -> Result<(), String> {
                 tls_cert_config,
                 &zone_dir,
                 &listen_addrs,
-                &runtime,
             )?;
         } else {
             info!("TLS protocol is disabled");
@@ -575,7 +567,6 @@ fn run() -> Result<(), String> {
                 tls_cert_config,
                 &zone_dir,
                 &listen_addrs,
-                &runtime,
             )?;
         } else {
             info!("HTTPS protocol is disabled");
@@ -591,7 +582,6 @@ fn run() -> Result<(), String> {
                 tls_cert_config,
                 &zone_dir,
                 &listen_addrs,
-                &runtime,
             )?;
         } else {
             info!("QUIC protocol is disabled");
@@ -636,20 +626,15 @@ fn config_tls(
     tls_cert_config: &TlsCertConfig,
     zone_dir: &Path,
     listen_addrs: &[IpAddr],
-    runtime: &runtime::Runtime,
 ) -> Result<(), String> {
     let tls_listen_port: u16 = args.tls_port.unwrap_or_else(|| config.tls_listen_port());
-    let tls_sockaddrs: Vec<SocketAddr> = listen_addrs
-        .iter()
-        .flat_map(|x| (*x, tls_listen_port).to_socket_addrs().unwrap())
-        .collect();
 
-    if tls_sockaddrs.is_empty() {
+    if listen_addrs.is_empty() {
         warn!("a tls certificate was specified, but no TLS addresses configured to listen on");
         return Ok(());
     }
 
-    for tls_listener in &tls_sockaddrs {
+    for addr in listen_addrs {
         let tls_cert_path = tls_cert_config.path();
         info!("loading cert for DNS over TLS: {tls_cert_path:?}");
 
@@ -657,12 +642,10 @@ fn config_tls(
             format!("failed to load tls certificate files from {tls_cert_path:?}: {err}")
         })?;
 
-        info!("binding TLS to {:?}", tls_listener);
-        let tls_listener = runtime
-            .block_on(TcpListener::bind(tls_listener))
-            .map_err(|err| {
-                format!("failed to bind to TLS socket address {tls_listener:?}: {err}")
-            })?;
+        info!("binding TLS to {addr:?}");
+
+        let tls_listener = build_tcp_listener(*addr, tls_listen_port)
+            .map_err(|err| format!("failed to bind to TLS socket address {addr:?}: {err}"))?;
 
         info!(
             "listening for TLS on {:?}",
@@ -671,7 +654,6 @@ fn config_tls(
                 .map_err(|err| format!("failed to lookup local address: {err}"))?
         );
 
-        let _guard = runtime.enter();
         server
             .register_tls_listener(tls_listener, config.tcp_request_timeout(), tls_cert)
             .map_err(|err| format!("failed to register TLS listener: {err}"))?;
@@ -687,23 +669,18 @@ fn config_https(
     tls_cert_config: &TlsCertConfig,
     zone_dir: &Path,
     listen_addrs: &[IpAddr],
-    runtime: &runtime::Runtime,
 ) -> Result<(), String> {
     let https_listen_port: u16 = args
         .https_port
         .unwrap_or_else(|| config.https_listen_port());
-    let https_sockaddrs: Vec<SocketAddr> = listen_addrs
-        .iter()
-        .flat_map(|x| (*x, https_listen_port).to_socket_addrs().unwrap())
-        .collect();
     let endpoint_path = config.http_endpoint();
 
-    if https_sockaddrs.is_empty() {
+    if listen_addrs.is_empty() {
         warn!("a tls certificate was specified, but no HTTPS addresses configured to listen on");
         return Ok(());
     }
 
-    for https_listener in &https_sockaddrs {
+    for addr in listen_addrs {
         let tls_cert_path = tls_cert_config.path();
         if let Some(endpoint_name) = tls_cert_config.endpoint_name() {
             info!("loading cert for DNS over TLS named {endpoint_name} from {tls_cert_path:?}");
@@ -715,12 +692,10 @@ fn config_https(
             format!("failed to load tls certificate files from {tls_cert_path:?}: {err}")
         })?;
 
-        info!("binding HTTPS to {:?}", https_listener);
-        let https_listener = runtime
-            .block_on(TcpListener::bind(https_listener))
-            .map_err(|err| {
-                format!("failed to bind to HTTPS socket address {https_listener:?}: {err}")
-            })?;
+        info!("binding HTTPS to {addr:?}");
+
+        let https_listener = build_tcp_listener(*addr, https_listen_port)
+            .map_err(|err| format!("failed to bind to HTTPS socket address {addr:?}: {err}"))?;
 
         info!(
             "listening for HTTPS on {:?}",
@@ -729,7 +704,6 @@ fn config_https(
                 .map_err(|err| format!("failed to lookup local address: {err}"))?
         );
 
-        let _guard = runtime.enter();
         server
             .register_https_listener(
                 https_listener,
@@ -752,20 +726,15 @@ fn config_quic(
     tls_cert_config: &TlsCertConfig,
     zone_dir: &Path,
     listen_addrs: &[IpAddr],
-    runtime: &runtime::Runtime,
 ) -> Result<(), String> {
     let quic_listen_port: u16 = args.quic_port.unwrap_or_else(|| config.quic_listen_port());
-    let quic_sockaddrs: Vec<SocketAddr> = listen_addrs
-        .iter()
-        .flat_map(|x| (*x, quic_listen_port).to_socket_addrs().unwrap())
-        .collect();
 
-    if quic_sockaddrs.is_empty() {
+    if listen_addrs.is_empty() {
         warn!("a tls certificate was specified, but no QUIC addresses configured to listen on");
         return Ok(());
     }
 
-    for quic_listener in &quic_sockaddrs {
+    for addr in listen_addrs {
         let tls_cert_path = tls_cert_config.path();
         if let Some(endpoint_name) = tls_cert_config.endpoint_name() {
             info!("loading cert for DNS over QUIC named {endpoint_name} from {tls_cert_path:?}");
@@ -777,12 +746,10 @@ fn config_quic(
             format!("failed to load tls certificate files from {tls_cert_path:?}: {err}")
         })?;
 
-        info!("Binding QUIC to {:?}", quic_listener);
-        let quic_listener = runtime
-            .block_on(UdpSocket::bind(quic_listener))
-            .map_err(|err| {
-                format!("failed to bind to QUIC socket address {quic_listener:?}: {err}")
-            })?;
+        info!("Binding QUIC to {addr:?}");
+
+        let quic_listener = build_udp_socket(*addr, quic_listen_port)
+            .map_err(|err| format!("failed to bind to QUIC socket address {addr:?}: {err}"))?;
 
         info!(
             "listening for QUIC on {:?}",
@@ -791,7 +758,6 @@ fn config_quic(
                 .map_err(|err| format!("failed to lookup local address: {err}"))?
         );
 
-        let _guard = runtime.enter();
         server
             .register_quic_listener(
                 quic_listener,
@@ -916,4 +882,43 @@ fn logger(level: tracing::Level) -> Result<(), String> {
         .init();
 
     Ok(())
+}
+
+/// Build a TcpListener for a given IP, port pair; IPv6 listeners will not accept v4 connections
+fn build_tcp_listener(ip: IpAddr, port: u16) -> Result<TcpListener, Error> {
+    let sock = if ip.is_ipv4() {
+        Socket::new(Domain::IPV4, Type::STREAM, None)?
+    } else {
+        let s = Socket::new(Domain::IPV6, Type::STREAM, None)?;
+        s.set_only_v6(true)?;
+        s
+    };
+
+    sock.set_nonblocking(true)?;
+
+    let s_addr = SocketAddr::new(ip, port);
+    sock.bind(&s_addr.into())?;
+
+    // this is a fairly typical backlog value, but we don't have any good data to support it as of yet
+    sock.listen(128)?;
+
+    TcpListener::from_std(sock.into())
+}
+
+/// Build a UdpSocket for a given IP, port pair; IPv6 sockets will not accept v4 connections
+fn build_udp_socket(ip: IpAddr, port: u16) -> Result<UdpSocket, Error> {
+    let sock = if ip.is_ipv4() {
+        Socket::new(Domain::IPV4, Type::DGRAM, None)?
+    } else {
+        let s = Socket::new(Domain::IPV6, Type::DGRAM, None)?;
+        s.set_only_v6(true)?;
+        s
+    };
+
+    sock.set_nonblocking(true)?;
+
+    let s_addr = SocketAddr::new(ip, port);
+    sock.bind(&s_addr.into())?;
+
+    UdpSocket::from_std(sock.into())
 }


### PR DESCRIPTION
Right now, the hickory server doesn't accept IPv6 connections unless an address is specified in listen_addrs_ipv6.  Additionally, IPv6 sockets are created as wildcard sockets, which will accept v4 and v6 connections. This has a few impacts:

  1. If a user specifies 0.0.0.0/0 in listen_addrs_ipv4 and ::0 in listen_addrs_ipv4 with a static port, they'll get a bind error.
  2. If a user configures just configures 0.0.0.0/0, no IPv6 connections will be accepted. If only ::0 is specified, then both v4 and v6 connections will be accepted over the same socket.
  2. If a user just specifies a ::0 v6 listen address, but has v4 allow or deny networks configured, those will not be evaluated correctly, generally resulting in every IPv4 address matching the deny list.

Note: we have tests today that have both listen_addrs_ipv4 = 0.0.0.0 and listen_addrs_ipv6 = ::0 configured. Those work by chance, because the test harness runs with port = 0, so a (different) random port is selected for each.

This change:
  1. Adds build_tcp_listener and build_udp_socket functions to the server to avoid duplication across the various call sites and uses socket2 to force IPv6 sockets to be v6-only.
  2.  Refactors the existing call sites to use the new functions
  3. Adds ::0 to the listener list if the user does not specify any listen IPs at all, so by default we will accept both IPv4 and IPv6 connections.

I considered just making the third change, but between the 0.0.0.0/0 and ::0 collision and the broken v4 in v6 allow/denylist logic, this seems like a less error-prone approach overall. I also considered combining the build_tcp_listener and build_udp_socket functions and adding a socket_type parameter, but that didn't really save any code and it made the existing functions more difficult to read, IMO.
