### PR TITLE
Increase logging to diagnose Windows CI issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      RUST_LOG: info,hickory_proto::udp::udp_stream=trace # Extra logging for issue #2649
     steps:
       - uses: actions/checkout@v4
 

--- a/crates/proto/src/udp/udp_stream.rs
+++ b/crates/proto/src/udp/udp_stream.rs
@@ -18,7 +18,7 @@ use futures_util::stream::Stream;
 use futures_util::{future::Future, ready, TryFutureExt};
 use rand;
 use rand::distributions::{uniform::Uniform, Distribution};
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 
 use crate::runtime::{RuntimeProvider, Time};
 use crate::udp::MAX_RECEIVE_BUFFER_SIZE;
@@ -313,6 +313,7 @@ impl<P: RuntimeProvider> Future for NextRandomUdpSocket<P> {
                         }
                     }
 
+                    trace!(port = bind_addr.port(), "binding UDP socket");
                     Some(Box::pin(
                         this.provider.bind_udp(bind_addr, this.name_server),
                     ))

--- a/tests/integration-tests/tests/integration/server_future_tests.rs
+++ b/tests/integration-tests/tests/integration/server_future_tests.rs
@@ -25,10 +25,13 @@ use hickory_proto::rr::{DNSClass, Name, RData, RecordType};
 use hickory_proto::xfer::{DnsHandle, DnsMultiplexer};
 use hickory_server::authority::{Authority, Catalog};
 use hickory_server::ServerFuture;
+use test_support::subscribe;
 
 #[tokio::test]
 #[allow(clippy::uninlined_format_args)]
 async fn test_server_www_udp() {
+    subscribe();
+
     let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0));
     let udp_socket = UdpSocket::bind(&addr).await.unwrap();
 
@@ -49,6 +52,8 @@ async fn test_server_www_udp() {
 #[tokio::test]
 #[allow(clippy::uninlined_format_args)]
 async fn test_server_www_tcp() {
+    subscribe();
+
     let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0));
     let tcp_listener = TcpListener::bind(&addr).await.unwrap();
 
@@ -68,6 +73,8 @@ async fn test_server_www_tcp() {
 
 #[tokio::test]
 async fn test_server_unknown_type() {
+    subscribe();
+
     let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0));
     let udp_socket = UdpSocket::bind(&addr).await.unwrap();
 
@@ -111,6 +118,8 @@ async fn test_server_unknown_type() {
 
 #[tokio::test]
 async fn test_server_form_error_on_multiple_queries() {
+    subscribe();
+
     let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0));
     let udp_socket = UdpSocket::bind(&addr).await.unwrap();
 
@@ -153,6 +162,8 @@ async fn test_server_form_error_on_multiple_queries() {
 
 #[tokio::test]
 async fn test_server_no_response_on_response() {
+    subscribe();
+
     let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0));
     let udp_socket = UdpSocket::bind(&addr).await.unwrap();
 
@@ -201,6 +212,8 @@ async fn test_server_www_tls() {
     use hickory_proto::rustls::tls_server;
     use std::env;
     use std::path::Path;
+
+    subscribe();
 
     let dns_name = "ns.example.com";
 


### PR DESCRIPTION
This improves logging in a few ways to help diagnose #2649.

* Added a trace-level log message showing what UDP port we are attempting to bind.
* Set up the test tracing subscriber throughout server_future_tests.
* Set a log filter in the cross-platform test to capture the above UDP port log message.