### PR TITLE
Recursor CNAME resource limit improvements

### DIFF
--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -156,6 +156,15 @@ pub enum ProtoErrorKind {
     #[error("maximum buffer size exceeded: {0}")]
     MaxBufferSizeExceeded(usize),
 
+    /// Maximum record limit was exceeded
+    #[error("maximum record limit for {record_type} exceeded: {count} records")]
+    MaxRecordLimitExceeded {
+        /// number of records
+        count: usize,
+        /// The record type that triggered the error.
+        record_type: RecordType,
+    },
+
     /// An error with an arbitrary message, referenced as &'static str
     #[error("{0}")]
     Message(&'static str),
@@ -753,6 +762,9 @@ impl Clone for ProtoErrorKind {
             LabelBytesTooLong(len) => LabelBytesTooLong(len),
             PointerNotPriorToLabel { idx, ptr } => PointerNotPriorToLabel { idx, ptr },
             MaxBufferSizeExceeded(max) => MaxBufferSizeExceeded(max),
+            MaxRecordLimitExceeded { count, record_type } => {
+                MaxRecordLimitExceeded { count, record_type }
+            }
             Message(msg) => Message(msg),
             Msg(ref msg) => Msg(msg.clone()),
             NoConnections => NoConnections,

--- a/tests/e2e-tests/src/recursor/cname/cname_loop.py
+++ b/tests/e2e-tests/src/recursor/cname/cname_loop.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+#
+from dnslib import DNSRecord, RCODE, RR, QTYPE, NS
+from dnslib.server import DNSServer
+
+class Resolver(object):
+  def resolve(self, request, handler):
+    qname = request.get_q().get_qname()
+    tokens = str(qname).split("-")
+    round = int(tokens[1]) + 1 if len(tokens) == 3 else 0
+
+    reply = request.reply()
+    reply.header.rcode = getattr(RCODE,'NOERROR')
+
+    # Stop before we hit the recursion depth limit
+    if round > 9:
+      reply.add_answer(*RR.fromZone(f"{qname} IN A 127.0.0.1"))
+    else:
+      for i in range(40):
+        host = f"c-{round}-{i}.testing."
+        reply.add_answer(*RR.fromZone(f"{qname} IN CNAME {host}"))
+    reply.auth = []
+    return reply
+
+if __name__ == "__main__":
+  resolver = Resolver()
+  server = DNSServer(resolver, address="0.0.0.0", port=53)
+  server.start()

--- a/tests/e2e-tests/src/recursor/cname/scenarios.rs
+++ b/tests/e2e-tests/src/recursor/cname/scenarios.rs
@@ -17,6 +17,7 @@
 ///  www10.example2.testing IN CNAME www11.example.testing.
 ///  www12.example2.testing IN CNAME www13.example.testing.
 ///
+use std::fs;
 use std::net::Ipv4Addr;
 use std::thread;
 use std::time::Duration;
@@ -162,6 +163,58 @@ fn multi_level_cname_tests() -> Result<()> {
     } else {
         panic!("Error");
     }
+
+    Ok(())
+}
+
+/// ensure that no more than MAX_CNAME_LOOKUPS will be resolved.
+#[test]
+fn cname_lookup_limit_test() -> Result<()> {
+    let target_fqdn = FQDN("host.testing.")?;
+
+    let network = Network::new()?;
+
+    let mut root_ns = NameServer::new(&Implementation::test_peer(), FQDN::ROOT, &network)?;
+    let leaf_ns = NameServer::new(&Implementation::Dnslib, FQDN::TEST_TLD, &network)?;
+
+    let script = fs::read_to_string("src/recursor/cname/cname_loop.py")?;
+
+    leaf_ns.cp("/script.py", &script[..])?;
+
+    root_ns.referral(
+        FQDN::TEST_TLD,
+        FQDN("primary.tld-server.testing.")?,
+        leaf_ns.ipv4_addr(),
+    );
+
+    let root_hint: Root = root_ns.root_hint();
+
+    let resolver =
+        Resolver::new(&network, root_hint).start_with_subject(&Implementation::hickory())?;
+
+    let client = Client::new(resolver.network())?;
+
+    let _root_ns = root_ns.start()?;
+    let _leaf_ns = leaf_ns.start()?;
+
+    thread::sleep(Duration::from_secs(2));
+    let a_settings = *DigSettings::default().recurse().authentic_data();
+    let res = client.dig(
+        a_settings,
+        resolver.ipv4_addr(),
+        RecordType::A,
+        &target_fqdn,
+    );
+
+    match res {
+        Ok(res) => {
+            assert!(res.status.is_servfail());
+            assert_eq!(res.answer.len(), 0);
+        }
+        Err(e) => panic!("error {e:?}; resolver logs: {}", resolver.logs().unwrap()),
+    }
+
+    assert!(resolver.logs().unwrap().contains("cname limit exceeded"));
 
     Ok(())
 }


### PR DESCRIPTION
Introduce an overall CNAME record lookup limit in the recursor to guard against memory exhaustion. (Currently based off of the recursor_recursion_improvements branch.)
