### PR TITLE
async-std-resolver: remove README reference to mdns support

### DIFF
--- a/crates/async-std-resolver/README.md
+++ b/crates/async-std-resolver/README.md
@@ -16,7 +16,6 @@ This library contains implementations for IPv4 (A) and IPv6 (AAAA) resolution, m
 - TBD (in tokio impl): DNSSEC validation
 - Generic Record Type Lookup
 - CNAME chain resolution
-- _experimental_ mDNS support (enable with `mdns` feature)
 - TBD (in tokio impl): DNS over TLS (utilizing `native-tls`, `rustls`, and `openssl`; `native-tls` or `rustls` are recommended)
 - TBD (in tokio impl): DNS over HTTPS (currently only supports `rustls`)
 


### PR DESCRIPTION
> Unfortunately this amounts to copy/pasta. https://github.com/hickory-dns/hickory-dns/commit/9f4d01aae7c73784299b16ef0e1343189a650637 added a README for async-std-resolver, but this particular crate never contained any mdns support (and https://github.com/hickory-dns/hickory-dns/pull/2324 removed the mostly disabled support that existed in the resolver crate). At this point we only have some lower-level support in the hickory-proto crate.

Fixes #2654.