### PR TITLE
Extend dig timeout in bad referral tests

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dns/scenarios/bad_referral.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/scenarios/bad_referral.rs
@@ -130,6 +130,6 @@ fn fixture(label: &str, addr: Ipv4Addr) -> Result<DigOutput> {
     let resolver = resolver.start()?;
 
     let client = Client::new(&network)?;
-    let settings = *DigSettings::default().recurse();
+    let settings = *DigSettings::default().recurse().timeout(7);
     client.dig(settings, resolver.ipv4_addr(), RecordType::A, &needle_fqdn)
 }


### PR DESCRIPTION
I saw two test flakes from the `resolver::dns::scenarios::bad_referral::v4_this_host` conformance test yesterday, one in CI and one locally. This PR extends the dig timeout so that it's longer than Hickory DNS's timeout, similar to #2540. This should make this test more reliable until we have a new approach for handling this case, other than relying on a timeout (see #2545). I stress-tested this change overnight, and didn't see any more failures.