### PR TITLE
proto: apply timeout to TLS/QUIC/H3 handshake phase

### DIFF
--- a/conformance/packages/dns-test/src/container.rs
+++ b/conformance/packages/dns-test/src/container.rs
@@ -31,6 +31,10 @@ pub enum Image {
 }
 
 impl Image {
+    pub fn hickory() -> Self {
+        Self::Hickory(Repository(crate::repo_root()))
+    }
+
     fn dockerfile(&self) -> &'static str {
         match self {
             Self::Bind => include_str!("docker/bind.Dockerfile"),

--- a/conformance/packages/dns-test/src/docker/client.Dockerfile
+++ b/conformance/packages/dns-test/src/docker/client.Dockerfile
@@ -5,4 +5,5 @@ FROM debian:bookworm-slim
 RUN apt-get update && \
     apt-get install -y \
         dnsutils \
-        iputils-ping
+        iputils-ping \
+        netcat-openbsd

--- a/conformance/packages/dns-test/src/docker/hickory.Dockerfile
+++ b/conformance/packages/dns-test/src/docker/hickory.Dockerfile
@@ -13,6 +13,9 @@ RUN apt-get update && \
 # a clone of the hickory repository. `./src` here refers to that clone; not to
 # any directory inside the `hickory-dns` repository
 COPY ./src /usr/src/hickory
-RUN --mount=type=cache,target=/usr/src/hickory/target cargo build --manifest-path /usr/src/hickory/Cargo.toml -p hickory-dns --features recursor,dnssec-openssl && \
-    cp /usr/src/hickory/target/debug/hickory-dns /usr/bin/
+RUN --mount=type=cache,target=/usr/src/hickory/target \
+    cargo build --manifest-path /usr/src/hickory/Cargo.toml -p hickory-dns --features recursor,dnssec-openssl && \
+    cargo build --manifest-path /usr/src/hickory/Cargo.toml --bin dns --features dns-over-https-rustls && \
+    cp /usr/src/hickory/target/debug/hickory-dns /usr/bin/ && \
+    cp /usr/src/hickory/target/debug/dns /usr/bin/
 ENV RUST_LOG=debug

--- a/conformance/packages/dns-test/src/docker/hickory.Dockerfile
+++ b/conformance/packages/dns-test/src/docker/hickory.Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && \
 COPY ./src /usr/src/hickory
 RUN --mount=type=cache,target=/usr/src/hickory/target \
     cargo build --manifest-path /usr/src/hickory/Cargo.toml -p hickory-dns --features recursor,dnssec-openssl && \
-    cargo build --manifest-path /usr/src/hickory/Cargo.toml --bin dns --features dns-over-https-rustls && \
+    cargo build --manifest-path /usr/src/hickory/Cargo.toml --bin dns --features dns-over-h3,dns-over-https-rustls,dns-over-quic && \
     cp /usr/src/hickory/target/debug/hickory-dns /usr/bin/ && \
     cp /usr/src/hickory/target/debug/dns /usr/bin/
 ENV RUST_LOG=debug

--- a/conformance/packages/dns-test/src/lib.rs
+++ b/conformance/packages/dns-test/src/lib.rs
@@ -14,7 +14,7 @@ pub use crate::resolver::Resolver;
 pub use crate::trust_anchor::TrustAnchor;
 
 pub mod client;
-mod container;
+pub mod container;
 mod fqdn;
 mod implementation;
 pub mod name_server;

--- a/crates/proto/src/h3/h3_client_stream.rs
+++ b/crates/proto/src/h3/h3_client_stream.rs
@@ -7,6 +7,7 @@
 
 use std::fmt::{self, Display};
 use std::future::{poll_fn, Future};
+use std::io;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::str::FromStr;
@@ -22,12 +23,15 @@ use http::header::{self, CONTENT_LENGTH};
 use quinn::crypto::rustls::QuicClientConfig;
 use quinn::{ClientConfig, Endpoint, EndpointConfig, TransportConfig};
 use tokio::sync::mpsc;
+use tokio::time::timeout;
 use tracing::{debug, warn};
 
 use crate::error::ProtoError;
 use crate::http::Version;
 use crate::udp::UdpSocket;
-use crate::xfer::{DnsRequest, DnsRequestSender, DnsResponse, DnsResponseStream};
+use crate::xfer::{
+    DnsRequest, DnsRequestSender, DnsResponse, DnsResponseStream, H3_HANDSHAKE_TIMEOUT,
+};
 
 use super::ALPN_H3;
 
@@ -403,10 +407,26 @@ impl H3ClientStreamBuilder {
         let quic_connection = if early_data_enabled {
             match connecting.into_0rtt() {
                 Ok((new_connection, _)) => new_connection,
-                Err(connecting) => connecting.await?,
+                Err(connecting) => {
+                    timeout(H3_HANDSHAKE_TIMEOUT, connecting)
+                        .await
+                        .map_err(|_| {
+                            io::Error::new(
+                                io::ErrorKind::TimedOut,
+                                format!("H3 handshake timed out after {H3_HANDSHAKE_TIMEOUT:?}"),
+                            )
+                        })??
+                }
             }
         } else {
-            connecting.await?
+            timeout(H3_HANDSHAKE_TIMEOUT, connecting)
+                .await
+                .map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        format!("H3 handshake timed out after {H3_HANDSHAKE_TIMEOUT:?}"),
+                    )
+                })??
         };
 
         let h3_connection = h3_quinn::Connection::new(quic_connection);

