### PR TITLE
fix: modify UDP port assignment to be handled by the OS

### DIFF
--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -70,6 +70,8 @@ wasm-bindgen = ["dep:wasm-bindgen-crate", "dep:js-sys"]
 
 backtrace = ["dep:backtrace"]
 
+auto-bind-port-udp = []
+
 [lib]
 name = "hickory_proto"
 path = "src/lib.rs"

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -70,8 +70,6 @@ wasm-bindgen = ["dep:wasm-bindgen-crate", "dep:js-sys"]
 
 backtrace = ["dep:backtrace"]
 
-auto-bind-port-udp = []
-
 [lib]
 name = "hickory_proto"
 path = "src/lib.rs"

--- a/crates/proto/src/tests/udp.rs
+++ b/crates/proto/src/tests/udp.rs
@@ -22,6 +22,7 @@ pub fn next_random_socket_test(mut exec: impl Executor, provider: impl RuntimePr
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 52),
         None,
         None,
+        false,
         provider,
     );
     drop(

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -32,6 +32,7 @@ pub struct UdpClientStreamBuilder<P> {
     signer: Option<Arc<dyn MessageFinalizer>>,
     bind_addr: Option<SocketAddr>,
     avoid_local_ports: Arc<HashSet<u16>>,
+    request_udp_port_from_os: bool,
     provider: P,
 }
 
@@ -50,6 +51,7 @@ impl<P> UdpClientStreamBuilder<P> {
             signer,
             bind_addr: self.bind_addr,
             avoid_local_ports: self.avoid_local_ports,
+            request_udp_port_from_os: self.request_udp_port_from_os,
             provider: self.provider,
         }
     }
@@ -70,6 +72,12 @@ impl<P> UdpClientStreamBuilder<P> {
         self
     }
 
+    /// Configures that OS should provide the ephemeral port, not the Hickory DNS
+    pub fn with_os_ephemeral_port(mut self, request_udp_port_from_os: bool) -> Self {
+        self.request_udp_port_from_os = request_udp_port_from_os;
+        self
+    }
+
     /// Construct a new UDP client stream.
     ///
     /// Returns a future that outputs the client stream.
@@ -80,6 +88,7 @@ impl<P> UdpClientStreamBuilder<P> {
             signer: self.signer,
             bind_addr: self.bind_addr,
             avoid_local_ports: self.avoid_local_ports.clone(),
+            request_udp_port_from_os: self.request_udp_port_from_os,
             provider: self.provider,
         }
     }
@@ -98,6 +107,7 @@ pub struct UdpClientStream<P> {
     signer: Option<Arc<dyn MessageFinalizer>>,
     bind_addr: Option<SocketAddr>,
     avoid_local_ports: Arc<HashSet<u16>>,
+    request_udp_port_from_os: bool,
     provider: P,
 }
 
@@ -110,6 +120,7 @@ impl<P: RuntimeProvider> UdpClientStream<P> {
             signer: None,
             bind_addr: None,
             avoid_local_ports: Arc::default(),
+            request_udp_port_from_os: false,
             provider,
         }
     }
@@ -183,12 +194,14 @@ impl<P: RuntimeProvider> DnsRequestSender for UdpClientStream<P> {
         let addr = message.addr();
         let bind_addr = self.bind_addr;
         let avoid_local_ports = self.avoid_local_ports.clone();
+        let request_udp_port_from_os = self.request_udp_port_from_os.clone();
 
         P::Timer::timeout::<Pin<Box<dyn Future<Output = Result<DnsResponse, ProtoError>> + Send>>>(
             self.timeout,
             Box::pin(async move {
                 let socket =
-                    NextRandomUdpSocket::new(addr, bind_addr, avoid_local_ports, provider).await?;
+                    NextRandomUdpSocket::new(addr, bind_addr, avoid_local_ports,
+                                             request_udp_port_from_os, provider).await?;
                 send_serial_message_inner(message, message_id, verifier, socket, recv_buf_size)
                     .await
             }),
@@ -226,6 +239,7 @@ pub struct UdpClientConnect<P> {
     signer: Option<Arc<dyn MessageFinalizer>>,
     bind_addr: Option<SocketAddr>,
     avoid_local_ports: Arc<HashSet<u16>>,
+    request_udp_port_from_os: bool,
     provider: P,
 }
 
@@ -241,6 +255,7 @@ impl<P: RuntimeProvider> Future for UdpClientConnect<P> {
             signer: self.signer.take(),
             bind_addr: self.bind_addr,
             avoid_local_ports: self.avoid_local_ports.clone(),
+            request_udp_port_from_os: self.request_udp_port_from_os,
             provider: self.provider.clone(),
         }))
     }

