### PR TITLE
Clean up references to AsyncClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The Resolver will properly follow CNAME chains as well as SRV record lookups. Th
 
 ## Client
 
-The Hickory DNS Client is intended to be used for operating against a DNS server directly. It can be used for verifying records or updating records for servers that support SIG0 and dynamic update. The Client is also capable of validating DNSSEC. As of now NSEC3 validation is not yet supported, though NSEC is. There are two interfaces that can be used, the async/await compatible AsyncClient and a blocking Client for ease of use. Today, Tokio is required for the executor Runtime.
+The Hickory DNS Client is intended to be used for operating against a DNS server directly. It can be used for verifying records or updating records for servers that support SIG0 and dynamic update. The Client is also capable of validating DNSSEC. As of now NSEC3 validation is not yet supported, though NSEC is. Today, the Tokio async runtime is required.
 
 ### Unique client side implementations
 
@@ -99,7 +99,7 @@ Support of TLS on the Server is managed through a pkcs12 der file. The documenta
 
 DoT and DoH are supported. This is accomplished through the use of one of `native-tls`, `openssl`, or `rustls` (only `rustls` is currently supported for DoH). The Resolver requires valid DoT or DoH resolvers being registered in order to be used.
 
-To use with the `Client`, the `TlsClientConnection` or `HttpsClientConnection` should be used. Similarly, to use with the tokio `AsyncClient` the `TlsClientStream` or `HttpsClientStream` should be used. ClientAuth, mTLS, is currently not supported, there are some issues still being worked on. TLS is useful for Server authentication and connection privacy.
+To use with the `Client`, the `TlsClientStream` or `HttpsClientStream` should be used. ClientAuth, mTLS, is currently not supported, there are some issues still being worked on. TLS is useful for Server authentication and connection privacy.
 
 To enable DoT one of the features `dns-over-native-tls`, `dns-over-openssl`, or `dns-over-rustls` must be enabled, `dns-over-https-rustls` is used for DoH.
 

--- a/bin/README.md
+++ b/bin/README.md
@@ -24,7 +24,7 @@ Support of TLS on the Server is managed through a pkcs12 der file. The documenta
 
 DoT and DoH are supported. This is accomplished through the use of one of `native-tls`, `openssl`, or `rustls` (only `rustls` is currently supported for DoH). The Resolver requires valid DoT or DoH resolvers being registered in order to be used.
 
-To use with the `Client`, the `TlsClientConnection` or `HttpsClientConnection` should be used. Similarly, to use with the tokio `AsyncClient` the `TlsClientStream` or `HttpsClientStream` should be used. ClientAuth, mTLS, is currently not supported, there are some issues still being worked on. TLS is useful for Server authentication and connection privacy.
+To use with the `Client`, the `TlsClientStream` or `HttpsClientStream` should be used. ClientAuth, mTLS, is currently not supported, there are some issues still being worked on. TLS is useful for Server authentication and connection privacy.
 
 To enable DoT one of the features `dns-over-native-tls`, `dns-over-openssl`, or `dns-over-rustls` must be enabled, `dns-over-https-rustls` is used for DoH.
 

