### PR TITLE
Add resolver logging to bad_txid test

### DIFF
--- a/tests/e2e-tests/src/recursor/security/scenarios.rs
+++ b/tests/e2e-tests/src/recursor/security/scenarios.rs
@@ -47,12 +47,13 @@ fn tx_id_validation_test() -> Result<()> {
         &target_fqdn,
     );
 
-    if let Ok(res) = &res {
-        // FIXME This should be servfail; need the error propagation fix from #2522
-        assert!(res.status.is_noerror());
-        assert_eq!(res.answer.len(), 0);
-    } else {
-        panic!("error");
+    match res {
+        Ok(res) => {
+            // FIXME This should be servfail; need the error propagation fix from #2522
+            assert!(res.status.is_noerror());
+            assert_eq!(res.answer.len(), 0);
+        }
+        Err(e) => panic!("error {e:?} resolver logs: {}", resolver.logs().unwrap()),
     }
 
     assert!(resolver.logs().unwrap().contains("expected message id:"));


### PR DESCRIPTION
This is to try to collect more data on the [test failure observed in 2388](https://github.com/hickory-dns/hickory-dns/actions/runs/11577413801/job/32228737228?pr=2388#step:10:461), should it re-occur.
