### PR TITLE
Add cargo-all-features configuration

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -93,3 +93,8 @@ webpki-roots.workspace = true
 
 [lints]
 workspace = true
+
+[package.metadata.cargo-all-features]
+skip_optional_dependencies = true
+denylist = ["dnssec", "dns-over-tls"]
+max_combination_size = 2

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -93,3 +93,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true
+
+[package.metadata.cargo-all-features]
+skip_optional_dependencies = true
+denylist = ["dnssec"]
+max_combination_size = 2

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -131,3 +131,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true
+
+[package.metadata.cargo-all-features]
+skip_optional_dependencies = true
+denylist = ["dnssec"]
+max_combination_size = 2

--- a/crates/recursor/Cargo.toml
+++ b/crates/recursor/Cargo.toml
@@ -128,3 +128,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true
+
+[package.metadata.cargo-all-features]
+skip_optional_dependencies = true
+denylist = ["dnssec"]
+max_combination_size = 2

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -134,3 +134,8 @@ required-features = ["tokio-runtime", "system-config"]
 
 [lints]
 workspace = true
+
+[package.metadata.cargo-all-features]
+skip_optional_dependencies = true
+denylist = ["dnssec", "dns-over-tls"]
+max_combination_size = 2

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -144,3 +144,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true
+
+[package.metadata.cargo-all-features]
+skip_optional_dependencies = true
+denylist = ["dnssec"]
+max_combination_size = 2

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -113,3 +113,8 @@ futures = { workspace = true, features = ["thread-pool"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
 test-support.workspace = true
 tracing-subscriber.workspace = true
+
+[package.metadata.cargo-all-features]
+skip_optional_dependencies = true
+denylist = ["dnssec"]
+max_combination_size = 2

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -108,3 +108,7 @@ hickory-recursor.workspace = true
 hickory-resolver = { workspace = true, features = ["system-config"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 webpki-roots = { workspace = true, optional = true }
+
+[package.metadata.cargo-all-features]
+skip_optional_dependencies = true
+max_combination_size = 2


### PR DESCRIPTION
This adds some `package.metadata` configuration to enable using [`cargo-all-features`](https://github.com/frewsxcv/cargo-all-features). I limited the number of features to enable at a time, because the powerset is impractically large in most cases. I set it to skip the `dnssec` and `dns-over-tls` features as appropriate, since these aren't intended to be enabled directly. Between this, #2584, #2585, and #2586, I got `cargo check-all-features` to pass.