--- a/crates/proto/src/runtime.rs
+++ b/crates/proto/src/runtime.rs
@@ -178,7 +178,7 @@ mod tokio_runtime {
 
                 socket.set_nodelay(true)?;
                 let future = socket.connect(server_addr);
-                let wait_for = wait_for.unwrap_or_else(|| Duration::from_secs(5));
+                let wait_for = wait_for.unwrap_or(TCP_HANDSHAKE_TIMEOUT);
                 match timeout(wait_for, future).await {
                     Ok(Ok(socket)) => Ok(AsyncIoTokioAsStd(socket)),
                     Ok(Err(e)) => Err(e),
@@ -228,6 +228,8 @@ mod tokio_runtime {
     }
 }
 
+#[cfg(feature = "tokio-runtime")]
+use crate::xfer::TCP_HANDSHAKE_TIMEOUT;
 #[cfg(feature = "tokio-runtime")]
 pub use tokio_runtime::{TokioHandle, TokioRuntimeProvider};
 

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -13,6 +13,7 @@ use std::task::{Context, Poll};
     feature = "tokio-runtime",
     feature = "dns-over-rustls",
     feature = "dns-over-https-rustls",
+    feature = "dns-over-quic",
 ))]
 use std::time::Duration;
 
@@ -53,6 +54,8 @@ pub use self::serial_message::SerialMessage;
 pub(crate) const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(feature = "tokio-runtime")]
 pub(crate) const TCP_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(feature = "dns-over-quic")]
+pub(crate) const QUIC_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Ignores the result of a send operation and logs and ignores errors
 fn ignore_send<M, T>(result: Result<M, mpsc::TrySendError<T>>) {

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -9,6 +9,8 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+#[cfg(feature = "dns-over-https-rustls")]
+use std::time::Duration;
 
 use futures_channel::mpsc;
 use futures_channel::oneshot;
@@ -42,6 +44,9 @@ pub use self::dns_response::{DnsResponse, DnsResponseStream};
 pub use self::dnssec_dns_handle::DnssecDnsHandle;
 pub use self::retry_dns_handle::RetryDnsHandle;
 pub use self::serial_message::SerialMessage;
+
+#[cfg(feature = "dns-over-https-rustls")]
+pub(crate) const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Ignores the result of a send operation and logs and ignores errors
 fn ignore_send<M, T>(result: Result<M, mpsc::TrySendError<T>>) {

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -9,7 +9,11 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-#[cfg(feature = "dns-over-https-rustls")]
+#[cfg(any(
+    feature = "tokio-runtime",
+    feature = "dns-over-rustls",
+    feature = "dns-over-https-rustls",
+))]
 use std::time::Duration;
 
 use futures_channel::mpsc;
