### PR TITLE
Box the query in ProtoErrorKind::Nsec

### DIFF
--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -100,7 +100,7 @@ pub enum ProtoErrorKind {
     #[error("DNSSEC Negative Record Response for {query}, {proof}")]
     Nsec {
         /// Query for which the NSEC was returned
-        query: crate::op::Query,
+        query: Box<Query>,
         /// DNSSEC proof of the record
         proof: Proof,
     },

--- a/crates/proto/src/xfer/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle/mod.rs
@@ -276,7 +276,7 @@ fn check_nsec(verified_message: DnsResponse, query: &Query) -> Result<DnsRespons
         debug!("returning Nsec error for {} {nsec_proof}", query.name());
         // TODO change this to remove the NSECs, like we do for the others?
         return Err(ProtoError::from(ProtoErrorKind::Nsec {
-            query: query.clone(),
+            query: Box::new(query.clone()),
             proof: nsec_proof,
         }));
     }


### PR DESCRIPTION
This boxes the query field in the NSEC error variant. This brings it in line with `ProtoErrorKind::NoRecordsFound` and `ForwardData`, plus it reduces the size of the enum from 104 bytes to 88 bytes on an all-features x86_64-unknown-linux-gnu build.