### PR TITLE
CI: Remove continue-on-error from steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,9 +48,9 @@ jobs:
 
       - name: just all-features
         run: just all-features
-        continue-on-error: true
 
       - name: just test-docs
+        if: ${{ !cancelled() }}
         run: just test-docs
 
   ## Measure test coverage, only on linux.
@@ -190,13 +190,13 @@ jobs:
       # Clippy
       - name: just clippy
         run: just clippy
-        continue-on-error: true
       # Rustfmt
       - name: just fmt
+        if: ${{ !cancelled() }}
         run: just fmt
-        continue-on-error: true
       # Audit
       - name: cargo audit
+        if: ${{ !cancelled() }}
         run: just audit
 
   # Build and run bind to test our compatibility with standard name servers

--- a/crates/proto/src/multicast/mdns_stream.rs
+++ b/crates/proto/src/multicast/mdns_stream.rs
@@ -331,8 +331,7 @@ impl NextRandomUdpSocket {
         match addr {
             SocketAddr::V4(..) => {
                 socket.set_multicast_loop_v4(true)?;
-                socket
-                    .set_multicast_if_v4(&self.ipv4_if.unwrap_or_else(|| Ipv4Addr::UNSPECIFIED))?;
+                socket.set_multicast_if_v4(&self.ipv4_if.unwrap_or(Ipv4Addr::UNSPECIFIED))?;
                 if let Some(ttl) = self.packet_ttl {
                     socket.set_ttl(ttl)?;
                     socket.set_multicast_ttl_v4(ttl)?;


### PR DESCRIPTION
I noticed that there's currently a clippy warning on main, and CI is still passing because of a `continue-on-error: true` setting on the relevant step. This PR removes those lines, and adds `if: success() || failure()` to all subsequent steps. (This overrides the default of `if: success()`) This achieves the same goal of not short-circuiting, and running as many checks as possible even if one fails, without accidentally ignoring earlier failures.

The downside of this approach is that these later commands with `success() || failure()` conditions will still run even if, for example, checking out the code or installing dependencies fails. This would create some extra error messages that would be confusing, but fixing that would require adding IDs to steps and writing more complicated conditions, and I don't think that would be worth it.