### PR TITLE
resolver: drop comparison/ordering implementations for configuration types

### DIFF
--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -392,15 +392,6 @@ impl fmt::Display for NameServerConfig {
     }
 }
 
-/// We consider a `NameServerConfig` equal if the `socket_addr` and `protocol` are equal
-impl PartialEq for NameServerConfig {
-    fn eq(&self, other: &Self) -> bool {
-        self.socket_addr == other.socket_addr && self.protocol == other.protocol
-    }
-}
-
-impl Eq for NameServerConfig {}
-
 /// A set of name_servers to associate with a [`ResolverConfig`].
 #[derive(Clone, Debug)]
 pub struct NameServerConfigGroup {
@@ -772,14 +763,6 @@ impl From<Vec<NameServerConfig>> for NameServerConfigGroup {
         }
     }
 }
-
-impl PartialEq for NameServerConfigGroup {
-    fn eq(&self, other: &Self) -> bool {
-        self.servers == other.servers
-    }
-}
-
-impl Eq for NameServerConfigGroup {}
 
 /// The lookup ip strategy
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -24,7 +24,7 @@ use crate::proto::rr::Name;
 use crate::proto::xfer::Protocol;
 
 /// Configuration for the upstream nameservers to use for resolution
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ResolverConfig {
     // base search domain

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -185,18 +185,6 @@ where
     }
 }
 
-impl<P> PartialEq for NameServer<P>
-where
-    P: ConnectionProvider + Send,
-{
-    /// NameServers are equal if the config (connection information) are equal
-    fn eq(&self, other: &Self) -> bool {
-        self.config == other.config
-    }
-}
-
-impl<P> Eq for NameServer<P> where P: ConnectionProvider + Send {}
-
 #[cfg(test)]
 #[cfg(feature = "tokio-runtime")]
 mod tests {

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -5,7 +5,6 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::cmp::Ordering;
 use std::fmt::{self, Debug, Formatter};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -183,30 +182,6 @@ where
         let this = self.clone();
         // if state is failed, return future::err(), unless retry delay expired..
         Box::pin(once(this.inner_send(request)))
-    }
-}
-
-impl<P> Ord for NameServer<P>
-where
-    P: ConnectionProvider + Send,
-{
-    /// Custom implementation of Ord for NameServer which incorporates the performance of the connection into it's ranking
-    fn cmp(&self, other: &Self) -> Ordering {
-        // if they are literally equal, just return
-        if self == other {
-            return Ordering::Equal;
-        }
-
-        self.stats.cmp(&other.stats)
-    }
-}
-
-impl<P> PartialOrd for NameServer<P>
-where
-    P: ConnectionProvider + Send,
-{
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
     }
 }
 

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -30,7 +30,7 @@ pub struct NameServer<P: ConnectionProvider> {
     options: ResolverOpts,
     client: Arc<Mutex<Option<P::Conn>>>,
     state: Arc<NameServerState>,
-    stats: Arc<NameServerStats>,
+    pub(crate) stats: Arc<NameServerStats>,
     connection_provider: P,
 }
 

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -167,7 +167,9 @@ where
             // select the highest priority connection
             //   reorder the connections based on current view...
             //   this reorders the inner set
