### PR TITLE
Fix conformance test DNSSEC feature handling

### DIFF
--- a/conformance/packages/dns-test/src/implementation.rs
+++ b/conformance/packages/dns-test/src/implementation.rs
@@ -160,7 +160,8 @@ impl Implementation {
                 }
 
                 Self::Hickory { dnssec_feature, .. } => {
-                    let use_pkcs8 = matches!(dnssec_feature, Some(HickoryDnssecFeature::Ring));
+                    let use_pkcs8 =
+                        matches!(dnssec_feature, None | Some(HickoryDnssecFeature::Ring));
                     minijinja::render!(
                         include_str!("templates/hickory.name-server.toml.jinja"),
                         fqdn => origin.as_str(),

--- a/justfile
+++ b/justfile
@@ -193,7 +193,7 @@ conformance-ignored:
 
     tmpfile="$(mktemp)"
     bash -c '[[ -n "$(git status -s)" ]] && echo "WARNING: uncommitted changes will NOT be tested" || true'
-    ( DNS_TEST_VERBOSE_DOCKER_BUILD=1 DNS_TEST_PEER=unbound DNS_TEST_SUBJECT="hickory {{justfile_directory()}}" cargo test --manifest-path conformance/Cargo.toml -p conformance-tests --lib -- --ignored || true ) | tee "$tmpfile"
+    ( DNS_TEST_VERBOSE_DOCKER_BUILD=1 DNS_TEST_PEER=unbound DNS_TEST_SUBJECT="hickory {{justfile_directory()}} dnssec-ring" cargo test --manifest-path conformance/Cargo.toml -p conformance-tests --lib -- --ignored || true ) | tee "$tmpfile"
     grep -e 'test result: \(ok\|FAILED\). 0 passed' "$tmpfile" || ( echo "expected ALL tests to fail but at least one passed; the passing tests must be un-#[ignore]-d" && exit 1 )
     bash -c '[[ -n "$(git status -s)" ]] && echo "WARNING: uncommitted changes were NOT tested" || true'
 


### PR DESCRIPTION
I realized my change to switch the default DNSSEC feature used in conformance tests was incomplete, because the logic to pick between a PEM or PKCS #8 key needs to change as well. As a result, some of the ignored tests have been failing for the wrong reason. This PR fixes that, and updates the `conformance-ignored` recipe so that it uses the same value for `DNS_TEST_SUBJECT` as `conformance-hickory-ring`.