### PR TITLE
Update the NSEC/NSEC3 Truth Table to correctly log responses with NSEC and NSEC3 records

### DIFF
--- a/crates/proto/src/xfer/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle/mod.rs
@@ -241,13 +241,18 @@ where
                                 &nsec3s,
                             ),
                             (true, false) => verify_nsec(&query, soa_name, nsecs.as_slice()),
-                            (true, true) => {
+                            (false, false) => {
                                 warn!(
                                     "response contains both NSEC and NSEC3 records\nQuery:\n{query:?}\nResponse:\n{verified_message:?}"
                                 );
                                 Proof::Bogus
                             },
-                            (false, false) => Proof::Bogus,
+                            (true, true) => {
+                                warn!(
+                                    "response does not contain NSEC or NSEC3 records. Query: {query:?} response: {verified_message:?}"
+                                );
+                                Proof::Bogus
+                            },
                         };
 
                         if !nsec_proof.is_secure() {


### PR DESCRIPTION
The NSEC/NSEC3 truth table returns Bogus if there are no NSEC/NSEC3 records at all, and if both record types are present.  That is fine, however the detection logic is backwards.  This fixes the matching logic so the 'both record types detected' log is fired in the correct condition.