### PR TITLE
Update default logging filter to match all crates

### DIFF
--- a/bin/src/hickory-dns.rs
+++ b/bin/src/hickory-dns.rs
@@ -848,7 +848,7 @@ fn get_env() -> String {
 
 fn all_hickory_dns(level: impl ToString) -> String {
     format!(
-        "hickory_dns={level},hickory_server={level},{env}",
+        "hickory_={level},{env}",
         level = level.to_string().to_lowercase(),
         env = get_env()
     )


### PR DESCRIPTION
This updates the default logging filter so that it matches targets from the hickory-proto, hickory-resolver, and hickory-recursor crates as well.