@@ -45,7 +49,7 @@ pub use self::dnssec_dns_handle::DnssecDnsHandle;
 pub use self::retry_dns_handle::RetryDnsHandle;
 pub use self::serial_message::SerialMessage;
 
-#[cfg(feature = "dns-over-https-rustls")]
+#[cfg(any(feature = "dns-over-rustls", feature = "dns-over-https-rustls"))]
 pub(crate) const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Ignores the result of a send operation and logs and ignores errors

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -14,6 +14,7 @@ use std::task::{Context, Poll};
     feature = "dns-over-rustls",
     feature = "dns-over-https-rustls",
     feature = "dns-over-quic",
+    feature = "dns-over-h3",
 ))]
 use std::time::Duration;
 
@@ -56,6 +57,8 @@ pub(crate) const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 pub(crate) const TCP_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(feature = "dns-over-quic")]
 pub(crate) const QUIC_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(feature = "dns-over-h3")]
+pub(crate) const H3_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Ignores the result of a send operation and logs and ignores errors
 fn ignore_send<M, T>(result: Result<M, mpsc::TrySendError<T>>) {

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -51,6 +51,8 @@ pub use self::serial_message::SerialMessage;
 
 #[cfg(any(feature = "dns-over-rustls", feature = "dns-over-https-rustls"))]
 pub(crate) const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(feature = "tokio-runtime")]
