### PR TITLE
Referral filtering

### DIFF
--- a/conformance/packages/dns-test/src/templates/hickory.resolver.toml.jinja
+++ b/conformance/packages/dns-test/src/templates/hickory.resolver.toml.jinja
@@ -4,4 +4,4 @@ group = "nogroup"
 [[zones]]
 zone = "."
 zone_type = "Hint"
-stores = { type = "recursor" , roots = "/etc/root.hints" {% if use_dnssec %}, dnssec_policy.ValidateWithStaticKey.path = "/etc/trusted-key.key" {% else %}, dnssec_policy = "ValidationDisabled" {% endif %}  }
+stores = { type = "recursor" , roots = "/etc/root.hints" {% if use_dnssec %}, dnssec_policy.ValidateWithStaticKey.path = "/etc/trusted-key.key" {% else %}, dnssec_policy = "ValidationDisabled" {% endif %} , allow_server = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"] }

--- a/crates/server/src/store/recursor/authority.rs
+++ b/crates/server/src/store/recursor/authority.rs
@@ -93,7 +93,7 @@ impl RecursiveAuthority {
 
         let recursor = builder
             .dnssec_policy(config.dnssec_policy.load()?)
-            .do_not_query(&config.do_not_query)
+            .nameserver_filter(config.allow_server.iter(), config.deny_server.iter())
             .recursion_limit(match config.recursion_limit {
                 0 => None,
                 limit => Some(limit),

--- a/crates/server/src/store/recursor/config.rs
+++ b/crates/server/src/store/recursor/config.rs
@@ -57,9 +57,13 @@ pub struct RecursiveConfig {
     #[serde(default)]
     pub dnssec_policy: DnssecPolicyConfig,
 
+    /// Networks that will be queried during resolution
+    #[serde(default)]
+    pub allow_server: Vec<IpNet>,
+
     /// Networks that will not be queried during resolution
     #[serde(default)]
-    pub do_not_query: Vec<IpNet>,
+    pub deny_server: Vec<IpNet>,
 
     /// Local UDP ports to avoid when making outgoing queries
     #[serde(default)]

--- a/tests/e2e-tests/src/resolver/do_not_query.toml.jinja
+++ b/tests/e2e-tests/src/resolver/do_not_query.toml.jinja
@@ -9,8 +9,13 @@ zone_type = "Hint"
 type = "recursor"
 roots = "/etc/root.hints"
 dnssec_policy = "ValidationDisabled"
-do_not_query = [
-    {% for network in do_not_query %}
+allow_server = [
+    {% for network in allow_server %}
+    "{{ network }}",
+    {% endfor %}
+]
+deny_server = [
+    {% for network in deny_server %}
     "{{ network }}",
     {% endfor %}
 ]

--- a/tests/test-data/test_configs/chained_blocklist.toml
+++ b/tests/test-data/test_configs/chained_blocklist.toml
@@ -50,5 +50,5 @@ roots = "default/root.zone"
 ns_cache_size = 1024
 record_cache_size = 1048576
 
-## do_not_query: these networks will not be sent queries during recursive resolution
-do_not_query = ["0.0.0.0/8", "127.0.0.0/8", "::/128", "::1/128"]
+## deny_server: these networks will not be sent queries during recursive resolution
+deny_server = ["0.0.0.0/8", "127.0.0.0/8", "::/128", "::1/128"]

--- a/tests/test-data/test_configs/consulting_blocklist.toml
+++ b/tests/test-data/test_configs/consulting_blocklist.toml
@@ -41,8 +41,8 @@ roots = "default/root.zone"
 ns_cache_size = 1024
 record_cache_size = 1048576
 
-## do_not_query: these networks will not be sent queries during recursive resolution
-do_not_query = ["0.0.0.0/8", "127.0.0.0/8", "::/128", "::1/128"]
+## deny_server: these networks will not be sent queries during recursive resolution
+deny_server = ["0.0.0.0/8", "127.0.0.0/8", "::/128", "::1/128"]
 
 ## Note that in this example, the recursor comes first and the blocklist is second.  Queries
 ## are sent to the authorities in-order, so a user query will go first to the recursor, which

--- a/tests/test-data/test_configs/example_recursor.toml
+++ b/tests/test-data/test_configs/example_recursor.toml
@@ -43,8 +43,38 @@ record_cache_size = 1048576
 recursion_limit = 12
 ns_recursion_limit = 16
 
-## do_not_query: these networks will not be sent queries during recursive resolution
-do_not_query = ["0.0.0.0/8", "127.0.0.0/8", "::/128", "::1/128"]
+## allow_server: these networks will override entries in deny_server and allow you to make
+## granular exceptions to networks you otherwise want to deny.  This allows queries to be
+## made to the nameserver at 127.0.0.254, even though 127.0.0.0/8 is in the deny_server list.
+allow_server = ["127.0.0.254/32"]
+## deny_server: these networks will not be sent queries during recursive resolution
+## Several networks are added to this list by default:
+##
+##    127.0.0.0/8        Loopback range
+##    0.0.0.0/8          Unspecified range
+##    255.255.255.255/32 Directed Broadcast
+##    10.0.0.0/8         RFC 1918 space
+##    172.16.0.0/12      RFC 1918 space
+##    192.168.0.0/16     RFC 1918 space
+##    100.64.0.0/10      CG NAT
+##    169.254.0.0/16     Link-local space
+##    192.0.0.0/24       IETF Reserved
+##    192.0.2.0/24       TEST-NET-1
+##    198.51.100.0/24    TEST-NET-2
+##    203.0.113.0/24     TEST-NET-3
+##    240.0.0.0/4        Class E Reserved
+##    ::1/128            v6 loopback
+##    ::/128             v6 unspecified
+##    100::/64           v6 discard prefix
+##    2001:db8::/32      v6 documentation prefix
+##    3fff::/20          v6 documentation prefix
+##    5f00::/16          v6 segment routing prefix
+##    fc00::/7           v6 private address,
+##    fe80::/64          v6 link local
+##    ff00::/8           v6 multicast
+##
+## you can override these default entries by adding exceptions to allow_server.
+deny_server = ["0.0.0.0/8", "127.0.0.0/8", "::/128", "::1/128"]
 
 ## cache_policy: set the minimum/maximum TTL for positive/negative responses.
 ## This can be set for all queries and for specific query types.


### PR DESCRIPTION
* Fixes a bug in the do not query match logic
* Adds some never-query hosts (127.0.0.0/8, 0.0.0.0/8, 255.255.255.255/32, ::/128, and ::1/128.) and an optional 'recommended filtering' setting that will filter against RFC 1918 and other reserved or special purpose addresses in the do not query list.
* Eliminates most reserved-/private- address range conformance tests and adds a test to verify referrals for the remaining bad referral tests are being dropped due to the failed do not query check, and not because of a timeout (see related discussion in #2545)

The recommended filtering list is enabled by default. I don't think the ranges included will cause problems for most users, although there are scenarios where it should be turned off:

* Organizations using private or reserved space for their DNS infrastructure
* Test environments (such as our CI) that use private address space
