### PR TITLE
ci: avoid hardcoded Rust versions in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -184,7 +184,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ steps.rust_version.outpus.version }}
+          toolchain: ${{ steps.rust_version.outputs.version }}
 
       - uses: extractions/setup-just@v2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,13 +168,23 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        version: ["1.71.1", beta, "nightly-2024-05-23"]
+        version: ["current_msrv", beta, "nightly"]
     steps:
       - uses: actions/checkout@v4
 
+      - name: Get Rust version to install
+        id: rust_version
+        run: |
+          if [ "${{ matrix.version }}" = "current_msrv" ]; then
+            msrv=$(cat Cargo.toml | grep rust-version | sed 's/.* = "//; s/"//')
+            echo "version=$msrv" >> $GITHUB_OUTPUT
+          else
+            echo "version=${{ matrix.version }}" >> $GITHUB_ENV
+          fi
+
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.version }}
+          toolchain: ${{ steps.rust_version.outpus.version }}
 
       - uses: extractions/setup-just@v2
 


### PR DESCRIPTION
This PR allows to avoid changes of CI scripts if MSRV changes.