### PR TITLE
Simplify platform-independent privilege dropping

### DIFF
--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -47,8 +47,6 @@ static DEFAULT_HTTPS_PORT: u16 = 443;
 static DEFAULT_QUIC_PORT: u16 = 853; // https://www.ietf.org/archive/id/draft-ietf-dprive-dnsoquic-11.html#name-reservation-of-dedicated-po
 static DEFAULT_H3_PORT: u16 = 443;
 static DEFAULT_TCP_REQUEST_TIMEOUT: u64 = 5;
-static DEFAULT_USER: &str = "nobody";
-static DEFAULT_GROUP: &str = "nobody";
 
 /// Server configuration
 #[derive(Deserialize, Debug)]
@@ -90,14 +88,12 @@ pub struct Config {
     ///
     /// Only supported on Unix-like platforms. If the real or effective UID of the hickory process
     /// is root, we will attempt to change to this user (or to nobody if no user is specified here.)
-    #[cfg(target_family = "unix")]
-    user: Option<String>,
+    pub user: Option<String>,
     /// Group to run the server as.
     ///
     /// Only supported on Unix-like platforms. If the real or effective UID of the hickory process
     /// is root, we will attempt to change to this group (or to nobody if no group is specified here.)
-    #[cfg(target_family = "unix")]
-    group: Option<String>,
+    pub group: Option<String>,
     /// List of configurations for zones
     #[serde(default)]
     zones: Vec<ZoneConfig>,
@@ -246,26 +242,6 @@ impl Config {
     /// get the networks allowed to connect to this server
     pub fn allow_networks(&self) -> &[IpNet] {
         &self.allow_networks
-    }
-
-    /// get the user name to run the server as
-    #[cfg(target_family = "unix")]
-    pub fn user(&self) -> &str {
-        self.user.as_deref().unwrap_or(DEFAULT_USER)
-    }
-    #[cfg(not(target_family = "unix"))]
-    pub fn user(&self) -> &str {
-        DEFAULT_USER
-    }
-
-    /// get the group name to run the server as
-    #[cfg(target_family = "unix")]
-    pub fn group(&self) -> &str {
-        self.group.as_deref().unwrap_or(DEFAULT_GROUP)
-    }
-    #[cfg(not(target_family = "unix"))]
-    pub fn group(&self) -> &str {
-        DEFAULT_GROUP
     }
 }
 


### PR DESCRIPTION
Simplify privilege dropping to support platform independence. Previously:

- #2630 
- #2598