### PR TITLE
Disable client_tests::test_nsec3_query_name_is_soa_name

### DIFF
--- a/tests/integration-tests/tests/integration/client_tests.rs
+++ b/tests/integration-tests/tests/integration/client_tests.rs
@@ -443,6 +443,7 @@ fn test_nsec3_no_data() {
 }
 
 #[test]
+#[ignore]
 #[cfg(feature = "dnssec")]
 fn test_nsec3_query_name_is_soa_name() {
     let name = Name::from_labels("valid.extended-dns-errors.com".split(".")).unwrap();


### PR DESCRIPTION
The extended DNS errors servers are intermittently returning SERVFAIL for the query in this test. This appears to be some sort of internal error on their side.