### PR TITLE
Don't send DAU/DHU options in responses

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dnssec.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec.rs
@@ -4,4 +4,5 @@ mod adhoc;
 mod fixtures;
 mod regression;
 mod rfc4035;
+mod rfc6975;
 mod scenarios;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc6975.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc6975.rs
@@ -1,0 +1,1 @@
+mod section_4;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc6975/section_4.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc6975/section_4.rs
@@ -1,0 +1,53 @@
+use dns_test::{
+    client::{Client, DigSettings},
+    name_server::{Graph, NameServer, Sign},
+    record::RecordType,
+    zone_file::SignSettings,
+    Network, Resolver, Result, FQDN,
+};
+
+/// Section 4.2.1, last paragraph, says "Validating recursive resolvers MUST NOT set the DAU, DHU,
+/// and/or N3U option(s) in the final response to the stub client."
+#[test]
+#[ignore = "hickory includes DAU and DHU in responses"]
+fn no_understood_options_in_response() -> Result<()> {
+    let network = Network::new()?;
+
+    let leaf_ns = NameServer::new(&dns_test::PEER, FQDN::TEST_DOMAIN, &network)?;
+
+    let Graph {
+        nameservers: _nameservers,
+        root,
+        trust_anchor,
+    } = Graph::build(
+        leaf_ns,
+        Sign::Yes {
+            settings: SignSettings::default(),
+        },
+    )?;
+
+    let trust_anchor = trust_anchor.unwrap();
+    let resolver = Resolver::new(&network, root)
+        .trust_anchor(&trust_anchor)
+        .start()?;
+    let resolver_addr = resolver.ipv4_addr();
+
+    let client = Client::new(&network)?;
+    let settings = *DigSettings::default().recurse();
+    let output = client.dig(settings, resolver_addr, RecordType::SOA, &FQDN::TEST_DOMAIN)?;
+
+    assert!(output.status.is_noerror());
+    // Disallow DAU, DHU, and N3U.
+    assert!(
+        output
+            .options
+            .iter()
+            .all(|(option_number, _)| *option_number != 5
+                && *option_number != 6
+                && *option_number != 7),
+        "{:?}",
+        output.options
+    );
+
+    Ok(())
+}

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc6975/section_4.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc6975/section_4.rs
@@ -9,7 +9,6 @@ use dns_test::{
 /// Section 4.2.1, last paragraph, says "Validating recursive resolvers MUST NOT set the DAU, DHU,
 /// and/or N3U option(s) in the final response to the stub client."
 #[test]
-#[ignore = "hickory includes DAU and DHU in responses"]
 fn no_understood_options_in_response() -> Result<()> {
     let network = Network::new()?;
 

--- a/crates/proto/src/xfer/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/xfer/dnssec_dns_handle/mod.rs
@@ -140,7 +140,6 @@ where
 
         let handle: Self = self.clone_with_context();
 
-        // TODO: cache response of the server about understood algorithms
         #[cfg(feature = "dnssec")]
         {
             request

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -55,10 +55,6 @@ async fn send_response<'a, R: ResponseHandler>(
     mut response_handle: R,
 ) -> io::Result<ResponseInfo> {
     if let Some(mut resp_edns) = response_edns {
-        #[cfg(feature = "dnssec")]
-        {
-            resp_edns.set_default_algorithms();
-        }
         response.set_edns(resp_edns);
     }
 


### PR DESCRIPTION
The DAU/DHU/N3U options from RFC 6975 are only intended to be sent by clients, not name servers. Different sections say that "Validating recursive resolvers MUST NOT set the DAU, DHU, and/or N3U option(s) in the final response to the stub client" and "Authoritative servers MUST NOT set the DAU, DHU, and/or N3U option(s) on any responses". This PR adds a conformance test checking the behavior of recursive resolvers, and stops adding the DAU and DHU options to responses in the `Catalog`.