### PR TITLE
server: Fix compilation of recursor authority without DNSSEC

### DIFF
--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -48,8 +48,8 @@ dnssec = [
     "serde/rc",
 ]
 # Recursive Resolution is Experimental!
-recursor = ["hickory-recursor", "hickory-resolver"]
-resolver = ["hickory-resolver"]
+recursor = ["dep:hickory-recursor", "dep:hickory-resolver"]
+resolver = ["dep:hickory-resolver"]
 sqlite = ["rusqlite"]
 blocklist = ["resolver"]
 toml = ["dep:toml"]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -48,7 +48,7 @@ dnssec = [
     "serde/rc",
 ]
 # Recursive Resolution is Experimental!
-recursor = ["hickory-recursor"]
+recursor = ["hickory-recursor", "hickory-resolver"]
 resolver = ["hickory-resolver"]
 sqlite = ["rusqlite"]
 blocklist = ["resolver"]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -49,9 +49,9 @@
 #[cfg(feature = "blocklist")]
 pub use crate::store::blocklist;
 pub use hickory_proto as proto;
-#[cfg(feature = "hickory-recursor")]
+#[cfg(feature = "recursor")]
 pub use hickory_recursor as recursor;
-#[cfg(feature = "hickory-resolver")]
+#[cfg(feature = "resolver")]
 pub use hickory_resolver as resolver;
 
 mod access;

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -51,7 +51,7 @@ pub use crate::store::blocklist;
 pub use hickory_proto as proto;
 #[cfg(feature = "recursor")]
 pub use hickory_recursor as recursor;
-#[cfg(feature = "resolver")]
+#[cfg(any(feature = "resolver", feature = "recursor"))]
 pub use hickory_resolver as resolver;
 
 mod access;

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -31,7 +31,7 @@ use crate::{
 
 /// An authority that will forward resolutions to upstream resolvers.
 ///
-/// This uses the hickory-resolver for resolving requests.
+/// This uses the hickory-resolver crate for resolving requests.
 pub struct ForwardAuthority<P: ConnectionProvider = TokioConnectionProvider> {
     origin: LowerName,
     resolver: Resolver<P>,

--- a/crates/server/src/store/forwarder/mod.rs
+++ b/crates/server/src/store/forwarder/mod.rs
@@ -5,7 +5,7 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#![cfg(feature = "hickory-resolver")]
+#![cfg(feature = "resolver")]
 
 //! Forwarding resolver related types
 

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -9,12 +9,10 @@ use std::{io, path::Path, time::Instant};
 
 use tracing::{debug, info};
 
-#[cfg(feature = "dnssec")]
-use crate::{authority::Nsec3QueryInfo, dnssec::NxProofKind, proto::dnssec::Proof};
 use crate::{
     authority::{
-        Authority, DnssecSummary, LookupControlFlow, LookupError, LookupObject, LookupOptions,
-        MessageRequest, UpdateResult, ZoneType,
+        Authority, LookupControlFlow, LookupError, LookupObject, LookupOptions, MessageRequest,
+        UpdateResult, ZoneType,
     },
     proto::{
         op::{Query, ResponseCode},
@@ -28,6 +26,12 @@ use crate::{
     },
     server::RequestInfo,
     store::recursor::RecursiveConfig,
+};
+#[cfg(feature = "dnssec")]
+use crate::{
+    authority::{DnssecSummary, Nsec3QueryInfo},
+    dnssec::NxProofKind,
+    proto::dnssec::Proof,
 };
 
 /// An authority that will forward resolutions to upstream resolvers.
@@ -222,6 +226,7 @@ impl LookupObject for RecursiveLookup {
         None
     }
 
+    #[cfg(feature = "dnssec")]
     fn dnssec_summary(&self) -> DnssecSummary {
         let mut all_secure = None;
         for record in self.0.records().iter() {

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -34,9 +34,9 @@ use crate::{
     proto::dnssec::Proof,
 };
 
-/// An authority that will forward resolutions to upstream resolvers.
+/// An authority that performs recursive resolutions.
 ///
-/// This uses the hickory-resolver for resolving requests.
+/// This uses the hickory-recursor crate for resolving requests.
 pub struct RecursiveAuthority {
     origin: LowerName,
     recursor: Recursor,

--- a/crates/server/src/store/recursor/config.rs
+++ b/crates/server/src/store/recursor/config.rs
@@ -20,19 +20,17 @@ use ipnet::IpNet;
 use serde::Deserialize;
 
 use crate::error::ConfigError;
+#[cfg(feature = "dnssec")]
+use crate::proto::{
+    dnssec::{PublicKeyEnum, TrustAnchor},
+    serialize::txt::trust_anchor::{self, Entry},
+};
 use crate::proto::{
     rr::{Name, RData, Record, RecordSet},
     serialize::txt::Parser,
 };
+use crate::recursor::DnssecPolicy;
 use crate::resolver::dns_lru::TtlConfig;
-#[cfg(feature = "dnssec")]
-use crate::{
-    proto::{
-        dnssec::{PublicKeyEnum, TrustAnchor},
-        serialize::txt::trust_anchor::{self, Entry},
-    },
-    recursor::DnssecPolicy,
-};
 
 /// Configuration for file based zones
 #[derive(Clone, Deserialize, Eq, PartialEq, Debug)]
@@ -56,7 +54,6 @@ pub struct RecursiveConfig {
     pub ns_recursion_limit: u8,
 
     /// DNSSEC policy
-    #[cfg(feature = "dnssec")]
     #[serde(default)]
     pub dnssec_policy: DnssecPolicyConfig,
 
@@ -112,6 +109,7 @@ fn ns_recursion_limit_default() -> u8 {
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
+#[allow(missing_copy_implementations)]
 pub enum DnssecPolicyConfig {
     /// security unaware; DNSSEC records will not be requested nor processed
     #[default]

--- a/crates/server/src/store/recursor/mod.rs
+++ b/crates/server/src/store/recursor/mod.rs
@@ -5,7 +5,7 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#![cfg(feature = "hickory-recursor")]
+#![cfg(feature = "recursor")]
 
 //! Recursive resolver related types
 


### PR DESCRIPTION
This fixes compilation when the `recursor` feature is enabled, but not `dnssec`. I also updated all conditional compilation using the `hickory-recursor` and `hickory-resolver` features (from optional dependencies) to use `recursor` and `resolver` (which are explicitly defined) instead. This helps because the recursor code requires importing some common types from `hickory-resolver`.