### PR TITLE
Log server config on connection failure.

### DIFF
--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -148,7 +148,7 @@ where
                 Ok(response)
             }
             Err(error) => {
-                debug!("name_server connection failure: {}", error);
+                debug!(config = ?self.config, "name_server connection failure: {}", error);
 
                 // this transitions the state to failure
                 self.state.fail(Instant::now());


### PR DESCRIPTION
To make it easier to debug issues like:
```
name_server/name_server.rs:151: name_server connection failure: io error: Network is unreachable (os error 101) 
name_server/name_server.rs:151: name_server connection failure: io error: Cannot assign requested address (os error 99)
```