### PR TITLE
Conformance: test Hickory DNS with ring as well

### DIFF
--- a/conformance/packages/conformance-tests/src/name_server/rfc5155.rs
+++ b/conformance/packages/conformance-tests/src/name_server/rfc5155.rs
@@ -310,12 +310,16 @@ fn query_nameserver(
     let ns = ns.start()?;
 
     let client = Client::new(&network)?;
-    let output = client.dig(
+    let output_res = client.dig(
         *DigSettings::default().dnssec().authentic_data(),
         ns.ipv4_addr(),
         qtype,
         qname,
-    )?;
+    );
+    if output_res.is_err() {
+        println!("{}", ns.logs().unwrap());
+    }
+    let output = output_res?;
 
     let nsec3_rrs_response = output
         .authority

--- a/conformance/packages/dns-test/src/container.rs
+++ b/conformance/packages/dns-test/src/container.rs
@@ -12,7 +12,7 @@ use std::{env, fs};
 use tempfile::{NamedTempFile, TempDir};
 
 pub use crate::container::network::Network;
-use crate::{Error, Implementation, Repository, Result};
+use crate::{Error, HickoryDnssecFeature, Implementation, Repository, Result};
 
 #[derive(Clone)]
 pub struct Container {
@@ -26,13 +26,19 @@ pub enum Image {
     Bind,
     Dnslib,
     Client,
-    Hickory(Repository<'static>),
+    Hickory {
+        repo: Repository<'static>,
+        dnssec_feature: Option<HickoryDnssecFeature>,
+    },
     Unbound,
 }
 
 impl Image {
     pub fn hickory() -> Self {
-        Self::Hickory(Repository(crate::repo_root()))
+        Self::Hickory {
+            repo: Repository(crate::repo_root()),
+            dnssec_feature: None,
+        }
     }
 
     fn dockerfile(&self) -> &'static str {
@@ -81,21 +87,33 @@ impl From<Implementation> for Image {
             Implementation::Bind => Self::Bind,
             Implementation::Dnslib => Self::Dnslib,
             Implementation::Unbound => Self::Unbound,
-            Implementation::Hickory(repo) => Self::Hickory(repo),
+            Implementation::Hickory {
+                repo,
+                dnssec_feature,
+            } => Self::Hickory {
+                repo,
+                dnssec_feature,
+            },
         }
     }
 }
 
 impl fmt::Display for Image {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = match self {
-            Self::Client => "client",
-            Self::Bind => "bind",
-            Self::Dnslib => "dnslib",
-            Self::Hickory { .. } => "hickory",
-            Self::Unbound => "unbound",
-        };
-        f.write_str(s)
+        match self {
+            Self::Client => f.write_str("client"),
+            Self::Bind => f.write_str("bind"),
+            Self::Dnslib => f.write_str("dnslib"),
+            Self::Hickory {
+                repo: _,
+                dnssec_feature: None,
+            } => f.write_str("hickory"),
+            Self::Hickory {
+                repo: _,
+                dnssec_feature: Some(dnssec_feature),
+            } => write!(f, "hickory-{dnssec_feature}"),
+            Self::Unbound => f.write_str("unbound"),
+        }
     }
 }
 
@@ -116,7 +134,15 @@ impl Container {
             .arg(&image_tag)
             .arg(docker_build_dir);
 
-        let repo = if let Image::Hickory(repo) = image {
+        if let Image::Hickory {
+            dnssec_feature: Some(dnssec_feature),
+            ..
+        } = image
+        {
+            command.arg(format!("--build-arg=DNSSEC_FEATURE={dnssec_feature}"));
+        };
+
+        let repo = if let Image::Hickory { repo, .. } = image {
             Some(repo)
         } else {
             None

--- a/conformance/packages/dns-test/src/docker/hickory.Dockerfile
+++ b/conformance/packages/dns-test/src/docker/hickory.Dockerfile
@@ -1,5 +1,7 @@
 FROM rust:1-slim-bookworm
 
+ARG DNSSEC_FEATURE=dnssec-openssl
+
 # ldns-utils = ldns-{key2ds,keygen,signzone}
 RUN apt-get update && \
     apt-get install -y \
@@ -14,7 +16,7 @@ RUN apt-get update && \
 # any directory inside the `hickory-dns` repository
 COPY ./src /usr/src/hickory
 RUN --mount=type=cache,target=/usr/src/hickory/target \
-    cargo build --manifest-path /usr/src/hickory/Cargo.toml -p hickory-dns --features recursor,dnssec-openssl && \
+    cargo build --manifest-path /usr/src/hickory/Cargo.toml -p hickory-dns --features recursor,$DNSSEC_FEATURE && \
     cargo build --manifest-path /usr/src/hickory/Cargo.toml --bin dns --features dns-over-h3,dns-over-https-rustls,dns-over-quic && \
     cp /usr/src/hickory/target/debug/hickory-dns /usr/bin/ && \
     cp /usr/src/hickory/target/debug/dns /usr/bin/

--- a/conformance/packages/dns-test/src/docker/hickory.Dockerfile
+++ b/conformance/packages/dns-test/src/docker/hickory.Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1-slim-bookworm
 
-ARG DNSSEC_FEATURE=dnssec-openssl
+ARG DNSSEC_FEATURE=dnssec-ring
 
 # ldns-utils = ldns-{key2ds,keygen,signzone}
 RUN apt-get update && \

--- a/conformance/packages/dns-test/src/implementation.rs
+++ b/conformance/packages/dns-test/src/implementation.rs
@@ -159,12 +159,14 @@ impl Implementation {
                     )
                 }
 
-                Self::Hickory { .. } => {
+                Self::Hickory { dnssec_feature, .. } => {
+                    let use_pkcs8 = matches!(dnssec_feature, Some(HickoryDnssecFeature::Ring));
                     minijinja::render!(
                         include_str!("templates/hickory.name-server.toml.jinja"),
                         fqdn => origin.as_str(),
                         use_dnssec => use_dnssec,
                         additional_zones => additional_zones.keys().map(|x| x.as_str()).collect::<Vec<&str>>(),
+                        use_pkcs8 => use_pkcs8,
                     )
                 }
             },

--- a/conformance/packages/dns-test/src/implementation.rs
+++ b/conformance/packages/dns-test/src/implementation.rs
@@ -2,11 +2,12 @@ use core::fmt;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::Path;
+use std::str::FromStr;
 
 use url::Url;
 
 use crate::zone_file::ZoneFile;
-use crate::FQDN;
+use crate::{Error, FQDN};
 
 #[derive(Clone)]
 pub enum Config<'a> {
@@ -42,7 +43,10 @@ pub enum Role {
 pub enum Implementation {
     Bind,
     Dnslib,
-    Hickory(Repository<'static>),
+    Hickory {
+        repo: Repository<'static>,
+        dnssec_feature: Option<HickoryDnssecFeature>,
+    },
     Unbound,
 }
 
@@ -51,14 +55,17 @@ impl Implementation {
         match self {
             Implementation::Bind => false,
             Implementation::Dnslib => true,
-            Implementation::Hickory(_) => true,
+            Implementation::Hickory { .. } => true,
             Implementation::Unbound => true,
         }
     }
 
     /// Returns the latest hickory-dns local revision
     pub fn hickory() -> Self {
-        Self::Hickory(Repository(crate::repo_root()))
+        Self::Hickory {
+            repo: Repository(crate::repo_root()),
+            dnssec_feature: None,
+        }
     }
 
     /// A test peer that cannot be changed using the `DNS_TEST_PEER` env variable
@@ -78,7 +85,7 @@ impl Implementation {
 
     #[must_use]
     pub fn is_hickory(&self) -> bool {
-        matches!(self, Self::Hickory(_))
+        matches!(self, Self::Hickory { .. })
     }
 
     #[must_use]
@@ -108,7 +115,7 @@ impl Implementation {
                     "".into()
                 }
 
-                Self::Hickory(_) => {
+                Self::Hickory { .. } => {
                     // TODO enable EDE in Hickory when supported
                     minijinja::render!(
                         include_str!("templates/hickory.resolver.toml.jinja"),
@@ -152,7 +159,7 @@ impl Implementation {
                     )
                 }
 
-                Self::Hickory(_) => {
+                Self::Hickory { .. } => {
                     minijinja::render!(
                         include_str!("templates/hickory.name-server.toml.jinja"),
                         fqdn => origin.as_str(),
@@ -170,7 +177,7 @@ impl Implementation {
 
             Self::Dnslib => None,
 
-            Self::Hickory(_) => Some("/etc/named.toml"),
+            Self::Hickory { .. } => Some("/etc/named.toml"),
 
             Self::Unbound => match role {
                 Role::NameServer => Some("/etc/nsd/nsd.conf"),
@@ -183,7 +190,7 @@ impl Implementation {
         let base = match self {
             Implementation::Bind => "named -g -d5",
             Implementation::Dnslib => "python3 /script.py",
-            Implementation::Hickory(_) => "hickory-dns -d",
+            Implementation::Hickory { .. } => "hickory-dns -d",
             Implementation::Unbound => match role {
                 Role::NameServer => "nsd -d",
                 Role::Resolver => "unbound -d",
@@ -217,7 +224,7 @@ impl Implementation {
 
             Implementation::Dnslib => "/tmp/dnslib",
 
-            Implementation::Hickory(_) => "/tmp/hickory",
+            Implementation::Hickory { .. } => "/tmp/hickory",
 
             Implementation::Unbound => match role {
                 Role::NameServer => "/tmp/nsd",
@@ -226,6 +233,37 @@ impl Implementation {
         };
 
         format!("{path}.{suffix}")
+    }
+}
+
+/// A Hickory DNS Cargo feature used to enable DNSSEC with a particular cryptography library.
+#[derive(Debug, Clone, Copy)]
+pub enum HickoryDnssecFeature {
+    Openssl,
+    Ring,
+}
+
+impl fmt::Display for HickoryDnssecFeature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Openssl => "dnssec-openssl",
+            Self::Ring => "dnssec-ring",
+        })
+    }
+}
+
+impl FromStr for HickoryDnssecFeature {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "dnssec-openssl" => Ok(Self::Openssl),
+            "dnssec-ring" => Ok(Self::Ring),
+            _ => Err(format!(
+                "invalid value for DNSSEC_FEATURE: {s}, expected dnssec-openssl or dnssec-ring"
+            )
+            .into()),
+        }
     }
 }
 
@@ -249,7 +287,7 @@ impl fmt::Display for Implementation {
         let s = match self {
             Implementation::Bind => "bind",
             Implementation::Dnslib => "dnslib",
-            Implementation::Hickory(_) => "hickory",
+            Implementation::Hickory { .. } => "hickory",
             Implementation::Unbound => "unbound",
         };
 

--- a/conformance/packages/dns-test/src/name_server.rs
+++ b/conformance/packages/dns-test/src/name_server.rs
@@ -427,7 +427,11 @@ impl NameServer<Running> {
     /// Returns the logs collected so far
     pub fn logs(&self) -> Result<String> {
         if self.implementation.is_hickory() {
-            self.stdout()
+            Ok(format!(
+                "STDOUT:\n{}\nSTDERR:\n{}",
+                self.stdout()?,
+                self.stderr()?,
+            ))
         } else {
             self.stderr()
         }

--- a/conformance/packages/dns-test/src/name_server.rs
+++ b/conformance/packages/dns-test/src/name_server.rs
@@ -323,12 +323,17 @@ impl NameServer<Stopped> {
 const ZONES_DIR: &str = "/etc/zones";
 const ZONE_FILENAME: &str = "main.zone";
 const ZSK_PRIVATE_FILENAME: &str = "zsk.key";
+const ZSK_PKCS8_FILENAME: &str = "zsk.pk8";
 
 fn zone_file_path() -> String {
     format!("{ZONES_DIR}/{ZONE_FILENAME}")
 }
 fn zsk_private_path() -> String {
     format!("{ZONES_DIR}/{ZSK_PRIVATE_FILENAME}")
+}
+
+fn zsk_pkcs8_path() -> String {
+    format!("{ZONES_DIR}/{ZSK_PKCS8_FILENAME}")
 }
 
 fn ns_count() -> usize {
@@ -371,6 +376,20 @@ impl NameServer<Signed> {
             // don't compare signatures in any of the conformance tests.
             let zsk = container.stdout(&["openssl", "genpkey", "-algorithm", "RSA"])?;
             container.cp(&zsk_private_path(), &zsk)?;
+            container.status_ok(&[
+                "openssl",
+                "pkcs8",
+                "-topk8",
+                "-nocrypt",
+                "-inform",
+                "pem",
+                "-in",
+                &zsk_private_path(),
+                "-outform",
+                "der",
+                "-out",
+                &zsk_pkcs8_path(),
+            ])?;
         } else {
             container.cp(&zone_file_path(), &state.signed.to_string())?;
         }

--- a/conformance/packages/dns-test/src/templates/hickory.name-server.toml.jinja
+++ b/conformance/packages/dns-test/src/templates/hickory.name-server.toml.jinja
@@ -9,7 +9,11 @@ enable_dnssec = {{ use_dnssec }}
 nx_proof_kind = { nsec3 = { iterations = 1 } }
 
 [[zones.keys]]
+{% if use_pkcs8 %}
+key_path = "/etc/zones/zsk.pk8"
+{% else %}
 key_path = "/etc/zones/zsk.key"
+{% endif %}
 algorithm = "RSASHA256"
 is_zone_signing_key = true
 

--- a/justfile
+++ b/justfile
@@ -187,9 +187,16 @@ conformance-bind filter='':
     DNS_TEST_VERBOSE_DOCKER_BUILD=1 DNS_TEST_PEER=unbound DNS_TEST_SUBJECT=bind cargo t --manifest-path conformance/Cargo.toml -p conformance-tests -- --include-ignored {{filter}}
 
 # runs the conformance test suite against the latest local hickory-dns commit -- changes that have not been commited will be ignored!
-conformance-hickory filter='':
+conformance-hickory: (conformance-hickory-openssl)
+
+conformance-hickory-openssl filter='':
     @ bash -c '[[ -n "$(git status -s)" ]] && echo "WARNING: uncommitted changes will NOT be tested" || true'
-    DNS_TEST_VERBOSE_DOCKER_BUILD=1 DNS_TEST_PEER=unbound DNS_TEST_SUBJECT="hickory {{justfile_directory()}}" cargo t --manifest-path conformance/Cargo.toml -p conformance-tests -- {{filter}}
+    DNS_TEST_VERBOSE_DOCKER_BUILD=1 DNS_TEST_PEER=unbound DNS_TEST_SUBJECT="hickory {{justfile_directory()}} dnssec-openssl" cargo t --manifest-path conformance/Cargo.toml -p conformance-tests -- {{filter}}
+    @ bash -c '[[ -n "$(git status -s)" ]] && echo "WARNING: uncommitted changes were NOT tested" || true'
+
+conformance-hickory-ring filter='':
+    @ bash -c '[[ -n "$(git status -s)" ]] && echo "WARNING: uncommitted changes will NOT be tested" || true'
+    DNS_TEST_VERBOSE_DOCKER_BUILD=1 DNS_TEST_PEER=unbound DNS_TEST_SUBJECT="hickory {{justfile_directory()}} dnssec-ring" cargo t --manifest-path conformance/Cargo.toml -p conformance-tests -- {{filter}}
     @ bash -c '[[ -n "$(git status -s)" ]] && echo "WARNING: uncommitted changes were NOT tested" || true'
 
 # checks that all conformance tests that pass with hickory-dns have been un-#[ignore]-d

--- a/justfile
+++ b/justfile
@@ -187,7 +187,7 @@ conformance-bind filter='':
     DNS_TEST_VERBOSE_DOCKER_BUILD=1 DNS_TEST_PEER=unbound DNS_TEST_SUBJECT=bind cargo t --manifest-path conformance/Cargo.toml -p conformance-tests -- --include-ignored {{filter}}
 
 # runs the conformance test suite against the latest local hickory-dns commit -- changes that have not been commited will be ignored!
-conformance-hickory: (conformance-hickory-openssl)
+conformance-hickory: (conformance-hickory-openssl) (conformance-hickory-ring)
 
 conformance-hickory-openssl filter='':
     @ bash -c '[[ -n "$(git status -s)" ]] && echo "WARNING: uncommitted changes will NOT be tested" || true'


### PR DESCRIPTION
This PR adds another optional parameter to the `DNS_TEST_SUBJECT` environment variable, to allow choosing between the `dnssec-openssl` and `dnssec-ring` Cargo features. I also added support for providing either a PEM or PKCS8 private key to a Hickory name server, depending on which library it is using. This flexibility will also be useful in the near future when we add aws-lc-rs.

This is a rebased version of #2593.