### PR TITLE
Fix dns-over-openssl

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,6 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        #   feature: [default-features, no-default-features, dns-over-rustls, dns-over-https-rustls, dns-over-native-tls, dns-over-openssl, dnssec-openssl, dnssec-ring, mdns, async-std]
         feature:
           [
             default,
@@ -113,6 +112,7 @@ jobs:
             dns-over-quic,
             dns-over-h3,
             dns-over-native-tls,
+            dns-over-openssl,
             dnssec-openssl,
             dnssec-ring,
             doc,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,7 @@ dependencies = [
  "hickory-server",
  "ipnet",
  "native-tls",
+ "openssl",
  "regex",
  "rusqlite",
  "rustls",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -33,7 +33,7 @@ default = ["sqlite", "resolver", "native-certs", "ascii-art"]
 ascii-art = []
 
 blocklist = ["hickory-server/blocklist"]
-dnssec-openssl = ["dnssec", "hickory-server/dnssec-openssl"]
+dnssec-openssl = ["dnssec", "hickory-server/dnssec-openssl", "dep:openssl"]
 dnssec-ring = ["dnssec", "hickory-server/dnssec-ring"]
 dnssec = []
 recursor = ["hickory-server/recursor"]
@@ -65,6 +65,7 @@ cfg-if.workspace = true
 clap = { workspace = true, default-features = false, features = ["cargo", "derive", "help", "std", "suggestions"] }
 futures-util = { workspace = true, default-features = false, features = ["std"] }
 ipnet = { workspace = true, features = ["serde"] }
+openssl = { workspace = true, features = ["v102", "v110"], optional = true }
 # rusqlite is actually only needed for test situations, but we need an optional dependency
 # here so we can disable it for MSRV tests (rusqlite only supports latest stable)
 rusqlite = { workspace = true, features = ["bundled", "time"], optional = true }

--- a/bin/src/dnssec.rs
+++ b/bin/src/dnssec.rs
@@ -10,7 +10,11 @@
 use std::path::Path;
 
 #[cfg(all(feature = "dns-over-openssl", not(feature = "dns-over-rustls")))]
-use openssl::{pkey::PKey, stack::Stack, x509::X509};
+use openssl::{
+    pkey::{PKey, Private},
+    stack::Stack,
+    x509::X509,
+};
 #[cfg(feature = "dns-over-rustls")]
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use serde::Deserialize;
@@ -306,17 +310,17 @@ pub fn load_cert(
 ) -> Result<((X509, Option<Stack<X509>>), PKey<Private>), String> {
     use tracing::{info, warn};
 
-    use crate::proto::openssl::tls_server::{
+    use hickory_proto::openssl::tls_server::{
         read_cert_pem, read_cert_pkcs12, read_key_from_der, read_key_from_pkcs8,
     };
 
-    let path = zone_dir.to_owned().join(tls_cert_config.get_path());
-    let cert_type = tls_cert_config.get_cert_type();
-    let password = tls_cert_config.get_password();
+    let path = zone_dir.to_owned().join(tls_cert_config.path());
+    let cert_type = tls_cert_config.cert_type();
+    let password = tls_cert_config.password();
     let private_key_path = tls_cert_config
-        .get_private_key()
+        .private_key()
         .map(|p| zone_dir.to_owned().join(p));
-    let private_key_type = tls_cert_config.get_private_key_type();
+    let private_key_type = tls_cert_config.private_key_type();
 
     // if it's pkcs12, we'll be collecting the key and certs from that, otherwise continue processing
     let (cert, cert_chain) = match cert_type {

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -74,6 +74,7 @@ dns-over-h3 = [
 # dns-over-native-tls = ["dns-over-tls",  "hickory-resolver/dns-over-native-tls", "hickory-server/dns-over-native-tls"]
 dns-over-openssl = [
     "dns-over-tls",
+    "dnssec-openssl",
     "hickory-proto/dns-over-openssl",
     "hickory-resolver/dns-over-openssl",
     "hickory-server/dns-over-openssl",


### PR DESCRIPTION
I noticed building with the `dns-over-openssl` feature is failing again. This PR fixes some bit rot, and adds it to CI.