### PR TITLE
Allow API consumer to use OS port assignment for UDP sockets

### DIFF
--- a/crates/proto/src/tests/udp.rs
+++ b/crates/proto/src/tests/udp.rs
@@ -22,6 +22,7 @@ pub fn next_random_socket_test(mut exec: impl Executor, provider: impl RuntimePr
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 52),
         None,
         None,
+        false,
         provider,
     );
     drop(

--- a/crates/proto/src/udp/udp_stream.rs
+++ b/crates/proto/src/udp/udp_stream.rs
@@ -93,6 +93,16 @@ impl<P: RuntimeProvider> UdpStream<P> {
     /// * `remote_addr` - socket address for the remote connection (used to determine IPv4 or IPv6)
     /// * `bind_addr` - optional local socket address to connect from (if a nonzero port number is
     ///                 specified, it will be used instead of randomly selecting a port)
+    /// * `os_port_selection` - optional parameter to specify whether to use the operating system's
+    ///                         standard UDP port selection logic instead of Hickory's logic to
+    ///                         securely select a random source port.  We do not recommend using
+    ///                         this option unless absolutely necessary, as the operating system
+    ///                         may select ephemeral ports from a smaller range than Hickory, which
+    ///                         can make response poisoning attacks easier to conduct.  Some
+    ///                         operating systems (notably, Windows) might display a user-prompt to
+    ///                         allow a Hickory-specified port to be used, and setting this option
+    ///                         will prevent those prompts from being displayed.  This option is
+    ///                         mutually exclusive with the avoid_local_ports configuration option.
     /// * `provider` - async runtime provider, for I/O and timers
     ///
     /// # Return
@@ -104,6 +114,7 @@ impl<P: RuntimeProvider> UdpStream<P> {
         remote_addr: SocketAddr,
         bind_addr: Option<SocketAddr>,
         avoid_local_ports: Option<Arc<HashSet<u16>>>,
+        os_port_selection: bool,
         provider: P,
     ) -> (
         Box<dyn Future<Output = Result<Self, io::Error>> + Send + Unpin>,
@@ -116,6 +127,7 @@ impl<P: RuntimeProvider> UdpStream<P> {
             remote_addr,
             bind_addr,
             avoid_local_ports.unwrap_or_default(),
+            os_port_selection,
             provider,
         );
 
@@ -223,6 +235,7 @@ pub(crate) struct NextRandomUdpSocket<P: RuntimeProvider> {
     #[allow(clippy::type_complexity)]
     future: Option<Pin<Box<dyn Send + Future<Output = io::Result<P::Udp>>>>>,
     avoid_local_ports: Arc<HashSet<u16>>,
+    os_port_selection: bool,
 }
 
 impl<P: RuntimeProvider> NextRandomUdpSocket<P> {
@@ -234,6 +247,7 @@ impl<P: RuntimeProvider> NextRandomUdpSocket<P> {
         name_server: SocketAddr,
         bind_addr: Option<SocketAddr>,
         avoid_local_ports: Arc<HashSet<u16>>,
+        os_port_selection: bool,
         provider: P,
     ) -> Self {
         let bind_address = match bind_addr {
@@ -251,6 +265,7 @@ impl<P: RuntimeProvider> NextRandomUdpSocket<P> {
             attempted: 0,
             future: None,
             avoid_local_ports,
+            os_port_selection,
         }
     }
 }
@@ -288,7 +303,8 @@ impl<P: RuntimeProvider> Future for NextRandomUdpSocket<P> {
                 },
                 None => {
                     let mut bind_addr = this.bind_address;
-                    if bind_addr.port() == 0 {
+
+                    if !this.os_port_selection && bind_addr.port() == 0 {
                         while this.attempted < ATTEMPT_RANDOM {
                             // Per RFC 6056 Section 3.2:
                             //

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -902,6 +902,17 @@ pub struct ResolverOpts {
     pub shuffle_dns_servers: bool,
     /// Local UDP ports to avoid when making outgoing queries
     pub avoid_local_udp_ports: Arc<HashSet<u16>>,
+    /// Request UDP bind ephemeral ports directly from the OS
+    ///
+    /// Boolean arameter to specify whether to use the operating system's standard UDP port
+    /// selection logic instead of Hickory's logic to securely select a random source port.  We do
+    /// not recommend using this option unless absolutely necessary, as the operating system may
+    /// select ephemeral ports from a smaller range than Hickory, which can make response poisoning
+    /// attacks easier to conduct.  Some operating systems (notably, Windows) might display a
+    /// user-prompt to allow a Hickory-specified port to be used, and setting this option will
+    /// prevent those prompts from being displayed.  This option is mutually exclusive with the
+    /// avoid_local_ports configuration option.
+    pub os_port_selection: bool,
 }
 
 impl Default for ResolverOpts {
@@ -935,6 +946,7 @@ impl Default for ResolverOpts {
             authentic_data: false,
             shuffle_dns_servers: false,
             avoid_local_udp_ports: Arc::new(HashSet::new()),
+            os_port_selection: false,
         }
     }
 }

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -216,6 +216,7 @@ impl<P: RuntimeProvider> ConnectionProvider for GenericConnector<P> {
                 let provider_handle = self.runtime_provider.clone();
                 let stream = UdpClientStream::builder(config.socket_addr, provider_handle)
                     .with_timeout(Some(options.timeout))
+                    .with_os_port_selection(options.os_port_selection)
                     .avoid_local_ports(options.avoid_local_udp_ports.clone())
                     .build();
                 let exchange = DnsExchange::connect(stream);


### PR DESCRIPTION
@djc this is #2565 with the changes I recommended.  I kept the boolean flag on the with_os_port_selection builder for UdpClientStreamBuilder - it seems to be the easiest way to bridge the configuration between the connection provider and the client stream builder.