### PR TITLE
tests: restore shorter timeout window in test

### DIFF
--- a/tests/integration-tests/tests/integration/client_tests.rs
+++ b/tests/integration-tests/tests/integration/client_tests.rs
@@ -307,7 +307,12 @@ async fn test_timeout_query_tcp() {
         .next()
         .unwrap();
 
-    let (stream, sender) = TcpClientStream::new(addr, None, None, TokioRuntimeProvider::default());
+    let (stream, sender) = TcpClientStream::new(
+        addr,
+        None,
+        Some(std::time::Duration::from_millis(1)),
+        TokioRuntimeProvider::default(),
+    );
     let multiplexer = DnsMultiplexer::new(stream, sender, None);
     match Client::connect(multiplexer).await {
         Err(e) if matches!(e.kind(), ProtoErrorKind::Timeout) => {}


### PR DESCRIPTION
In f6b7c4be7787327b52744f6c7a11da0386990d3f, I refactored tests to use the async client API. Because of the large amount of changes, there was some amount of copy and pasting involved, and it looks like I missed the shorter timeout window that this test specified.

<img width="1225" alt="Screenshot 2024-10-24 at 09 43 23" src="https://github.com/user-attachments/assets/087d62c6-2099-470e-937c-423a53c79e46">

Restore the timeout duration to its previous value. @divergentdave can you test whether this solves the issue for you?

Fixes #2526 (hopefully).