### PR TITLE
Add conformance test to simulate packet loss

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
@@ -7,6 +7,7 @@ use dns_test::tshark::{Capture, Direction};
 use dns_test::{Network, Resolver, Result, FQDN};
 
 mod bad_referral;
+mod packet_loss;
 
 #[test]
 fn can_resolve() -> Result<()> {

--- a/conformance/packages/conformance-tests/src/resolver/dns/scenarios/packet_loss.py
+++ b/conformance/packages/conformance-tests/src/resolver/dns/scenarios/packet_loss.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# This server ignores the first query it receives, and replies to all
+# subsequent queries, in order to simulate packet loss.
+from dnslib import A, DNSError, DNSLabel, DNSRecord, QTYPE, RCODE, RR
+from dnslib.server import BaseResolver, DNSHandler, DNSServer
+
+
+class Resolver(BaseResolver):
+    def __init__(self):
+        self.first = True
+        self.expected_name = DNSLabel("example.testing.")
+        self.a = A("192.0.2.1")  # in TEST-NET-1
+
+    def resolve(self, request: DNSRecord, _handler: DNSHandler) -> DNSRecord:
+        reply = request.reply()
+        if request.q.qname == self.expected_name:
+            reply.header.rcode = RCODE.NOERROR
+            if request.q.qtype == QTYPE.A:
+                if self.first:
+                    self.first = False
+                    # This will be caught by the try-except block in
+                    # DNSHandler.handle(), which results in no response being
+                    # sent.
+                    raise DNSError("Ignoring first query")
+                reply.add_answer(RR(
+                    request.q.qname,
+                    QTYPE.A,
+                    rdata=self.a,
+                ))
+        else:
+            reply.header.rcode = RCODE.NXDOMAIN
+        return reply
+
+
+if __name__ == "__main__":
+    resolver = Resolver()
+    server = DNSServer(resolver, address="0.0.0.0", port=53)
+    server.start()

--- a/conformance/packages/conformance-tests/src/resolver/dns/scenarios/packet_loss.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/scenarios/packet_loss.rs
@@ -1,0 +1,50 @@
+//! Test how resolvers respond to packet loss.
+
+use std::{fs, net::Ipv4Addr};
+
+use dns_test::{
+    client::{Client, DigSettings, DigStatus},
+    name_server::NameServer,
+    record::RecordType,
+    Implementation, Network, Resolver, Result, FQDN,
+};
+
+#[test]
+#[ignore = "hickory-recursor does not have a retransmission policy"]
+fn packet_loss_udp() -> Result<()> {
+    let target_fqdn = FQDN("example.testing.")?;
+    let network = Network::new()?;
+
+    let mut root_ns = NameServer::new(&Implementation::test_peer(), FQDN::ROOT, &network)?;
+    let leaf_ns = NameServer::new(&Implementation::Dnslib, FQDN::TEST_TLD, &network)?;
+    let script = fs::read_to_string("src/resolver/dns/scenarios/packet_loss.py")?;
+    leaf_ns.cp("/script.py", &script)?;
+
+    root_ns.referral_nameserver(&leaf_ns);
+
+    let root_hint = root_ns.root_hint();
+    let resolver = Resolver::new(&network, root_hint).start()?;
+    let client = Client::new(resolver.network())?;
+    let dig_settings = *DigSettings::default().recurse().timeout(10);
+
+    let _root_ns = root_ns.start()?;
+    let _leaf_ns = leaf_ns.start()?;
+
+    let result = client.dig(
+        dig_settings,
+        resolver.ipv4_addr(),
+        RecordType::A,
+        &target_fqdn,
+    );
+    let response = result
+        .unwrap_or_else(|e| panic!("error {e:?} resolver logs: {}", resolver.logs().unwrap()));
+
+    assert_eq!(response.status, DigStatus::NOERROR);
+    assert_eq!(response.answer.len(), 1, "{:?}", response.answer);
+    assert_eq!(
+        response.answer[0].clone().try_into_a().unwrap().ipv4_addr,
+        Ipv4Addr::new(192, 0, 2, 1)
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
This adds a conformance test that simulates packet loss, using dnslib. Related to #2645.