### PR TITLE
Add RFC 8906 conformance tests

### DIFF
--- a/conformance/packages/conformance-tests/src/name_server.rs
+++ b/conformance/packages/conformance-tests/src/name_server.rs
@@ -1,3 +1,4 @@
 mod rfc4035;
 mod rfc5155;
+mod rfc8906;
 mod scenarios;

--- a/conformance/packages/conformance-tests/src/name_server/rfc8906.rs
+++ b/conformance/packages/conformance-tests/src/name_server/rfc8906.rs
@@ -1,0 +1,18 @@
+use dns_test::{
+    client::Client,
+    name_server::{NameServer, Running},
+    zone_file::SignSettings,
+    Network, Result, FQDN,
+};
+
+mod basic;
+mod extended;
+
+fn setup() -> Result<(Network, NameServer<Running>, Client)> {
+    let network = Network::new()?;
+    let ns = NameServer::new(&dns_test::SUBJECT, FQDN::TEST_DOMAIN, &network)?;
+    let ns = ns.sign(SignSettings::default())?;
+    let ns = ns.start()?;
+    let client = Client::new(&network)?;
+    Ok((network, ns, client))
+}

--- a/conformance/packages/conformance-tests/src/name_server/rfc8906/basic.rs
+++ b/conformance/packages/conformance-tests/src/name_server/rfc8906/basic.rs
@@ -1,0 +1,193 @@
+use dns_test::{
+    client::{DigSettings, DigStatus},
+    record::RecordType,
+    Result, FQDN,
+};
+
+use crate::name_server::rfc8906::setup;
+
+#[test]
+fn test_8_1_1_zone_configured() -> Result<()> {
+    let (_network, ns, client) = setup()?;
+
+    let settings = *DigSettings::default().edns(None);
+    let output = client.dig(
+        settings,
+        ns.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(output.flags.authoritative_answer);
+    assert!(!output.flags.recursion_desired);
+    assert!(!output.flags.authenticated_data);
+    assert!(!output.opt);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_1_2_unknown_types() -> Result<()> {
+    let (_network, ns, client) = setup()?;
+
+    let settings = *DigSettings::default().edns(None);
+    let output = client.dig(
+        settings,
+        ns.ipv4_addr(),
+        RecordType::Unknown(1000),
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert!(output.answer.is_empty());
+    assert!(output.flags.authoritative_answer);
+    assert!(!output.flags.recursion_desired);
+    assert!(!output.flags.authenticated_data);
+    assert!(!output.opt);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_1_3_1_header_bits_cd_1() -> Result<()> {
+    let (_network, ns, client) = setup()?;
+
+    let settings = *DigSettings::default().edns(None).checking_disabled();
+    let output = client.dig(
+        settings,
+        ns.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(output.flags.authoritative_answer);
+    assert!(!output.flags.recursion_desired);
+    assert!(!output.flags.authenticated_data);
+    assert!(!output.opt);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_1_3_2_header_bits_ad_1() -> Result<()> {
+    let (_network, ns, client) = setup()?;
+
+    let settings = *DigSettings::default().edns(None).authentic_data();
+    let output = client.dig(
+        settings,
+        ns.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(output.flags.authoritative_answer);
+    assert!(!output.flags.recursion_desired);
+    assert!(!output.opt);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_1_3_3_header_bits_reserved() -> Result<()> {
+    let (_network, ns, client) = setup()?;
+
+    let settings = *DigSettings::default().edns(None).set_z_flag();
+    let output = client.dig(
+        settings,
+        ns.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(!output.must_be_zero);
+    assert!(output.flags.authoritative_answer);
+    assert!(!output.flags.recursion_desired);
+    assert!(!output.flags.authenticated_data);
+    assert!(!output.opt);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_1_3_4_header_bits_recursive_query() -> Result<()> {
+    let (_network, ns, client) = setup()?;
+
+    let settings = *DigSettings::default().edns(None).recurse();
+    let output = client.dig(
+        settings,
+        ns.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(output.flags.authoritative_answer);
+    assert!(output.flags.recursion_desired);
+    assert!(!output.flags.authenticated_data);
+    assert!(!output.opt);
+
+    Ok(())
+}
+
+#[test]
+#[ignore = "hickory does not respond"]
+fn test_8_1_4_unknown_opcodes() -> Result<()> {
+    let (_network, ns, client) = setup()?;
+
+    let settings = *DigSettings::default().edns(None).opcode(15).header_only();
+    let output = client.dig(
+        settings,
+        ns.ipv4_addr(),
+        RecordType::SOA, // The type will be ignored, since we are specifying +header-only.
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOTIMP);
+    assert_eq!(output.opcode, "RESERVED15");
+    assert!(output.answer.is_empty());
+    assert!(output.authority.is_empty());
+    assert!(output.additional.is_empty());
+    assert!(!output.flags.authoritative_answer);
+    assert!(!output.flags.recursion_desired);
+    assert!(!output.flags.authenticated_data);
+    assert!(!output.opt);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_1_5_tcp() -> Result<()> {
+    let (_network, ns, client) = setup()?;
+
+    let settings = *DigSettings::default().edns(None).tcp();
+    let output = client.dig(
+        settings,
+        ns.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(output.flags.authoritative_answer);
+    assert!(!output.flags.recursion_desired);
+    assert!(!output.flags.authenticated_data);
+    assert!(!output.opt);
+
+    Ok(())
+}

--- a/conformance/packages/conformance-tests/src/name_server/rfc8906/extended.rs
+++ b/conformance/packages/conformance-tests/src/name_server/rfc8906/extended.rs
@@ -1,0 +1,255 @@
+use dns_test::{
+    client::{DigSettings, DigStatus},
+    record::RecordType,
+    Result, FQDN,
+};
+
+use crate::name_server::rfc8906::setup;
+
+#[test]
+fn test_8_2_1_minimal_edns() -> Result<()> {
+    let (_network, ns, client) = setup()?;
+
+    let settings = *DigSettings::default().edns(Some(0)).nocookie();
+    let output = client.dig(
+        settings,
+        ns.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(output.opt);
+    assert_eq!(output.edns_version, Some(0));
+    assert!(output.flags.authoritative_answer);
+    assert!(!output.flags.authenticated_data);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_2_2_edns_version_negotiation() -> Result<()> {
+    let (_network, ns, client) = setup()?;
+
+    let settings = *DigSettings::default().edns(Some(1)).nocookie().noednsneg();
+    let output = client.dig(
+        settings,
+        ns.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::BADVERS);
+    assert!(output.answer.is_empty());
+    assert!(output.opt);
+    assert_eq!(output.edns_version, Some(0));
+    assert!(!output.flags.authoritative_answer);
+    assert!(!output.flags.authenticated_data);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_2_3_unknown_edns_options() -> Result<()> {
+    let (_network, ns, client) = setup()?;
+
+    let settings = *DigSettings::default().nocookie().ednsoption(100);
+    let output = client.dig(
+        settings,
+        ns.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(output.opt);
+    assert!(output.options.is_empty());
+    assert_eq!(output.edns_version, Some(0));
+    assert!(output.flags.authoritative_answer);
+    assert!(!output.flags.authenticated_data);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_2_4_unknown_edns_flags() -> Result<()> {
+    let (_network, ns, client) = setup()?;
+
+    let settings = *DigSettings::default().nocookie().set_ednsflags(0x40);
+    let output = client.dig(
+        settings,
+        ns.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(output.opt);
+    assert!(!output.edns_must_be_zero);
+    assert_eq!(output.edns_version, Some(0));
+    assert!(output.options.is_empty());
+    assert!(output.flags.authoritative_answer);
+    assert!(!output.flags.authenticated_data);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_2_5_edns_version_negotiation_with_unknown_edns_flags() -> Result<()> {
+    let (_network, ns, client) = setup()?;
+
+    let settings = *DigSettings::default()
+        .nocookie()
+        .edns(Some(1))
+        .noednsneg()
+        .set_ednsflags(0x40);
+    let output = client.dig(
+        settings,
+        ns.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::BADVERS);
+    assert!(output.answer.is_empty());
+    assert!(output.opt);
+    assert!(!output.edns_must_be_zero);
+    assert_eq!(output.edns_version, Some(0));
+    assert!(!output.flags.authoritative_answer);
+    assert!(!output.flags.authenticated_data);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_2_6_edns_version_negotiation_with_unknown_edns_options() -> Result<()> {
+    let (_network, ns, client) = setup()?;
+
+    let settings = *DigSettings::default()
+        .nocookie()
+        .edns(Some(1))
+        .noednsneg()
+        .ednsoption(100);
+    let output = client.dig(
+        settings,
+        ns.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::BADVERS);
+    assert!(output.answer.is_empty());
+    assert!(output.opt);
+    assert!(output.options.is_empty());
+    assert_eq!(output.edns_version, Some(0));
+    assert!(!output.flags.authoritative_answer);
+    assert!(!output.flags.authenticated_data);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_2_7_truncated_responses() -> Result<()> {
+    let (_network, ns, client) = setup()?;
+
+    let settings = *DigSettings::default()
+        .nocookie()
+        .ignore()
+        .bufsize(512)
+        .dnssec();
+    let output = client.dig(
+        settings,
+        ns.ipv4_addr(),
+        RecordType::DNSKEY,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert!(output.flags.truncation);
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert!(output.opt);
+    assert_eq!(output.edns_version, Some(0));
+
+    Ok(())
+}
+
+#[test]
+fn test_8_2_8_do_1() -> Result<()> {
+    let (_network, ns, client) = setup()?;
+
+    let settings = *DigSettings::default().nocookie().edns(Some(0)).dnssec();
+    let output = client.dig(
+        settings,
+        ns.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert!(!output.answer.is_empty());
+    assert!(output.answer[0].is_soa());
+    assert!(output.opt);
+    assert!(output.dnssec_ok_flag);
+    assert_eq!(output.edns_version, Some(0));
+    assert!(output.flags.authoritative_answer);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_2_9_edns_version_negotiation_with_do_1() -> Result<()> {
+    let (_network, ns, client) = setup()?;
+
+    let settings = *DigSettings::default()
+        .nocookie()
+        .edns(Some(1))
+        .noednsneg()
+        .dnssec();
+    let output = client.dig(
+        settings,
+        ns.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::BADVERS);
+    assert!(output.answer.is_empty());
+    assert!(output.opt);
+    if !dns_test::SUBJECT.is_unbound() {
+        // unbound does not set DO=1 in the BADVERS response
+        assert!(output.dnssec_ok_flag);
+    }
+    assert_eq!(output.edns_version, Some(0));
+    assert!(!output.flags.authoritative_answer);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_2_10_multiple_defined_edns_options() -> Result<()> {
+    let (_network, ns, client) = setup()?;
+
+    let settings = *DigSettings::default().nsid().expire().subnet_zero();
+    let output = client.dig(
+        settings,
+        ns.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(output.opt);
+    assert_eq!(output.edns_version, Some(0));
+    assert!(output.flags.authoritative_answer);
+    assert!(!output.flags.authenticated_data);
+
+    Ok(())
+}

--- a/conformance/packages/conformance-tests/src/resolver/dns.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns.rs
@@ -1,4 +1,5 @@
 //! plain DNS functionality
 
 mod rfc1035;
+mod rfc8906;
 mod scenarios;

--- a/conformance/packages/conformance-tests/src/resolver/dns/rfc8906.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/rfc8906.rs
@@ -1,0 +1,23 @@
+use dns_test::{
+    client::Client,
+    name_server::{Graph, NameServer},
+    zone_file::SignSettings,
+    Network, Resolver, Result, FQDN,
+};
+
+mod basic;
+mod extended;
+
+fn setup() -> Result<(Network, Graph, Resolver, Client)> {
+    let network = Network::new()?;
+    let leaf_ns = NameServer::new(&dns_test::PEER, FQDN::TEST_DOMAIN, &network)?;
+    let graph = Graph::build(
+        leaf_ns,
+        dns_test::name_server::Sign::Yes {
+            settings: SignSettings::default(),
+        },
+    )?;
+    let resolver = Resolver::new(&network, graph.root.clone()).start()?;
+    let client = Client::new(&network)?;
+    Ok((network, graph, resolver, client))
+}

--- a/conformance/packages/conformance-tests/src/resolver/dns/rfc8906/basic.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/rfc8906/basic.rs
@@ -1,0 +1,211 @@
+use dns_test::{
+    client::{DigSettings, DigStatus},
+    record::RecordType,
+    Result, FQDN,
+};
+
+use crate::resolver::dns::rfc8906::setup;
+
+// Note that expected flag values are different when testing recursive servers, as explained in
+// section 8.
+//
+// * For the QUERY opcode, expect RD=1 instead of RD=0.
+// * Expect AA=0 instead of AA=1.
+// * If the server is validating responses, and one or both of AD=1 or DO=1 is set in the query,
+//   expect AD=1 instead of AD=0.
+
+#[test]
+fn test_8_1_1_zone_configured() -> Result<()> {
+    let (_network, _graph, resolver, client) = setup()?;
+
+    let settings = *DigSettings::default().recurse().edns(None);
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(!output.flags.authoritative_answer);
+    assert!(output.flags.recursion_desired);
+    assert!(!output.flags.authenticated_data);
+    assert!(!output.opt);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_1_2_unknown_types() -> Result<()> {
+    let (_network, _graph, resolver, client) = setup()?;
+
+    let settings = *DigSettings::default().recurse().edns(None);
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::Unknown(1000),
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert!(output.answer.is_empty());
+    assert!(!output.flags.authoritative_answer);
+    assert!(output.flags.recursion_desired);
+    assert!(!output.flags.authenticated_data);
+    assert!(!output.opt);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_1_3_1_header_bits_cd_1() -> Result<()> {
+    let (_network, _graph, resolver, client) = setup()?;
+
+    let settings = *DigSettings::default()
+        .recurse()
+        .edns(None)
+        .checking_disabled();
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(!output.flags.authoritative_answer);
+    assert!(output.flags.recursion_desired);
+    assert!(!output.flags.authenticated_data);
+    assert!(!output.opt);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_1_3_2_header_bits_ad_1() -> Result<()> {
+    let (_network, _graph, resolver, client) = setup()?;
+
+    let settings = *DigSettings::default().recurse().edns(None).authentic_data();
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(!output.flags.authoritative_answer);
+    assert!(output.flags.recursion_desired);
+    assert!(!output.opt);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_1_3_3_header_bits_reserved() -> Result<()> {
+    let (_network, _graph, resolver, client) = setup()?;
+
+    let settings = *DigSettings::default().recurse().edns(None).set_z_flag();
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(!output.must_be_zero);
+    assert!(!output.flags.authoritative_answer);
+    assert!(output.flags.recursion_desired);
+    assert!(!output.flags.authenticated_data);
+    assert!(!output.opt);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_1_3_4_header_bits_recursive_query() -> Result<()> {
+    let (_network, _graph, resolver, client) = setup()?;
+
+    let settings = *DigSettings::default().recurse().edns(None);
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(!output.flags.authoritative_answer);
+    assert!(output.flags.recursion_desired);
+    assert!(!output.flags.authenticated_data);
+    assert!(!output.opt);
+
+    Ok(())
+}
+
+#[test]
+#[ignore = "hickory does not respond"]
+fn test_8_1_4_unknown_opcodes() -> Result<()> {
+    let (_network, _graph, resolver, client) = setup()?;
+
+    let settings = *DigSettings::default()
+        .recurse()
+        .edns(None)
+        .opcode(15)
+        .header_only();
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::SOA, // The type will be ignored, since we are specifying +header-only.
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOTIMP);
+    assert_eq!(output.opcode, "RESERVED15");
+    assert!(output.answer.is_empty());
+    assert!(output.authority.is_empty());
+    assert!(output.additional.is_empty());
+    assert!(!output.flags.authoritative_answer);
+    if !dns_test::SUBJECT.is_unbound() {
+        // unbound still sets RD=1 in the NOTIMP response
+        assert!(!output.flags.recursion_desired);
+    }
+    assert!(!output.flags.authenticated_data);
+    assert!(!output.opt);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_1_5_tcp() -> Result<()> {
+    let (_network, _graph, resolver, client) = setup()?;
+
+    let settings = *DigSettings::default().recurse().edns(None).tcp();
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(!output.flags.authoritative_answer);
+    assert!(output.flags.recursion_desired);
+    assert!(!output.flags.authenticated_data);
+    assert!(!output.opt);
+
+    Ok(())
+}

--- a/conformance/packages/conformance-tests/src/resolver/dns/rfc8906/extended.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/rfc8906/extended.rs
@@ -1,0 +1,279 @@
+use dns_test::{
+    client::{DigSettings, DigStatus},
+    record::RecordType,
+    Result, FQDN,
+};
+
+use super::setup;
+
+// Note that expected flag values are different when testing recursive servers, as explained in
+// section 8.
+//
+// * For the QUERY opcode, expect RD=1 instead of RD=0.
+// * Expect AA=0 instead of AA=1.
+// * If the server is validating responses, and one or both of AD=1 or DO=1 is set in the query,
+//   expect AD=1 instead of AD=0.
+
+#[test]
+fn test_8_2_1_minimal_edns() -> Result<()> {
+    let (_network, _graph, resolver, client) = setup()?;
+
+    let settings = *DigSettings::default().recurse().edns(Some(0)).nocookie();
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(output.opt);
+    assert_eq!(output.edns_version, Some(0));
+    assert!(!output.flags.authoritative_answer);
+    assert!(!output.flags.authenticated_data);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_2_2_edns_version_negotiation() -> Result<()> {
+    let (_network, _graph, resolver, client) = setup()?;
+
+    let settings = *DigSettings::default()
+        .recurse()
+        .edns(Some(1))
+        .nocookie()
+        .noednsneg();
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::BADVERS);
+    assert!(output.answer.is_empty());
+    assert!(output.opt);
+    assert_eq!(output.edns_version, Some(0));
+    assert!(!output.flags.authoritative_answer);
+    assert!(!output.flags.authenticated_data);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_2_3_unknown_edns_options() -> Result<()> {
+    let (_network, _graph, resolver, client) = setup()?;
+
+    let settings = *DigSettings::default().recurse().nocookie().ednsoption(100);
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(output.opt);
+    assert!(output.options.is_empty());
+    assert_eq!(output.edns_version, Some(0));
+    assert!(!output.flags.authoritative_answer);
+    assert!(!output.flags.authenticated_data);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_2_4_unknown_edns_flags() -> Result<()> {
+    let (_network, _graph, resolver, client) = setup()?;
+
+    let settings = *DigSettings::default()
+        .recurse()
+        .nocookie()
+        .set_ednsflags(0x40);
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(output.opt);
+    assert!(!output.edns_must_be_zero);
+    assert_eq!(output.edns_version, Some(0));
+    assert!(output.options.is_empty());
+    assert!(!output.flags.authoritative_answer);
+    assert!(!output.flags.authenticated_data);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_2_5_edns_version_negotiation_with_unknown_edns_flags() -> Result<()> {
+    let (_network, _graph, resolver, client) = setup()?;
+
+    let settings = *DigSettings::default()
+        .recurse()
+        .edns(Some(1))
+        .nocookie()
+        .noednsneg()
+        .set_ednsflags(0x40);
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::BADVERS);
+    assert!(output.answer.is_empty());
+    assert!(output.opt);
+    assert!(!output.edns_must_be_zero);
+    assert_eq!(output.edns_version, Some(0));
+    assert!(!output.flags.authoritative_answer);
+    assert!(!output.flags.authenticated_data);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_2_6_edns_version_negotiation_with_unknown_edns_options() -> Result<()> {
+    let (_network, _graph, resolver, client) = setup()?;
+
+    let settings = *DigSettings::default()
+        .recurse()
+        .nocookie()
+        .edns(Some(1))
+        .noednsneg()
+        .ednsoption(100);
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::BADVERS);
+    assert!(output.answer.is_empty());
+    assert!(output.opt);
+    assert!(output.options.is_empty());
+    assert_eq!(output.edns_version, Some(0));
+    assert!(!output.flags.authoritative_answer);
+    assert!(!output.flags.authenticated_data);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_2_7_truncated_responses() -> Result<()> {
+    let (_network, _graph, resolver, client) = setup()?;
+
+    let settings = *DigSettings::default()
+        .recurse()
+        .nocookie()
+        .ignore()
+        .bufsize(512)
+        .dnssec();
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::DNSKEY,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert!(output.flags.truncation);
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert!(output.opt);
+    assert_eq!(output.edns_version, Some(0));
+
+    Ok(())
+}
+
+#[test]
+fn test_8_2_8_do_1() -> Result<()> {
+    let (_network, _graph, resolver, client) = setup()?;
+
+    let settings = *DigSettings::default()
+        .recurse()
+        .nocookie()
+        .edns(Some(0))
+        .dnssec();
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert!(!output.answer.is_empty());
+    assert!(output.answer[0].is_soa());
+    assert!(output.opt);
+    assert!(output.dnssec_ok_flag);
+    assert_eq!(output.edns_version, Some(0));
+    assert!(!output.flags.authoritative_answer);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_2_9_edns_version_negotiation_with_do_1() -> Result<()> {
+    let (_network, _graph, resolver, client) = setup()?;
+
+    let settings = *DigSettings::default()
+        .recurse()
+        .nocookie()
+        .edns(Some(1))
+        .noednsneg()
+        .dnssec();
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::BADVERS);
+    assert!(output.answer.is_empty());
+    assert!(output.opt);
+    assert!(output.dnssec_ok_flag);
+    assert_eq!(output.edns_version, Some(0));
+    assert!(!output.flags.authoritative_answer);
+
+    Ok(())
+}
+
+#[test]
+fn test_8_2_10_multiple_defined_edns_options() -> Result<()> {
+    let (_network, _graph, resolver, client) = setup()?;
+
+    let settings = *DigSettings::default()
+        .recurse()
+        .nsid()
+        .expire()
+        .subnet_zero();
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(output.answer.len(), 1);
+    assert!(output.answer[0].is_soa());
+    assert!(output.opt);
+    assert_eq!(output.edns_version, Some(0));
+    assert!(!output.flags.authoritative_answer);
+    assert!(!output.flags.authenticated_data);
+
+    Ok(())
+}

--- a/conformance/packages/dns-test/src/client.rs
+++ b/conformance/packages/dns-test/src/client.rs
@@ -87,6 +87,10 @@ impl Client {
         if let Some(edns_option_flag) = edns_option_flag.as_ref() {
             command_and_args.push(edns_option_flag.as_str());
         }
+        let edns_flags = settings.extra_edns_flags();
+        if let Some(edns_flags) = edns_flags.as_ref() {
+            command_and_args.push(edns_flags.as_str());
+        }
 
         let server_arg = format!("@{server}");
         let record_type_name = record_type.as_name();
@@ -121,6 +125,7 @@ pub struct DigSettings {
     cookie: bool,
     ednsneg: bool,
     extra_edns_option: Option<u16>,
+    extra_edns_flags: Option<u16>,
 }
 
 impl Default for DigSettings {
@@ -139,6 +144,7 @@ impl Default for DigSettings {
             cookie: true,
             ednsneg: true,
             extra_edns_option: None,
+            extra_edns_flags: None,
         }
     }
 }
@@ -312,6 +318,16 @@ impl DigSettings {
 
     fn ednsoptionflag(&self) -> Option<String> {
         Some(format!("+ednsopt={}", self.extra_edns_option?))
+    }
+
+    /// Set reserved EDNS flags.
+    pub fn set_ednsflags(&mut self, value: u16) -> &mut Self {
+        self.extra_edns_flags = Some(value);
+        self
+    }
+
+    fn extra_edns_flags(&self) -> Option<String> {
+        Some(format!("+ednsflags={}", self.extra_edns_flags?))
     }
 }
 

--- a/conformance/packages/dns-test/src/client.rs
+++ b/conformance/packages/dns-test/src/client.rs
@@ -466,6 +466,7 @@ impl FromStr for DigFlags {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum DigStatus {
     NOERROR,
+    NOTIMP,
     NXDOMAIN,
     REFUSED,
     SERVFAIL,
@@ -493,8 +494,9 @@ impl FromStr for DigStatus {
 
     fn from_str(input: &str) -> Result<Self> {
         let status = match input {
-            "NXDOMAIN" => Self::NXDOMAIN,
             "NOERROR" => Self::NOERROR,
+            "NOTIMP" => Self::NOTIMP,
+            "NXDOMAIN" => Self::NXDOMAIN,
             "REFUSED" => Self::REFUSED,
             "SERVFAIL" => Self::SERVFAIL,
             _ => return Err(format!("unknown status: {input}").into()),

--- a/conformance/packages/dns-test/src/client.rs
+++ b/conformance/packages/dns-test/src/client.rs
@@ -547,6 +547,7 @@ impl FromStr for DigFlags {
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum DigStatus {
+    BADVERS,
     NOERROR,
     NOTIMP,
     NXDOMAIN,
@@ -576,6 +577,7 @@ impl FromStr for DigStatus {
 
     fn from_str(input: &str) -> Result<Self> {
         let status = match input {
+            "BADVERS" => Self::BADVERS,
             "NOERROR" => Self::NOERROR,
             "NOTIMP" => Self::NOTIMP,
             "NXDOMAIN" => Self::NXDOMAIN,

--- a/conformance/packages/dns-test/src/client.rs
+++ b/conformance/packages/dns-test/src/client.rs
@@ -98,6 +98,9 @@ impl Client {
         if let Some(bufsize_flag) = bufsize_flag.as_ref() {
             command_and_args.push(bufsize_flag);
         }
+        if let Some(subnetflag) = settings.subnetflag() {
+            command_and_args.push(subnetflag);
+        }
 
         let server_arg = format!("@{server}");
         let record_type_name = record_type.as_name();
@@ -137,6 +140,7 @@ pub struct DigSettings {
     bufsize: Option<u16>,
     nsid: bool,
     expire: bool,
+    subnet_zero: bool,
 }
 
 impl Default for DigSettings {
@@ -160,6 +164,7 @@ impl Default for DigSettings {
             bufsize: None,
             nsid: false,
             expire: false,
+            subnet_zero: false,
         }
     }
 }
@@ -391,6 +396,19 @@ impl DigSettings {
         match self.expire {
             true => "+expire",
             false => "+noexpire",
+        }
+    }
+
+    pub fn subnet_zero(&mut self) -> &mut Self {
+        self.subnet_zero = true;
+        self
+    }
+
+    /// Send the EDNS client subnet option, with the subnet 0.0.0.0/0.
+    fn subnetflag(&self) -> Option<&'static str> {
+        match self.subnet_zero {
+            true => Some("+subnet=0"),
+            false => None,
         }
     }
 }

--- a/conformance/packages/dns-test/src/client.rs
+++ b/conformance/packages/dns-test/src/client.rs
@@ -74,6 +74,7 @@ impl Client {
             settings.zflag(),
             settings.opcodeflag().as_str(),
             settings.header_only_flag(),
+            settings.tcpflag(),
             &format!("@{server}"),
             record_type.as_name().as_ref(),
             fqdn.as_str(),
@@ -98,6 +99,7 @@ pub struct DigSettings {
     zflag: bool,
     opcode: u8,
     header_only: bool,
+    tcp: bool,
 }
 
 impl Default for DigSettings {
@@ -112,6 +114,7 @@ impl Default for DigSettings {
             zflag: false,
             opcode: 0,
             header_only: false,
+            tcp: false,
         }
     }
 }
@@ -229,6 +232,19 @@ impl DigSettings {
         match self.header_only {
             true => "+header-only",
             false => "+noheader-only",
+        }
+    }
+
+    /// Use TCP instead of UDP.
+    pub fn tcp(&mut self) -> &mut Self {
+        self.tcp = true;
+        self
+    }
+
+    fn tcpflag(&self) -> &'static str {
+        match self.tcp {
+            true => "+tcp",
+            false => "+notcp",
         }
     }
 }

--- a/conformance/packages/dns-test/src/client.rs
+++ b/conformance/packages/dns-test/src/client.rs
@@ -82,6 +82,7 @@ impl Client {
             settings.cookieflag(),
             settings.ednsnegflag(),
             settings.ignoreflag(),
+            settings.nsidflag(),
         ];
 
         let edns_option_flag = settings.ednsoptionflag();
@@ -133,6 +134,7 @@ pub struct DigSettings {
     extra_edns_flags: Option<u16>,
     ignore_truncation: bool,
     bufsize: Option<u16>,
+    nsid: bool,
 }
 
 impl Default for DigSettings {
@@ -154,6 +156,7 @@ impl Default for DigSettings {
             extra_edns_flags: None,
             ignore_truncation: false,
             bufsize: None,
+            nsid: false,
         }
     }
 }
@@ -360,6 +363,19 @@ impl DigSettings {
 
     fn bufsizeflag(&self) -> Option<String> {
         Some(format!("+bufsize={}", self.bufsize?))
+    }
+
+    /// Include an EDNS name server ID request.
+    pub fn nsid(&mut self) -> &mut Self {
+        self.nsid = true;
+        self
+    }
+
+    fn nsidflag(&self) -> &'static str {
+        match self.nsid {
+            true => "+nsid",
+            false => "+nonsid",
+        }
     }
 }
 

--- a/conformance/packages/dns-test/src/client.rs
+++ b/conformance/packages/dns-test/src/client.rs
@@ -71,6 +71,7 @@ impl Client {
             settings.cdflag(),
             settings.timeoutflag().as_str(),
             settings.ednsflag().as_str(),
+            settings.zflag(),
             &format!("@{server}"),
             record_type.as_name().as_ref(),
             fqdn.as_str(),
@@ -92,6 +93,7 @@ pub struct DigSettings {
     /// `None` indicates EDNS should not be used, while Some indicates EDNS should be used, with
     /// the given version number.
     edns: Option<u8>,
+    zflag: bool,
 }
 
 impl Default for DigSettings {
@@ -103,6 +105,7 @@ impl Default for DigSettings {
             recurse: false,
             timeout: None,
             edns: Some(0),
+            zflag: false,
         }
     }
 }
@@ -183,6 +186,19 @@ impl DigSettings {
         match self.edns {
             Some(version) => format!("+edns={version}"),
             None => "+noedns".into(),
+        }
+    }
+
+    /// Set the reserved "Z" flag.
+    pub fn set_z_flag(&mut self) -> &mut Self {
+        self.zflag = true;
+        self
+    }
+
+    fn zflag(&self) -> &'static str {
+        match self.zflag {
+            true => "+zflag",
+            false => "+nozflag",
         }
     }
 }

--- a/conformance/packages/dns-test/src/client.rs
+++ b/conformance/packages/dns-test/src/client.rs
@@ -75,6 +75,7 @@ impl Client {
             settings.opcodeflag().as_str(),
             settings.header_only_flag(),
             settings.tcpflag(),
+            settings.cookieflag(),
             &format!("@{server}"),
             record_type.as_name().as_ref(),
             fqdn.as_str(),
@@ -100,6 +101,7 @@ pub struct DigSettings {
     opcode: u8,
     header_only: bool,
     tcp: bool,
+    cookie: bool,
 }
 
 impl Default for DigSettings {
@@ -115,6 +117,7 @@ impl Default for DigSettings {
             opcode: 0,
             header_only: false,
             tcp: false,
+            cookie: true,
         }
     }
 }
@@ -245,6 +248,22 @@ impl DigSettings {
         match self.tcp {
             true => "+tcp",
             false => "+notcp",
+        }
+    }
+
+    /// Do not send a COOKIE EDNS option.
+    pub fn nocookie(&mut self) -> &mut Self {
+        self.cookie = false;
+        self
+    }
+
+    fn cookieflag(&self) -> &'static str {
+        // Only use "+cookie" when EDNS is enabled (the default). Otherwise, "+cookie" overrides
+        // "+noedns".
+        if self.edns.is_some() && self.cookie {
+            "+cookie"
+        } else {
+            "+nocookie"
         }
     }
 }

--- a/conformance/packages/dns-test/src/client.rs
+++ b/conformance/packages/dns-test/src/client.rs
@@ -594,6 +594,7 @@ pub struct DigFlags {
     pub qr: bool,
     pub recursion_available: bool,
     pub recursion_desired: bool,
+    pub truncation: bool,
 }
 
 impl FromStr for DigFlags {
@@ -606,6 +607,7 @@ impl FromStr for DigFlags {
         let mut authoritative_answer = false;
         let mut authenticated_data = false;
         let mut checking_disabled = false;
+        let mut truncation = false;
 
         for flag in input.split_whitespace() {
             match flag {
@@ -615,6 +617,7 @@ impl FromStr for DigFlags {
                 "aa" => authoritative_answer = true,
                 "ad" => authenticated_data = true,
                 "cd" => checking_disabled = true,
+                "tc" => truncation = true,
                 _ => return Err(format!("unknown flag: {flag}").into()),
             }
         }
@@ -626,6 +629,7 @@ impl FromStr for DigFlags {
             qr,
             recursion_available,
             recursion_desired,
+            truncation,
         })
     }
 }

--- a/conformance/packages/dns-test/src/client.rs
+++ b/conformance/packages/dns-test/src/client.rs
@@ -92,6 +92,10 @@ impl Client {
         if let Some(edns_flags) = edns_flags.as_ref() {
             command_and_args.push(edns_flags.as_str());
         }
+        let bufsize_flag = settings.bufsizeflag();
+        if let Some(bufsize_flag) = bufsize_flag.as_ref() {
+            command_and_args.push(bufsize_flag);
+        }
 
         let server_arg = format!("@{server}");
         let record_type_name = record_type.as_name();
@@ -128,6 +132,7 @@ pub struct DigSettings {
     extra_edns_option: Option<u16>,
     extra_edns_flags: Option<u16>,
     ignore_truncation: bool,
+    bufsize: Option<u16>,
 }
 
 impl Default for DigSettings {
@@ -148,6 +153,7 @@ impl Default for DigSettings {
             extra_edns_option: None,
             extra_edns_flags: None,
             ignore_truncation: false,
+            bufsize: None,
         }
     }
 }
@@ -344,6 +350,16 @@ impl DigSettings {
             true => "+ignore",
             false => "+noignore",
         }
+    }
+
+    /// Set the UDP buffer size.
+    pub fn bufsize(&mut self, bufsize: u16) -> &mut Self {
+        self.bufsize = Some(bufsize);
+        self
+    }
+
+    fn bufsizeflag(&self) -> Option<String> {
+        Some(format!("+bufsize={}", self.bufsize?))
     }
 }
 

--- a/conformance/packages/dns-test/src/client.rs
+++ b/conformance/packages/dns-test/src/client.rs
@@ -72,6 +72,8 @@ impl Client {
             settings.timeoutflag().as_str(),
             settings.ednsflag().as_str(),
             settings.zflag(),
+            settings.opcodeflag().as_str(),
+            settings.header_only_flag(),
             &format!("@{server}"),
             record_type.as_name().as_ref(),
             fqdn.as_str(),
@@ -94,6 +96,8 @@ pub struct DigSettings {
     /// the given version number.
     edns: Option<u8>,
     zflag: bool,
+    opcode: u8,
+    header_only: bool,
 }
 
 impl Default for DigSettings {
@@ -106,6 +110,8 @@ impl Default for DigSettings {
             timeout: None,
             edns: Some(0),
             zflag: false,
+            opcode: 0,
+            header_only: false,
         }
     }
 }
@@ -199,6 +205,30 @@ impl DigSettings {
         match self.zflag {
             true => "+zflag",
             false => "+nozflag",
+        }
+    }
+
+    /// Set the opcode.
+    pub fn opcode(&mut self, opcode: u8) -> &mut Self {
+        assert!(opcode < 16, "invalid opcode: {opcode}");
+        self.opcode = opcode;
+        self
+    }
+
+    fn opcodeflag(&self) -> String {
+        format!("+opcode={}", self.opcode)
+    }
+
+    /// Send a header only, with no question section.
+    pub fn header_only(&mut self) -> &mut Self {
+        self.header_only = true;
+        self
+    }
+
+    fn header_only_flag(&self) -> &'static str {
+        match self.header_only {
+            true => "+header-only",
+            false => "+noheader-only",
         }
     }
 }

--- a/conformance/packages/dns-test/src/client.rs
+++ b/conformance/packages/dns-test/src/client.rs
@@ -96,10 +96,9 @@ impl DigSettings {
     }
 
     fn adflag(&self) -> &'static str {
-        if self.adflag {
-            "+adflag"
-        } else {
-            "+noadflag"
+        match self.adflag {
+            true => "+adflag",
+            false => "+noadflag",
         }
     }
 
@@ -110,10 +109,9 @@ impl DigSettings {
     }
 
     fn cdflag(&self) -> &'static str {
-        if self.cdflag {
-            "+cdflag"
-        } else {
-            "+nocdflag"
+        match self.cdflag {
+            true => "+cdflag",
+            false => "+nocdflag",
         }
     }
 
@@ -124,10 +122,9 @@ impl DigSettings {
     }
 
     fn do_bit(&self) -> &'static str {
-        if self.dnssec {
-            "+dnssec"
-        } else {
-            "+nodnssec"
+        match self.dnssec {
+            true => "+dnssec",
+            false => "+nodnssec",
         }
     }
 
@@ -138,10 +135,9 @@ impl DigSettings {
     }
 
     fn rdflag(&self) -> &'static str {
-        if self.recurse {
-            "+recurse"
-        } else {
-            "+norecurse"
+        match self.recurse {
+            true => "+recurse",
+            false => "+norecurse",
         }
     }
 

--- a/conformance/packages/dns-test/src/client.rs
+++ b/conformance/packages/dns-test/src/client.rs
@@ -83,6 +83,7 @@ impl Client {
             settings.ednsnegflag(),
             settings.ignoreflag(),
             settings.nsidflag(),
+            settings.expireflag(),
         ];
 
         let edns_option_flag = settings.ednsoptionflag();
@@ -135,6 +136,7 @@ pub struct DigSettings {
     ignore_truncation: bool,
     bufsize: Option<u16>,
     nsid: bool,
+    expire: bool,
 }
 
 impl Default for DigSettings {
@@ -157,6 +159,7 @@ impl Default for DigSettings {
             ignore_truncation: false,
             bufsize: None,
             nsid: false,
+            expire: false,
         }
     }
 }
@@ -375,6 +378,19 @@ impl DigSettings {
         match self.nsid {
             true => "+nsid",
             false => "+nonsid",
+        }
+    }
+
+    /// Send the EDNS Expire option.
+    pub fn expire(&mut self) -> &mut Self {
+        self.expire = true;
+        self
+    }
+
+    fn expireflag(&self) -> &'static str {
+        match self.expire {
+            true => "+expire",
+            false => "+noexpire",
         }
     }
 }

--- a/conformance/packages/dns-test/src/client.rs
+++ b/conformance/packages/dns-test/src/client.rs
@@ -81,6 +81,7 @@ impl Client {
             settings.tcpflag(),
             settings.cookieflag(),
             settings.ednsnegflag(),
+            settings.ignoreflag(),
         ];
 
         let edns_option_flag = settings.ednsoptionflag();
@@ -126,6 +127,7 @@ pub struct DigSettings {
     ednsneg: bool,
     extra_edns_option: Option<u16>,
     extra_edns_flags: Option<u16>,
+    ignore_truncation: bool,
 }
 
 impl Default for DigSettings {
@@ -145,6 +147,7 @@ impl Default for DigSettings {
             ednsneg: true,
             extra_edns_option: None,
             extra_edns_flags: None,
+            ignore_truncation: false,
         }
     }
 }
@@ -328,6 +331,19 @@ impl DigSettings {
 
     fn extra_edns_flags(&self) -> Option<String> {
         Some(format!("+ednsflags={}", self.extra_edns_flags?))
+    }
+
+    /// Ignore truncation, and do not retry with TCP.
+    pub fn ignore(&mut self) -> &mut Self {
+        self.ignore_truncation = true;
+        self
+    }
+
+    fn ignoreflag(&self) -> &'static str {
+        match self.ignore_truncation {
+            true => "+ignore",
+            false => "+noignore",
+        }
     }
 }
 

--- a/conformance/packages/dns-test/src/client.rs
+++ b/conformance/packages/dns-test/src/client.rs
@@ -76,6 +76,7 @@ impl Client {
             settings.header_only_flag(),
             settings.tcpflag(),
             settings.cookieflag(),
+            settings.ednsnegflag(),
             &format!("@{server}"),
             record_type.as_name().as_ref(),
             fqdn.as_str(),
@@ -102,6 +103,7 @@ pub struct DigSettings {
     header_only: bool,
     tcp: bool,
     cookie: bool,
+    ednsneg: bool,
 }
 
 impl Default for DigSettings {
@@ -118,6 +120,7 @@ impl Default for DigSettings {
             header_only: false,
             tcp: false,
             cookie: true,
+            ednsneg: true,
         }
     }
 }
@@ -264,6 +267,19 @@ impl DigSettings {
             "+cookie"
         } else {
             "+nocookie"
+        }
+    }
+
+    /// Disable EDNS version negotiation.
+    pub fn noednsneg(&mut self) -> &mut Self {
+        self.ednsneg = false;
+        self
+    }
+
+    fn ednsnegflag(&self) -> &'static str {
+        match self.ednsneg {
+            true => "+ednsneg",
+            false => "+noednsneg",
         }
     }
 }

--- a/conformance/packages/dns-test/src/client.rs
+++ b/conformance/packages/dns-test/src/client.rs
@@ -52,7 +52,7 @@ impl Client {
             "-a",
             TRUST_ANCHOR_PATH,
             fqdn.as_str(),
-            record_type.as_str(),
+            record_type.as_name().as_ref(),
         ])
     }
 
@@ -71,7 +71,7 @@ impl Client {
             settings.cdflag(),
             settings.timeoutflag().as_str(),
             &format!("@{server}"),
-            record_type.as_str(),
+            record_type.as_name().as_ref(),
             fqdn.as_str(),
         ])?;
 


### PR DESCRIPTION
This adds a conformance test suite for RFC 8906. All the tests in section 8 are translated to the dns-test framework. I had to add a number of features to the wrapper around `dig`, since the tests use a wide range of command-line flags, and the expected behavior includes fields of the output we weren't using previously. See #2572.

Currently, Hickory is only failing the two tests regarding unknown opcodes, because it fails to respond, instead of responding with `NOTIMP`. BIND passes all tests. Unbound is failing two tests regarding flags in specific error responses.