### PR TITLE
Use larger fallback for `max_payload()` to accommodate larger nam server responses

### DIFF
--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -604,7 +604,7 @@ impl Message {
     ///
     /// the max payload value as it's defined in the EDNS section.
     pub fn max_payload(&self) -> u16 {
-        let max_size = self.edns.as_ref().map_or(512, Edns::max_payload);
+        let max_size = self.edns.as_ref().map_or(1024, Edns::max_payload);
         if max_size < 512 {
             512
         } else {


### PR DESCRIPTION
First off, let me say: thank you for developing the hickory set of crates 💛  These are super helpful! 

We are using the hickory resolver in reqwest and ran into an issue in Azure, where hickory failed to resolve our URLs with warnings like this:
```
2024-11-07T15:48:47.050514Z  WARN hickory_proto::udp::udp_client_stream: dropped malformed message waiting for id: 50916 err: unexpected end of input reached
```
After some investigation, we figured out that Azure name servers were sending responses that were larger than 512 bytes to non-eDNS requests. In our understanding, this is a problem because hickory seems to use a receive buffer of 512 bytes for non-eDNS responses.

This PR increases the buffer size for non-eDNS responses to avoid this problem.
 