### PR TITLE
Docs: resolver no longer returns background future

### DIFF
--- a/crates/async-std-resolver/src/lib.rs
+++ b/crates/async-std-resolver/src/lib.rs
@@ -119,13 +119,6 @@ pub type AsyncStdResolver = AsyncResolver<AsyncStdConnectionProvider>;
 ///
 /// * `config` - configuration, name_servers, etc. for the Resolver
 /// * `options` - basic lookup options for the resolver
-///
-/// # Returns
-///
-/// A tuple containing the new `AsyncResolver` and a future that drives the
-/// background task that runs resolutions for the `AsyncResolver`. See the
-/// documentation for `AsyncResolver` for more information on how to use
-/// the background future.
 pub async fn resolver(
     config: config::ResolverConfig,
     options: config::ResolverOpts,

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -292,16 +292,6 @@ pub use resolver::Resolver;
 
 /// This is an alias for [`AsyncResolver`], which replaced the type previously
 /// called `ResolverFuture`.
-///
-/// # Note
-///
-/// For users of `ResolverFuture`, the return type for `ResolverFuture::new`
-/// has changed since version 0.9 of `hickory-resolver`. It now returns
-/// a tuple of an [`AsyncResolver`] _and_ a background future, which must
-/// be spawned on a reactor before any lookup futures will run.
-///
-/// See the [`AsyncResolver`] documentation for more information on how to
-/// use the background future.
 #[deprecated(note = "use [`hickory_resolver::AsyncResolver`] instead")]
 #[cfg(feature = "tokio-runtime")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio-runtime")))]


### PR DESCRIPTION
This updates some documentation in the resolver crates to remove outdated mentions of background futures being returned by constructors. The async resolver now spawns a background task for each lookup using its runtime provider, see `ConnectionFuture` in `crates/resolver/src/name_server/connection_provider.rs`.