### PR TITLE
Remove redundant cache insert in resolve_cnames()

### DIFF
--- a/crates/recursor/src/recursor_dns_handle.rs
+++ b/crates/recursor/src/recursor_dns_handle.rs
@@ -19,7 +19,7 @@ use tracing::{debug, trace, warn};
 use crate::{
     proto::{
         op::Query,
-        rr::{rdata::NS, RData, RData::CNAME, Record, RecordType},
+        rr::{rdata::NS, RData, RData::CNAME, RecordType},
         runtime::TokioRuntimeProvider,
         ForwardNSData, ProtoErrorKind,
     },
@@ -277,12 +277,6 @@ impl RecursorDnsHandle {
     ) -> Result<Lookup, Error> {
         let query_type = query.query_type();
         let query_name = query.name().clone();
-
-        self.record_cache.insert_records(
-            query.clone(),
-            lookup.records().iter().map(Record::to_owned),
-            now,
-        );
 
         // Don't resolve CNAME lookups for a CNAME (or ANY) query
         if query_type == RecordType::CNAME || query_type == RecordType::ANY {


### PR DESCRIPTION
This removes a call to `DnsLru::insert_records()` in `RecursorDnsHandle::resolve_cnames()`. This is a follow-up to #2576. We can remove this call because it is always redundant with either a preceding cache fetch or cache insert. `RecursorDnsHandle::resolve_cnames()` is called from three places in `RecursorDnsHandle::resolve()`. The first callsite is after a successful cache hit, and results in re-inserting the same `Lookup`. The other two callsites are after a successful call to `RecursorDnsHandle::lookup()`, returning a positive response. The last thing that `RecursorDnsHandle::lookup()` does is call `cache_response()`, which calls `DnsLru::insert_records()`, and in doing so flattens a response into a `Lookup`. Then, the call to `DnsLru::insert_records()` in `RecursorDnsHandle::resolve_cnames()` would store the same lookup again.

I tested the performance impact of this change as before, using `dnsperf` and making the same request three million times. The improvement from eliminating these cache inserts was drastic.

> before: 20206qps, 20099qps, 20866qps, 20929qps, 20919qps
> after: 134957qps, 131468qps, 129588qps, 132800qps, 128908qps