### PR TITLE
Skip fuzzer in past-future job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,7 +149,7 @@ jobs:
           version: ${{ env.CARGO_WS_VERSION }}
 
       - name: just no-default-features
-        run: just no-default-features
+        run: just no-default-features '' '--ignore hickory-proto-fuzz'
 
       - name: just build-bench
         if: contains( matrix.version, 'nightly' )

--- a/justfile
+++ b/justfile
@@ -53,7 +53,7 @@ dnssec-ring: (default "--features=dnssec-ring" "--ignore=\\{async-std-resolver,h
 # Run check on all projects in the workspace
 check feature='' ignore='':
     cargo ws exec {{ignore}} cargo {{MSRV}} check --locked --all-targets {{feature}}
-    cargo {{MSRV}} check --manifest-path fuzz/Cargo.toml --all-targets
+    cargo ws --manifest-path fuzz/Cargo.toml exec {{ignore}} cargo {{MSRV}} check --all-targets
 
 # Run build on all projects in the workspace
 build feature='' ignore='':


### PR DESCRIPTION
The past-future-matrix job is currently failing because a new version of the `arbitrary` crate is not compatible with Rust 1.70. We don't need to maintain MSRV compatibility for the fuzzer targets, especially since they are only used alongside nightly-only sanitizer flags. Furthermore, the `fuzz` workspace does not have its lockfile checked in, so we do not have complete control over the package versions used. This PR excludes the fuzzer targets from this job by using the `--ignore` flag from `cargo-ws`.