### PR TITLE
Add caching policy configuration to recursor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,6 +996,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-openssl",
  "tokio-rustls",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "webpki-roots",

--- a/crates/recursor/src/recursor_dns_handle.rs
+++ b/crates/recursor/src/recursor_dns_handle.rs
@@ -43,6 +43,7 @@ pub(crate) struct RecursorDnsHandle {
 }
 
 impl RecursorDnsHandle {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         roots: impl Into<NameServerConfigGroup>,
         ns_cache_size: usize,
@@ -51,6 +52,7 @@ impl RecursorDnsHandle {
         security_aware: bool,
         do_not_query: Vec<IpNet>,
         avoid_local_udp_ports: Arc<HashSet<u16>>,
+        ttl_config: TtlConfig,
     ) -> Result<Self, ResolveError> {
         // configure the hickory-resolver
         let roots: NameServerConfigGroup = roots.into();
@@ -63,7 +65,7 @@ impl RecursorDnsHandle {
             GenericNameServerPool::from_config(roots, opts, TokioConnectionProvider::default());
         let roots = RecursorPool::from(Name::root(), roots);
         let name_server_cache = Arc::new(Mutex::new(NameServerCache::new(ns_cache_size)));
-        let record_cache = DnsLru::new(record_cache_size, TtlConfig::default());
+        let record_cache = DnsLru::new(record_cache_size, ttl_config);
 
         let mut do_not_query_v4 = PrefixSet::new();
         let mut do_not_query_v6 = PrefixSet::new();

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -107,6 +107,7 @@ ipconfig = { workspace = true, optional = true }
 futures-executor = { workspace = true, default-features = false, features = ["std"] }
 test-support.workspace = true
 tokio = { workspace = true, features = ["macros", "test-util"] }
+toml.workspace = true
 tracing-subscriber.workspace = true
 
 [package.metadata.docs.rs]

--- a/crates/resolver/src/dns_lru/ttl_config_deserialize.rs
+++ b/crates/resolver/src/dns_lru/ttl_config_deserialize.rs
@@ -1,0 +1,101 @@
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use hickory_proto::rr::RecordType;
+
+use super::{TtlBounds, TtlConfig};
+
+#[derive(Deserialize)]
+pub(super) struct TtlConfigMap(HashMap<TtlConfigField, TtlBounds>);
+
+impl From<TtlConfigMap> for TtlConfig {
+    fn from(value: TtlConfigMap) -> Self {
+        let mut default = TtlBounds::default();
+        let mut by_query_type = HashMap::new();
+        for (field, bounds) in value.0.into_iter() {
+            match field {
+                TtlConfigField::RecordType(record_type) => {
+                    by_query_type.insert(record_type, bounds);
+                }
+                TtlConfigField::Default => default = bounds,
+            }
+        }
+        Self {
+            default,
+            by_query_type,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Hash, Deserialize)]
+enum TtlConfigField {
+    #[serde(rename = "default")]
+    Default,
+    #[serde(untagged)]
+    RecordType(RecordType),
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    use crate::dns_lru::TtlConfig;
+
+    #[test]
+    fn error_cases() {
+        // Duplicate of "default"
+        let input = r#"[default]
+positive_max_ttl = 3600
+[default]
+positive_max_ttl = 3599"#;
+        let error = toml::from_str::<TtlConfig>(input).unwrap_err();
+        assert!(
+            error.message().contains("duplicate key `default`"),
+            "wrong error message: {error}"
+        );
+
+        // Duplicate of a record type
+        let input = r#"[default]
+positive_max_ttl = 86400
+[OPENPGPKEY]
+positive_max_ttl = 3600
+[OPENPGPKEY]
+negative_min_ttl = 60"#;
+        let error = toml::from_str::<TtlConfig>(input).unwrap_err();
+        assert!(
+            error.message().contains("duplicate key `OPENPGPKEY`"),
+            "wrong error message: {error}"
+        );
+
+        // Neither "default" nor a record type
+        let input = r#"[not_a_record_type]
+positive_max_ttl = 3600"#;
+        let error = toml::from_str::<TtlConfig>(input).unwrap_err();
+        assert!(
+            error.message().contains("data did not match any variant"),
+            "wrong error message: {error}"
+        );
+
+        // Array instead of table
+        #[derive(Debug, Deserialize)]
+        struct Wrapper {
+            #[allow(unused)]
+            cache_policy: TtlConfig,
+        }
+        let input = r#"cache_policy = []"#;
+        let error = toml::from_str::<Wrapper>(input).unwrap_err();
+        assert!(
+            error.message().contains("invalid type: sequence"),
+            "wrong error message: {error}"
+        );
+
+        // String instead of table
+        let input = r#"cache_policy = "yes""#;
+        let error = toml::from_str::<Wrapper>(input).unwrap_err();
+        assert!(
+            error.message().contains("invalid type: string"),
+            "wrong error message: {error}"
+        );
+    }
+}

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -92,6 +92,7 @@ impl RecursiveAuthority {
             .do_not_query(&config.do_not_query)
             .recursion_limit(config.recursion_limit)
             .avoid_local_udp_ports(config.avoid_local_udp_ports.clone())
+            .ttl_config(config.cache_policy.clone())
             .build(roots)
             .map_err(|e| format!("failed to initialize recursor: {e}"))?;
 

--- a/tests/test-data/test_configs/example_recursor.toml
+++ b/tests/test-data/test_configs/example_recursor.toml
@@ -44,3 +44,14 @@ recursion_limit = 12
 
 ## do_not_query: these networks will not be sent queries during recursive resolution
 do_not_query = ["0.0.0.0/8", "127.0.0.0/8", "::/128", "::1/128"]
+
+## cache_policy: set the minimum/maximum TTL for positive/negative responses.
+## This can be set for all queries and for specific query types.
+[zones.stores.cache_policy.default]
+positive_max_ttl = 86400
+
+[zones.stores.cache_policy.A]
+positive_max_ttl = 3600
+
+[zones.stores.cache_policy.AAAA]
+positive_max_ttl = 3600


### PR DESCRIPTION
This implements #1720. New configuration fields are added to set minimum and maximum TTL limits for the recursor. In addition, separate minimum and maximum TTL limits can be set for specific query types.