### PR TITLE
Skip copying configuration file for dnslib

### DIFF
--- a/conformance/packages/dns-test/src/implementation.rs
+++ b/conformance/packages/dns-test/src/implementation.rs
@@ -164,17 +164,17 @@ impl Implementation {
         }
     }
 
-    pub(crate) fn conf_file_path(&self, role: Role) -> &'static str {
+    pub(crate) fn conf_file_path(&self, role: Role) -> Option<&'static str> {
         match self {
-            Self::Bind => "/etc/bind/named.conf",
+            Self::Bind => Some("/etc/bind/named.conf"),
 
-            Self::Dnslib => "/dev/null",
+            Self::Dnslib => None,
 
-            Self::Hickory(_) => "/etc/named.toml",
+            Self::Hickory(_) => Some("/etc/named.toml"),
 
             Self::Unbound => match role {
-                Role::NameServer => "/etc/nsd/nsd.conf",
-                Role::Resolver => "/etc/unbound/unbound.conf",
+                Role::NameServer => Some("/etc/nsd/nsd.conf"),
+                Role::Resolver => Some("/etc/unbound/unbound.conf"),
             },
         }
     }

--- a/conformance/packages/dns-test/src/name_server.rs
+++ b/conformance/packages/dns-test/src/name_server.rs
@@ -273,10 +273,12 @@ impl NameServer<Stopped> {
             additional_zones: additional_zones.clone(),
         };
 
-        container.cp(
-            implementation.conf_file_path(config.role()),
-            &implementation.format_config(config.clone()),
-        )?;
+        if let Some(conf_file_path) = implementation.conf_file_path(config.role()) {
+            container.cp(
+                conf_file_path,
+                &implementation.format_config(config.clone()),
+            )?;
+        }
 
         container.status_ok(&["mkdir", "-p", ZONES_DIR])?;
         container.cp(&zone_file_path(), &zone_file.to_string())?;
@@ -353,10 +355,12 @@ impl NameServer<Signed> {
             additional_zones: additional_zones.clone(),
         };
 
-        container.cp(
-            implementation.conf_file_path(config.role()),
-            &implementation.format_config(config.clone()),
-        )?;
+        if let Some(conf_file_path) = implementation.conf_file_path(config.role()) {
+            container.cp(
+                conf_file_path,
+                &implementation.format_config(config.clone()),
+            )?;
+        }
 
         if implementation.is_hickory() && state.use_dnssec {
             // FIXME: Hickory does not support pre-signed zonefiles. We copy the unsigned

--- a/conformance/packages/dns-test/src/resolver.rs
+++ b/conformance/packages/dns-test/src/resolver.rs
@@ -109,10 +109,9 @@ impl ResolverSettings {
             };
             &implementation.format_config(config)
         };
-        container.cp(
-            implementation.conf_file_path(Role::Resolver),
-            config_contents,
-        )?;
+        if let Some(conf_file_path) = implementation.conf_file_path(Role::Resolver) {
+            container.cp(conf_file_path, config_contents)?;
+        }
 
         if use_dnssec {
             let path = if implementation.is_bind() {


### PR DESCRIPTION
When running the new dnslib-based conformance test on my system, I get the following error message.

```
Error: "[dns-test-dnslib-76873-22] `[\"chmod\", \"666\", \"/dev/null\"]` failed"
```

I think this is likely due to my use of a rootless Docker installation, perhaps in combination with AppArmor hardening.

This PR fixes the issue by making `conf_file_path()` return an `Option`, so we can skip the copying and permissions changes, instead of using `/dev/null` in place of an actual file.