### PR TITLE
Parse unknown opcodes

### DIFF
--- a/conformance/packages/conformance-tests/src/name_server/rfc8906/basic.rs
+++ b/conformance/packages/conformance-tests/src/name_server/rfc8906/basic.rs
@@ -144,7 +144,7 @@ fn test_8_1_3_4_header_bits_recursive_query() -> Result<()> {
 }
 
 #[test]
-#[ignore = "hickory does not respond"]
+#[ignore = "hickory returns FORMERR"]
 fn test_8_1_4_unknown_opcodes() -> Result<()> {
     let (_network, ns, client) = setup()?;
 

--- a/conformance/packages/conformance-tests/src/name_server/rfc8906/basic.rs
+++ b/conformance/packages/conformance-tests/src/name_server/rfc8906/basic.rs
@@ -169,6 +169,32 @@ fn test_8_1_4_unknown_opcodes() -> Result<()> {
     Ok(())
 }
 
+/// This is a variant of test 8.1.4 with +noheader-only.
+#[test]
+fn test_unknown_opcode_with_query() -> Result<()> {
+    let (_network, ns, client) = setup()?;
+
+    let settings = *DigSettings::default().edns(None).opcode(15);
+    let output = client.dig(
+        settings,
+        ns.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOTIMP);
+    assert_eq!(output.opcode, "RESERVED15");
+    assert!(output.answer.is_empty());
+    assert!(output.authority.is_empty());
+    assert!(output.additional.is_empty());
+    assert!(!output.flags.authoritative_answer);
+    assert!(!output.flags.recursion_desired);
+    assert!(!output.flags.authenticated_data);
+    assert!(!output.opt);
+
+    Ok(())
+}
+
 #[test]
 fn test_8_1_5_tcp() -> Result<()> {
     let (_network, ns, client) = setup()?;

--- a/conformance/packages/conformance-tests/src/resolver/dns/rfc8906/basic.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/rfc8906/basic.rs
@@ -187,6 +187,36 @@ fn test_8_1_4_unknown_opcodes() -> Result<()> {
     Ok(())
 }
 
+/// This is a variant of test 8.1.4 with +noheader-only.
+#[test]
+#[ignore = "hickory sets RD=1 in the NOTIMP response"]
+fn test_unknown_opcode_with_query() -> Result<()> {
+    let (_network, _graph, resolver, client) = setup()?;
+
+    let settings = *DigSettings::default().recurse().edns(None).opcode(15);
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::SOA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+
+    assert_eq!(output.status, DigStatus::NOTIMP);
+    assert_eq!(output.opcode, "RESERVED15");
+    assert!(output.answer.is_empty());
+    assert!(output.authority.is_empty());
+    assert!(output.additional.is_empty());
+    assert!(!output.flags.authoritative_answer);
+    if !dns_test::SUBJECT.is_unbound() {
+        // unbound still sets RD=1 in the NOTIMP response
+        assert!(!output.flags.recursion_desired);
+    }
+    assert!(!output.flags.authenticated_data);
+    assert!(!output.opt);
+
+    Ok(())
+}
+
 #[test]
 fn test_8_1_5_tcp() -> Result<()> {
     let (_network, _graph, resolver, client) = setup()?;

--- a/conformance/packages/conformance-tests/src/resolver/dns/rfc8906/basic.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/rfc8906/basic.rs
@@ -155,7 +155,7 @@ fn test_8_1_3_4_header_bits_recursive_query() -> Result<()> {
 }
 
 #[test]
-#[ignore = "hickory does not respond"]
+#[ignore = "hickory returns FORMERR"]
 fn test_8_1_4_unknown_opcodes() -> Result<()> {
     let (_network, _graph, resolver, client) = setup()?;
 

--- a/crates/proto/src/op/header.rs
+++ b/crates/proto/src/op/header.rs
@@ -557,7 +557,7 @@ impl<'r> BinDecodable<'r> for Header {
             MessageType::Query
         };
         // the 4bit opcode, masked and then shifted right 3bits for the u8...
-        let op_code: OpCode = OpCode::from_u8((0b0111_1000 & q_opcd_a_t_r) >> 3)?;
+        let op_code = OpCode::from_u8((0b0111_1000 & q_opcd_a_t_r) >> 3);
         let authoritative = (0b0000_0100 & q_opcd_a_t_r) == 0b0000_0100;
         let truncation = (0b0000_0010 & q_opcd_a_t_r) == 0b0000_0010;
         let recursion_desired = (0b0000_0001 & q_opcd_a_t_r) == 0b0000_0001;

--- a/crates/proto/src/op/op_code.rs
+++ b/crates/proto/src/op/op_code.rs
@@ -9,8 +9,6 @@
 
 use std::{convert::From, fmt};
 
-use crate::error::*;
-
 /// Operation code for queries, updates, and responses
 ///
 /// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://tools.ietf.org/html/rfc1035)
@@ -42,18 +40,20 @@ pub enum OpCode {
 
     /// Update message [RFC 2136](https://tools.ietf.org/html/rfc2136)
     Update,
+
+    /// Any other opcode
+    Unknown(u8),
 }
 
 impl fmt::Display for OpCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        let s = match self {
-            Self::Query => "QUERY",
-            Self::Status => "STATUS",
-            Self::Notify => "NOTIFY",
-            Self::Update => "UPDATE",
-        };
-
-        f.write_str(s)
+        match self {
+            Self::Query => f.write_str("QUERY"),
+            Self::Status => f.write_str("STATUS"),
+            Self::Notify => f.write_str("NOTIFY"),
+            Self::Update => f.write_str("UPDATE"),
+            Self::Unknown(opcode) => write!(f, "Unknown opcode ({opcode})"),
+        }
     }
 }
 
@@ -78,6 +78,7 @@ impl From<OpCode> for u8 {
             OpCode::Notify => 4,
             OpCode::Update => 5,
             // 6-15	Unassigned
+            OpCode::Unknown(opcode) => opcode,
         }
     }
 }
@@ -87,18 +88,18 @@ impl From<OpCode> for u8 {
 /// ```
 /// use hickory_proto::op::op_code::OpCode;
 ///
-/// let var: OpCode = OpCode::from_u8(0).unwrap();
+/// let var: OpCode = OpCode::from_u8(0);
 /// assert_eq!(OpCode::Query, var);
 /// ```
 impl OpCode {
     /// Decodes the binary value of the OpCode
-    pub fn from_u8(value: u8) -> ProtoResult<Self> {
+    pub fn from_u8(value: u8) -> Self {
         match value {
-            0 => Ok(Self::Query),
-            2 => Ok(Self::Status),
-            4 => Ok(Self::Notify),
-            5 => Ok(Self::Update),
-            _ => Err(format!("unknown OpCode: {value}").into()),
+            0 => Self::Query,
+            2 => Self::Status,
+            4 => Self::Notify,
+            5 => Self::Update,
+            _ => Self::Unknown(value),
         }
     }
 }


### PR DESCRIPTION
This adds an `Unknown` variant to the `OpCode` enum, so that all opcodes can be parsed and represented. Previously, a `NOTIMP` return code could only be returned for `NOTIFY`, `STATUS`, and (conditionally) `UPDATE`, while all reserved opcodes would get no response, due to a decoding error in the header. Eliminating that decoding error allows returning `NOTIMP` in some cases. This is thus a partial fix for #2572. The RFC 8906 tests are still failing, due to an unrelated decoding error later on, but I added two more test variants that only exercise the unknown opcode code path.