### PR TITLE
Replace DnsResponse::new() constructor

### DIFF
--- a/crates/proto/src/h2/h2_client_stream.rs
+++ b/crates/proto/src/h2/h2_client_stream.rs
@@ -30,7 +30,6 @@ use tracing::{debug, warn};
 
 use crate::error::ProtoError;
 use crate::http::Version;
-use crate::op::Message;
 use crate::runtime::iocompat::AsyncIoStdAsTokio;
 use crate::runtime::RuntimeProvider;
 use crate::tcp::DnsTcpStream;
@@ -183,8 +182,7 @@ impl HttpsClientStream {
         };
 
         // and finally convert the bytes into a DNS message
-        let message = Message::from_vec(&response_bytes)?;
-        Ok(DnsResponse::new(message, response_bytes.to_vec()))
+        DnsResponse::from_buffer(response_bytes.to_vec())
     }
 }
 

--- a/crates/proto/src/h3/h3_client_stream.rs
+++ b/crates/proto/src/h3/h3_client_stream.rs
@@ -27,7 +27,6 @@ use tracing::{debug, warn};
 
 use crate::error::ProtoError;
 use crate::http::Version;
-use crate::op::Message;
 use crate::udp::UdpSocket;
 use crate::xfer::{DnsRequest, DnsRequestSender, DnsResponse, DnsResponseStream};
 
@@ -185,8 +184,7 @@ impl H3ClientStream {
         };
 
         // and finally convert the bytes into a DNS message
-        let message = Message::from_vec(&response_bytes)?;
-        Ok(DnsResponse::new(message, response_bytes.to_vec()))
+        DnsResponse::from_buffer(response_bytes.to_vec())
     }
 }
 

--- a/crates/proto/src/quic/quic_stream.rs
+++ b/crates/proto/src/quic/quic_stream.rs
@@ -169,7 +169,7 @@ impl QuicStream {
             return Err(ProtoErrorKind::QuicMessageIdNot0(message.id()).into());
         }
 
-        Ok(DnsResponse::new(message, bytes.to_vec()))
+        DnsResponse::from_buffer(bytes.to_vec())
     }
 
     // TODO: we should change the protocol handlers to work with Messages since some require things like 0 for the Message ID.

--- a/crates/proto/src/rr/dnssec/tsig.rs
+++ b/crates/proto/src/rr/dnssec/tsig.rs
@@ -214,10 +214,7 @@ impl MessageFinalizer for TSigner {
             {
                 signature = last_sig;
                 remote_time = rt;
-                Ok(DnsResponse::new(
-                    Message::from_vec(dns_response)?,
-                    dns_response.to_vec(),
-                ))
+                DnsResponse::from_buffer(dns_response.to_vec())
             } else {
                 Err(ProtoError::from("tsig validation error: outdated response"))
             }

--- a/crates/proto/src/xfer/dns_response.rs
+++ b/crates/proto/src/xfer/dns_response.rs
@@ -135,17 +135,20 @@ pub struct DnsResponse {
 
 // TODO: when `impl Trait` lands in stable, remove this, and expose FlatMap over answers, et al.
 impl DnsResponse {
-    /// Constructs a new DnsResponse
-    pub fn new(message: Message, buffer: Vec<u8>) -> Self {
-        Self { message, buffer }
-    }
-
     /// Constructs a new DnsResponse with a buffer synthesized from the message
     pub fn from_message(message: Message) -> Result<Self, ProtoError> {
         Ok(Self {
             buffer: message.to_vec()?,
             message,
         })
+    }
+
+    /// Constructs a new DnsResponse by parsing a message from a buffer.
+    ///
+    /// Returns an error if the response message cannot be decoded.
+    pub fn from_buffer(buffer: Vec<u8>) -> Result<Self, ProtoError> {
+        let message = Message::from_vec(&buffer)?;
+        Ok(Self { message, buffer })
     }
 
     /// Retrieves the SOA from the response. This will only exist if it was an authoritative response.


### PR DESCRIPTION
This removes the `DnsResponse::new()` constructor, and adds a new one, `DnsResponse::from_buffer()`, which parses a response message from a `Vec<u8>`. This is a follow-up to #2553.