### PR TITLE
Remove unneeded vecs in ForwardNSData and wrap in an Arc

### DIFF
--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -191,7 +191,7 @@ pub enum ProtoErrorKind {
         soa: Option<Box<Record<SOA>>>,
         /// Nameservers may be present in addition to or in lieu of an SOA for a referral
         /// The tuple struct layout is vec[(Nameserver, [vec of glue records])]
-        ns: Option<Vec<ForwardNSData>>,
+        ns: Option<Arc<[ForwardNSData]>>,
         /// negative ttl, as determined from DnsResponse::negative_ttl
         ///  this will only be present if the SOA was also present.
         negative_ttl: Option<u32>,
@@ -351,7 +351,7 @@ pub struct ForwardNSData {
     /// The referant NS record
     pub ns: Record,
     /// Any glue records associated with the referant NS record.
-    pub glue: Vec<Record>,
+    pub glue: Arc<[Record]>,
 }
 
 /// The error type for errors that get returned in the crate
@@ -371,7 +371,7 @@ impl ProtoError {
     pub fn nx_error(
         query: Query,
         soa: Option<Record<SOA>>,
-        ns: Option<Vec<ForwardNSData>>,
+        ns: Option<Arc<[ForwardNSData]>>,
         negative_ttl: Option<u32>,
         response_code: ResponseCode,
         trusted: bool,
@@ -510,11 +510,11 @@ impl ProtoError {
                                 None
                             })
                             .collect::<Vec<Record>>();
-                        referral_name_servers.push(ForwardNSData { ns: Record::to_owned(ns), glue })
+                        referral_name_servers.push(ForwardNSData { ns: Record::to_owned(ns), glue: glue.into() })
                     }
 
                     let option_ns = if !referral_name_servers.is_empty() {
-                        Some(referral_name_servers)
+                        Some(referral_name_servers.into())
                     } else {
                         None
                     };

--- a/crates/recursor/src/error.rs
+++ b/crates/recursor/src/error.rs
@@ -9,7 +9,7 @@
 
 #![deny(missing_docs)]
 
-use std::{fmt, io};
+use std::{fmt, io, sync::Arc};
 
 use crate::proto::error::ForwardNSData;
 use enum_as_inner::EnumAsInner;
@@ -41,7 +41,7 @@ pub enum ErrorKind {
     /// Upstream DNS authority returned a referral to another set of nameservers in the form of
     /// additional NS records.
     #[error("forward NS Response")]
-    ForwardNS(Vec<ForwardNSData>),
+    ForwardNS(Arc<[ForwardNSData]>),
 
     /// An error got returned from IO
     #[error("io error: {0}")]

--- a/crates/recursor/src/recursor_dns_handle.rs
+++ b/crates/recursor/src/recursor_dns_handle.rs
@@ -562,7 +562,7 @@ impl RecursorDnsHandle {
     async fn ns_pool_for_referral(
         &self,
         query: Query,
-        nameservers: Vec<ForwardNSData>,
+        nameservers: Arc<[ForwardNSData]>,
         request_time: Instant,
     ) -> Result<RecursorPool<TokioRuntimeProvider>, Error> {
         let query_name = query.name().clone();
@@ -572,8 +572,8 @@ impl RecursorDnsHandle {
         let mut config_group = NameServerConfigGroup::new();
         let mut need_ips_for_names = Vec::new();
 
-        for nameserver in nameservers.into_iter() {
-            let ns = nameserver.ns;
+        for nameserver in nameservers.iter() {
+            let ns = &nameserver.ns;
 
             let ns_name = if let Some(ns_name) = ns.data().as_ns() {
                 ns_name.0.clone()

--- a/crates/recursor/src/recursor_dns_handle.rs
+++ b/crates/recursor/src/recursor_dns_handle.rs
@@ -620,7 +620,7 @@ impl RecursorDnsHandle {
             if glue_ips.peek().is_some() {
                 config_group.append_ips(glue_ips, true);
             } else {
-                debug!("ns_pool_for_referral glue not found for {}", ns);
+                debug!("ns_pool_for_referral glue not found for {ns}");
                 need_ips_for_names.push(ns);
             }
         }
@@ -630,7 +630,7 @@ impl RecursorDnsHandle {
         // collect missing IP addresses, select over them all, get the addresses
         // make it configurable to query for all records?
         if config_group.is_empty() && !need_ips_for_names.is_empty() {
-            debug!("ns_pool_for_referral need glue for {}", query_name);
+            debug!("ns_pool_for_referral need glue for {query_name}");
 
             let mut resolve_futures = FuturesUnordered::new();
             for rec_type in [RecordType::A, RecordType::AAAA] {
@@ -653,10 +653,7 @@ impl RecursorDnsHandle {
             .await;
         }
 
-        debug!(
-            "ns_pool_for_referral found nameservers for {}: {config_group:?}",
-            query_name
-        );
+        debug!("ns_pool_for_referral found nameservers for {query_name}: {config_group:?}");
 
         // now construct a namesever pool based off the NS and glue records
         let ns = GenericNameServerPool::from_config(

--- a/crates/resolver/src/caching_client.rs
+++ b/crates/resolver/src/caching_client.rs
@@ -283,7 +283,7 @@ where
         valid_nsec: bool,
         query: Query,
         soa: Option<Record<SOA>>,
-        ns: Option<Vec<ForwardNSData>>,
+        ns: Option<Arc<[ForwardNSData]>>,
         negative_ttl: Option<u32>,
         response_code: ResponseCode,
         trusted: bool,


### PR DESCRIPTION
This removes some unneeded Vecs in the ForwardNSData structure and wraps the overall structure in an Arc. It doesn't eliminate the need to clone the ForwardNSData structure when promoting from ProtoError to RecursorError, but the Arc should make the clone a bit less expensive.