--- a/crates/proto/src/udp/udp_stream.rs
+++ b/crates/proto/src/udp/udp_stream.rs
@@ -286,11 +286,9 @@ impl<P: RuntimeProvider> Future for NextRandomUdpSocket<P> {
                         return Poll::Pending;
                     }
                 },
-                None => {
-                    Some(Box::pin(
-                        this.provider.bind_udp(this.bind_address, this.name_server),
-                    ))
-                }
+                None => Some(Box::pin(
+                    this.provider.bind_udp(this.bind_address, this.name_server),
+                )),
             }
         }
     }

--- a/crates/proto/src/udp/udp_stream.rs
+++ b/crates/proto/src/udp/udp_stream.rs
@@ -260,6 +260,69 @@ impl<P: RuntimeProvider> Future for NextRandomUdpSocket<P> {
 
     /// polls until there is an available next random UDP port,
     /// if no port has been specified in bind_addr.
+    #[cfg(not(feature = "auto-bind-port-udp"))]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        loop {
+            this.future = match this.future.take() {
+                Some(mut future) => match future.as_mut().poll(cx) {
+                    Poll::Ready(Ok(socket)) => {
+                        debug!("created socket successfully");
+                        return Poll::Ready(Ok(socket));
+                    }
+                    Poll::Ready(Err(err)) => match err.kind() {
+                        io::ErrorKind::AddrInUse if this.attempted < ATTEMPT_RANDOM + 1 => {
+                            debug!("unable to bind port, attempt: {}: {err}", this.attempted);
+                            this.attempted += 1;
+                            None
+                        }
+                        _ => {
+                            debug!("failed to bind port: {}", err);
+                            return Poll::Ready(Err(err));
+                        }
+                    },
+                    Poll::Pending => {
+                        debug!("unable to bind port, attempt: {}", this.attempted);
+                        this.future = Some(future);
+                        return Poll::Pending;
+                    }
+                },
+                None => {
+                    let mut bind_addr = this.bind_address;
+                    if bind_addr.port() == 0 {
+                        while this.attempted < ATTEMPT_RANDOM {
+                            // Per RFC 6056 Section 3.2:
+                            //
+                            // As mentioned in Section 2.1, the dynamic ports consist of the range
+                            // 49152-65535.  However, ephemeral port selection algorithms should use
+                            // the whole range 1024-65535.
+                            let rand_port_range = Uniform::new_inclusive(1_024, u16::MAX);
+                            let mut rand = rand::thread_rng();
+                            let port = rand_port_range.sample(&mut rand);
+                            if this.avoid_local_ports.contains(&port) {
+                                // Count this against the total number of attempts to pick a port.
+                                // RFC 6056 Section 3.3.2 notes that this algorithm should find a
+                                // suitable port in one or two attempts with high probability in
+                                // common scenarios. If `avoid_local_ports` is pathologically large,
+                                // then incrementing the counter here will prevent an infinite loop.
+                                this.attempted += 1;
+                                continue;
+                            } else {
+                                bind_addr = SocketAddr::new(bind_addr.ip(), port);
+                                break;
+                            }
+                        }
+                    }
+
+                    Some(Box::pin(
+                        this.provider.bind_udp(bind_addr, this.name_server),
+                    ))
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "auto-bind-port-udp")]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
         loop {

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -880,6 +880,8 @@ pub struct ResolverOpts {
     pub shuffle_dns_servers: bool,
     /// Local UDP ports to avoid when making outgoing queries
     pub avoid_local_udp_ports: Arc<HashSet<u16>>,
+    /// Request UDP bind ephemeral ports directly from the OS
+    pub request_udp_port_from_os: bool,
 }
 
 impl Default for ResolverOpts {
@@ -913,6 +915,7 @@ impl Default for ResolverOpts {
             authentic_data: false,
             shuffle_dns_servers: false,
             avoid_local_udp_ports: Arc::new(HashSet::new()),
+            request_udp_port_from_os: false,
         }
     }
 }

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -224,6 +224,7 @@ impl<P: RuntimeProvider> ConnectionProvider for GenericConnector<P> {
                 let provider_handle = self.runtime_provider.clone();
                 let stream = UdpClientStream::builder(config.socket_addr, provider_handle)
                     .with_timeout(Some(options.timeout))
+                    .with_os_ephemeral_port(options.request_udp_port_from_os)
                     .avoid_local_ports(options.avoid_local_udp_ports.clone())
                     .build();
                 let exchange = DnsExchange::connect(stream);


### PR DESCRIPTION
Hi, 
In the current implementation of the UDP port assignment, the compiled binary triggers Windows Firewall whenever it requests a particular port directly.
However, should the ephemeral port request be relayed to the OS directly, everything still works, is handled automatically and no firewall is triggered.