### PR TITLE
hickory-proto(serde): fix transparent structs and allow (de)serializing more types.

### DIFF
--- a/crates/proto/src/op/edns.rs
+++ b/crates/proto/src/op/edns.rs
@@ -10,7 +10,7 @@
 use std::fmt;
 
 #[cfg(feature = "serde")]
-use serde::{ Deserialize, Serialize };
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "dnssec")]
 use crate::rr::dnssec::{Algorithm, SupportedAlgorithms};

--- a/crates/proto/src/op/edns.rs
+++ b/crates/proto/src/op/edns.rs
@@ -9,6 +9,9 @@
 
 use std::fmt;
 
+#[cfg(feature = "serde")]
+use serde::{ Deserialize, Serialize };
+
 #[cfg(feature = "dnssec")]
 use crate::rr::dnssec::{Algorithm, SupportedAlgorithms};
 use crate::{
@@ -25,6 +28,7 @@ use crate::{
 
 /// Edns implements the higher level concepts for working with extended dns as it is used to create or be
 /// created from OPT record data.
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Edns {
     // high 8 bits that make up the 12 bit total field when included with the 4bit rcode from the

--- a/crates/proto/src/op/header.rs
+++ b/crates/proto/src/op/header.rs
@@ -9,6 +9,9 @@
 
 use std::{convert::From, fmt};
 
+#[cfg(feature = "serde")]
+use serde::{ Deserialize, Serialize };
+
 use crate::{
     error::*,
     op::{op_code::OpCode, response_code::ResponseCode},
@@ -47,6 +50,7 @@ use crate::{
 ///
 /// ```
 ///
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Hash)]
 pub struct Header {
     id: u16,
@@ -83,6 +87,7 @@ impl fmt::Display for Header {
 }
 
 /// Message types are either Query (also Update) or Response
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, PartialOrd, Copy, Clone, Hash)]
 pub enum MessageType {
     /// Queries are Client requests, these are either Queries or Updates

--- a/crates/proto/src/op/header.rs
+++ b/crates/proto/src/op/header.rs
@@ -10,7 +10,7 @@
 use std::{convert::From, fmt};
 
 #[cfg(feature = "serde")]
-use serde::{ Deserialize, Serialize };
+use serde::{Deserialize, Serialize};
 
 use crate::{
     error::*,

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -12,7 +12,7 @@ use std::{fmt, iter, mem, ops::Deref};
 use tracing::{debug, warn};
 
 #[cfg(feature = "serde")]
-use serde::{ Deserialize, Serialize };
+use serde::{Deserialize, Serialize};
 
 use crate::{
     error::*,

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -11,6 +11,9 @@ use std::{fmt, iter, mem, ops::Deref};
 
 use tracing::{debug, warn};
 
+#[cfg(feature = "serde")]
+use serde::{ Deserialize, Serialize };
+
 use crate::{
     error::*,
     op::{Edns, Header, MessageType, OpCode, Query, ResponseCode},
@@ -61,6 +64,7 @@ use crate::{
 ///
 /// By default Message is a Query. Use the Message::as_update() to create and update, or
 ///  Message::new_update()
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct Message {
     header: Header,

--- a/crates/proto/src/op/op_code.rs
+++ b/crates/proto/src/op/op_code.rs
@@ -9,6 +9,9 @@
 
 use std::{convert::From, fmt};
 
+#[cfg(feature = "serde")]
+use serde::{ Deserialize, Serialize };
+
 use crate::error::*;
 
 /// Operation code for queries, updates, and responses
@@ -28,6 +31,7 @@ use crate::error::*;
 ///
 ///                 3-15            reserved for future use
 /// ```
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, PartialOrd, Copy, Clone, Hash)]
 #[allow(dead_code)]
 pub enum OpCode {

--- a/crates/proto/src/op/op_code.rs
+++ b/crates/proto/src/op/op_code.rs
@@ -10,7 +10,7 @@
 use std::{convert::From, fmt};
 
 #[cfg(feature = "serde")]
-use serde::{ Deserialize, Serialize };
+use serde::{Deserialize, Serialize};
 
 use crate::error::*;
 

--- a/crates/proto/src/op/query.rs
+++ b/crates/proto/src/op/query.rs
@@ -20,7 +20,7 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 
 #[cfg(feature = "serde")]
-use serde::{ Deserialize, Serialize };
+use serde::{Deserialize, Serialize};
 
 use crate::error::*;
 use crate::rr::dns_class::DNSClass;

--- a/crates/proto/src/op/query.rs
+++ b/crates/proto/src/op/query.rs
@@ -19,6 +19,9 @@
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
+#[cfg(feature = "serde")]
+use serde::{ Deserialize, Serialize };
+
 use crate::error::*;
 use crate::rr::dns_class::DNSClass;
 use crate::rr::domain::Name;
@@ -58,6 +61,7 @@ const MDNS_UNICAST_RESPONSE: u16 = 1 << 15;
 ///     +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
 ///
 /// ```
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Query {
     name: Name,

--- a/crates/proto/src/op/response_code.rs
+++ b/crates/proto/src/op/response_code.rs
@@ -21,6 +21,9 @@
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
+#[cfg(feature = "serde")]
+use serde::{ Deserialize, Serialize };
+
 /// The status code of the response to a query.
 ///
 /// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://tools.ietf.org/html/rfc1035)
@@ -60,6 +63,7 @@ use std::fmt::{Display, Formatter};
 ///                 6-15            Reserved for future use.
 ///  ```
 #[derive(Debug, Eq, PartialEq, PartialOrd, Copy, Clone, Hash)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[allow(dead_code)]
 pub enum ResponseCode {
     /// No Error [RFC 1035](https://tools.ietf.org/html/rfc1035)

--- a/crates/proto/src/op/response_code.rs
+++ b/crates/proto/src/op/response_code.rs
@@ -22,7 +22,7 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 
 #[cfg(feature = "serde")]
-use serde::{ Deserialize, Serialize };
+use serde::{Deserialize, Serialize};
 
 /// The status code of the response to a query.
 ///

--- a/crates/proto/src/rr/dnssec/rdata/cdnskey.rs
+++ b/crates/proto/src/rr/dnssec/rdata/cdnskey.rs
@@ -23,6 +23,7 @@ use super::{DNSSECRData, DNSKEY};
 /// RRSIG is really a derivation of the original SIG record data. See SIG for more documentation
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct CDNSKEY(DNSKEY);
 
 impl Deref for CDNSKEY {

--- a/crates/proto/src/rr/dnssec/rdata/cds.rs
+++ b/crates/proto/src/rr/dnssec/rdata/cds.rs
@@ -23,6 +23,7 @@ use super::{DNSSECRData, DS};
 /// RRSIG is really a derivation of the original SIG record data. See SIG for more documentation
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct CDS(DS);
 
 impl Deref for CDS {

--- a/crates/proto/src/rr/dnssec/rdata/rrsig.rs
+++ b/crates/proto/src/rr/dnssec/rdata/rrsig.rs
@@ -23,6 +23,7 @@ use super::{DNSSECRData, SIG};
 /// RRSIG is really a derivation of the original SIG record data. See SIG for more documentation
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct RRSIG(SIG);
 
 impl RRSIG {

--- a/crates/proto/src/rr/rdata/a.rs
+++ b/crates/proto/src/rr/rdata/a.rs
@@ -46,6 +46,7 @@ use crate::{
 /// The DNS A record type, an IPv4 address
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct A(pub Ipv4Addr);
 
 impl A {

--- a/crates/proto/src/rr/rdata/aaaa.rs
+++ b/crates/proto/src/rr/rdata/aaaa.rs
@@ -38,6 +38,7 @@ use crate::{
 /// The DNS AAAA record type, an IPv6 address
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct AAAA(pub Ipv6Addr);
 
 impl AAAA {

--- a/crates/proto/src/rr/rdata/https.rs
+++ b/crates/proto/src/rr/rdata/https.rs
@@ -23,6 +23,7 @@ use super::SVCB;
 /// HTTPS is really a derivation of the original SVCB record data. See SVCB for more documentation
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct HTTPS(pub SVCB);
 
 impl Deref for HTTPS {

--- a/crates/proto/src/rr/rdata/name.rs
+++ b/crates/proto/src/rr/rdata/name.rs
@@ -77,6 +77,7 @@ macro_rules! name_rdata {
         #[doc = stringify!(new type for the RecordData of $name)]
         #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
         #[derive(Debug, PartialEq, Eq, Hash, Clone)]
+        #[cfg_attr(feature = "serde", serde(transparent))]
         pub struct $name(pub Name);
 
         impl BinEncodable for $name {

--- a/crates/proto/src/rr/rdata/svcb.rs
+++ b/crates/proto/src/rr/rdata/svcb.rs
@@ -567,6 +567,7 @@ impl fmt::Display for SvcParamValue {
 /// ```
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 #[repr(transparent)]
 pub struct Mandatory(pub Vec<SvcParamKey>);
 
@@ -743,6 +744,7 @@ impl fmt::Display for Mandatory {
 /// ```
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 #[repr(transparent)]
 pub struct Alpn(pub Vec<String>);
 
@@ -926,6 +928,7 @@ impl fmt::Debug for EchConfigList {
 /// ```
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[cfg_attr(feature = "serde", serde(transparent))]
 #[repr(transparent)]
 pub struct IpHint<T>(pub Vec<T>);
 


### PR DESCRIPTION
Makes the following enums/structs (De)Serializable.

1. `Message`
2. `Header`
3. `OpCode`
4. `ResponseCode`
5. `Query`
6. `Edns`

And introduces `#[serde(transparent)]` on transparent structs that would otherwise fail to deserialize after being serialized.

Each commit is self-contained, so I'd advise you to review the changes made by looking at each commit.

---

Resolves #2511