### PR TITLE
Add resolver/recursor configuration to avoid udp ports

### DIFF
--- a/bin/benches/comparison_benches.rs
+++ b/bin/benches/comparison_benches.rs
@@ -57,7 +57,7 @@ fn wrap_process(named: Child, server_port: u16) -> NamedProcess {
             .unwrap()
             .next()
             .unwrap();
-        let stream = UdpClientStream::new(addr, provider.clone());
+        let stream = UdpClientStream::builder(addr, provider.clone()).build();
         let client = AsyncClient::connect(stream);
         let (mut client, bg) = io_loop.block_on(client).expect("failed to create client");
         io_loop.spawn(bg);
@@ -151,7 +151,7 @@ fn hickory_udp_bench(b: &mut Bencher) {
         .unwrap()
         .next()
         .unwrap();
-    let stream = UdpClientStream::new(addr, TokioRuntimeProvider::new());
+    let stream = UdpClientStream::builder(addr, TokioRuntimeProvider::new()).build();
     bench(b, stream);
 
     // cleaning up the named process
@@ -168,7 +168,7 @@ fn hickory_udp_bench_prof(b: &mut Bencher) {
         .unwrap()
         .next()
         .unwrap();
-    let stream = UdpClientStream::new(addr, TokioRuntimeProvider::new());
+    let stream = UdpClientStream::builder(addr, TokioRuntimeProvider::new()).build();
     bench(b, stream);
 }
 
@@ -239,7 +239,7 @@ fn bind_udp_bench(b: &mut Bencher) {
         .unwrap()
         .next()
         .unwrap();
-    let stream = UdpClientStream::new(addr, TokioRuntimeProvider::new());
+    let stream = UdpClientStream::builder(addr, TokioRuntimeProvider::new()).build();
     bench(b, stream);
 
     // cleaning up the named process

--- a/bin/tests/integration/named_tests.rs
+++ b/bin/tests/integration/named_tests.rs
@@ -219,7 +219,7 @@ fn test_server_continues_on_bad_data_udp() {
             udp_port.expect("no udp_port"),
         );
 
-        let stream = UdpClientStream::new(addr, provider.clone());
+        let stream = UdpClientStream::builder(addr, provider.clone()).build();
         let client = AsyncClient::connect(stream);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
@@ -239,7 +239,7 @@ fn test_server_continues_on_bad_data_udp() {
             Ipv4Addr::new(127, 0, 0, 1).into(),
             udp_port.expect("no udp_port"),
         );
-        let stream = UdpClientStream::new(addr, provider);
+        let stream = UdpClientStream::builder(addr, provider).build();
         let client = AsyncClient::connect(stream);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");

--- a/crates/client/src/udp/udp_client_connection.rs
+++ b/crates/client/src/udp/udp_client_connection.rs
@@ -69,12 +69,10 @@ impl ClientConnection for UdpClientConnection {
     type SenderFuture = UdpClientConnect<TokioRuntimeProvider, Signer>;
 
     fn new_stream(&self, signer: Option<Arc<Signer>>) -> Self::SenderFuture {
-        UdpClientStream::with_timeout_and_signer_and_bind_addr(
-            self.name_server,
-            self.timeout,
-            signer,
-            self.bind_addr,
-            TokioRuntimeProvider::new(),
-        )
+        UdpClientStream::builder(self.name_server, TokioRuntimeProvider::new())
+            .with_signer(signer)
+            .with_timeout(Some(self.timeout))
+            .with_bind_addr(self.bind_addr)
+            .build()
     }
 }

--- a/crates/proto/src/tests/udp.rs
+++ b/crates/proto/src/tests/udp.rs
@@ -206,7 +206,9 @@ pub fn udp_client_stream_test<E: Executor>(
     // the tests should run within 5 seconds... right?
     // TODO: add timeout here, so that test never hangs...
     // let timeout = Timeout::new(Duration::from_secs(5));
-    let stream = UdpClientStream::with_timeout(server_addr, Duration::from_millis(500), provider);
+    let stream = UdpClientStream::builder(server_addr, provider)
+        .with_timeout(Some(Duration::from_millis(500)))
+        .build();
     let mut stream = exec.block_on(stream).ok().unwrap();
     let mut worked_once = false;
 

--- a/crates/proto/src/tests/udp.rs
+++ b/crates/proto/src/tests/udp.rs
@@ -21,6 +21,7 @@ pub fn next_random_socket_test(mut exec: impl Executor, provider: impl RuntimePr
     let (stream, _) = UdpStream::new(
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 52),
         None,
+        None,
         provider,
     );
     drop(

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -98,55 +98,6 @@ where
 }
 
 impl<P: RuntimeProvider> UdpClientStream<P, NoopMessageFinalizer> {
-    /// it is expected that the resolver wrapper will be responsible for creating and managing
-    ///  new UdpClients such that each new client would have a random port (reduce chance of cache
-    ///  poisoning)
-    ///
-    /// # Return
-    ///
-    /// A Future of a Stream which will handle sending and receiving messages.
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(name_server: SocketAddr, provider: P) -> UdpClientConnect<P> {
-        Self::builder(name_server, provider).build()
-    }
-
-    /// Constructs a new UdpStream for a client to the specified SocketAddr.
-    ///
-    /// # Arguments
-    ///
-    /// * `name_server` - the IP and Port of the DNS server to connect to
-    /// * `timeout` - connection timeout
-    /// * `provider` - async runtime provider, for I/O and timers
-    pub fn with_timeout(
-        name_server: SocketAddr,
-        timeout: Duration,
-        provider: P,
-    ) -> UdpClientConnect<P> {
-        Self::builder(name_server, provider)
-            .with_timeout(Some(timeout))
-            .build()
-    }
-
-    /// Constructs a new UdpStream for a client to the specified SocketAddr.
-    ///
-    /// # Arguments
-    ///
-    /// * `name_server` - the IP and Port of the DNS server to connect to
-    /// * `bind_addr` - the IP and port to connect from
-    /// * `timeout` - connection timeout
-    /// * `provider` - async runtime provider, for I/O and timers
-    pub fn with_bind_addr_and_timeout(
-        name_server: SocketAddr,
-        bind_addr: Option<SocketAddr>,
-        timeout: Duration,
-        provider: P,
-    ) -> UdpClientConnect<P> {
-        Self::builder(name_server, provider)
-            .with_timeout(Some(timeout))
-            .with_bind_addr(bind_addr)
-            .build()
-    }
-
     /// Construct a new [`UdpClientStream`] via a [`UdpClientStreamBuilder`].
     pub fn builder(
         name_server: SocketAddr,
@@ -159,68 +110,6 @@ impl<P: RuntimeProvider> UdpClientStream<P, NoopMessageFinalizer> {
             bind_addr: None,
             provider,
         }
-    }
-}
-
-impl<P: RuntimeProvider, MF: MessageFinalizer> UdpClientStream<P, MF> {
-    /// Constructs a new UdpStream for a client to the specified SocketAddr.
-    ///
-    /// # Arguments
-    ///
-    /// * `name_server` - the IP and Port of the DNS server to connect to
-    /// * `timeout` - connection timeout
-    /// * `signer` - optional final amendment
-    /// * `provider` - async runtime provider, for I/O and timers
-    pub fn with_timeout_and_signer(
-        name_server: SocketAddr,
-        timeout: Duration,
-        signer: Option<Arc<MF>>,
-        provider: P,
-    ) -> UdpClientConnect<P, MF> {
-        UdpClientStream::builder(name_server, provider)
-            .with_timeout(Some(timeout))
-            .with_signer(signer)
-            .build()
-    }
-
-    /// Constructs a new UdpStream for a client to the specified SocketAddr.
-    ///
-    /// # Arguments
-    ///
-    /// * `name_server` - the IP and Port of the DNS server to connect to
-    /// * `timeout` - connection timeout
-    /// * `signer` - optional final amendment
-    /// * `bind_addr` - the IP address and port to connect from
-    /// * `provider` - async runtime provider, for I/O and timers
-    pub fn with_timeout_and_signer_and_bind_addr(
-        name_server: SocketAddr,
-        timeout: Duration,
-        signer: Option<Arc<MF>>,
-        bind_addr: Option<SocketAddr>,
-        provider: P,
-    ) -> UdpClientConnect<P, MF> {
-        UdpClientStream::builder(name_server, provider)
-            .with_timeout(Some(timeout))
-            .with_signer(signer)
-            .with_bind_addr(bind_addr)
-            .build()
-    }
-
-    /// Constructs a new UdpStream for a client to the specified SocketAddr.
-    ///
-    /// # Arguments
-    ///
-    /// * `name_server` - the IP and Port of the DNS server to connect to
-    /// * `signer` - optional final amendment
-    /// * `timeout` - connection timeout
-    /// * `provider` - async runtime provider, for I/O and timers
-    pub fn with_provider(
-        name_server: SocketAddr,
-        signer: Option<Arc<MF>>,
-        timeout: Duration,
-        provider: P,
-    ) -> UdpClientConnect<P, MF> {
-        Self::with_timeout_and_signer(name_server, timeout, signer, provider)
     }
 }
 

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -89,7 +89,7 @@ rand.workspace = true
 resolv-conf = { workspace = true, optional = true, features = ["system"] }
 rustls = { workspace = true, optional = true }
 rustls-native-certs = { workspace = true, optional = true }
-serde = { workspace = true, features = ["derive"], optional = true }
+serde = { workspace = true, features = ["derive", "rc"], optional = true }
 smallvec.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -8,13 +8,12 @@
 //! Configuration for a resolver
 #![allow(clippy::use_self)]
 
+use std::collections::HashSet;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::ops::{Deref, DerefMut};
-use std::time::Duration;
-
-#[cfg(feature = "dns-over-rustls")]
 use std::sync::Arc;
+use std::time::Duration;
 
 use proto::rr::Name;
 use proto::xfer::Protocol;
@@ -907,6 +906,8 @@ pub struct ResolverOpts {
     pub authentic_data: bool,
     /// Shuffle DNS servers before each query.
     pub shuffle_dns_servers: bool,
+    /// Local UDP ports to avoid when making outgoing queries
+    pub avoid_local_udp_ports: Arc<HashSet<u16>>,
 }
 
 impl Default for ResolverOpts {
@@ -939,6 +940,7 @@ impl Default for ResolverOpts {
             recursion_desired: true,
             authentic_data: false,
             shuffle_dns_servers: false,
+            avoid_local_udp_ports: Arc::new(HashSet::new()),
         }
     }
 }

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -224,12 +224,9 @@ impl<P: RuntimeProvider> ConnectionProvider for GenericConnector<P> {
         let dns_connect = match (config.protocol, self.runtime_provider.quic_binder()) {
             (Protocol::Udp, _) => {
                 let provider_handle = self.runtime_provider.clone();
-                let stream = UdpClientStream::with_provider(
-                    config.socket_addr,
-                    None,
-                    options.timeout,
-                    provider_handle,
-                );
+                let stream = UdpClientStream::builder(config.socket_addr, provider_handle)
+                    .with_timeout(Some(options.timeout))
+                    .build();
                 let exchange = DnsExchange::connect(stream);
                 ConnectionConnect::Udp(exchange)
             }

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -226,6 +226,7 @@ impl<P: RuntimeProvider> ConnectionProvider for GenericConnector<P> {
                 let provider_handle = self.runtime_provider.clone();
                 let stream = UdpClientStream::builder(config.socket_addr, provider_handle)
                     .with_timeout(Some(options.timeout))
+                    .avoid_local_ports(options.avoid_local_udp_ports.clone())
                     .build();
                 let exchange = DnsExchange::connect(stream);
                 ConnectionConnect::Udp(exchange)

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -91,6 +91,7 @@ impl RecursiveAuthority {
             .dnssec_policy(config.dnssec_policy.load()?)
             .do_not_query(&config.do_not_query)
             .recursion_limit(config.recursion_limit)
+            .avoid_local_udp_ports(config.avoid_local_udp_ports.clone())
             .build(roots)
             .map_err(|e| format!("failed to initialize recursor: {e}"))?;
 

--- a/crates/server/src/store/recursor/config.rs
+++ b/crates/server/src/store/recursor/config.rs
@@ -9,6 +9,7 @@
 use std::sync::Arc;
 use std::{
     borrow::Cow,
+    collections::HashSet,
     fs::File,
     io::Read,
     net::SocketAddr,
@@ -52,6 +53,10 @@ pub struct RecursiveConfig {
     /// Networks that will not be queried during resolution
     #[serde(default)]
     pub do_not_query: Vec<IpNet>,
+
+    /// Local UDP ports to avoid when making outgoing queries
+    #[serde(default)]
+    pub avoid_local_udp_ports: HashSet<u16>,
 }
 
 impl RecursiveConfig {

--- a/tests/integration-tests/tests/integration/client_future_tests.rs
+++ b/tests/integration-tests/tests/integration/client_future_tests.rs
@@ -64,7 +64,7 @@ fn test_query_nonet() {
 fn test_query_udp_ipv4() {
     let io_loop = Runtime::new().unwrap();
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
-    let stream = UdpClientStream::new(addr, TokioRuntimeProvider::new());
+    let stream = UdpClientStream::builder(addr, TokioRuntimeProvider::new()).build();
     let client = AsyncClient::connect(stream);
     let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
     hickory_proto::runtime::spawn_bg(&io_loop, bg);
@@ -84,7 +84,7 @@ fn test_query_udp_ipv6() {
         .unwrap()
         .next()
         .unwrap();
-    let stream = UdpClientStream::new(addr, TokioRuntimeProvider::new());
+    let stream = UdpClientStream::builder(addr, TokioRuntimeProvider::new()).build();
     let client = AsyncClient::connect(stream);
     let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
     hickory_proto::runtime::spawn_bg(&io_loop, bg);
@@ -1001,11 +1001,9 @@ fn test_timeout_query_udp() {
         .next()
         .unwrap();
 
-    let stream = UdpClientStream::with_timeout(
-        addr,
-        std::time::Duration::from_millis(1),
-        TokioRuntimeProvider::new(),
-    );
+    let stream = UdpClientStream::builder(addr, TokioRuntimeProvider::new())
+        .with_timeout(Some(std::time::Duration::from_millis(1)))
+        .build();
     let client = AsyncClient::connect(stream);
     let (client, bg) = io_loop.block_on(client).expect("client failed to connect");
     hickory_proto::runtime::spawn_bg(&io_loop, bg);

--- a/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
+++ b/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
@@ -273,7 +273,7 @@ where
 
     let io_loop = Runtime::new().unwrap();
     let addr: SocketAddr = ("8.8.8.8", 53).to_socket_addrs().unwrap().next().unwrap();
-    let stream = UdpClientStream::new(addr, TokioRuntimeProvider::new());
+    let stream = UdpClientStream::builder(addr, TokioRuntimeProvider::new()).build();
     let client = AsyncClient::connect(stream);
     let (client, bg) = io_loop.block_on(client).expect("client failed to connect");
     hickory_proto::runtime::spawn_bg(&io_loop, bg);

--- a/tests/integration-tests/tests/integration/truncation_tests.rs
+++ b/tests/integration-tests/tests/integration/truncation_tests.rs
@@ -37,7 +37,7 @@ async fn test_truncation() {
     server.register_socket(udp_socket);
 
     // Create the UDP client.
-    let stream = UdpClientStream::new(nameserver, TokioRuntimeProvider::new());
+    let stream = UdpClientStream::builder(nameserver, TokioRuntimeProvider::new()).build();
     let (client, bg) = AsyncClient::connect(stream).await.unwrap();
 
     // Run the client exchange in the background.

--- a/util/src/bin/dns.rs
+++ b/util/src/bin/dns.rs
@@ -254,7 +254,7 @@ async fn udp(opts: Opts, provider: impl RuntimeProvider) -> Result<(), Box<dyn s
     let nameserver = opts.nameserver;
 
     println!("; using udp:{nameserver}");
-    let stream = UdpClientStream::new(nameserver, provider);
+    let stream = UdpClientStream::builder(nameserver, provider).build();
     let (client, bg) = AsyncClient::connect(stream).await?;
     let handle = tokio::spawn(bg);
     handle_request(opts.class, opts.zone, opts.command, client).await?;


### PR DESCRIPTION
This addresses #1722 for UDP sockets by adding configuration options to avoid binding to a list of local UDP ports. I added a builder for `UdpClientStream` to clean up the existing constructors, and add the ability to pass on this new configuration. (note that two of the existing constructors were identical save for argument order) I put the list of ports to avoid in an `Arc` from `ResolverOpts` and onward, to avoid cloning `HashSet`s after startup.

I manually tested this by adding a bias to the random port selection and extra logging statements, and confirming that the new rejection sampling loop kicked in.