### PR TITLE
Remove mention of Subject Public Key Info in docs

### DIFF
--- a/crates/proto/src/h2/h2_client_stream.rs
+++ b/crates/proto/src/h2/h2_client_stream.rs
@@ -313,7 +313,7 @@ impl<P: RuntimeProvider> HttpsClientStreamBuilder<P> {
     /// # Arguments
     ///
     /// * `name_server` - IP and Port for the remote DNS resolver
-    /// * `dns_name` - The DNS name, Subject Public Key Info (SPKI) name, as associated to a certificate
+    /// * `dns_name` - The DNS name associated with a certificate
     /// * `http_endpoint` - The HTTP endpoint where the remote DNS resolver provides service, typically `/dns-query`
     pub fn build(
         mut self,

--- a/crates/proto/src/h3/h3_client_stream.rs
+++ b/crates/proto/src/h3/h3_client_stream.rs
@@ -314,7 +314,7 @@ impl H3ClientStreamBuilder {
     /// # Arguments
     ///
     /// * `name_server` - IP and Port for the remote DNS resolver
-    /// * `dns_name` - The DNS name, Subject Public Key Info (SPKI) name, as associated to a certificate
+    /// * `dns_name` - The DNS name associated with a certificate
     pub fn build(
         self,
         name_server: SocketAddr,

--- a/crates/proto/src/native_tls/tls_client_stream.rs
+++ b/crates/proto/src/native_tls/tls_client_stream.rs
@@ -55,7 +55,7 @@ impl<P: RuntimeProvider> TlsClientStreamBuilder<P> {
     ///
     /// * 'future` - future of TCP stream
     /// * `name_server` - IP and Port for the remote DNS resolver
-    /// * `dns_name` - The DNS name, Subject Public Key Info (SPKI) name, as associated to a certificate
+    /// * `dns_name` - The DNS name associated with a certificate
     #[allow(clippy::type_complexity)]
     pub fn build_with_future<F>(
         self,
@@ -85,7 +85,7 @@ impl<P: RuntimeProvider> TlsClientStreamBuilder<P> {
     /// # Arguments
     ///
     /// * `name_server` - IP and Port for the remote DNS resolver
-    /// * `dns_name` - The DNS name, Subject Public Key Info (SPKI) name, as associated to a certificate
+    /// * `dns_name` - The DNS name associated with a certificate
     #[allow(clippy::type_complexity)]
     pub fn build(
         self,

--- a/crates/proto/src/openssl/tls_client_stream.rs
+++ b/crates/proto/src/openssl/tls_client_stream.rs
@@ -62,7 +62,7 @@ impl<P: RuntimeProvider> TlsClientStreamBuilder<P> {
     ///
     /// * `future` - future for underlying tcp stream
     /// * `name_server` - IP and Port for the remote DNS resolver
-    /// * `dns_name` - The DNS name, Subject Public Key Info (SPKI) name, as associated to a certificate
+    /// * `dns_name` - The DNS name associated with a certificate
     #[allow(clippy::type_complexity)]
     pub fn build_with_future<F>(
         self,
@@ -93,7 +93,7 @@ impl<P: RuntimeProvider> TlsClientStreamBuilder<P> {
     ///
     /// * `name_server` - IP and Port for the remote DNS resolver
     /// * `bind_addr` - IP and port to connect from
-    /// * `dns_name` - The DNS name, Subject Public Key Info (SPKI) name, as associated to a certificate
+    /// * `dns_name` - The DNS name associated with a certificate
     #[allow(clippy::type_complexity)]
     pub fn build(
         self,

--- a/crates/proto/src/openssl/tls_stream.rs
+++ b/crates/proto/src/openssl/tls_stream.rs
@@ -254,7 +254,7 @@ impl<P: RuntimeProvider> TlsStreamBuilder<P> {
     /// # Arguments
     ///
     /// * `name_server` - IP and Port for the remote DNS resolver
-    /// * `dns_name` - The DNS name, Subject Public Key Info (SPKI) name, as associated to a certificate
+    /// * `dns_name` - The DNS name associated with a certificate
     #[allow(clippy::type_complexity)]
     pub fn build(
         self,

--- a/crates/proto/src/quic/quic_client_stream.rs
+++ b/crates/proto/src/quic/quic_client_stream.rs
@@ -174,7 +174,7 @@ impl QuicClientStreamBuilder {
     /// # Arguments
     ///
     /// * `name_server` - IP and Port for the remote DNS resolver
-    /// * `dns_name` - The DNS name, Subject Public Key Info (SPKI) name, as associated to a certificate
+    /// * `dns_name` - The DNS name associated with a certificate
     pub fn build(self, name_server: SocketAddr, dns_name: String) -> QuicClientConnect {
         QuicClientConnect(Box::pin(self.connect(name_server, dns_name)) as _)
     }

--- a/crates/proto/src/rustls/tls_client_stream.rs
+++ b/crates/proto/src/rustls/tls_client_stream.rs
@@ -33,7 +33,7 @@ pub type TlsClientStream<S> =
 ///
 /// * `name_server` - IP and Port for the remote DNS resolver
 /// * `bind_addr` - IP and port to connect from
-/// * `dns_name` - The DNS name, Subject Public Key Info (SPKI) name, as associated to a certificate
+/// * `dns_name` - The DNS name associated with a certificate
 #[allow(clippy::type_complexity)]
 pub fn tls_client_connect<P: RuntimeProvider>(
     name_server: SocketAddr,
@@ -53,7 +53,7 @@ pub fn tls_client_connect<P: RuntimeProvider>(
 ///
 /// * `name_server` - IP and Port for the remote DNS resolver
 /// * `bind_addr` - IP and port to connect from
-/// * `dns_name` - The DNS name, Subject Public Key Info (SPKI) name, as associated to a certificate
+/// * `dns_name` - The DNS name associated with a certificate
 #[allow(clippy::type_complexity)]
 pub fn tls_client_connect_with_bind_addr<P: RuntimeProvider>(
     name_server: SocketAddr,
@@ -82,7 +82,7 @@ pub fn tls_client_connect_with_bind_addr<P: RuntimeProvider>(
 /// # Arguments
 ///
 /// * `future` - A future producing DnsTcpStream
-/// * `dns_name` - The DNS name, Subject Public Key Info (SPKI) name, as associated to a certificate
+/// * `dns_name` - The DNS name associated with a certificate
 #[allow(clippy::type_complexity)]
 pub fn tls_client_connect_with_future<S, F>(
     future: F,

--- a/crates/proto/src/rustls/tls_stream.rs
+++ b/crates/proto/src/rustls/tls_stream.rs
@@ -70,7 +70,7 @@ pub fn tls_from_stream<S: DnsTcpStream>(
 ///
 /// * `name_server` - IP and Port for the remote DNS resolver
 /// * `bind_addr` - IP and port to connect from
-/// * `dns_name` - The DNS name,  Subject Public Key Info (SPKI) name, as associated to a certificate
+/// * `dns_name` - The DNS name associated with a certificate
 #[allow(clippy::type_complexity)]
 pub fn tls_connect<P: RuntimeProvider>(
     name_server: SocketAddr,
@@ -99,7 +99,7 @@ pub fn tls_connect<P: RuntimeProvider>(
 ///
 /// * `name_server` - IP and Port for the remote DNS resolver
 /// * `bind_addr` - IP and port to connect from
-/// * `dns_name` - The DNS name,  Subject Public Key Info (SPKI) name, as associated to a certificate
+/// * `dns_name` - The DNS name associated with a certificate
 #[allow(clippy::type_complexity)]
 pub fn tls_connect_with_bind_addr<P: RuntimeProvider>(
     name_server: SocketAddr,
@@ -144,7 +144,7 @@ pub fn tls_connect_with_bind_addr<P: RuntimeProvider>(
 ///
 /// * `name_server` - IP and Port for the remote DNS resolver
 /// * `bind_addr` - IP and port to connect from
-/// * `dns_name` - The DNS name,  Subject Public Key Info (SPKI) name, as associated to a certificate
+/// * `dns_name` - The DNS name associated with a certificate
 #[allow(clippy::type_complexity)]
 pub fn tls_connect_with_future<S, F>(
     future: F,


### PR DESCRIPTION
This fixes documentation of various secure transport APIs that was incorrectly referring to Subject Public Key Info. These arguments are all only used for DNS names, in certificate name validation and SNI. Subject Public Key Info is a structure from RFC 5280, containing an algorithm identifier and a public key, and thus not a name.