### PR TITLE
Conformance dig timeout

### DIFF
--- a/conformance/packages/dns-test/src/client.rs
+++ b/conformance/packages/dns-test/src/client.rs
@@ -69,6 +69,7 @@ impl Client {
             settings.do_bit(),
             settings.adflag(),
             settings.cdflag(),
+            settings.timeoutflag().as_str(),
             &format!("@{server}"),
             record_type.as_str(),
             fqdn.as_str(),
@@ -84,6 +85,7 @@ pub struct DigSettings {
     cdflag: bool,
     dnssec: bool,
     recurse: bool,
+    timeout: Option<u8>,
 }
 
 impl DigSettings {
@@ -140,6 +142,19 @@ impl DigSettings {
             "+recurse"
         } else {
             "+norecurse"
+        }
+    }
+
+    /// Sets the timeout for the query, specified in seconds
+    pub fn timeout(&mut self, timeout: u8) -> &mut Self {
+        self.timeout = Some(timeout);
+        self
+    }
+
+    fn timeoutflag(&self) -> String {
+        match self.timeout {
+            Some(timeout) => format!("+timeout={timeout}"),
+            None => "+timeout=5".into(),
         }
     }
 }

--- a/tests/e2e-tests/src/recursor/security/scenarios.rs
+++ b/tests/e2e-tests/src/recursor/security/scenarios.rs
@@ -40,7 +40,7 @@ fn tx_id_validation_test() -> Result<()> {
     let _leaf_ns = leaf_ns.start()?;
 
     thread::sleep(Duration::from_secs(2));
-    let a_settings = *DigSettings::default().recurse();
+    let a_settings = *DigSettings::default().recurse().timeout(7);
     let res = client.dig(
         a_settings,
         resolver.ipv4_addr(),

--- a/tests/e2e-tests/src/recursor/security/scenarios.rs
+++ b/tests/e2e-tests/src/recursor/security/scenarios.rs
@@ -40,7 +40,7 @@ fn tx_id_validation_test() -> Result<()> {
     let _leaf_ns = leaf_ns.start()?;
 
     thread::sleep(Duration::from_secs(2));
-    let a_settings = *DigSettings::default().recurse().authentic_data();
+    let a_settings = *DigSettings::default().recurse();
     let res = client.dig(
         a_settings,
         resolver.ipv4_addr(),


### PR DESCRIPTION
Add support for setting the dig timeout option in the conformance test suite. See issue #2539 