-            ServerOrderingStrategy::QueryStatistics => conns.sort_unstable(),
+            ServerOrderingStrategy::QueryStatistics => {
+                conns.sort_by(|a, b| a.stats.decayed_srtt().total_cmp(&b.stats.decayed_srtt()));
+            }
             ServerOrderingStrategy::UserProvidedOrder => {}
             ServerOrderingStrategy::RoundRobin => {
                 let num_concurrent_reqs = if opts.num_concurrent_reqs > 1 {

--- a/crates/resolver/src/name_server/name_server_stats.rs
+++ b/crates/resolver/src/name_server/name_server_stats.rs
@@ -181,25 +181,11 @@ impl PartialEq for NameServerStats {
 
 impl Eq for NameServerStats {}
 
-// TODO: Replace this with `f64::total_cmp` once the Rust version is bumped to
-// 1.62.0 (the method is stable beyond that version). In the meantime, the
-// implementation is copied from here:
-// https://github.com/rust-lang/rust/blob/master/library/core/src/num/f64.rs#L1336
-fn total_cmp(x: f64, y: f64) -> Ordering {
-    let mut left = x.to_bits() as i64;
-    let mut right = y.to_bits() as i64;
-
-    left ^= (((left >> 63) as u64) >> 1) as i64;
-    right ^= (((right >> 63) as u64) >> 1) as i64;
-
-    left.cmp(&right)
-}
-
 impl Ord for NameServerStats {
     /// Custom implementation of Ord for NameServer which incorporates the
     /// performance of the connection into it's ranking.
     fn cmp(&self, other: &Self) -> Ordering {
-        total_cmp(self.decayed_srtt(), other.decayed_srtt())
+        self.decayed_srtt().total_cmp(&other.decayed_srtt())
     }
 }
 

--- a/crates/resolver/src/name_server/name_server_stats.rs
+++ b/crates/resolver/src/name_server/name_server_stats.rs
@@ -133,7 +133,7 @@ impl NameServerStats {
     /// 1. It helps distribute query load.
     /// 2. It helps detect positive network changes. For example, decreases in
     ///    latency or a server that has recovered from a failure.
-    fn decayed_srtt(&self) -> f64 {
+    pub(crate) fn decayed_srtt(&self) -> f64 {
         let srtt = f64::from(self.srtt_microseconds.load(atomic::Ordering::Acquire));
         self.last_update.lock().map_or(srtt, |last_update| {
             // In general, if the time between queries is relatively short, then

--- a/crates/resolver/src/name_server/name_server_stats.rs
+++ b/crates/resolver/src/name_server/name_server_stats.rs
@@ -118,6 +118,7 @@ impl NameServerStats {
     /// Returns the raw SRTT value.
     ///
     /// Prefer to use `decayed_srtt` when ordering name servers.
+    #[cfg(test)]
     fn srtt(&self) -> Duration {
         Duration::from_micros(u64::from(
             self.srtt_microseconds.load(atomic::Ordering::Acquire),
@@ -171,14 +172,6 @@ impl NameServerStats {
         );
     }
 }
-
-impl PartialEq for NameServerStats {
-    fn eq(&self, other: &Self) -> bool {
-        self.srtt() == other.srtt()
-    }
-}
-
-impl Eq for NameServerStats {}
 
 #[cfg(test)]
 #[allow(clippy::extra_unused_type_parameters)]

--- a/crates/resolver/src/system_conf/unix.rs
+++ b/crates/resolver/src/system_conf/unix.rs
@@ -174,7 +174,10 @@ mod tests {
     fn test_name_server() {
         let parsed = parse_resolv_conf("nameserver 127.0.0.1").expect("failed");
         let cfg = empty_config(nameserver_config("127.0.0.1").to_vec());
-        assert_eq!(cfg.name_servers(), parsed.0.name_servers());
+        assert_eq!(
+            cfg.name_servers()[0].socket_addr,
+            parsed.0.name_servers()[0].socket_addr
+        );
         is_default_opts(parsed.1);
     }
 
@@ -195,7 +198,7 @@ mod tests {
         let mut cfg = empty_config(nameserver_config("127.0.0.53").to_vec());
 
         {
-            assert_eq!(cfg.name_servers(), parsed.0.name_servers());
+            assert_eq!(cfg.name_servers()[0].socket_addr, parsed.0.name_servers()[0].socket_addr);
             is_default_opts(parsed.1);
         }
 

--- a/crates/resolver/src/system_conf/unix.rs
+++ b/crates/resolver/src/system_conf/unix.rs
@@ -198,7 +198,10 @@ mod tests {
         let mut cfg = empty_config(nameserver_config("127.0.0.53").to_vec());
 
         {
-            assert_eq!(cfg.name_servers()[0].socket_addr, parsed.0.name_servers()[0].socket_addr);
+            assert_eq!(
+                cfg.name_servers()[0].socket_addr,
+                parsed.0.name_servers()[0].socket_addr
+            );
             is_default_opts(parsed.1);
         }
 

--- a/crates/resolver/src/system_conf/unix.rs
+++ b/crates/resolver/src/system_conf/unix.rs
@@ -221,7 +221,11 @@ mod tests {
         let parsed = parse_resolv_conf("domain example.com\nnameserver 127.0.0.1").expect("failed");
         let mut cfg = empty_config(nameserver_config("127.0.0.1").to_vec());
         cfg.set_domain(Name::from_str("example.com").unwrap());
-        assert_eq!(cfg, parsed.0);
+        assert_eq!(
+            cfg.name_servers()[0].socket_addr,
+            parsed.0.name_servers()[0].socket_addr
+        );
+        assert_eq!(cfg.domain(), parsed.0.domain());
         is_default_opts(parsed.1);
     }
 

--- a/tests/integration-tests/tests/integration/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/integration/name_server_pool_tests.rs
@@ -464,11 +464,13 @@ fn test_trust_nx_responses_fails() {
         true,
     );
 
+    let mut opts = ResolverOpts::default();
+    opts.server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
     let pool = mock_nameserver_pool(
         vec![fail_nameserver, succeed_nameserver],
         vec![],
         None,
-        ResolverOpts::default(),
+        opts,
     );
 
     // Lookup on UDP should fail, since we trust nx responses.
@@ -691,7 +693,10 @@ fn test_return_error_from_highest_priority_nameserver() {
             mock_nameserver(vec![Err(response)], ResolverOpts::default())
         })
         .collect();
-    let pool = mock_nameserver_pool(name_servers, vec![], None, ResolverOpts::default());
+
+    let mut opts = ResolverOpts::default();
+    opts.server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
+    let pool = mock_nameserver_pool(name_servers, vec![], None, opts);
 
     let request = message(query, vec![], vec![], vec![]);
     let future = pool.send(request).first_answer();
@@ -767,6 +772,7 @@ where
 #[test]
 fn test_concurrent_requests_2_conns() {
     let mut options = ResolverOpts::default();
+    options.server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
 
     // there are only 2 conns, so this matches that count
     options.num_concurrent_reqs = 2;
@@ -810,6 +816,7 @@ fn test_concurrent_requests_2_conns() {
 #[test]
 fn test_concurrent_requests_more_than_conns() {
     let mut options = ResolverOpts::default();
+    options.server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
 
     // there are only two conns, but this requests 3 concurrent requests, only 2 called
     options.num_concurrent_reqs = 3;


### PR DESCRIPTION
I don't think there are obvious use cases for these implementations, and it would be nice to have the flexibility to introduce internal configuration/state that is not `PartialEq`/`Eq`/`PartialOrd`/`Ord`. I also don't think the implementations are obviously correct (even before #2569, which dropped the `TlsClientConfig` wrapper that papered over the inability to compare TLS configurations) or conceptually obvious.