### PR TITLE
Redirect output of command to clean up test output

### DIFF
--- a/conformance/packages/dns-test/src/container.rs
+++ b/conformance/packages/dns-test/src/container.rs
@@ -226,7 +226,9 @@ impl Container {
         let mut command = Command::new("docker");
         command
             .args(["exec", &self.inner.id])
-            .args(command_and_args);
+            .args(command_and_args)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
 
         Ok(command.status()?)
     }


### PR DESCRIPTION
This redirects command output when using `Command::status()`, which defaults to inheriting the parent's stdout/stderr. This keeps `dnssec-signzone`'s chatty output from being interspersed with the test harness's output.