### PR TITLE
Dnssec insecure delegations

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/insecure.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/insecure.rs
@@ -16,7 +16,7 @@ mod deprecated_algorithm;
 #[test]
 #[ignore]
 fn unsigned_zone_nsec3() -> Result<()> {
-    unsigned_zone_fixture(Nsec::_3 { salt: None })
+    unsigned_zone_fixture(Nsec::_3 { opt_out: false, salt: None })
 }
 
 #[test]

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/insecure.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/insecure.rs
@@ -14,13 +14,11 @@ mod deprecated_algorithm;
 // a validating resolver should not respond with SERVFAIL to queries about the unsigned zone because
 // the security status of the whole zone is "Insecure", not "Bogus"
 #[test]
-#[ignore]
 fn unsigned_zone_nsec3() -> Result<()> {
     unsigned_zone_fixture(Nsec::_3 { opt_out: false, salt: None })
 }
 
 #[test]
-#[ignore]
 fn unsigned_zone_nsec() -> Result<()> {
     unsigned_zone_fixture(Nsec::_1)
 }
@@ -40,9 +38,6 @@ fn unsigned_zone_fixture(nsec: Nsec) -> Result<()> {
     let mut tld_ns = NameServer::new(&dns_test::PEER, FQDN::TEST_TLD, &network)?;
     let mut root_ns = NameServer::new(&dns_test::PEER, FQDN::ROOT, &network)?;
 
-    sibling_ns.add(root_ns.a());
-    sibling_ns.add(tld_ns.a());
-    sibling_ns.add(unsigned_ns.a());
     sibling_ns.add(sibling_ns.a());
 
     root_ns.referral_nameserver(&tld_ns);
@@ -79,12 +74,8 @@ fn unsigned_zone_fixture(nsec: Nsec) -> Result<()> {
     for zone in [FQDN::ROOT, FQDN::TEST_TLD, FQDN::TEST_DOMAIN] {
         let output = client.dig(settings, resolver.ipv4_addr(), RecordType::SOA, &zone)?;
 
-        // XXX unclear why BIND & hickory fail this sanity check but that doesn't affect the
-        // main assertion below
-        if zone != FQDN::TEST_DOMAIN || dns_test::SUBJECT.is_unbound() {
-            assert!(output.status.is_noerror());
-            assert!(output.flags.authenticated_data);
-        }
+        assert!(output.status.is_noerror());
+        assert!(output.flags.authenticated_data);
     }
 
     let settings = *DigSettings::default().recurse();
@@ -103,7 +94,6 @@ fn unsigned_zone_fixture(nsec: Nsec) -> Result<()> {
 // `no-ds.testing./DS` (which is why we cannot use `Graph::build` + `Sign::AndAmend` to produce
 // this network)
 #[test]
-#[ignore = "hickory-dns responds with SERVFAIL"]
 fn no_ds_record() -> Result<()> {
     let sign_settings = SignSettings::default();
 

--- a/conformance/packages/conformance-tests/src/resolver/nsec.rs
+++ b/conformance/packages/conformance-tests/src/resolver/nsec.rs
@@ -12,7 +12,10 @@ use dns_test::{
 
 #[test]
 fn zone_exist_domain_does_not_nsec3() -> Result<()> {
-    zone_exist_domain_does_not(Nsec::_3 { salt: None })
+    zone_exist_domain_does_not(Nsec::_3 {
+        opt_out: false,
+        salt: None,
+    })
 }
 
 #[test]
@@ -22,7 +25,10 @@ fn zone_exist_domain_does_not_nsec() -> Result<()> {
 
 #[test]
 fn zone_does_not_exist_nsec3() -> Result<()> {
-    zone_does_not_exist(Nsec::_3 { salt: None })
+    zone_does_not_exist(Nsec::_3 {
+        opt_out: false,
+        salt: None,
+    })
 }
 
 #[test]
@@ -32,7 +38,10 @@ fn zone_does_not_exist_nsec() -> Result<()> {
 
 #[test]
 fn domain_exists_record_type_does_not_nsec3() -> Result<()> {
-    domain_exists_record_type_does_not(Nsec::_3 { salt: None })
+    domain_exists_record_type_does_not(Nsec::_3 {
+        opt_out: false,
+        salt: None,
+    })
 }
 
 #[test]

--- a/conformance/packages/dns-test/src/docker/bind.Dockerfile
+++ b/conformance/packages/dns-test/src/docker/bind.Dockerfile
@@ -6,5 +6,6 @@ RUN apt-get update && \
     apt-get install -y \
         bind9 \
         ldnsutils \
+        bind9-utils \
         tshark && \
     rm -f /etc/bind/*

--- a/conformance/packages/dns-test/src/docker/hickory.Dockerfile
+++ b/conformance/packages/dns-test/src/docker/hickory.Dockerfile
@@ -4,6 +4,7 @@ FROM rust:1-slim-bookworm
 RUN apt-get update && \
     apt-get install -y \
         ldnsutils \
+        bind9-utils \
         tshark \
         libssl-dev \
         pkg-config

--- a/conformance/packages/dns-test/src/docker/unbound.Dockerfile
+++ b/conformance/packages/dns-test/src/docker/unbound.Dockerfile
@@ -5,6 +5,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && \
     apt-get install -y \
         ldnsutils \
+        bind9-utils \
         nsd \
         tshark \
         curl \

--- a/conformance/packages/dns-test/src/zone_file/mod.rs
+++ b/conformance/packages/dns-test/src/zone_file/mod.rs
@@ -76,8 +76,14 @@ impl FromStr for ZoneFile {
     fn from_str(input: &str) -> Result<Self> {
         let mut records = vec![];
         let mut maybe_soa = None;
+
         for line in input.lines() {
-            let line = line.trim();
+            let mut line = line.trim();
+
+            // When using dnssec-signzone, comments are inserted; remove them.
+            if let Some((item, _)) = line.split_once(';') {
+                line = item.trim_matches('\n');
+            }
 
             if line.is_empty() {
                 continue;

--- a/conformance/packages/dns-test/src/zone_file/signer.rs
+++ b/conformance/packages/dns-test/src/zone_file/signer.rs
@@ -27,6 +27,7 @@ pub struct SignSettings {
     expiration: Option<u64>,
     inception: Option<u64>,
     nsec: Nsec,
+    implementation: Implementation,
 }
 
 impl SignSettings {
@@ -38,6 +39,7 @@ impl SignSettings {
             expiration: None,
             inception: None,
             nsec: Nsec::default(),
+            implementation: Implementation::default(),
         }
     }
 
@@ -49,6 +51,7 @@ impl SignSettings {
             expiration: None,
             inception: None,
             nsec: Nsec::default(),
+            implementation: Implementation::default(),
         }
     }
 
@@ -60,6 +63,23 @@ impl SignSettings {
             expiration: None,
             inception: None,
             nsec: Nsec::default(),
+            implementation: Implementation::default(),
+        }
+    }
+
+    pub fn rsasha256_nsec3_optout() -> Self {
+        Self {
+            algorithm: Algorithm::RSASHA256,
+            // 2048-bit SHA256 matches `$ dig DNSKEY .` in length
+            zsk_bits: 2_048,
+            ksk_bits: 2_048,
+            expiration: None,
+            inception: None,
+            nsec: Nsec::_3 {
+                salt: None,
+                opt_out: true,
+            },
+            implementation: Implementation::Bindutils,
         }
     }
 
@@ -72,6 +92,7 @@ impl SignSettings {
             expiration: None,
             inception: None,
             nsec: Nsec::default(),
+            implementation: Implementation::default(),
         }
     }
 
@@ -109,12 +130,15 @@ impl Default for SignSettings {
 #[derive(Clone)]
 pub enum Nsec {
     _1,
-    _3 { salt: Option<String> },
+    _3 { opt_out: bool, salt: Option<String> },
 }
 
 impl Default for Nsec {
     fn default() -> Self {
-        Self::_3 { salt: None }
+        Self::_3 {
+            opt_out: false,
+            salt: None,
+        }
     }
 }
 
@@ -132,6 +156,13 @@ impl fmt::Display for Algorithm {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self, f)
     }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+enum Implementation {
+    #[default]
+    Ldns,
+    Bindutils,
 }
 
 /// Generates the command string to generate ZSK using `ldns-keygen`
@@ -185,7 +216,7 @@ impl<'a> Signer<'a> {
         let (zsk, zsk_filename) = self.gen_zsk_key(zone)?;
         let (ksk, ksk_filename) = self.gen_ksk_key(zone)?;
 
-        let signzone_cmd = self.sign_zone_cmd([zsk_filename, ksk_filename].iter().cloned());
+        let signzone_cmd = self.sign_zone_cmd(zone, [zsk_filename, ksk_filename].iter().cloned());
         let signzone = format!("cd {ZONES_DIR} && {}", signzone_cmd);
         self.container.status_ok(&["sh", "-c", &signzone])?;
 
@@ -234,31 +265,81 @@ impl<'a> Signer<'a> {
         Ok((signed_key, key_filename))
     }
 
-    fn sign_zone_cmd<T>(&self, keys: T) -> String
+    fn sign_zone_cmd<T>(&self, zone: &FQDN, keys: T) -> String
     where
         T: Iterator<Item = String>,
     {
-        let mut args = vec![String::from("ldns-signzone"), "-A".to_string()];
+        match self.settings.implementation {
+            Implementation::Ldns => {
+                let mut args = vec![String::from("ldns-signzone"), "-A".to_string()];
 
-        if let Some(expiration) = self.settings.expiration {
-            args.push(format!("-e {}", expiration));
-        }
-        if let Some(inception) = self.settings.inception {
-            args.push(format!("-i {}", inception));
-        }
+                if let Some(expiration) = self.settings.expiration {
+                    args.push(format!("-e {}", expiration));
+                }
+                if let Some(inception) = self.settings.inception {
+                    args.push(format!("-i {}", inception));
+                }
 
-        // NSEC3 related options
-        // -n = use NSEC3 instead of NSEC
-        if let Nsec::_3 { salt } = &self.settings.nsec {
-            args.push("-n".to_string());
+                // NSEC3 related options
+                // -n = use NSEC3 instead of NSEC
+                if let Nsec::_3 { salt, opt_out } = &self.settings.nsec {
+                    args.push("-n".to_string());
 
-            if let Some(salt) = salt {
-                args.push(format!("-s {}", salt));
+                    if *opt_out {
+                        args.push("-p".to_string());
+                    }
+
+                    if let Some(salt) = salt {
+                        args.push(format!("-s {}", salt));
+                    }
+                }
+                args.push(ZONE_FILENAME.to_string());
+
+                args.extend(keys);
+                args.join(" ")
+            }
+            Implementation::Bindutils => {
+                let mut args = vec!["dnssec-signzone".to_string()];
+
+                // This will include record names for all records and use compact record
+                // formats, which the dns-test record parsing code needs.
+                args.push("-O full".to_string());
+
+                if let Some(expiration) = self.settings.expiration {
+                    args.push(format!("-e {}", expiration));
+                }
+                if let Some(inception) = self.settings.inception {
+                    args.push(format!("-s {}", inception));
+                }
+
+                // Set -3 for NSEC3, optionally followed by a salt.
+                // -A sets opt-out
+                if let Nsec::_3 { salt, opt_out } = &self.settings.nsec {
+                    args.push("-3".to_string());
+
+                    if let Some(salt) = salt {
+                        args.push(salt.to_string());
+                    } else {
+                        // Set no salt, or else dnssec-signzone will interepret the next
+                        // argument as a salt.
+                        args.push("''".to_string());
+                    }
+
+                    if *opt_out {
+                        args.push("-A".to_string());
+                    }
+                }
+
+                // We must pass dnssec-signzone the origin of the zone, and specify
+                // -S to include the DNSKEY records for the keys passed in on the CLI.
+                args.push(format!("-o {zone}"));
+                args.push("-S".to_string());
+
+                args.push(ZONE_FILENAME.to_string());
+
+                args.extend(keys);
+                args.join(" ")
             }
         }
-        args.push(ZONE_FILENAME.to_string());
-
-        args.extend(keys);
-        args.join(" ")
     }
 }

--- a/crates/proto/src/xfer/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle/mod.rs
@@ -1162,9 +1162,9 @@ pub fn verify_nsec(query: &Query, soa_name: &Name, nsecs: &[&Record]) -> Proof {
                 !rdata.type_bit_maps().contains(&query.query_type())
             })
         {
-            return ds_proof_override;
+            return proof_log_yield(ds_proof_override, query.name(), "nsec1", "direct match");
         } else {
-            return Proof::Bogus;
+            return proof_log_yield(Proof::Bogus, query.name(), "nsec1", "direct match");
         }
     }
 
@@ -1186,7 +1186,7 @@ pub fn verify_nsec(query: &Query, soa_name: &Name, nsecs: &[&Record]) -> Proof {
 
     // continue to validate there is no wildcard
     if !verify_nsec_coverage(query.name()) {
-        return Proof::Bogus;
+        return proof_log_yield(Proof::Bogus, query.name(), "nsec1", "no wildcard");
     }
 
     // validate ANY or *.domain record existence
@@ -1202,14 +1202,29 @@ pub fn verify_nsec(query: &Query, soa_name: &Name, nsecs: &[&Record]) -> Proof {
     // don't need to validate the same name again
     if wildcard == *query.name() {
         // this was validated by the nsec coverage over the query.name()
-        ds_proof_override
+        proof_log_yield(
+            ds_proof_override,
+            query.name(),
+            "nsec1",
+            "direct wildcard match",
+        )
     } else {
         // this is the final check, return it's value
         //  if there is wildcard coverage, we're good.
         if verify_nsec_coverage(&wildcard) {
-            ds_proof_override
+            proof_log_yield(
+                ds_proof_override,
+                query.name(),
+                "nsec1",
+                "covering wildcard match",
+            )
         } else {
-            Proof::Bogus
+            proof_log_yield(
+                Proof::Bogus,
+                query.name(),
+                "nsec1",
+                "covering wildcard match",
+            )
         }
     }
 }
@@ -1220,6 +1235,12 @@ fn current_time() -> u32 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs() as u32
+}
+
+/// Logs a debug message and yields a Proof type for return
+fn proof_log_yield(proof: Proof, name: &Name, nsec_type: &str, msg: &str) -> Proof {
+    debug!("{nsec_type} proof for {name}, returning {proof}: {msg}");
+    proof
 }
 
 mod rrset {

--- a/crates/proto/src/xfer/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle/mod.rs
@@ -217,6 +217,14 @@ fn check_nsec(verified_message: DnsResponse, query: &Query) -> Result<DnsRespons
         return Ok(verified_message);
     }
 
+    if verified_message
+        .name_servers()
+        .iter()
+        .all(|x| x.proof() == Proof::Insecure)
+    {
+        return Ok(verified_message);
+    }
+
     // get SOA name
     let soa_name = if let Some(soa_name) = verified_message
         .name_servers()
@@ -272,6 +280,7 @@ fn check_nsec(verified_message: DnsResponse, query: &Query) -> Result<DnsRespons
     };
 
     if !nsec_proof.is_secure() {
+        debug!("returning Nsec error for {} {nsec_proof}", query.name());
         // TODO change this to remove the NSECs, like we do for the others?
         return Err(ProtoError::from(ProtoErrorKind::Nsec {
             query: query.clone(),
@@ -386,7 +395,12 @@ where
                 (proof, adjusted_ttl)
             }
             Err(ProofError { proof, kind }) => {
-                debug!("failed to verify: {name} record_type: {record_type}: {kind}",);
+                match kind {
+                    ProofErrorKind::DsResponseNsec { .. } => {
+                        debug!("verified insecure {name}/{record_type}")
+                    }
+                    _ => debug!("failed to verify: {name} record_type: {record_type}: {kind}"),
+                }
                 (proof, None)
             }
         };
@@ -658,13 +672,17 @@ where
     };
 
     // if the DS record was an NSEC then we have an insecure zone
-    if let Some((query, proof)) = error
+    if let Some((query, _proof)) = error
         .kind()
         .as_nsec()
-        .filter(|(_query, proof)| proof.is_secure())
+        .filter(|(_query, proof)| proof.is_insecure())
     {
+        debug!(
+            "marking {} as insecure based on NSEC/NSEC3 proof",
+            query.name()
+        );
         return Err(ProofError::new(
-            *proof,
+            Proof::Insecure,
             ProofErrorKind::DsResponseNsec {
                 name: query.name().to_owned(),
             },
@@ -1122,6 +1140,14 @@ fn verify_rrset_with_dnskey(_: &DNSKEY, _: &RRSIG, _: &Rrset) -> ProtoResult<()>
 pub fn verify_nsec(query: &Query, soa_name: &Name, nsecs: &[&Record]) -> Proof {
     // TODO: consider converting this to Result, and giving explicit reason for the failure
 
+    // DS queries resulting in NoData responses with accompanying NSEC records can prove that an
+    // insecure delegation exists; this is used to return Proof::Insecure instead of Proof::Secure
+    // in those situations.
+    let ds_proof_override = match query.query_type() {
+        RecordType::DS => Proof::Insecure,
+        _ => Proof::Secure,
+    };
+
     // first look for a record with the same name
     //  if they are, then the query_type should not exist in the NSEC record.
     //  if we got an NSEC record of the same name, but it is listed in the NSEC types,
@@ -1136,7 +1162,7 @@ pub fn verify_nsec(query: &Query, soa_name: &Name, nsecs: &[&Record]) -> Proof {
                 !rdata.type_bit_maps().contains(&query.query_type())
             })
         {
-            return Proof::Secure;
+            return ds_proof_override;
         } else {
             return Proof::Bogus;
         }
@@ -1176,12 +1202,12 @@ pub fn verify_nsec(query: &Query, soa_name: &Name, nsecs: &[&Record]) -> Proof {
     // don't need to validate the same name again
     if wildcard == *query.name() {
         // this was validated by the nsec coverage over the query.name()
-        Proof::Secure
+        ds_proof_override
     } else {
         // this is the final check, return it's value
         //  if there is wildcard coverage, we're good.
         if verify_nsec_coverage(&wildcard) {
-            Proof::Secure
+            ds_proof_override
         } else {
             Proof::Bogus
         }

--- a/crates/proto/src/xfer/dnssec_dns_handle/nsec3_validation.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle/nsec3_validation.rs
@@ -486,8 +486,9 @@ fn closest_encloser_proof<'a>(
 /// This function addresses three situations:
 ///
 /// Case 2. Name exists but there's no record of this type
-/// Case 3. Name is serviced by wildcard that has a record of this type
-/// Case 4. Name is serviced by wildcard that doesn't have a record of this type
+/// Case 3. Opt-out proof for Name exists
+/// Case 4. Name is serviced by wildcard that has a record of this type
+/// Case 5. Name is serviced by wildcard that doesn't have a record of this type
 fn validate_nodata_response(
     query_name: &Name,
     soa_name: &Name,
@@ -496,8 +497,9 @@ fn validate_nodata_response(
     nsec3s: &[Nsec3RecordPair<'_>],
 ) -> Proof {
     // 2. Name exists but there's no record of this type
-    // 3. Name is serviced by wildcard that has a record of this type
-    // 4. Name is serviced by wildcard that doesn't have a record of this type
+    // 3. Opt-out proof for Name exists
+    // 4. Name is serviced by wildcard that has a record of this type
+    // 5. Name is serviced by wildcard that doesn't have a record of this type
 
     debug_assert!(!nsec3s.is_empty());
     let salt = nsec3s[0].nsec3_data.salt();
@@ -506,26 +508,113 @@ fn validate_nodata_response(
     let hashed_query_name = nsec3hash(query_name, salt, iterations);
     let base32_hashed_query_name = data_encoding::BASE32_DNSSEC.encode(&hashed_query_name);
 
+    // DS queries resulting in NoData responses with accompanying NSEC3 records can prove that an
+    // insecure delegation exists; this is used to return Proof::Insecure instead of Proof::Secure
+    // in those situations.
+    let ds_proof_override = match query_type {
+        RecordType::DS => Proof::Insecure,
+        _ => Proof::Secure,
+    };
+
     let query_name_record = nsec3s
         .iter()
         .find(|record| record.base32_hashed_name == base32_hashed_query_name.as_bytes());
 
     // Case 2:
     // Name exists but there's no record of this type
+    //
+    // RFC 5155 § 8.5 et seq.
+    //
+    //   8.5.  Validating No Data Responses, QTYPE is not DS
+    //
+    //   The validator MUST verify that an NSEC3 RR that matches QNAME is
+    //   present and that both the QTYPE and the CNAME type are not set in its
+    //   Type Bit Maps field.
+    //
+    //   Note that this test also covers the case where the NSEC3 RR exists
+    //   because it corresponds to an empty non-terminal, in which case the
+    //   NSEC3 RR will have an empty Type Bit Maps field.
+    //
+    //   8.6.  Validating No Data Responses, QTYPE is DS
+    //
+    //   If there is an NSEC3 RR that matches QNAME present in the response,
+    //   then that NSEC3 RR MUST NOT have the bits corresponding to DS and
+    //   CNAME set in its Type Bit Maps field.
+    //
+    //   If there is no such NSEC3 RR, then the validator MUST verify that a
+    //   closest provable encloser proof for QNAME is present in the response,
+    //   and that the NSEC3 RR that covers the "next closer" name has the Opt-
+    //   Out bit set.
     if let Some(query_record) = query_name_record {
         if query_record
             .nsec3_data
             .type_bit_maps()
             .contains(&query_type)
+            || query_record
+                .nsec3_data
+                .type_bit_maps()
+                .contains(&RecordType::CNAME)
         {
             return Proof::Bogus;
         } else {
-            return Proof::Secure;
+            return ds_proof_override;
         }
     }
 
+    // Case 3:
+    // Query type is DS, records for name exist, but there are no DS records (opt-out proof)
+    //
+    // RFC 5155 § 6
+    //
+    //   In this specification, as in [RFC4033], [RFC4034] and [RFC4035], NS
+    //   RRSets at delegation points are not signed and may be accompanied by
+    //   a DS RRSet.  With the Opt-Out bit clear, the security status of the
+    //   child zone is determined by the presence or absence of this DS RRSet,
+    //   cryptographically proven by the signed NSEC3 RR at the hashed owner
+    //   name of the delegation.  Setting the Opt-Out flag modifies this by
+    //   allowing insecure delegations to exist within the signed zone without
+    //   a corresponding NSEC3 RR at the hashed owner name of the delegation.
+    //
+    //   An Opt-Out NSEC3 RR is said to cover a delegation if the hash of the
+    //   owner name or "next closer" name of the delegation is between the
+    //   owner name of the NSEC3 RR and the next hashed owner name.
+    //
+    //   An Opt-Out NSEC3 RR does not assert the existence or non-existence of
+    //   the insecure delegations that it may cover.  This allows for the
+    //   addition or removal of these delegations without recalculating or re-
+    //   signing RRs in the NSEC3 RR chain.  However, Opt-Out NSEC3 RRs do
+    //   assert the (non)existence of other, authoritative RRSets.
+    //
+    //   An Opt-Out NSEC3 RR MAY have the same original owner name as an
+    //   insecure delegation.  In this case, the delegation is proven insecure
+    //   by the lack of a DS bit in the type map and the signed NSEC3 RR does
+    //   assert the existence of the delegation.
+    //
+    //   Zones using Opt-Out MAY contain a mixture of Opt-Out NSEC3 RRs and
+    //   non-Opt-Out NSEC3 RRs.  If an NSEC3 RR is not Opt-Out, there MUST NOT
+    //   be any hashed owner names of insecure delegations (nor any other RRs)
+    //   between it and the name indicated by the next hashed owner name in
+    //   the NSEC3 RDATA.  If it is Opt-Out, it MUST only cover hashed owner
+    //   names or hashed "next closer" names of insecure delegations.
+    //
+    //   The effects of the Opt-Out flag on signing, serving, and validating
+    //   responses are covered in following sections.
+    //
+    // *Note*: the case of an opt-out NSEC3 record having the same original owner
+    // name as the hashed query name and not having the DS bit set in the type flags
+    // is covered here by case 2.
+    if query_type == RecordType::DS
+        && find_covering_record(nsec3s, &hashed_query_name, &base32_hashed_query_name[..])
+            .iter()
+            .all(|x| {
+                x.nsec3_data.type_bit_maps().contains(&RecordType::DS) && x.nsec3_data.opt_out()
+            })
+    {
+        return Proof::Insecure;
+    }
+
     match wildcard_encloser_num_labels {
-        // Case 3:
+        // Case 4:
         // Name is serviced by wildcard that has a record of this type
         Some(wildcard_encloser_num_labels) => {
             if query_name.num_labels() <= wildcard_encloser_num_labels {
@@ -549,12 +638,12 @@ fn validate_nodata_response(
                 &next_closer_base32_hashed_name,
             );
             match next_closer_record {
-                Some(_) => Proof::Secure,
+                Some(_) => ds_proof_override,
                 None => Proof::Bogus,
             }
         }
 
-        // Case 4:
+        // Case 5:
         // Name is serviced by wildcard that doesn't have a record of this type
         None => {
             let ClosestEncloserProofInfo {
@@ -563,9 +652,9 @@ fn validate_nodata_response(
                 closest_encloser_wildcard,
             } = wildcard_based_encloser_proof(query_name, soa_name, nsec3s);
             match (closest_encloser, next_closer, closest_encloser_wildcard) {
-                (Some(_), Some(_), Some(_)) => Proof::Secure,
-                (None, Some(_), Some(_)) if &query_name.base_name() == soa_name => Proof::Secure,
-                (None, None, None) if query_name == soa_name => Proof::Secure,
+                (Some(_), Some(_), Some(_)) => ds_proof_override,
+                (None, Some(_), Some(_)) if &query_name.base_name() == soa_name => ds_proof_override,
+                (None, None, None) if query_name == soa_name => ds_proof_override,
                 _ => Proof::Bogus,
             }
         }


### PR DESCRIPTION
This is hopefully the last change set to close out #2503. Originally, I thought the problem was isolated to a lack of support for NSEC3 opt-out proofs, but it looks like that in addition to that problem, insecure delegations are always being marked bogus by the current code, so there is a fix for that as well.

To facilitate testing these scenarios, there is also a commit for adding support to sign zones in dns-test with NSEC3 opt-out proofs, and one that adds debug-level logs to the nsec and nsec3 verification routines to indicate why a given proof is being returned as secure or bogus.

Making this a draft for now as there is some work to do on the nsec3 opt-out proof commit.