### PR TITLE
Conformance dnslib support

### DIFF
--- a/conformance/packages/dns-test/src/docker/dnslib.Dockerfile
+++ b/conformance/packages/dns-test/src/docker/dnslib.Dockerfile
@@ -1,0 +1,6 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y \
+        python3 \
+        python3-dnslib

--- a/tests/e2e-tests/src/recursor.rs
+++ b/tests/e2e-tests/src/recursor.rs
@@ -1,2 +1,3 @@
 pub mod basic;
 pub mod cname;
+pub mod security;

--- a/tests/e2e-tests/src/recursor/security.rs
+++ b/tests/e2e-tests/src/recursor/security.rs
@@ -1,0 +1,1 @@
+mod scenarios;

--- a/tests/e2e-tests/src/recursor/security/bad_txid.py
+++ b/tests/e2e-tests/src/recursor/security/bad_txid.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+#
+# This server will answer any query with an incorrect transaction ID.
+#
+from dnslib import DNSRecord, RCODE, RR, QTYPE, A
+from dnslib.server import DNSServer
+
+class Resolver(object):
+  def resolve(self, request, handler):
+    reply = request.reply()
+    if reply.header.id == 0:
+      reply.header.id = 65535
+    else:
+      reply.header.id = reply.header.id - 1
+    reply.header.rcode = getattr(RCODE,'NOERROR')
+    reply.add_answer(RR(request.q.qname, QTYPE.A, rdata=A("192.0.2.1")))
+    return reply
+
+if __name__ == "__main__":
+  resolver = Resolver()
+  server = DNSServer(resolver, address="0.0.0.0", port=53)
+  server.start()

--- a/tests/e2e-tests/src/recursor/security/scenarios.rs
+++ b/tests/e2e-tests/src/recursor/security/scenarios.rs
@@ -1,0 +1,61 @@
+/// These scenarios use a Dnslib-based server which returns invalid answers that should be dropped
+use std::fs;
+
+use dns_test::{
+    client::{Client, DigSettings},
+    name_server::NameServer,
+    record::RecordType,
+    zone_file::Root,
+    Implementation, Network, Resolver, Result, FQDN,
+};
+
+/// Transaction ID check - verify that Hickory will drop an invalidate transaction id.
+#[test]
+fn tx_id_validation_test() -> Result<()> {
+    let target_fqdn = FQDN("www.example.testing.")?;
+
+    let network = Network::new()?;
+
+    let mut root_ns = NameServer::new(&Implementation::test_peer(), FQDN::ROOT, &network)?;
+    let leaf_ns = NameServer::new(&Implementation::Dnslib, FQDN::TEST_TLD, &network)?;
+
+    let script = fs::read_to_string("src/recursor/security/bad_txid.py")?;
+
+    leaf_ns.cp("/script.py", &script[..])?;
+
+    root_ns.referral(
+        FQDN::TEST_TLD,
+        FQDN("primary.tld-server.testing.")?,
+        leaf_ns.ipv4_addr(),
+    );
+
+    let root_hint: Root = root_ns.root_hint();
+
+    let resolver =
+        Resolver::new(&network, root_hint).start_with_subject(&Implementation::hickory())?;
+
+    let client = Client::new(resolver.network())?;
+
+    let _root_ns = root_ns.start()?;
+    let _leaf_ns = leaf_ns.start()?;
+
+    let a_settings = *DigSettings::default().recurse().authentic_data();
+    let res = client.dig(
+        a_settings,
+        resolver.ipv4_addr(),
+        RecordType::A,
+        &target_fqdn,
+    );
+
+    if let Ok(res) = &res {
+        // FIXME This should be servfail; need the error propagation fix from #2522
+        assert!(res.status.is_noerror());
+        assert_eq!(res.answer.len(), 0);
+    } else {
+        panic!("error");
+    }
+
+    assert!(resolver.logs().unwrap().contains("expected message id:"));
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds support for a new implementation target for the conformance test suite: a container that is designed to run a Python script using [dnslib](https://github.com/paulc/dnslib/). This purpose of this target is to easily support end to end tests that involve abnormal or incorrect DNS responses that could not easily be generated using regular DNS servers, but with more flexibility than a packet capture replay.

This also includes an example test that verifies Hickory is dropping messages with incorrect transaction IDs.

My rationale for using dnslib is:
* The library is reasonably popular, is easy to write test servers with, and is commonly used by researchers writing DNS attack proofs of concept.
* Good feature support for the class of problems we will likely want to write tests for - invalid headers, cache poisoning attacks, bad referrals, etc. 
* Easy to integrate with the dns-test framework

cc: @bluejekyll and @djc 