### PR TITLE
Update windows.rs to use crate::proto::xfer::Protocol

### DIFF
--- a/crates/resolver/src/system_conf/windows.rs
+++ b/crates/resolver/src/system_conf/windows.rs
@@ -15,7 +15,8 @@ use ipconfig::get_adapters;
 
 use proto::rr::Name;
 
-use crate::config::{NameServerConfig, Protocol, ResolverConfig, ResolverOpts};
+use crate::config::{NameServerConfig, ResolverConfig, ResolverOpts};
+use crate::proto::xfer::Protocol;
 use crate::error::ResolveResult;
 
 /// Returns the name servers of the computer (of all adapters)

--- a/crates/resolver/src/system_conf/windows.rs
+++ b/crates/resolver/src/system_conf/windows.rs
@@ -16,8 +16,8 @@ use ipconfig::get_adapters;
 use proto::rr::Name;
 
 use crate::config::{NameServerConfig, ResolverConfig, ResolverOpts};
-use crate::proto::xfer::Protocol;
 use crate::error::ResolveResult;
+use crate::proto::xfer::Protocol;
 
 /// Returns the name servers of the computer (of all adapters)
 fn get_name_servers() -> ResolveResult<Vec<NameServerConfig>> {


### PR DESCRIPTION
enum import `Protocol` is private in crate::config::Protocol, use crate::proto::xfer::Protocol