### PR TITLE
Conformance support for multiple zones on a nameserver

### DIFF
--- a/conformance/packages/dns-test/src/fqdn.rs
+++ b/conformance/packages/dns-test/src/fqdn.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use crate::{Error, Result};
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Eq, Hash, PartialEq)]
 pub struct FQDN {
     inner: Cow<'static, str>,
 }

--- a/conformance/packages/dns-test/src/templates/hickory.name-server.toml.jinja
+++ b/conformance/packages/dns-test/src/templates/hickory.name-server.toml.jinja
@@ -9,3 +9,10 @@ nx_proof_kind = { nsec3 = { iterations = 1 } }
 key_path = "/etc/zones/zsk.key"
 algorithm = "RSASHA256"
 is_zone_signing_key = true
+
+{% for zone in additional_zones -%}
+[[zones]]
+zone = "{{ zone }}"
+zone_type = "Primary"
+file = "/etc/zones/{{ zone }}zone"
+{% endfor -%}

--- a/conformance/packages/dns-test/src/templates/named.name-server.conf.jinja
+++ b/conformance/packages/dns-test/src/templates/named.name-server.conf.jinja
@@ -12,3 +12,10 @@ zone "{{ fqdn }}" IN {
      type primary;
      file "/etc/zones/main.zone";
 };
+
+{% for zone in additional_zones -%}
+zone "{{ zone }}" IN {
+    type primary;
+    file "/etc/zones/{{ zone }}zone";
+};
+{% endfor -%}

--- a/conformance/packages/dns-test/src/templates/nsd.conf.jinja
+++ b/conformance/packages/dns-test/src/templates/nsd.conf.jinja
@@ -7,3 +7,9 @@ remote-control:
 zone:
   name: {{ fqdn }}
   zonefile: /etc/zones/main.zone
+
+{% for zone in additional_zones -%}
+zone:
+  name: {{ zone }}
+  zonefile: /etc/zones/{{ zone }}zone
+{% endfor -%}


### PR DESCRIPTION
This adds support to dns-test for adding multiple zones on a nameserver in order to replicate an offline version of extended-dns-errors.com, and to efficiently support other tests which benefit from multiple domain names.
