### PR TITLE
CI: Check hickory-proto with WASI preview 1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,20 @@ jobs:
         if: ${{ !cancelled() }}
         run: just test-docs
 
+  wasm:
+    name: wasm
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1
+
+      - name: check
+        run: cargo check -p hickory-proto --target wasm32-wasip1 --no-default-features
+
   ## Measure test coverage, only on linux.
   code-coverage:
     name: coverage


### PR DESCRIPTION
There are users currently making use of Hickory DNS in WASM-based projects, and `ProtoError` has a `wasm-bindgen` trait implementation to help with such applications. This PR thus adds a job to CI to check that the `hickory-proto` crate compiles on a WASM target, with the `tokio-runtime` feature off and the `wasm-bindgen` feature on.