### PR TITLE
Make serde use RFC names for enum variants

### DIFF
--- a/bin/tests/integration/txt_tests.rs
+++ b/bin/tests/integration/txt_tests.rs
@@ -405,7 +405,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     .cloned()
     .expect("tlsa record not found");
     if let RData::TLSA(rdata) = tlsa_record.data() {
-        assert_eq!(rdata.cert_usage(), CertUsage::CA);
+        assert_eq!(rdata.cert_usage(), CertUsage::PkixTa);
         assert_eq!(rdata.selector(), Selector::Full);
         assert_eq!(rdata.matching(), Matching::Sha256);
         assert_eq!(

--- a/crates/proto/src/dnssec/algorithm.rs
+++ b/crates/proto/src/dnssec/algorithm.rs
@@ -122,6 +122,7 @@ pub enum Algorithm {
     #[deprecated(
         note = "this is a compromised hashing function, it is here for backward compatibility"
     )]
+    #[cfg_attr(feature = "serde", serde(rename = "RSASHA1-NSEC3-SHA1"))]
     RSASHA1NSEC3SHA1,
     /// RSA public key with SHA256 hash
     RSASHA256,

--- a/crates/proto/src/dnssec/mod.rs
+++ b/crates/proto/src/dnssec/mod.rs
@@ -53,14 +53,16 @@ pub use self::verifier::Verifier;
 
 /// DNSSEC Delegation Signer (DS) Resource Record (RR) Type Digest Algorithms
 ///
-///```text
-/// 0 Reserved - [RFC3658]
-/// 1 SHA-1 MANDATORY [RFC3658]
-/// 2 SHA-256 MANDATORY [RFC4509]
-/// 3 GOST R 34.11-94 OPTIONAL [RFC5933]
-/// 4 SHA-384 OPTIONAL [RFC6605]
-/// 5 ED25519 [RFC draft-ietf-curdle-dnskey-eddsa-03]
-/// 5-255 Unassigned -
+/// [IANA Registry](https://www.iana.org/assignments/ds-rr-types/ds-rr-types.xhtml)
+/// ```text
+/// Value    Description           Status       Reference
+///  0        Reserved              -            [RFC3658]
+///  1        SHA-1                 MANDATORY    [RFC3658]
+///  2        SHA-256               MANDATORY    [RFC4509]
+///  3        GOST R 34.11-94       DEPRECATED   [RFC5933][Change the status of GOST Signature Algorithms in DNSSEC in the IETF stream to Historic]
+///  4        SHA-384               OPTIONAL     [RFC6605]
+///  5        GOST R 34.11-2012     OPTIONAL     [RFC9558]
+///  6        SM3                   OPTIONAL     [RFC9563]
 /// ```
 ///
 /// <https://www.iana.org/assignments/ds-rr-types/ds-rr-types.xhtml>
@@ -69,10 +71,13 @@ pub use self::verifier::Verifier;
 #[non_exhaustive]
 pub enum DigestType {
     /// [RFC 3658](https://tools.ietf.org/html/rfc3658)
+    #[cfg_attr(feature = "serde", serde(rename = "SHA-1"))]
     SHA1,
     /// [RFC 4509](https://tools.ietf.org/html/rfc4509)
+    #[cfg_attr(feature = "serde", serde(rename = "SHA-256"))]
     SHA256,
     /// [RFC 6605](https://tools.ietf.org/html/rfc6605)
+    #[cfg_attr(feature = "serde", serde(rename = "SHA-384"))]
     SHA384,
 }
 

--- a/crates/proto/src/dnssec/nsec3.rs
+++ b/crates/proto/src/dnssec/nsec3.rs
@@ -103,6 +103,7 @@ use crate::serialize::binary::{BinEncodable, BinEncoder};
 pub enum Nsec3HashAlgorithm {
     /// Hash for the Nsec3 records
     #[default]
+    #[cfg_attr(feature = "serde", serde(rename = "SHA-1"))]
     SHA1,
 }
 

--- a/crates/proto/src/dnssec/rdata/tsig.rs
+++ b/crates/proto/src/dnssec/rdata/tsig.rs
@@ -184,24 +184,34 @@ pub struct TSIG {
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum TsigAlgorithm {
     /// HMAC-MD5.SIG-ALG.REG.INT (not supported for cryptographic operations)
+    #[cfg_attr(feature = "serde", serde(rename = "HMAC-MD5.SIG-ALG.REG.INT"))]
     HmacMd5,
     /// gss-tsig (not supported for cryptographic operations)
+    #[cfg_attr(feature = "serde", serde(rename = "gss-tsig"))]
     Gss,
     /// hmac-sha1 (not supported for cryptographic operations)
+    #[cfg_attr(feature = "serde", serde(rename = "hmac-sha1"))]
     HmacSha1,
     /// hmac-sha224 (not supported for cryptographic operations)
+    #[cfg_attr(feature = "serde", serde(rename = "hmac-sha224"))]
     HmacSha224,
     /// hmac-sha256
+    #[cfg_attr(feature = "serde", serde(rename = "hmac-sha256"))]
     HmacSha256,
     /// hmac-sha256-128 (not supported for cryptographic operations)
+    #[cfg_attr(feature = "serde", serde(rename = "hmac-sha256-128"))]
     HmacSha256_128,
     /// hmac-sha384
+    #[cfg_attr(feature = "serde", serde(rename = "hmac-sha384"))]
     HmacSha384,
     /// hmac-sha384-192 (not supported for cryptographic operations)
+    #[cfg_attr(feature = "serde", serde(rename = "hmac-sha384-192"))]
     HmacSha384_192,
     /// hmac-sha512
+    #[cfg_attr(feature = "serde", serde(rename = "hmac-sha512"))]
     HmacSha512,
     /// hmac-sha512-256 (not supported for cryptographic operations)
+    #[cfg_attr(feature = "serde", serde(rename = "hmac-sha512-256"))]
     HmacSha512_256,
     /// Unknown algorithm
     Unknown(Name),

--- a/crates/proto/src/rr/rdata/caa.rs
+++ b/crates/proto/src/rr/rdata/caa.rs
@@ -153,12 +153,14 @@ pub enum Property {
     ///    Name`` or a party acting under the explicit authority of the holder
     ///    of that domain name to issue certificates for the domain in which
     ///    the property is published.
+    #[cfg_attr(feature = "serde", serde(rename = "issue"))]
     Issue,
     /// The issuewild
     ///    property entry authorizes the holder of the domain name `Issuer
     ///    Domain Name` or a party acting under the explicit authority of the
     ///    holder of that domain name to issue wildcard certificates for the
     ///    domain in which the property is published.
+    #[cfg_attr(feature = "serde", serde(rename = "issuewild"))]
     IssueWild,
     /// Specifies a URL to which an issuer MAY report
     ///    certificate issue requests that are inconsistent with the issuer's
@@ -166,6 +168,7 @@ pub enum Property {
     ///    Certificate Evaluator may use to report observation of a possible
     ///    policy violation. The Incident Object Description Exchange Format
     ///    (IODEF) format is used [RFC7970](https://www.rfc-editor.org/rfc/rfc7970).
+    #[cfg_attr(feature = "serde", serde(rename = "iodef"))]
     Iodef,
     /// Unknown format to Hickory DNS
     Unknown(String),

--- a/crates/proto/src/rr/rdata/sshfp.rs
+++ b/crates/proto/src/rr/rdata/sshfp.rs
@@ -202,9 +202,11 @@ pub enum FingerprintType {
     Reserved,
 
     /// SHA-1
+    #[cfg_attr(feature = "serde", serde(rename = "SHA-1"))]
     SHA1,
 
     /// SHA-256
+    #[cfg_attr(feature = "serde", serde(rename = "SHA-256"))]
     SHA256,
 
     /// Unassigned value

--- a/crates/proto/src/rr/rdata/svcb.rs
+++ b/crates/proto/src/rr/rdata/svcb.rs
@@ -205,18 +205,25 @@ impl SVCB {
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum SvcParamKey {
     /// Mandatory keys in this RR
+    #[cfg_attr(feature = "serde", serde(rename = "mandatory"))]
     Mandatory,
     /// Additional supported protocols
+    #[cfg_attr(feature = "serde", serde(rename = "alpn"))]
     Alpn,
     /// No support for default protocol
+    #[cfg_attr(feature = "serde", serde(rename = "no-default-alpn"))]
     NoDefaultAlpn,
     /// Port for alternative endpoint
+    #[cfg_attr(feature = "serde", serde(rename = "port"))]
     Port,
     /// IPv4 address hints
+    #[cfg_attr(feature = "serde", serde(rename = "ipv4hint"))]
     Ipv4Hint,
     /// Encrypted Client Hello configuration list
+    #[cfg_attr(feature = "serde", serde(rename = "ech"))]
     EchConfigList,
     /// IPv6 address hints
+    #[cfg_attr(feature = "serde", serde(rename = "ipv6hint"))]
     Ipv6Hint,
     /// Private Use
     Key(u16),
@@ -359,6 +366,7 @@ pub enum SvcParamValue {
     ///    mandatory keys that are present.
     ///
     /// see `Mandatory`
+    #[cfg_attr(feature = "serde", serde(rename = "mandatory"))]
     Mandatory(Mandatory),
     ///  [RFC 9460 SVCB and HTTPS Resource Records, Nov 2023](https://datatracker.ietf.org/doc/html/rfc9460#section-7.1)
     ///
@@ -368,10 +376,12 @@ pub enum SvcParamValue {
     ///    identifiers [Alpn] and associated transport protocols supported by
     ///    this service endpoint (the "SVCB ALPN set").
     /// ```
+    #[cfg_attr(feature = "serde", serde(rename = "alpn"))]
     Alpn(Alpn),
     /// For "no-default-alpn", the presentation and wire format values MUST
     ///    be empty.
     /// See also `Alpn`
+    #[cfg_attr(feature = "serde", serde(rename = "no-default-alpn"))]
     NoDefaultAlpn,
     ///  [RFC 9460 SVCB and HTTPS Resource Records, Nov 2023](https://datatracker.ietf.org/doc/html/rfc9460#section-7.2)
     ///
@@ -395,6 +405,7 @@ pub enum SvcParamValue {
     ///   client to lose access to the service, so operators should exercise
     ///   caution when using this SvcParamKey to specify a non-default port.
     /// ```
+    #[cfg_attr(feature = "serde", serde(rename = "port"))]
     Port(u16),
     ///  [RFC 9460 SVCB and HTTPS Resource Records, Nov 2023](https://datatracker.ietf.org/doc/html/rfc9460#section-7.2)
     ///
@@ -410,6 +421,7 @@ pub enum SvcParamValue {
     ///   or other geo-aware features and thereby degrade client performance.
     ///
     /// see `IpHint`
+    #[cfg_attr(feature = "serde", serde(rename = "ipv4hint"))]
     Ipv4Hint(IpHint<A>),
     /// [draft-ietf-tls-svcb-ech-01 Bootstrapping TLS Encrypted ClientHello with DNS Service Bindings, Sep 2024](https://datatracker.ietf.org/doc/html/draft-ietf-tls-svcb-ech-01)
     ///
@@ -421,8 +433,10 @@ pub enum SvcParamValue {
     ///   (including DTLS [RFC9147] and QUIC version 1 [RFC9001]) unless otherwise
     ///   specified.
     /// ```
+    #[cfg_attr(feature = "serde", serde(rename = "ech"))]
     EchConfigList(EchConfigList),
     /// See `IpHint`
+    #[cfg_attr(feature = "serde", serde(rename = "ipv6hint"))]
     Ipv6Hint(IpHint<AAAA>),
     /// Unparsed network data. Refer to documents on the associated key value
     ///

--- a/crates/proto/src/rr/rdata/tlsa.rs
+++ b/crates/proto/src/rr/rdata/tlsa.rs
@@ -92,6 +92,7 @@ pub enum CertUsage {
     ///       the certificate might or might not have the basicConstraints
     ///       extension present.
     /// ```
+    #[cfg_attr(feature = "serde", serde(rename = "PKIX-TA"))]
     CA,
 
     /// ```text
@@ -104,6 +105,7 @@ pub enum CertUsage {
     ///       certificate MUST pass PKIX certification path validation and MUST
     ///       match the TLSA record.
     /// ```
+    #[cfg_attr(feature = "serde", serde(rename = "PKIX-EE"))]
     Service,
 
     /// ```text
@@ -119,6 +121,7 @@ pub enum CertUsage {
     ///       certificate matching the TLSA record considered to be a trust
     ///       anchor for this certification path validation.
     /// ```
+    #[cfg_attr(feature = "serde", serde(rename = "DANE-TA"))]
     TrustAnchor,
 
     /// ```text
@@ -133,6 +136,7 @@ pub enum CertUsage {
     ///       requires that the certificate pass PKIX validation, but PKIX
     ///       validation is not tested for certificate usage 3.
     /// ```
+    #[cfg_attr(feature = "serde", serde(rename = "DANE-EE"))]
     DomainIssued,
 
     /// Unassigned at the time of this implementation
@@ -190,15 +194,18 @@ impl From<CertUsage> for u8 {
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum Selector {
     /// Full certificate: the Certificate binary structure as defined in [RFC5280](https://tools.ietf.org/html/rfc5280)
+    #[cfg_attr(feature = "serde", serde(rename = "Cert"))]
     Full,
 
     /// SubjectPublicKeyInfo: DER-encoded binary structure as defined in [RFC5280](https://tools.ietf.org/html/rfc5280)
+    #[cfg_attr(feature = "serde", serde(rename = "SPKI"))]
     Spki,
 
     /// Unassigned at the time of this writing
     Unassigned(u8),
 
     /// Private usage
+    #[cfg_attr(feature = "serde", serde(rename = "PrivSel"))]
     Private,
 }
 
@@ -249,18 +256,22 @@ impl From<Selector> for u8 {
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum Matching {
     /// Exact match on selected content
+    #[cfg_attr(feature = "serde", serde(rename = "Full"))]
     Raw,
 
     /// SHA-256 hash of selected content [RFC6234](https://tools.ietf.org/html/rfc6234)
+    #[cfg_attr(feature = "serde", serde(rename = "SHA2-256"))]
     Sha256,
 
     /// SHA-512 hash of selected content [RFC6234](https://tools.ietf.org/html/rfc6234)
+    #[cfg_attr(feature = "serde", serde(rename = "SHA2-512"))]
     Sha512,
 
     /// Unassigned at the time of this writing
     Unassigned(u8),
 
     /// Private usage
+    #[cfg_attr(feature = "serde", serde(rename = "PrivMatch"))]
     Private,
 }
 


### PR DESCRIPTION
Right now, when using `hmac-sha256` and loading it from a config file using the serde interface automatically derived for these, I need to write `HmacSha256` instead of the name used in the RFC. This is unexpected and potentially confusing to users.

This PR makes it so that the old names based on the enum variants *don't* work anymore, and the names specified in the RFC start working. Alternatively, we could use `serde(alias = "<name here>")` instead of `serde(rename = "<name here>")`, which would allow the RFC names to work but wouldn't break existing users.

In my opinion, we should push for correct names, and as long as hickory isn't at a 1.0, breaking changes like this should potentially be expected.

I'll be looking through the code base some more to see if I find more occurrences of this and will put it into this PR as well, but I thought I should probably open this PR early so that discussion on `alias` vs `rename` can start already.