### PR TITLE
Conformance: tests for handling of TC=1 responses

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dns.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns.rs
@@ -1,3 +1,4 @@
 //! plain DNS functionality
 
+mod rfc1035;
 mod scenarios;

--- a/conformance/packages/conformance-tests/src/resolver/dns/rfc1035.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/rfc1035.rs
@@ -1,0 +1,1 @@
+mod truncation;

--- a/conformance/packages/conformance-tests/src/resolver/dns/rfc1035/truncated_udp_only.py
+++ b/conformance/packages/conformance-tests/src/resolver/dns/rfc1035/truncated_udp_only.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# This server replies with the truncated bit set over UDP, and changes the
+# record set it returns each time. This allows tests to detect improper
+# caching of truncated responses.
+from dnslib import DNSLabel, DNSRecord, QTYPE, RCODE, RR, TXT
+from dnslib.server import BaseResolver, DNSHandler, DNSServer
+
+
+class Resolver(BaseResolver):
+    def __init__(self):
+        self.counter = 0
+        self.expected_name = DNSLabel("example.testing.")
+
+    def resolve(self, request: DNSRecord, _handler: DNSHandler) -> DNSRecord:
+        reply = request.reply()
+        if request.q.qname == self.expected_name:
+            reply.header.rcode = RCODE.NOERROR
+            if request.q.qtype == QTYPE.TXT:
+                rdata = TXT(f"counter={self.counter}".encode("ASCII"))
+                self.counter += 1
+                reply.add_answer(RR(
+                    request.q.qname,
+                    QTYPE.TXT,
+                    ttl=86400,
+                    rdata=rdata,
+                ))
+                reply.header.tc = 1
+        else:
+            reply.header.rcode = RCODE.NXDOMAIN
+        return reply
+
+
+if __name__ == "__main__":
+    resolver = Resolver()
+    server = DNSServer(resolver, address="0.0.0.0", port=53)
+    server.start()

--- a/conformance/packages/conformance-tests/src/resolver/dns/rfc1035/truncated_with_tcp_fallback.py
+++ b/conformance/packages/conformance-tests/src/resolver/dns/rfc1035/truncated_with_tcp_fallback.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# This server listens on both TCP and UDP ports. It always responds to UDP
+# requests with the truncated bit set. The TCP server will allow clients to
+# fall back and get a non-truncated response. The record set returned by the
+# server changes each time, to allow tests to detect improper caching of
+# truncated responses.
+from dnslib import DNSLabel, DNSRecord, QTYPE, RCODE, RR, TXT
+from dnslib.server import BaseResolver, DNSHandler, DNSServer
+
+
+class Resolver(BaseResolver):
+    def __init__(self, tcp):
+        self.tcp = tcp
+        self.counter = 0
+        self.expected_name = DNSLabel("example.testing.")
+
+    def resolve(self, request: DNSRecord, _handler: DNSHandler) -> DNSRecord:
+        reply = request.reply()
+        if request.q.qname == self.expected_name:
+            reply.header.rcode = RCODE.NOERROR
+            if request.q.qtype == QTYPE.TXT:
+                counter_text = f"counter={self.counter}".encode("ASCII")
+                self.counter += 1
+                if self.tcp:
+                    rdata = TXT([b"protocol=TCP", counter_text])
+                else:
+                    reply.header.tc = 1
+                    rdata = TXT([b"protocol=UDP", counter_text])
+                reply.add_answer(RR(
+                    request.q.qname,
+                    QTYPE.TXT,
+                    ttl=86400,
+                    rdata=rdata,
+                ))
+        else:
+            reply.header.rcode = RCODE.NXDOMAIN
+        return reply
+
+
+if __name__ == "__main__":
+    udp_resolver = Resolver(False)
+    udp_server = DNSServer(udp_resolver, address="0.0.0.0", port=53)
+    udp_server.start_thread()
+    tcp_resolver = Resolver(True)
+    tcp_server = DNSServer(tcp_resolver, address="0.0.0.0", port=53, tcp=True)
+    tcp_server.start()

