### PR TITLE
Recursor: Create DnsResponse with consistent buffer

### DIFF
--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -552,14 +552,14 @@ mod for_dnssec {
                         // sections into the answers section
                         msg.add_answers(lookup.records().iter().cloned());
 
-                        DnsResponse::new(msg, vec![])
+                        DnsResponse::from_message(msg)
                     })
                     .map_err(|e| match e.kind() {
                         // Translate back into a ProtoError::NoRecordsFound
                         ErrorKind::Forward(_fwd) => e.into(),
                         _ => ProtoError::from(e.to_string()),
                     })
-                    .await
+                    .await?
             })
             .boxed()
         }


### PR DESCRIPTION
`DnsResponse` contains a `Message` and a buffer, which is supposed to be the encoding of that message. This changes one use of the `new()` constructor inside the recursor that was providing an inconsistent buffer. I don't think this was causing any issues, since the response object is consumed internally by the `DnssecDnsHandle`, relying on the `Message`, but I think it would be safest to keep them consistent, in case future changes start reading the buffer.