+pub(crate) const TCP_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Ignores the result of a send operation and logs and ignores errors
 fn ignore_send<M, T>(result: Result<M, mpsc::TrySendError<T>>) {

--- a/tests/e2e-tests/src/client.rs
+++ b/tests/e2e-tests/src/client.rs
@@ -10,7 +10,6 @@ fn tls_handshake_timeout_dns_over_https() -> Result<()> {
 }
 
 #[test]
-#[ignore = "FIXME unresponsive client"]
 fn tls_handshake_timeout_dns_over_tls() -> Result<()> {
     tls_handshake_timeout("tls")
 }
@@ -56,7 +55,8 @@ fn tls_handshake_timeout(protocol: &str) -> Result<()> {
             let output = client_process.wait()?;
 
             assert!(!output.status.success());
-            assert!(output.stdout.contains("TLS handshake timed out"));
+            println!("stdout:\n {}", output.stdout);
+            assert!(output.stdout.contains("timed out"));
 
             return Ok(());
         } else {

--- a/tests/e2e-tests/src/client.rs
+++ b/tests/e2e-tests/src/client.rs
@@ -20,7 +20,6 @@ fn tls_handshake_timeout_dns_over_quic() -> Result<()> {
 }
 
 #[test]
-#[ignore = "FIXME unresponsive client"]
 fn tls_handshake_timeout_dns_over_h3() -> Result<()> {
     tls_handshake_timeout("h3")
 }

--- a/tests/e2e-tests/src/client.rs
+++ b/tests/e2e-tests/src/client.rs
@@ -5,7 +5,6 @@ use dns_test::container::{Container, Image};
 use dns_test::{Network, Result};
 
 #[test]
-#[ignore = "hickory hangs when server is unresponsive during TLS handshake"]
 fn tls_handshake_timeout() -> Result<()> {
     const PORT: u16 = 8443;
 

--- a/tests/e2e-tests/src/client.rs
+++ b/tests/e2e-tests/src/client.rs
@@ -15,7 +15,6 @@ fn tls_handshake_timeout_dns_over_tls() -> Result<()> {
 }
 
 #[test]
-#[ignore = "FIXME unresponsive client"]
 fn tls_handshake_timeout_dns_over_quic() -> Result<()> {
     tls_handshake_timeout("quic")
 }

--- a/tests/e2e-tests/src/client.rs
+++ b/tests/e2e-tests/src/client.rs
@@ -5,7 +5,29 @@ use dns_test::container::{Container, Image};
 use dns_test::{Network, Result};
 
 #[test]
-fn tls_handshake_timeout() -> Result<()> {
+fn tls_handshake_timeout_dns_over_https() -> Result<()> {
+    tls_handshake_timeout("https")
+}
+
+#[test]
+#[ignore = "FIXME unresponsive client"]
+fn tls_handshake_timeout_dns_over_tls() -> Result<()> {
+    tls_handshake_timeout("tls")
+}
+
+#[test]
+#[ignore = "FIXME unresponsive client"]
+fn tls_handshake_timeout_dns_over_quic() -> Result<()> {
+    tls_handshake_timeout("quic")
+}
+
+#[test]
+#[ignore = "FIXME unresponsive client"]
+fn tls_handshake_timeout_dns_over_h3() -> Result<()> {
+    tls_handshake_timeout("h3")
+}
+
+fn tls_handshake_timeout(protocol: &str) -> Result<()> {
     const PORT: u16 = 8443;
 
     let network = Network::new().unwrap();
@@ -19,7 +41,7 @@ fn tls_handshake_timeout() -> Result<()> {
     let mut client_process = client_container.spawn(&[
         "dns",
         "-p",
-        "https",
+        protocol,
         "-n",
         &format!("{server_addr}:{PORT}"),
         "--tls-dns-name",

--- a/tests/e2e-tests/src/client.rs
+++ b/tests/e2e-tests/src/client.rs
@@ -1,0 +1,47 @@
+use core::time::Duration;
+use std::thread;
+
+use dns_test::container::{Container, Image};
+use dns_test::{Network, Result};
+
+#[test]
+#[ignore = "hickory hangs when server is unresponsive during TLS handshake"]
+fn tls_handshake_timeout() -> Result<()> {
+    const PORT: u16 = 8443;
+
+    let network = Network::new().unwrap();
+
+    let server_container = Container::run(&Image::Client, &network)?;
+    let _server_process = server_container.spawn(&["nc", "-l", "-p", &PORT.to_string()])?;
+
+    let client_container = Container::run(&Image::hickory(), &network)?;
+
+    let server_addr = server_container.ipv4_addr();
+    let mut client_process = client_container.spawn(&[
+        "dns",
+        "-p",
+        "https",
+        "-n",
+        &format!("{server_addr}:{PORT}"),
+        "--tls-dns-name",
+        "dont-care",
+        "query",
+        "dont.care",
+        "A",
+    ])?;
+
+    for _ in 0..10 {
+        if client_process.try_wait()?.is_some() {
+            let output = client_process.wait()?;
+
+            assert!(!output.status.success());
+            assert!(output.stdout.contains("TLS handshake timed out"));
+
+            return Ok(());
+        } else {
+            thread::sleep(Duration::from_secs(1))
+        }
+    }
+
+    panic!("`dns` client is unresponsive")
+}

--- a/tests/e2e-tests/src/lib.rs
+++ b/tests/e2e-tests/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::env;
 
+mod client;
 mod recursor;
 mod resolver;
 


### PR DESCRIPTION
a timeout is applied to [the TCP connection phase](https://github.com/hickory-dns/hickory-dns/blob/d40f11fb7307f9fb9707750dea6619220802ba98/crates/proto/src/runtime.rs#L182) but no timeout is applied to TLS handshake. this results in clients "hanging" (blocking forever) when trying to establish a TLS connection to a DNS server.

this PR applies a timeout to the TLS handshake to prevent the problem.

an E2E test has been added to serve as a regression test. 