--- a/bin/tests/integration/named_test_rsa_dnssec.rs
+++ b/bin/tests/integration/named_test_rsa_dnssec.rs
@@ -66,7 +66,7 @@ async fn standard_tcp_conn<P: RuntimeProvider>(
     let (stream, sender) = TcpClientStream::new(addr, None, None, provider);
     Client::new(stream, sender, None)
         .await
-        .expect("new AsyncClient failed")
+        .expect("new Client failed")
 }
 
 fn generic_test(config_toml: &str, key_path: &str, key_format: KeyFormat, algorithm: Algorithm) {

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -60,7 +60,7 @@ if let Some(RData::A(A(ref ip))) = answers[0].data() {
 
 DoT and DoH are supported. This is accomplished through the use of one of `native-tls`, `openssl`, or `rustls` (only `rustls` is currently supported for DoH).
 
-To use with the `Client`, the `TlsClientConnection` or `HttpsClientConnection` should be used. Similarly, to use with the tokio `AsyncClient` the `TlsClientStream` or `HttpsClientStream` should be used. ClientAuth, mTLS, is currently not supported, there are some issues still being worked on. TLS is useful for Server authentication and connection privacy.
+To use with the `Client`, the `TlsClientStream` or `HttpsClientStream` should be used. ClientAuth, mTLS, is currently not supported, there are some issues still being worked on. TLS is useful for Server authentication and connection privacy.
 
 To enable DoT one of the features `dns-over-native-tls`, `dns-over-openssl`, or `dns-over-rustls` must be enabled, `dns-over-https-rustls` is used for DoH.
 

--- a/crates/client/src/client/client.rs
+++ b/crates/client/src/client/client.rs
@@ -33,7 +33,7 @@ use hickory_proto::{
 };
 
 #[doc(hidden)]
-#[deprecated(since = "0.25.0", note = "use `AsyncClient` instead")]
+#[deprecated(since = "0.25.0", note = "use `Client` instead")]
 pub type ClientFuture = Client;
 
 /// A DNS Client implemented over futures-rs.
@@ -47,7 +47,7 @@ pub struct Client {
 }
 
 impl Client {
-    /// Spawns a new AsyncClient Stream. This uses a default timeout of 5 seconds for all requests.
+    /// Spawns a new Client Stream. This uses a default timeout of 5 seconds for all requests.
     ///
     /// # Arguments
     ///
@@ -68,7 +68,7 @@ impl Client {
         Self::with_timeout(stream, stream_handle, Duration::from_secs(5), signer).await
     }
 
-    /// Spawns a new AsyncClient Stream.
+    /// Spawns a new Client Stream.
     ///
     /// # Arguments
     ///
@@ -1110,7 +1110,7 @@ mod tests {
         }
 
         let message_parsed = Message::from_vec(&buffer)
-            .expect("buffer was parsed already by AsyncClient so we should be able to do it again");
+            .expect("buffer was parsed already by Client so we should be able to do it again");
 
         // validate it's what we expected
         if let RData::A(addr) = message_parsed.answers()[0].data() {

--- a/crates/resolver/README.md
+++ b/crates/resolver/README.md
@@ -49,7 +49,7 @@ if address.is_ipv4() {
 
 DoT and DoH are supported. This is accomplished through the use of one of `native-tls`, `openssl`, or `rustls` (only `rustls` is currently supported for DoH). The Resolver requires valid DoT or DoH resolvers being registered in order to be used.
 
-To use with the `Client`, the `TlsClientConnection` or `HttpsClientConnection` should be used. Similarly, to use with the tokio `AsyncClient` the `TlsClientStream` or `HttpsClientStream` should be used. ClientAuth, mTLS, is currently not supported, there are some issues still being worked on. TLS is useful for Server authentication and connection privacy.
+To use with the `Client`, the `TlsClientStream` or `HttpsClientStream` should be used. ClientAuth, mTLS, is currently not supported, there are some issues still being worked on. TLS is useful for Server authentication and connection privacy.
 
 To enable DoT one of the features `dns-over-native-tls`, `dns-over-openssl`, or `dns-over-rustls` must be enabled, `dns-over-https-rustls` is used for DoH.
 

--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -182,7 +182,7 @@ impl fmt::Debug for TestClientStream {
     }
 }
 
-// need to do something with the message channel, otherwise the AsyncClient will think there
+// need to do something with the message channel, otherwise the Client will think there
 //  is no one listening to messages and shutdown...
 #[allow(dead_code)]
 pub struct NeverReturnsClientStream {

--- a/tests/integration-tests/tests/integration/client_future_tests.rs
+++ b/tests/integration-tests/tests/integration/client_future_tests.rs
@@ -315,7 +315,7 @@ async fn create_sig0_ready_client() -> (
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
     let client = Client::new(stream, sender, Some(signer))
         .await
-        .expect("failed to get new AsyncClient");
+        .expect("failed to get new Client");
 
     (client, origin.into())
 }


### PR DESCRIPTION
This cleans up some stray references to AsyncClient in documentation, comments, and error messages.