### PR TITLE
ci: don't build benchmarks, only check them

### DIFF
--- a/justfile
+++ b/justfile
@@ -76,7 +76,7 @@ compatibility: init-bind9
 
 # Build all bench marking tools, i.e. check that they work, but don't run
 build-bench:
-    RUSTFLAGS="--cfg=nightly" cargo ws exec cargo +nightly-{{NIGHTLY_DATE}} bench --locked --no-run
+    RUSTFLAGS="--cfg=nightly" cargo ws exec cargo +nightly-{{NIGHTLY_DATE}} check --locked --benches
 
 [private]
 clippy-inner feature='':


### PR DESCRIPTION
CI currently takes about 17 minutes for a full run, which feels long. The long pole appears to be the nightly job which builds benchmarks (but doesn't run them) in release mode. The goal here should be to make sure that they compile, so instead of running `cargo bench --no-run` we can run `cargo check --benches` which should be substantially faster.