### PR TITLE
Coverage improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
-          #files: target/llvm-cov-target/hickory-dns-coverage.json
+          #files: coverage/hickory-dns-coverage.json
 
   ## Work through all of the variations of the different features, only on linux to save concurrent resources
   exhaustive-features-matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ rls/**
 fuzz/artifacts/**
 fuzz/corpus/**
 *~
+
+# Code coverage output
+/coverage

--- a/justfile
+++ b/justfile
@@ -114,7 +114,7 @@ coverage: init-llvm-cov
 
     echo $RUSTFLAGS
 
-    cargo +nightly llvm-cov clean
+    cargo +nightly llvm-cov clean --workspace
     mkdir -p {{COV_OUTPUT_DIR}}
 
     cargo +nightly llvm-cov test --workspace --no-report --all-targets --all-features

--- a/justfile
+++ b/justfile
@@ -116,7 +116,6 @@ coverage: init-llvm-cov
     cargo +nightly llvm-cov clean
     mkdir -p {{COV_CARGO_LLVM_COV_TARGET_DIR}}
 
-    cargo +nightly build --workspace --all-targets --all-features
     cargo +nightly llvm-cov test --workspace --no-report --all-targets --all-features
     cargo +nightly llvm-cov test --workspace --no-report --doc --doctests --all-features
     cargo +nightly llvm-cov report --codecov --output-path {{join(COV_CARGO_LLVM_COV_TARGET_DIR, "hickory-dns-coverage.json")}}

--- a/justfile
+++ b/justfile
@@ -14,6 +14,7 @@ COV_CARGO_INCREMENTAL := "0"
 COV_CARGO_LLVM_COV := "1"
 COV_CARGO_LLVM_COV_TARGET_DIR := join(TARGET_DIR, "llvm-cov-target")
 COV_LLVM_PROFILE_FILE := join(COV_CARGO_LLVM_COV_TARGET_DIR, "hickory-dns-%p-%m_%c.profraw")
+COV_OUTPUT_DIR := join(justfile_directory(), "coverage")
 
 BIND_VER := "9.16.41"
 
@@ -114,11 +115,11 @@ coverage: init-llvm-cov
     echo $RUSTFLAGS
 
     cargo +nightly llvm-cov clean
-    mkdir -p {{COV_CARGO_LLVM_COV_TARGET_DIR}}
+    mkdir -p {{COV_OUTPUT_DIR}}
 
     cargo +nightly llvm-cov test --workspace --no-report --all-targets --all-features
     cargo +nightly llvm-cov test --workspace --no-report --doc --doctests --all-features
-    cargo +nightly llvm-cov report --codecov --output-path {{join(COV_CARGO_LLVM_COV_TARGET_DIR, "hickory-dns-coverage.json")}}
+    cargo +nightly llvm-cov report --codecov --output-path {{join(COV_OUTPUT_DIR, "hickory-dns-coverage.json")}}
 
 # Open the html view of the coverage report
 coverage-html: coverage
@@ -130,7 +131,7 @@ coverage-html: coverage
     export CARGO_LLVM_COV_TARGET_DIR={{COV_CARGO_LLVM_COV_TARGET_DIR}}
     export LLVM_PROFILE_FILE={{COV_LLVM_PROFILE_FILE}}
 
-    cargo +nightly llvm-cov report --html --open --output-dir {{COV_CARGO_LLVM_COV_TARGET_DIR}}
+    cargo +nightly llvm-cov report --html --open --output-dir {{COV_OUTPUT_DIR}}
 
 # Export coverage data in lcov format
 coverage-lcov: coverage
@@ -142,7 +143,7 @@ coverage-lcov: coverage
     export CARGO_LLVM_COV_TARGET_DIR={{COV_CARGO_LLVM_COV_TARGET_DIR}}
     export LLVM_PROFILE_FILE={{COV_LLVM_PROFILE_FILE}}
 
-    cargo +nightly llvm-cov report --lcov --output-path {{join(COV_CARGO_LLVM_COV_TARGET_DIR, "lcov.info")}}
+    cargo +nightly llvm-cov report --lcov --output-path {{join(COV_OUTPUT_DIR, "lcov.info")}}
 
 # (Re)generates Test Certificates, if tests are failing, this needs to be run yearly
 generate-test-certs: init-openssl

--- a/justfile
+++ b/justfile
@@ -119,7 +119,7 @@ coverage: init-llvm-cov
 
     cargo +nightly llvm-cov test --workspace --no-report --all-targets --all-features
     cargo +nightly llvm-cov test --workspace --no-report --doc --doctests --all-features
-    cargo +nightly llvm-cov report --codecov --output-path {{join(COV_OUTPUT_DIR, "hickory-dns-coverage.json")}}
+    cargo +nightly llvm-cov report --doctests --codecov --output-path {{join(COV_OUTPUT_DIR, "hickory-dns-coverage.json")}}
 
 # Open the html view of the coverage report
 coverage-html: coverage
@@ -131,7 +131,7 @@ coverage-html: coverage
     export CARGO_LLVM_COV_TARGET_DIR={{COV_CARGO_LLVM_COV_TARGET_DIR}}
     export LLVM_PROFILE_FILE={{COV_LLVM_PROFILE_FILE}}
 
-    cargo +nightly llvm-cov report --html --open --output-dir {{COV_OUTPUT_DIR}}
+    cargo +nightly llvm-cov report --doctests --html --open --output-dir {{COV_OUTPUT_DIR}}
 
 # Export coverage data in lcov format
 coverage-lcov: coverage
@@ -143,7 +143,7 @@ coverage-lcov: coverage
     export CARGO_LLVM_COV_TARGET_DIR={{COV_CARGO_LLVM_COV_TARGET_DIR}}
     export LLVM_PROFILE_FILE={{COV_LLVM_PROFILE_FILE}}
 
-    cargo +nightly llvm-cov report --lcov --output-path {{join(COV_OUTPUT_DIR, "lcov.info")}}
+    cargo +nightly llvm-cov report --doctests --lcov --output-path {{join(COV_OUTPUT_DIR, "lcov.info")}}
 
 # (Re)generates Test Certificates, if tests are failing, this needs to be run yearly
 generate-test-certs: init-openssl


### PR DESCRIPTION
This makes some further improvements to the code coverage recipes.

* Skip a `cargo +nightly build`. This does not use the same RUSTFLAGS as `cargo llvm-cov`, let alone the same target directory, so it doesn't help with subsequent compilations.
* Reports are moved to a separate output directory. I used `/coverage`, because this is a common convention in other repositories and coverage-related tools.
* Run `cargo llvm-cov clean --workspace`, as recommended in the cargo-llvm-cov README, instead of `cargo llvm-cov clean`. This avoids removing the entire target directory, and instead deletes `.profraw` files, intermediate compilation artifacts for workspace crates, and executables. The README says this deletes "artifacts that may affect the coverage results". This speeds up successive coverage runs.
* Pass `--doctests` when creating reports, in addition to when running tests.