### PR TITLE
Clean up ignored tests

### DIFF
--- a/bin/tests/integration/forwarder.rs
+++ b/bin/tests/integration/forwarder.rs
@@ -12,7 +12,6 @@ use hickory_server::{
     store::forwarder::ForwardAuthority,
 };
 
-#[ignore]
 #[test]
 fn test_lookup() {
     let runtime = Runtime::new().expect("failed to create Tokio Runtime");

--- a/crates/proto/src/h2/h2_client_stream.rs
+++ b/crates/proto/src/h2/h2_client_stream.rs
@@ -713,7 +713,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // cloudflare has been unreliable as a public test service.
+    #[ignore = "cloudflare has been unreliable as a public test service"]
     fn test_https_cloudflare() {
         subscribe();
 

--- a/crates/proto/src/h3/h3_client_stream.rs
+++ b/crates/proto/src/h3/h3_client_stream.rs
@@ -604,7 +604,7 @@ mod tests {
 
     /// Currently fails, see <https://github.com/hyperium/h3/issues/206>.
     #[test]
-    #[ignore] // cloudflare has been unreliable as a public test service.
+    #[ignore = "cloudflare has been unreliable as a public test service"]
     fn test_h3_cloudflare() {
         subscribe();
 

--- a/crates/proto/src/native_tls/tests.rs
+++ b/crates/proto/src/native_tls/tests.rs
@@ -15,10 +15,8 @@
 use std::env;
 use std::fs::File;
 use std::io::{Read, Write};
-#[cfg(not(target_os = "linux"))]
-use std::net::Ipv6Addr;
 use std::net::SocketAddr;
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::atomic;
 use std::sync::Arc;
 use std::{thread, time};
@@ -36,22 +34,20 @@ use crate::runtime::TokioRuntimeProvider;
 use crate::xfer::SerialMessage;
 use crate::{runtime::iocompat::AsyncIoTokioAsStd, DnsStreamHandle};
 
-// this fails on linux for some reason. It appears that a buffer somewhere is dirty
-//  and subsequent reads of a message buffer reads the wrong length. It works for 2 iterations
-//  but not 3?
-// #[cfg(not(target_os = "linux"))]
 #[test]
-#[cfg_attr(target_os = "macos", ignore)] // TODO: add back once https://github.com/sfackler/rust-native-tls/issues/143 is fixed
+// TODO: add back once https://github.com/sfackler/rust-native-tls/issues/143 is fixed, or test
+// certificates are regenerated to work with macos
+#[cfg_attr(target_os = "macos", ignore = "test certificate is rejected on macos")]
 fn test_tls_client_stream_ipv4() {
     tls_client_stream_test(IpAddr::V4(Ipv4Addr::LOCALHOST))
 }
 
 #[test]
-#[cfg_attr(target_os = "macos", ignore)] // TODO: add back once https://github.com/sfackler/rust-native-tls/issues/143 is fixed
-#[cfg(not(target_os = "linux"))] // ignored until Travis-CI fixes IPv6
-#[cfg(not(target_os = "macos"))] // certificates are failing on macOS now
+// TODO: add back once https://github.com/sfackler/rust-native-tls/issues/143 is fixed, or test
+// certificates are regenerated to work with macos
+#[cfg_attr(target_os = "macos", ignore = "test certificate is rejected on macos")]
 fn test_tls_client_stream_ipv6() {
-    tls_client_stream_test(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), false)
+    tls_client_stream_test(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)))
 }
 
 const TEST_BYTES: &[u8; 8] = b"DEADBEEF";

--- a/tests/integration-tests/tests/integration/client_tests.rs
+++ b/tests/integration-tests/tests/integration/client_tests.rs
@@ -223,7 +223,7 @@ async fn test_query_edns(client: Client) {
 }
 
 #[tokio::test]
-#[ignore] // this getting finnicky responses with UDP
+#[ignore = "flaky test against internet server"]
 #[allow(deprecated)]
 #[cfg(feature = "dnssec")]
 async fn test_secure_query_example_udp() {
@@ -353,7 +353,7 @@ async fn test_timeout_query_tcp() {
 // }
 
 #[tokio::test]
-#[ignore]
+#[ignore = "flaky test against internet server"]
 #[allow(deprecated)]
 #[cfg(feature = "dnssec")]
 async fn test_nsec_query_example_udp() {
@@ -362,7 +362,7 @@ async fn test_nsec_query_example_udp() {
 }
 
 #[tokio::test]
-#[ignore]
+#[ignore = "flaky test against internet server"]
 #[allow(deprecated)]
 #[cfg(feature = "dnssec")]
 async fn test_nsec_query_example_tcp() {
@@ -383,7 +383,7 @@ async fn test_nsec_query_example(mut client: DnssecClient) {
 }
 
 #[tokio::test]
-#[ignore]
+#[ignore = "flaky test against internet server"]
 #[cfg(feature = "dnssec")]
 async fn test_nsec_query_type() {
     let mut client = tcp_dnssec_client(GOOGLE_V4).await;
@@ -430,7 +430,7 @@ async fn test_nsec3_no_data() {
 }
 
 #[tokio::test]
-#[ignore]
+#[ignore = "flaky test against internet server"]
 #[cfg(feature = "dnssec")]
 async fn test_nsec3_query_name_is_soa_name() {
     let name = Name::from_labels("valid.extended-dns-errors.com".split(".")).unwrap();

--- a/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
+++ b/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
@@ -27,7 +27,7 @@ fn test_secure_query_example_nonet() {
 }
 
 #[test]
-#[ignore] // this getting finnicky responses with UDP
+#[ignore = "flaky test against internet server"]
 fn test_secure_query_example_udp() {
     with_udp(test_secure_query_example);
 }
@@ -76,13 +76,13 @@ fn test_nsec_query_example_nonet() {
 }
 
 #[test]
-#[ignore]
+#[ignore = "flaky test against internet server"]
 fn test_nsec_query_example_udp() {
     with_udp(test_nsec_query_example);
 }
 
 #[test]
-#[ignore]
+#[ignore = "flaky test against internet server"]
 fn test_nsec_query_example_tcp() {
     with_tcp(test_nsec_query_example);
 }
@@ -106,13 +106,13 @@ where
 // }
 
 #[test]
-#[ignore]
+#[ignore = "flaky test against internet server"]
 fn test_nsec_query_type_udp() {
     with_udp(test_nsec_query_type);
 }
 
 #[test]
-#[ignore]
+#[ignore = "flaky test against internet server"]
 fn test_nsec_query_type_tcp() {
     with_tcp(test_nsec_query_type);
 }


### PR DESCRIPTION
This re-enables a couple tests, and sets the ignore reason field where there are existing explanatory comments.