### PR TITLE
conformance: enable unbound control interface

### DIFF
--- a/conformance/packages/dns-test/src/templates/nsd.conf.jinja
+++ b/conformance/packages/dns-test/src/templates/nsd.conf.jinja
@@ -2,7 +2,8 @@ server:
     pidfile: /tmp/nsd.pid
 
 remote-control:
-  control-enable: no
+  control-enable: yes
+  control-interface: /run/unbound.ctl
 
 zone:
   name: {{ fqdn }}

--- a/conformance/packages/dns-test/src/templates/unbound.conf.jinja
+++ b/conformance/packages/dns-test/src/templates/unbound.conf.jinja
@@ -18,4 +18,5 @@ server:
 {% endif %}
 
 remote-control:
-    control-enable: no
+    control-enable: yes
+    control-interface: /run/unbound.ctl


### PR DESCRIPTION
This enables unbound's control interface in its configuration files. I used this a while back in order to inspect its internal statistics, along with `unbound-control -s /run/unbound.ctl -c /etc/unbound/unbound.conf stats_noreset`. Baking in the configuration option may save a step for someone in the future, as `control-enable` defaults to `no`.