### PR TITLE
Remove workaround in clippy justfile target

### DIFF
--- a/justfile
+++ b/justfile
@@ -81,7 +81,6 @@ clippy-inner feature='':
 
 # Run clippy on all targets and all sources
 clippy:
-    find {{justfile_directory()}} -name '*.rs' -exec touch {} \;
     just clippy-inner --no-default-features
     just clippy-inner
     just clippy-inner --all-features


### PR DESCRIPTION
This removes a workaround in `just clippy`. Previously this would touch every source file, in order to ensure `cargo clippy` would process the source tree even if `cargo check` had just run. This is no longer an issue, as the caching issue across `cargo check` and `cargo clippy` has been resolved, and clippy can now print out lint messages cached from a previous run.