--- a/conformance/packages/conformance-tests/src/resolver/dns/rfc1035/truncation.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/rfc1035/truncation.rs
@@ -1,0 +1,161 @@
+//! Section 7.4, "Using the cache" says in part, "When several RRs of the same type are available
+//! for a particular owner name, the resolver should either cache them all or none at all. When a
+//! response is truncated, and a resolver doesn't know whether it has a complete set, it should not
+//! cache a possibly partial set of RRs."
+
+use std::{fs, thread, time::Duration};
+
+use dns_test::{
+    client::{Client, DigSettings, DigStatus},
+    name_server::{Graph, NameServer},
+    record::{Record, RecordType},
+    Implementation, Network, Resolver, Result, FQDN,
+};
+
+/// Verify that resolvers will retry a query over TCP if they get a truncated response via UDP, and
+/// only cache the complete TCP response.
+#[test]
+fn truncated_response_caching_with_tcp_fallback() -> Result<()> {
+    let target_fqdn = FQDN("example.testing.")?;
+    let (resolver, client, _graph) =
+        setup("src/resolver/dns/rfc1035/truncated_with_tcp_fallback.py")?;
+
+    let dig_settings = *DigSettings::default().recurse().timeout(7);
+
+    let result_1 = client.dig(
+        dig_settings,
+        resolver.ipv4_addr(),
+        RecordType::TXT,
+        &target_fqdn,
+    );
+    let response_1 = result_1
+        .unwrap_or_else(|e| panic!("error {e:?} resolver logs: {}", resolver.logs().unwrap()));
+    println!("first response: {response_1:?}");
+    let (protocol_1, counter_1) = parse_txt_records(&response_1.answer)?;
+
+    assert_eq!(response_1.status, DigStatus::NOERROR);
+
+    // Check that the resolver fell back to TCP.
+    assert_eq!(protocol_1.as_deref(), Some("TCP"));
+    assert!(counter_1.is_some());
+
+    let result_2 = client.dig(
+        dig_settings,
+        resolver.ipv4_addr(),
+        RecordType::TXT,
+        &target_fqdn,
+    );
+    let response_2 = result_2
+        .unwrap_or_else(|e| panic!("error {e:?} resolver logs: {}", resolver.logs().unwrap()));
+    println!("second response: {response_2:?}");
+    let (protocol_2, counter_2) = parse_txt_records(&response_2.answer)?;
+
+    println!("{}", resolver.logs()?);
+
+    assert_eq!(response_2.status, DigStatus::NOERROR);
+
+    // Check that we got a cached response.
+    assert_eq!(protocol_2.as_deref(), Some("TCP"));
+    assert_eq!(counter_1, counter_2);
+
+    Ok(())
+}
+
+/// Verify that resolvers will not cache a truncated response received via UDP if the authoritative
+/// server does not reply to TCP fallback queries.
+#[test]
+#[ignore = "hickory caches a truncated response if querying over TCP fails"]
+fn truncated_response_caching_udp_only() -> Result<()> {
+    let target_fqdn = FQDN("example.testing.")?;
+    let (resolver, client, _graph) = setup("src/resolver/dns/rfc1035/truncated_udp_only.py")?;
+
+    let dig_settings = *DigSettings::default().recurse().timeout(7);
+
+    let result_1 = client.dig(
+        dig_settings,
+        resolver.ipv4_addr(),
+        RecordType::TXT,
+        &target_fqdn,
+    );
+    let response_1 = result_1
+        .unwrap_or_else(|e| panic!("error {e:?} resolver logs: {}", resolver.logs().unwrap()));
+    println!("first response: {response_1:?}");
+    let (_protocol_1, counter_1) = parse_txt_records(&response_1.answer)?;
+
+    if response_1.status == DigStatus::SERVFAIL {
+        // Unbound and BIND return an error instead of returning the truncated UDP response, if there's no
+        // reply via TCP.
+        return Ok(());
+    }
+
+    assert_eq!(response_1.status, DigStatus::NOERROR);
+
+    let result_2 = client.dig(
+        dig_settings,
+        resolver.ipv4_addr(),
+        RecordType::TXT,
+        &target_fqdn,
+    );
+    let response_2 = result_2
+        .unwrap_or_else(|e| panic!("error {e:?} resolver logs: {}", resolver.logs().unwrap()));
+    println!("second response: {response_2:?}");
+    let (_protocol_2, counter_2) = parse_txt_records(&response_2.answer)?;
+
+    println!("{}", resolver.logs()?);
+
+    assert_eq!(response_2.status, DigStatus::NOERROR);
+
+    // Check that the resolver did not cache the truncated response.
+    assert_ne!(counter_1, counter_2);
+
+    Ok(())
+}
+
+fn setup(script_path: &str) -> Result<(Resolver, Client, Graph)> {
+    let network = Network::new()?;
+
+    let mut root_ns = NameServer::new(&Implementation::test_peer(), FQDN::ROOT, &network)?;
+    let leaf_ns = NameServer::new(&Implementation::Dnslib, FQDN::TEST_TLD, &network)?;
+    let script = fs::read_to_string(script_path)?;
+    leaf_ns.cp("/script.py", &script)?;
+
+    root_ns.referral_nameserver(&leaf_ns);
+
+    let root_hint = root_ns.root_hint();
+    let resolver = Resolver::new(&network, root_hint.clone()).start()?;
+
+    let client = Client::new(resolver.network())?;
+
+    let root_ns = root_ns.start()?;
+    let leaf_ns = leaf_ns.start()?;
+
+    thread::sleep(Duration::from_secs(2));
+
+    let graph = Graph {
+        nameservers: vec![root_ns, leaf_ns],
+        root: root_hint,
+        trust_anchor: None,
+    };
+
+    Ok((resolver, client, graph))
+}
+
+/// Parse the protocol name and counter value from the dnslib-based name server's response.
+fn parse_txt_records(records: &[Record]) -> Result<(Option<String>, Option<u64>)> {
+    let mut protocol = None;
+    let mut counter = None;
+    for record in records.iter() {
+        let Record::TXT(text) = record else {
+            continue;
+        };
+        for string in text.character_strings.iter() {
+            if let Some(protocol_str) = string.strip_prefix("protocol=") {
+                protocol = Some(protocol_str.to_string());
+            }
+            if let Some(counter_str) = string.strip_prefix("counter=") {
+                counter = Some(counter_str.parse::<u64>().unwrap());
+            }
+        }
+    }
+    Ok((protocol, counter))
+}


### PR DESCRIPTION
This adds two conformance tests for handling of responses with TC=1. See #2608. The first test checks that recursive resolvers retry queries via TCP if they get a truncated response over UDP. The second test checks what happens if resolvers get a truncated response, but the authoritative server doesn't respond to TCP queries. Currently, BIND and Unbound return a SERVFAIL, while Hickory passes on the truncated response, and caches it. Both tests use dnslib-based authoritative servers, which return records indicating what transport protocol is in use, with different incrementing counter values in each response, so we can tell whether the recursive resolver is caching responses.