### PR TITLE
Bump dependency version for internal dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,11 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 # hickory
-hickory-client = { version = "0.25.0-alpha.2", path = "crates/client", default-features = false }
-hickory-recursor = { version = "0.25.0-alpha.2", path = "crates/recursor", default-features = false }
-hickory-resolver = { version = "0.25.0-alpha.2", path = "crates/resolver", default-features = false }
-hickory-server = { version = "0.25.0-alpha.2", path = "crates/server", default-features = false }
-hickory-proto = { version = "0.25.0-alpha.2", path = "crates/proto", default-features = false }
+hickory-client = { version = "0.25.0-alpha.3", path = "crates/client", default-features = false }
+hickory-recursor = { version = "0.25.0-alpha.3", path = "crates/recursor", default-features = false }
+hickory-resolver = { version = "0.25.0-alpha.3", path = "crates/resolver", default-features = false }
+hickory-server = { version = "0.25.0-alpha.3", path = "crates/server", default-features = false }
+hickory-proto = { version = "0.25.0-alpha.3", path = "crates/proto", default-features = false }
 test-support.path = "tests/test-support"
 
 


### PR DESCRIPTION
Missed these in #2561.