### PR TITLE
Start cleaning up DNSSEC API

### DIFF
--- a/bin/src/dnssec.rs
+++ b/bin/src/dnssec.rs
@@ -18,7 +18,7 @@ use serde::Deserialize;
 use hickory_proto::rr::domain::Name;
 #[cfg(feature = "dnssec")]
 use hickory_proto::rr::{
-    dnssec::{Algorithm, KeyFormat, KeyPair, Private, SigSigner},
+    dnssec::{Algorithm, KeyFormat, KeyPair, Private, PublicKey, SigSigner},
     domain::IntoName,
 };
 use hickory_proto::serialize::txt::ParseResult;
@@ -286,8 +286,9 @@ fn load_key(zone_name: Name, key_config: &KeyConfig) -> Result<SigSigner, String
     // add the key to the zone
     // TODO: allow the duration of signatures to be customized
     let dnskey = key
-        .to_dnskey(algorithm)
-        .map_err(|e| format!("error converting to dnskey: {e}"))?;
+        .to_public_key()
+        .map_err(|e| format!("error getting public key: {e}"))?
+        .to_dnskey(algorithm);
     Ok(SigSigner::dnssec(
         dnskey,
         key,

--- a/bin/src/hickory-dns.rs
+++ b/bin/src/hickory-dns.rs
@@ -90,6 +90,8 @@ where
     A: DnssecAuthority<Lookup = L>,
     L: Send + Sync + Sized + 'static,
 {
+    use hickory_proto::rr::dnssec::PublicKey;
+
     if zone_config.is_dnssec_enabled() {
         for key_config in zone_config.keys() {
             info!(
@@ -114,8 +116,9 @@ where
                     })?;
                 let public_key = update_auth_signer
                     .key()
-                    .to_sig0key_with_usage(update_auth_signer.algorithm(), KeyUsage::Host)
-                    .map_err(|err| format!("failed to get sig0 key: {err}"))?;
+                    .to_public_key()
+                    .map_err(|err| format!("failed to get public key: {err}"))?
+                    .to_sig0key_with_usage(update_auth_signer.algorithm(), KeyUsage::Host);
                 authority
                     .add_update_auth_key(zone_name.clone(), public_key)
                     .await

--- a/bin/tests/integration/authority_battery/dynamic_update.rs
+++ b/bin/tests/integration/authority_battery/dynamic_update.rs
@@ -11,7 +11,7 @@ use futures_executor::block_on;
 use hickory_proto::{
     op::{update_message, Header, Message, Query, ResponseCode},
     rr::{
-        dnssec::{Algorithm, SigSigner, SupportedAlgorithms, Verifier},
+        dnssec::{Algorithm, PublicKey, SigSigner, SupportedAlgorithms, Verifier},
         rdata::{A as A4, AAAA},
         DNSClass, Name, RData, Record, RecordSet, RecordType,
     },
@@ -795,8 +795,9 @@ pub fn add_auth<A: DnssecAuthority>(authority: &mut A) -> Vec<SigSigner> {
             .expect("failed to read key_config");
         let public_key = signer
             .key()
-            .to_sig0key_with_usage(Algorithm::RSASHA512, KeyUsage::Host)
-            .expect("failed to get sig0 key");
+            .to_public_key()
+            .expect("failed to get public key")
+            .to_sig0key_with_usage(Algorithm::RSASHA512, KeyUsage::Host);
 
         block_on(authority.add_update_auth_key(update_name.clone(), public_key))
             .expect("failed to add signer to zone");
@@ -855,8 +856,9 @@ pub fn add_auth<A: DnssecAuthority>(authority: &mut A) -> Vec<SigSigner> {
             .expect("failed to read key_config");
         let public_key = signer
             .key()
-            .to_sig0key_with_usage(Algorithm::ED25519, KeyUsage::Host)
-            .expect("failed to get sig0 key");
+            .to_public_key()
+            .expect("failed to get public key")
+            .to_sig0key_with_usage(Algorithm::ED25519, KeyUsage::Host);
 
         block_on(authority.add_update_auth_key(update_name, public_key))
             .expect("failed to add signer to zone");

--- a/crates/proto/src/rr/dnssec/digest_type.rs
+++ b/crates/proto/src/rr/dnssec/digest_type.rs
@@ -19,7 +19,6 @@ use serde::{Deserialize, Serialize};
 use crate::error::*;
 use crate::rr::dnssec::Algorithm;
 
-#[cfg(any(feature = "dnssec-ring", feature = "dnssec-openssl"))]
 use super::Digest;
 
 /// This is the digest format for the

--- a/crates/proto/src/rr/dnssec/keypair.rs
+++ b/crates/proto/src/rr/dnssec/keypair.rs
@@ -34,11 +34,8 @@ use ring::{
 
 use crate::error::*;
 use crate::rr::dnssec::rdata::key::KeyUsage;
-use crate::rr::dnssec::rdata::{DS, KEY};
-use crate::rr::dnssec::{
-    Algorithm, DigestType, HasPrivate, HasPublic, Private, PublicKey, PublicKeyBuf, TBS,
-};
-use crate::rr::Name;
+use crate::rr::dnssec::rdata::KEY;
+use crate::rr::dnssec::{Algorithm, DigestType, HasPrivate, HasPublic, Private, PublicKeyBuf, TBS};
 
 /// A public and private key pair, the private portion is not required.
 ///
@@ -215,29 +212,6 @@ impl<K: HasPublic> KeyPair<K> {
                 bytes,
             )
         })
-    }
-
-    /// Creates a DS record for this KeyPair associated to the given name
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - name of the DNSKEY record covered by the new DS record
-    /// * `algorithm` - the algorithm of the DNSKEY
-    /// * `digest_type` - the digest_type used to
-    pub fn to_ds(
-        &self,
-        name: &Name,
-        algorithm: Algorithm,
-        digest_type: DigestType,
-    ) -> DnsSecResult<DS> {
-        let pub_key = self.to_public_key()?;
-        let dnskey = pub_key.to_dnskey(algorithm);
-        Ok(DS::new(
-            pub_key.key_tag(),
-            algorithm,
-            digest_type,
-            dnskey.to_digest(name, digest_type)?.as_ref().to_owned(),
-        ))
     }
 }
 

--- a/crates/proto/src/rr/dnssec/keypair.rs
+++ b/crates/proto/src/rr/dnssec/keypair.rs
@@ -21,8 +21,6 @@ use openssl::rsa::Rsa as OpenSslRsa;
 #[cfg(feature = "dnssec-openssl")]
 use openssl::sign::Signer;
 
-#[allow(deprecated)]
-use crate::rr::dnssec::rdata::key::{KeyTrust, Protocol, UpdateScope};
 #[cfg(feature = "dnssec-ring")]
 use ring::{
     rand,
@@ -32,9 +30,7 @@ use ring::{
     },
 };
 
-use crate::error::*;
-use crate::rr::dnssec::rdata::key::KeyUsage;
-use crate::rr::dnssec::rdata::KEY;
+use crate::error::{DnsSecError, DnsSecErrorKind, DnsSecResult};
 use crate::rr::dnssec::{Algorithm, DigestType, HasPrivate, HasPublic, Private, PublicKeyBuf, TBS};
 
 /// A public and private key pair, the private portion is not required.
@@ -169,49 +165,6 @@ impl<K: HasPublic> KeyPair<K> {
     /// Returns a PublicKeyBuf of the KeyPair
     pub fn to_public_key(&self) -> DnsSecResult<PublicKeyBuf> {
         Ok(PublicKeyBuf::new(self.to_public_bytes()?))
-    }
-
-    /// Convert this keypair into a KEY record type for usage with SIG0
-    /// with key type entity (`KeyUsage::Entity`).
-    ///
-    /// # Arguments
-    ///
-    /// * `algorithm` - algorithm of the KEY
-    ///
-    /// # Return
-    ///
-    /// the KEY record data
-    pub fn to_sig0key(&self, algorithm: Algorithm) -> DnsSecResult<KEY> {
-        self.to_sig0key_with_usage(algorithm, KeyUsage::default())
-    }
-
-    /// Convert this keypair into a KEY record type for usage with SIG0
-    /// with a given key (usage) type.
-    ///
-    /// # Arguments
-    ///
-    /// * `algorithm` - algorithm of the KEY
-    /// * `usage`     - the key type
-    ///
-    /// # Return
-    ///
-    /// the KEY record data
-    pub fn to_sig0key_with_usage(
-        &self,
-        algorithm: Algorithm,
-        usage: KeyUsage,
-    ) -> DnsSecResult<KEY> {
-        self.to_public_bytes().map(|bytes| {
-            KEY::new(
-                KeyTrust::default(),
-                usage,
-                #[allow(deprecated)]
-                UpdateScope::default(),
-                Protocol::default(),
-                algorithm,
-                bytes,
-            )
-        })
     }
 }
 

--- a/crates/proto/src/rr/dnssec/keypair.rs
+++ b/crates/proto/src/rr/dnssec/keypair.rs
@@ -34,14 +34,10 @@ use ring::{
 
 use crate::error::*;
 use crate::rr::dnssec::rdata::key::KeyUsage;
-#[cfg(any(feature = "dnssec-openssl", feature = "dnssec-ring"))]
-use crate::rr::dnssec::rdata::DS;
-use crate::rr::dnssec::rdata::KEY;
-#[cfg(any(feature = "dnssec-openssl", feature = "dnssec-ring"))]
-use crate::rr::dnssec::DigestType;
-use crate::rr::dnssec::{Algorithm, PublicKey, PublicKeyBuf};
-use crate::rr::dnssec::{HasPrivate, HasPublic, Private, TBS};
-#[cfg(any(feature = "dnssec-openssl", feature = "dnssec-ring"))]
+use crate::rr::dnssec::rdata::{DS, KEY};
+use crate::rr::dnssec::{
+    Algorithm, DigestType, HasPrivate, HasPublic, Private, PublicKey, PublicKeyBuf, TBS,
+};
 use crate::rr::Name;
 
 /// A public and private key pair, the private portion is not required.

--- a/crates/proto/src/rr/dnssec/mod.rs
+++ b/crates/proto/src/rr/dnssec/mod.rs
@@ -68,8 +68,7 @@ impl Digest {
 #[cfg(any(feature = "dnssec-openssl", feature = "dnssec-ring"))]
 pub use self::key_format::KeyFormat;
 pub use self::keypair::KeyPair;
-#[allow(deprecated)]
-pub use self::signer::{SigSigner, Signer};
+pub use self::signer::SigSigner;
 
 #[cfg(feature = "dnssec-openssl")]
 pub use openssl::pkey::{HasPrivate, HasPublic, Private, Public};

--- a/crates/proto/src/rr/dnssec/nsec3.rs
+++ b/crates/proto/src/rr/dnssec/nsec3.rs
@@ -21,12 +21,9 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[cfg(any(feature = "dnssec-openssl", feature = "dnssec-ring"))]
 use super::{Digest, DigestType};
 use crate::error::*;
-#[cfg(any(feature = "dnssec-openssl", feature = "dnssec-ring"))]
 use crate::rr::Name;
-#[cfg(any(feature = "dnssec-openssl", feature = "dnssec-ring"))]
 use crate::serialize::binary::{BinEncodable, BinEncoder};
 
 /// ```text

--- a/crates/proto/src/rr/dnssec/public_key.rs
+++ b/crates/proto/src/rr/dnssec/public_key.rs
@@ -40,6 +40,74 @@ use crate::rr::dnssec::rsa_public_key::RSAPublicKey;
 ///
 /// In DNS the KEY and DNSKEY types are generally the RData types which store public key material.
 pub trait PublicKey {
+    /// The key tag is calculated as a hash to more quickly lookup a DNSKEY.
+    ///
+    /// [RFC 1035](https://tools.ietf.org/html/rfc1035), DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987
+    ///
+    /// ```text
+    /// RFC 2535                DNS Security Extensions               March 1999
+    ///
+    /// 4.1.6 Key Tag Field
+    ///
+    ///  The "key Tag" is a two octet quantity that is used to efficiently
+    ///  select between multiple keys which may be applicable and thus check
+    ///  that a public key about to be used for the computationally expensive
+    ///  effort to check the signature is possibly valid.  For algorithm 1
+    ///  (MD5/RSA) as defined in [RFC 2537], it is the next to the bottom two
+    ///  octets of the public key modulus needed to decode the signature
+    ///  field.  That is to say, the most significant 16 of the least
+    ///  significant 24 bits of the modulus in network (big endian) order. For
+    ///  all other algorithms, including private algorithms, it is calculated
+    ///  as a simple checksum of the KEY RR as described in Appendix C.
+    ///
+    /// Appendix C: Key Tag Calculation
+    ///
+    ///  The key tag field in the SIG RR is just a means of more efficiently
+    ///  selecting the correct KEY RR to use when there is more than one KEY
+    ///  RR candidate available, for example, in verifying a signature.  It is
+    ///  possible for more than one candidate key to have the same tag, in
+    ///  which case each must be tried until one works or all fail.  The
+    ///  following reference implementation of how to calculate the Key Tag,
+    ///  for all algorithms other than algorithm 1, is in ANSI C.  It is coded
+    ///  for clarity, not efficiency.  (See section 4.1.6 for how to determine
+    ///  the Key Tag of an algorithm 1 key.)
+    ///
+    ///  /* assumes int is at least 16 bits
+    ///     first byte of the key tag is the most significant byte of return
+    ///     value
+    ///     second byte of the key tag is the least significant byte of
+    ///     return value
+    ///     */
+    ///
+    ///  int keytag (
+    ///
+    ///          unsigned char key[],  /* the RDATA part of the KEY RR */
+    ///          unsigned int keysize, /* the RDLENGTH */
+    ///          )
+    ///  {
+    ///  long int    ac;    /* assumed to be 32 bits or larger */
+    ///
+    ///  for ( ac = 0, i = 0; i < keysize; ++i )
+    ///      ac += (i&1) ? key[i] : key[i]<<8;
+    ///  ac += (ac>>16) & 0xFFFF;
+    ///  return ac & 0xFFFF;
+    ///  }
+    /// ```
+    fn key_tag(&self) -> u16 {
+        let mut ac = 0;
+
+        for (i, k) in self.public_bytes().iter().enumerate() {
+            ac += if i & 0x0001 == 0x0001 {
+                *k as usize
+            } else {
+                (*k as usize) << 8
+            };
+        }
+
+        ac += (ac >> 16) & 0xFFFF;
+        (ac & 0xFFFF) as u16 // this is unnecessary, no?
+    }
+
     /// Returns the public bytes of the public key, in DNS format
     fn public_bytes(&self) -> &[u8];
 

--- a/crates/proto/src/rr/dnssec/signer.rs
+++ b/crates/proto/src/rr/dnssec/signer.rs
@@ -620,7 +620,8 @@ mod tests {
 
         let rsa = Rsa::generate(2_048).unwrap();
         let key = KeyPair::from_rsa(rsa).unwrap();
-        let sig0key = key.to_sig0key(Algorithm::RSASHA256).unwrap();
+        let pub_key = key.to_public_key().unwrap();
+        let sig0key = pub_key.to_sig0key(Algorithm::RSASHA256);
         let signer = SigSigner::sig0(sig0key.clone(), key, Name::root());
 
         let pre_sig0 = pre_sig0(&signer, 0, 300);
@@ -649,9 +650,8 @@ mod tests {
     fn test_sign_and_verify_rrset() {
         let rsa = Rsa::generate(2_048).unwrap();
         let key = KeyPair::from_rsa(rsa).unwrap();
-        let sig0key = key
-            .to_sig0key_with_usage(Algorithm::RSASHA256, KeyUsage::Zone)
-            .unwrap();
+        let pub_key = key.to_public_key().unwrap();
+        let sig0key = pub_key.to_sig0key_with_usage(Algorithm::RSASHA256, KeyUsage::Zone);
         let signer = SigSigner::sig0(sig0key, key, Name::root());
 
         let origin: Name = Name::parse("example.com.", None).unwrap();
@@ -732,9 +732,8 @@ mod tests {
             println!("pkey:\n{}", String::from_utf8(rsa_pem).unwrap());
 
             let key = KeyPair::from_rsa(rsa).unwrap();
-            let sig0key = key
-                .to_sig0key_with_usage(Algorithm::RSASHA256, KeyUsage::Zone)
-                .unwrap();
+            let pub_key = key.to_public_key().unwrap();
+            let sig0key = pub_key.to_sig0key_with_usage(Algorithm::RSASHA256, KeyUsage::Zone);
             let signer = SigSigner::sig0(sig0key, key, Name::root());
             let key_tag = signer.calculate_key_tag().unwrap();
 
@@ -755,9 +754,8 @@ MC0CAQACBQC+L6pNAgMBAAECBQCYj0ZNAgMA9CsCAwDHZwICeEUCAnE/AgMA3u0=
         println!("pkey:\n{}", String::from_utf8(rsa_pem).unwrap());
 
         let key = KeyPair::from_rsa(rsa).unwrap();
-        let sig0key = key
-            .to_sig0key_with_usage(Algorithm::RSASHA256, KeyUsage::Zone)
-            .unwrap();
+        let pub_key = key.to_public_key().unwrap();
+        let sig0key = pub_key.to_sig0key_with_usage(Algorithm::RSASHA256, KeyUsage::Zone);
         let signer = SigSigner::sig0(sig0key, key, Name::root());
         let key_tag = signer.calculate_key_tag().unwrap();
 
@@ -780,7 +778,8 @@ MC0CAQACBQC+L6pNAgMBAAECBQCYj0ZNAgMA9CsCAwDHZwICeEUCAnE/AgMA3u0=
         fn test_rrset_tbs() {
             let rsa = Rsa::generate(2_048).unwrap();
             let key = KeyPair::from_rsa(rsa).unwrap();
-            let sig0key = key.to_sig0key(Algorithm::RSASHA256).unwrap();
+            let pub_key = key.to_public_key().unwrap();
+            let sig0key = pub_key.to_sig0key(Algorithm::RSASHA256);
             let signer = SigSigner::sig0(sig0key, key, Name::root());
 
             let origin: Name = Name::parse("example.com.", None).unwrap();

--- a/crates/proto/src/rr/dnssec/signer.rs
+++ b/crates/proto/src/rr/dnssec/signer.rs
@@ -8,26 +8,19 @@
 //! signer is a structure for performing many of the signing processes of the DNSSEC specification
 use tracing::debug;
 
-#[cfg(feature = "dnssec")]
 use std::time::Duration;
 
-#[cfg(feature = "dnssec")]
 use crate::{
-    error::DnsSecResult,
+    error::{DnsSecResult, ProtoErrorKind, ProtoResult},
+    op::{Message, MessageFinalizer, MessageVerifier},
     rr::{
         dnssec::{
             rdata::{DNSSECRData, DNSKEY, KEY, SIG},
             tbs, Algorithm, KeyPair, Private, TBS,
         },
-        {DNSClass, Name, RData, RecordType},
+        Record, {DNSClass, Name, RData, RecordType},
     },
-    serialize::binary::BinEncoder,
-};
-use crate::{
-    error::{ProtoErrorKind, ProtoResult},
-    op::{Message, MessageFinalizer, MessageVerifier},
-    rr::Record,
-    serialize::binary::BinEncodable,
+    serialize::binary::{BinEncodable, BinEncoder},
 };
 
 use super::PublicKey;

--- a/crates/proto/src/rr/dnssec/signer.rs
+++ b/crates/proto/src/rr/dnssec/signer.rs
@@ -242,15 +242,6 @@ pub struct SigSigner {
     is_zone_signing_key: bool,
 }
 
-/// Placeholder type for when OpenSSL and *ring* are disabled; enable OpenSSL and Ring for support
-#[cfg(not(feature = "dnssec"))]
-#[allow(missing_copy_implementations)]
-pub struct SigSigner;
-
-/// See [`SigSigner`]
-#[deprecated(note = "renamed to SigSigner")]
-pub type Signer = SigSigner;
-
 #[cfg(feature = "dnssec")]
 impl SigSigner {
     /// Version of Signer for verifying RRSIGs and SIG0 records.

--- a/crates/proto/src/rr/dnssec/signer.rs
+++ b/crates/proto/src/rr/dnssec/signer.rs
@@ -30,6 +30,8 @@ use crate::{
     serialize::binary::BinEncodable,
 };
 
+use super::PublicKey;
+
 /// Use for performing signing and validation of DNSSEC based components. The SigSigner can be used for singing requests and responses with SIG0, or DNSSEC RRSIG records. The format is based on the SIG record type.
 ///
 /// TODO: warning this struct and it's impl are under high volatility, expect breaking changes
@@ -304,9 +306,8 @@ impl SigSigner {
         is_zone_signing_key: bool,
         _: bool,
     ) -> Self {
-        let dnskey = key
-            .to_dnskey(algorithm)
-            .expect("something went wrong, use one of the SIG0 or DNSSEC constructors");
+        let pub_key = key.to_public_key().expect("key is not a private key");
+        let dnskey = pub_key.to_dnskey(algorithm);
 
         Self {
             key_rdata: dnskey.into(),

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -32,7 +32,7 @@ use crate::{
         error::ProtoResult,
         rr::dnssec::{
             rdata::{key::KEY, DNSSECRData, NSEC, NSEC3, NSEC3PARAM},
-            DnsSecResult, Nsec3HashAlgorithm, SigSigner, SupportedAlgorithms,
+            DnsSecResult, Nsec3HashAlgorithm, PublicKey, SigSigner, SupportedAlgorithms,
         },
     },
 };
@@ -277,7 +277,7 @@ impl InMemoryAuthority {
     ) -> DnsSecResult<()> {
         // also add the key to the zone
         let zone_ttl = inner.minimum_ttl(origin);
-        let dnskey = signer.key().to_dnskey(signer.algorithm())?;
+        let dnskey = signer.key().to_public_key()?.to_dnskey(signer.algorithm());
         let dnskey = Record::from_rdata(
             origin.clone().into(),
             zone_ttl,

--- a/tests/integration-tests/src/example_authority.rs
+++ b/tests/integration-tests/src/example_authority.rs
@@ -204,7 +204,7 @@ pub fn create_secure_example() -> InMemoryAuthority {
     let mut authority = create_example();
     let rsa = Rsa::generate(2_048).unwrap();
     let key = KeyPair::from_rsa(rsa).unwrap();
-    let dnskey = key.to_dnskey(Algorithm::RSASHA256).unwrap();
+    let dnskey = key.to_public_key().unwrap().to_dnskey(Algorithm::RSASHA256);
     let signer = SigSigner::dnssec(
         dnskey,
         key,

--- a/tests/integration-tests/tests/integration/client_future_tests.rs
+++ b/tests/integration-tests/tests/integration/client_future_tests.rs
@@ -281,7 +281,7 @@ async fn create_sig0_ready_client() -> (
     Name,
 ) {
     use hickory_proto::rr::dnssec::rdata::DNSSECRData;
-    use hickory_proto::rr::dnssec::{Algorithm, KeyPair};
+    use hickory_proto::rr::dnssec::{Algorithm, KeyPair, PublicKey};
     use hickory_server::store::sqlite::SqliteAuthority;
     use openssl::rsa::Rsa;
 
@@ -293,7 +293,8 @@ async fn create_sig0_ready_client() -> (
 
     let rsa = Rsa::generate(2_048).unwrap();
     let key = KeyPair::from_rsa(rsa).unwrap();
-    let sig0_key = key.to_sig0key(Algorithm::RSASHA256).unwrap();
+    let pub_key = key.to_public_key().unwrap();
+    let sig0_key = pub_key.to_sig0key(Algorithm::RSASHA256);
 
     let signer = SigSigner::sig0(sig0_key.clone(), key, trusted_name.clone());
 

--- a/tests/integration-tests/tests/integration/client_tests.rs
+++ b/tests/integration-tests/tests/integration/client_tests.rs
@@ -477,7 +477,7 @@ async fn test_nsec3_query_name_is_soa_name() {
 #[cfg(all(feature = "dnssec", feature = "sqlite"))]
 async fn create_sig0_ready_client(mut catalog: Catalog) -> (Client, Name) {
     use hickory_proto::rr::dnssec::rdata::{DNSSECRData, KEY};
-    use hickory_proto::rr::dnssec::{Algorithm, KeyPair, Signer as SigSigner};
+    use hickory_proto::rr::dnssec::{Algorithm, KeyPair, SigSigner};
     use hickory_server::store::sqlite::SqliteAuthority;
     use openssl::rsa::Rsa;
 


### PR DESCRIPTION
As part of integrating support for aws-lc-rs (as a ring alternative) and untangling the dependency on OpenSSL in ring signing tests, I've started cleaning up the `KeyPair` API. As a starting point, I've moved all the API that was actually only dependent on the public key to the `PublicKey` trait, which seems like a more obvious way to expose the API.

It seems like the abstraction originally tried to leverage openssl traits like `HasPublic` and `Private`, but (a) it makes very little sense to have a `KeyPair` type that does not have access to the private key and (b) we would definitely prefer for the high-level API not to depend on OpenSSL.