### PR TITLE
dns: improve error message when Cargo feature is missing

### DIFF
--- a/util/src/bin/dns.rs
+++ b/util/src/bin/dns.rs
@@ -319,7 +319,7 @@ async fn https(
     _opts: Opts,
     _provider: impl RuntimeProvider,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    panic!("`dns-over-https` feature is required during compilation");
+    panic!("`dns-over-https-rustls` feature is required during compilation");
 }
 
 #[cfg(feature = "dns-over-https-rustls")]


### PR DESCRIPTION
the `dns-over-https` feature does not exist. the correct feature name is `dns-over-https-rustls`