### PR TITLE
Recursor: set RD=0 in queries to nameservers

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
@@ -3,6 +3,7 @@ use std::net::Ipv4Addr;
 use dns_test::client::{Client, DigSettings};
 use dns_test::name_server::{Graph, NameServer, Sign};
 use dns_test::record::{Record, RecordType};
+use dns_test::tshark::{Capture, Direction};
 use dns_test::{Network, Resolver, Result, FQDN};
 
 mod bad_referral;
@@ -64,6 +65,66 @@ fn nxdomain() -> Result<()> {
     let output = client.dig(settings, resolver_ip_addr, RecordType::A, &needle_fqdn)?;
 
     assert!(dbg!(output).status.is_nxdomain());
+
+    Ok(())
+}
+
+#[test]
+fn recursion_desired_flag() -> Result<()> {
+    let expected_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
+    let needle_fqdn = FQDN::EXAMPLE_SUBDOMAIN;
+
+    let network = Network::new()?;
+
+    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::TEST_DOMAIN, &network)?;
+    leaf_ns.add(Record::a(needle_fqdn.clone(), expected_ipv4_addr));
+
+    let Graph {
+        nameservers, root, ..
+    } = Graph::build(leaf_ns, Sign::No)?;
+
+    let resolver = Resolver::new(&network, root).start()?;
+    let resolver_ip_addr = resolver.ipv4_addr();
+
+    let client = Client::new(&network)?;
+
+    let mut tshark = resolver.eavesdrop()?;
+
+    let settings = *DigSettings::default().recurse();
+    let output = client.dig(settings, resolver_ip_addr, RecordType::A, &needle_fqdn)?;
+
+    assert!(output.status.is_noerror());
+
+    let [answer] = output.answer.try_into().unwrap();
+    let a = answer.try_into_a().unwrap();
+
+    assert_eq!(needle_fqdn, a.fqdn);
+    assert_eq!(expected_ipv4_addr, a.ipv4_addr);
+
+    tshark.wait_for_capture()?;
+    let captures = tshark.terminate()?;
+
+    // Query from client to resolver should have RD=1.
+    // Queries from resolver to nameservers should have RD=0.
+    let mut seen_incoming_query = false;
+    let mut seen_outgoing_query = false;
+    for Capture { message, direction } in captures.iter() {
+        match direction {
+            Direction::Incoming { source } if *source == client.ipv4_addr() => {
+                seen_incoming_query = true;
+                assert!(message.is_rd_flag_set(), "{message:#?}");
+            }
+            Direction::Outgoing { destination }
+                if nameservers.iter().any(|ns| *destination == ns.ipv4_addr()) =>
+            {
+                seen_outgoing_query = true;
+                assert!(!message.is_rd_flag_set(), "{message:#?}");
+            }
+            _ => {}
+        }
+    }
+    assert!(seen_incoming_query, "{captures:#?}");
+    assert!(seen_outgoing_query, "{captures:#?}");
 
     Ok(())
 }

--- a/conformance/packages/dns-test/src/tshark.rs
+++ b/conformance/packages/dns-test/src/tshark.rs
@@ -226,6 +226,23 @@ impl Message {
 
         None
     }
+
+    pub fn is_rd_flag_set(&self) -> bool {
+        let Some(recursion_desired) = self.inner["dns.flags_tree"]
+            .as_object()
+            .unwrap()
+            .get("dns.flags.recdesired")
+        else {
+            return false;
+        };
+
+        let recursion_desired = recursion_desired.as_str().unwrap();
+        match recursion_desired {
+            "1" => true,
+            "0" => false,
+            _ => panic!("unexpected value for dns.flags.recdesired: {recursion_desired}"),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/crates/recursor/src/recursor_pool.rs
+++ b/crates/recursor/src/recursor_pool.rs
@@ -93,6 +93,11 @@ where
                 options.use_edns = security_aware;
                 options.edns_set_dnssec_ok = security_aware;
 
+                // Set RD=0 in queries made by the recursive resolver. See the last figure in
+                // section 2.2 of RFC 1035, for example. Failure to do so may allow for loops
+                // between recursive resolvers following referrals to each other.
+                options.recursion_desired = false;
+
                 // convert the lookup into a shared future
                 let lookup = ns
                     .lookup(query_cpy, options)


### PR DESCRIPTION
I noticed while using the `explore` example target that the Hickory recursor is setting `RD=1` in outgoing queries. A default value of `true` was inherited from `DnsRequestOptions::default()`, and never cleared. This can be a problem if another recursive resolver is erroneously listed as an authority for some zone. (If the name server isn't authoritative, then further queries are wasteful, and two such servers and erroneous zone referrals could be set up into a loop) This PR corrects that, and adds a conformance test checking the flag.