### PR TITLE
Propagate NX domain and no record found errors

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
@@ -42,7 +42,6 @@ fn can_resolve() -> Result<()> {
     Ok(())
 }
 
-#[ignore]
 #[test]
 fn nxdomain() -> Result<()> {
     let needle_fqdn = FQDN::TEST_DOMAIN.push_label("unicorn");

--- a/conformance/packages/conformance-tests/src/resolver/nsec.rs
+++ b/conformance/packages/conformance-tests/src/resolver/nsec.rs
@@ -17,7 +17,6 @@ fn zone_exist_domain_does_not_nsec3() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn zone_exist_domain_does_not_nsec() -> Result<()> {
     zone_exist_domain_does_not(Nsec::_1)
 }
@@ -29,19 +28,16 @@ fn zone_does_not_exist_nsec3() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn zone_does_not_exist_nsec() -> Result<()> {
     zone_does_not_exist(Nsec::_1)
 }
 
 #[test]
-#[ignore]
 fn domain_exists_record_type_does_not_nsec3() -> Result<()> {
     domain_exists_record_type_does_not(Nsec::_3 { salt: None })
 }
 
 #[test]
-#[ignore]
 fn domain_exists_record_type_does_not_nsec() -> Result<()> {
     domain_exists_record_type_does_not(Nsec::_1)
 }

--- a/crates/recursor/src/recursor_dns_handle.rs
+++ b/crates/recursor/src/recursor_dns_handle.rs
@@ -178,17 +178,17 @@ impl RecursorDnsHandle {
                 Err(e) => match e.kind() {
                     ErrorKind::Forward(name) => {
                         // if we already had this name, don't try again
-                        if &zone == name {
-                            debug!("zone previously searched for {}", name);
+                        if zone == name.name {
+                            debug!("zone previously searched for {}", name.name);
                             break 'max_forward;
                         };
 
                         debug!(
                             "ns for {} forwarded to {} via SOA record",
                             query.name(),
-                            name
+                            name.name
                         );
-                        zone = name.clone();
+                        zone = name.name.clone();
                     }
                     _ => return Err(e),
                 },

--- a/crates/resolver/src/caching_client.rs
+++ b/crates/resolver/src/caching_client.rs
@@ -149,12 +149,13 @@ where
                     RecordType::PTR => return Ok(Lookup::from_rdata(query, LOCALHOST.clone())),
                     _ => {
                         return Err(ProtoError::nx_error(
-                            query,
+                            Box::new(query),
                             None,
                             None,
                             None,
                             ResponseCode::NoError,
                             false,
+                            None,
                         ))
                     } // Are there any other types we can use?
                 },
@@ -163,12 +164,13 @@ where
                 ResolverUsage::LinkLocal => (),
                 ResolverUsage::NxDomain => {
                     return Err(ProtoError::nx_error(
-                        query,
+                        Box::new(query),
                         None,
                         None,
                         None,
                         ResponseCode::NXDomain,
                         false,
+                        None,
                     ))
                 }
                 ResolverUsage::Normal => (),
@@ -211,6 +213,7 @@ where
                         response_code,
                         trusted,
                         ns,
+                        ..
                     } => {
                         Err(Self::handle_nxdomain(
                             is_dnssec,
@@ -297,6 +300,7 @@ where
                 negative_ttl,
                 response_code,
                 trusted: true,
+                authorities: None,
             }
             .into()
         } else {
@@ -308,6 +312,7 @@ where
                 negative_ttl: None,
                 response_code,
                 trusted,
+                authorities: None,
             }
             .into()
         }
@@ -540,7 +545,7 @@ mod tests {
         .unwrap_err()
         .kind()
         {
-            assert_eq!(**query, Query::new());
+            assert_eq!(*query, Box::new(Query::new()));
             assert_eq!(*negative_ttl, None);
         } else {
             panic!("wrong error received")

--- a/crates/resolver/src/dns_lru.rs
+++ b/crates/resolver/src/dns_lru.rs
@@ -493,6 +493,7 @@ mod tests {
             negative_ttl: Some(1),
             response_code: ResponseCode::NoError,
             trusted: false,
+            authorities: None,
         };
         let nx_error = lru.negative(name.clone(), err.into(), now);
         match nx_error.kind() {
@@ -512,6 +513,7 @@ mod tests {
             negative_ttl: Some(3),
             response_code: ResponseCode::NoError,
             trusted: false,
+            authorities: None,
         };
         let nx_error = lru.negative(name, err.into(), now);
         match nx_error.kind() {
@@ -585,6 +587,7 @@ mod tests {
             negative_ttl: Some(62),
             response_code: ResponseCode::NoError,
             trusted: false,
+            authorities: None,
         };
         let nx_error = lru.negative(name.clone(), err.into(), now);
         match nx_error.kind() {
@@ -604,6 +607,7 @@ mod tests {
             negative_ttl: Some(59),
             response_code: ResponseCode::NoError,
             trusted: false,
+            authorities: None,
         };
         let nx_error = lru.negative(name, err.into(), now);
         match nx_error.kind() {

--- a/crates/server/src/authority/auth_lookup.rs
+++ b/crates/server/src/authority/auth_lookup.rs
@@ -11,6 +11,9 @@ use std::sync::Arc;
 
 use cfg_if::cfg_if;
 
+#[cfg(feature = "dnssec")]
+use crate::{authority::DnssecSummary, proto::rr::dnssec::Proof};
+
 use crate::authority::{LookupObject, LookupOptions};
 use crate::proto::rr::{LowerName, Record, RecordSet, RecordType, RrsetRecords};
 
@@ -105,6 +108,25 @@ impl LookupObject for AuthLookup {
     fn take_additionals(&mut self) -> Option<Box<dyn LookupObject>> {
         let additionals = Self::take_additionals(self);
         additionals.map(|a| Box::new(a) as Box<dyn LookupObject>)
+    }
+
+    #[cfg(feature = "dnssec")]
+    fn dnssec_summary(&self) -> DnssecSummary {
+        let mut all_secure = None;
+        for record in self {
+            match record.proof() {
+                Proof::Secure => {
+                    all_secure.get_or_insert(true);
+                }
+                Proof::Bogus => return DnssecSummary::Bogus,
+                _ => all_secure = Some(false),
+            }
+        }
+
+        match all_secure {
+            Some(true) => DnssecSummary::Secure,
+            _ => DnssecSummary::Insecure,
+        }
     }
 }
 

--- a/tests/e2e-tests/src/recursor.rs
+++ b/tests/e2e-tests/src/recursor.rs
@@ -1,1 +1,2 @@
+pub mod basic;
 pub mod cname;

--- a/tests/e2e-tests/src/recursor/basic.rs
+++ b/tests/e2e-tests/src/recursor/basic.rs
@@ -1,0 +1,1 @@
+mod scenarios;

--- a/tests/e2e-tests/src/recursor/basic/scenarios.rs
+++ b/tests/e2e-tests/src/recursor/basic/scenarios.rs
@@ -1,0 +1,141 @@
+/// These scenarios use a single test network with the following records:
+///
+/// example.testing:
+///  www.example.testing IN A 192.0.2.1
+use std::net::Ipv4Addr;
+use std::thread;
+use std::time::Duration;
+
+use dns_test::{
+    client::{Client, DigOutput, DigSettings},
+    name_server::{NameServer, Running},
+    record::{Record, RecordType},
+    zone_file::Root,
+    Implementation, Network, Resolver, Result, FQDN,
+};
+
+/// Error code tests
+///
+/// Querying IN A www.example.testing yields NOERROR and 1 answer record
+/// Querying IN AAAA www.example.testing yields NOERROR and 0 answer records + 1 authority record
+/// Querying IN A www2.example.testing yields NXDOMAIN and 1 authority records.
+#[test]
+fn error_code_tests() -> Result<()> {
+    let target_fqdn = FQDN("www.example.testing.")?;
+    let target_ipv4_addr = Ipv4Addr::new(192, 0, 2, 1);
+
+    let test = TestNetwork::new().unwrap();
+
+    let res = test.dig(RecordType::A, &target_fqdn);
+
+    if let Ok(res) = &res {
+        assert!(res.status.is_noerror());
+        assert_eq!(res.answer.len(), 1);
+        if let Record::A(rec) = res.answer.first().unwrap() {
+            assert_eq!(rec.fqdn, target_fqdn);
+            assert_eq!(rec.ipv4_addr, target_ipv4_addr);
+        } else {
+            panic!("error");
+        }
+    } else {
+        panic!("error");
+    }
+
+    let res = test.dig(RecordType::AAAA, &target_fqdn);
+
+    if let Ok(res) = &res {
+        assert!(res.status.is_noerror());
+        assert_eq!(res.answer.len(), 0);
+        assert_eq!(res.authority.len(), 1);
+        if let Record::SOA(rec) = res.authority.first().unwrap() {
+            assert_eq!(rec.zone, FQDN("example.testing.")?);
+        } else {
+            panic!("error");
+        }
+    } else {
+        panic!("error");
+    }
+
+    let res = test.dig(RecordType::A, &FQDN("www2.example.testing.")?);
+
+    if let Ok(res) = &res {
+        assert!(res.status.is_nxdomain());
+        assert_eq!(res.answer.len(), 0);
+        assert_eq!(res.authority.len(), 1);
+        if let Record::SOA(rec) = res.authority.first().unwrap() {
+            assert_eq!(rec.zone, FQDN("example.testing.")?);
+        } else {
+            panic!("error");
+        }
+    } else {
+        panic!("error");
+    }
+
+    Ok(())
+}
+
+struct TestNetwork {
+    _network: Network,
+    _root_ns: NameServer<Running>,
+    _tld_ns: NameServer<Running>,
+    _example_ns: NameServer<Running>,
+    resolver: Resolver,
+    client: Client,
+}
+
+impl TestNetwork {
+    fn new() -> Result<Self> {
+        let www_fqdn = FQDN("www.example.testing.")?;
+        let www_ipv4 = Ipv4Addr::new(192, 0, 2, 1);
+
+        let network = Network::new()?;
+
+        let mut root_ns = NameServer::new(&Implementation::test_peer(), FQDN::ROOT, &network)?;
+        let mut tld_ns = NameServer::new(&Implementation::test_peer(), FQDN::TEST_TLD, &network)?;
+
+        let mut example_ns = NameServer::new(
+            &Implementation::test_peer(),
+            FQDN("example.testing.")?,
+            &network,
+        )?;
+
+        example_ns.add(Record::a(www_fqdn, www_ipv4));
+
+        root_ns.referral(
+            FQDN::TEST_TLD,
+            FQDN("primary.tld-server.testing.")?,
+            tld_ns.ipv4_addr(),
+        );
+        tld_ns.referral(
+            FQDN("example.testing.")?,
+            FQDN("ns.example.testing.")?,
+            example_ns.ipv4_addr(),
+        );
+
+        let root_hint: Root = root_ns.root_hint();
+
+        let resolver =
+            Resolver::new(&network, root_hint).start_with_subject(&Implementation::hickory())?;
+
+        let client = Client::new(resolver.network())?;
+
+        let ret = Self {
+            _network: network,
+            _root_ns: root_ns.start()?,
+            _tld_ns: tld_ns.start()?,
+            _example_ns: example_ns.start()?,
+            resolver,
+            client,
+        };
+
+        thread::sleep(Duration::from_secs(2));
+
+        Ok(ret)
+    }
+
+    fn dig(&self, r_type: RecordType, q_name: &FQDN) -> Result<DigOutput> {
+        let a_settings = *DigSettings::default().recurse().authentic_data();
+        self.client
+            .dig(a_settings, self.resolver.ipv4_addr(), r_type, q_name)
+    }
+}

--- a/tests/integration-tests/tests/integration/chained_authority_tests.rs
+++ b/tests/integration-tests/tests/integration/chained_authority_tests.rs
@@ -148,7 +148,7 @@ async fn chained_authority_test() {
 
     // Eighth test -- Primary returns Break(Err); secondary consult WOULD result in a record
     // returned; verify no records
-    error_test(&catalog, "breakerr.example.com.", ResponseCode::NoError).await;
+    error_test(&catalog, "breakerr.example.com.", ResponseCode::NXDomain).await;
 }
 
 struct TestAuthority {


### PR DESCRIPTION
This PR allows the Hickory recursor to more accurately provide NXDomain and NoData responses to queries.  This required a number of changes to accomplish:

1. Change the ProtoErrorKind::Forward variant to preserve authority records and introduce a conversion method from RecursorErrorKind::Forward to ProtoErrorKind::NoRecordsFound for sending accurate responses back to clients.
2. Change the catalog forward response building method to preserve authority records
3. Change the DNSSEC Handler in the recursor to send back ProtoErrorKind::NoRecordsFound when dealing with NXDomain and NoData responses
4. Change the DNSSEC send handler to process error messages.  Previously, the DNSSEC handler would ignore any error responses, which resulted in those responses not undergoing validation, even when Hickory is configured in validating mode.

There are also new tests for basic response code correctness to validate the changes above, and un-ignoring some conformance tests that now pass.

This change-set covers all of the NXDomain and NoError response mangling scenarios I could find in the code base, and it fixes a few DNSSEC-related issues.  Significant DNSSEC-related processing issues remain, however, and I think will need to be addressed in a separate PR.  While working on this fix, I also noticed:

* The NSEC3 code does not appear to handle opt-out proofs at all
* The DNSSEC code does not appear to correctly handle insecure delegations, partially due to the above.

The net result of this is that any queries to an insecure delegation from a secure parent will fail if hickory is configured as a validating resolver (i.e., almost all queries will fail if hickory is configured as a validating resolver.)

This PR does not fix the insecure delegation validation problem, but any realistic fix is contingent on fixing this issues this PR does address.

Related Issues/PRs:
* Issue #2503
* Issue #2435 
* Issue #2395
* Issue #2514
* PR #2477 
* PR #2388 
