### PR TITLE
conformance: allow hickory in DNS_TEST_PEER

### DIFF
--- a/conformance/packages/dns-test/src/lib.rs
+++ b/conformance/packages/dns-test/src/lib.rs
@@ -92,7 +92,15 @@ pub fn inspect(clients: &[Client], resolvers: &[Resolver], nameservers: &[NameSe
 }
 
 fn parse_subject() -> Implementation {
-    if let Ok(subject) = env::var("DNS_TEST_SUBJECT") {
+    parse_implementation("DNS_TEST_SUBJECT")
+}
+
+fn parse_peer() -> Implementation {
+    parse_implementation("DNS_TEST_PEER")
+}
+
+fn parse_implementation(env_var: &str) -> Implementation {
+    if let Ok(subject) = env::var(env_var) {
         if subject == "unbound" {
             return Implementation::Unbound;
         }
@@ -103,7 +111,7 @@ fn parse_subject() -> Implementation {
 
         if subject.starts_with("hickory") {
             let Some(rest) = subject.strip_prefix("hickory ") else {
-                panic!("the syntax of DNS_TEST_SUBJECT is 'hickory $URL' or 'hickory $URL $DNSSEC_FEATURE', e.g. 'hickory /tmp/hickory' or 'hickory https://github.com/owner/repo'")
+                panic!("the syntax of {env_var} is 'hickory $URL' or 'hickory $URL $DNSSEC_FEATURE', e.g. 'hickory /tmp/hickory' or 'hickory https://github.com/owner/repo'")
             };
             let (url, dnssec_feature) = if let Some((url, dnssec_feature)) = rest.split_once(' ') {
                 (url, Some(dnssec_feature.parse().unwrap()))
@@ -116,18 +124,6 @@ fn parse_subject() -> Implementation {
             }
         } else {
             panic!("unknown implementation: {subject}")
-        }
-    } else {
-        Implementation::default()
-    }
-}
-
-fn parse_peer() -> Implementation {
-    if let Ok(peer) = env::var("DNS_TEST_PEER") {
-        match peer.as_str() {
-            "unbound" => Implementation::Unbound,
-            "bind" => Implementation::Bind,
-            _ => panic!("`{peer}` is not supported as a test peer implementation"),
         }
     } else {
         Implementation::default()


### PR DESCRIPTION
This changes the handling of `DNS_TEST_PEER` to match `DNS_TEST_SUBJECT`, so Hickory DNS can be used as the peer as well. This was useful for me recently when troubleshooting an issue in #2670, because I was able to use Hickory nameservers in the `explore` example.