### PR TITLE
Implement RFC #2195

### DIFF
--- a/bin/src/hickory-dns.rs
+++ b/bin/src/hickory-dns.rs
@@ -61,7 +61,7 @@ use tracing_subscriber::{
 
 #[cfg(feature = "dns-over-tls")]
 use hickory_dns::dnssec::{self, TlsCertConfig};
-use hickory_dns::{Config, StoreConfig, ZoneConfig};
+use hickory_dns::{Config, ServerStoreConfig, ZoneConfig};
 use hickory_proto::rr::Name;
 #[cfg(feature = "blocklist")]
 use hickory_server::store::blocklist::BlocklistAuthority;
@@ -182,7 +182,7 @@ async fn load_zone(
     for store in &zone_config.stores {
         let authority: Arc<dyn AuthorityObject> = match store {
             #[cfg(feature = "sqlite")]
-            StoreConfig::Sqlite(config) => {
+            ServerStoreConfig::Sqlite(config) => {
                 let mut authority = SqliteAuthority::try_from_config(
                     zone_name.clone(),
                     zone_type,
@@ -199,7 +199,7 @@ async fn load_zone(
                 load_keys(&mut authority, zone_name_for_signer.clone(), zone_config).await?;
                 Arc::new(authority)
             }
-            StoreConfig::File(config) => {
+            ServerStoreConfig::File(config) => {
                 let mut authority = FileAuthority::try_from_config(
                     zone_name.clone(),
                     zone_type,
@@ -215,14 +215,14 @@ async fn load_zone(
                 Arc::new(authority)
             }
             #[cfg(feature = "resolver")]
-            StoreConfig::Forward(config) => {
+            ServerStoreConfig::Forward(config) => {
                 let forwarder =
                     ForwardAuthority::try_from_config(zone_name.clone(), zone_type, config)?;
 
                 Arc::new(forwarder)
             }
             #[cfg(feature = "recursor")]
-            StoreConfig::Recursor(config) => {
+            ServerStoreConfig::Recursor(config) => {
                 let recursor = RecursiveAuthority::try_from_config(
                     zone_name.clone(),
                     zone_type,
@@ -233,7 +233,7 @@ async fn load_zone(
                 Arc::new(authority)
             }
             #[cfg(feature = "blocklist")]
-            StoreConfig::Blocklist(ref config) => Arc::new(
+            ServerStoreConfig::Blocklist(ref config) => Arc::new(
                 BlocklistAuthority::try_from_config(
                     zone_name.clone(),
                     zone_type,

--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -460,7 +460,7 @@ impl ServerZoneConfig {
     pub fn is_dnssec_enabled(&self) -> bool {
         cfg_if! {
             if #[cfg(feature = "dnssec")] {
-                self.keys.iter().any(|key| key.is_zone_signing_key() || key.is_zone_update_auth())
+                !self.keys.is_empty()
             } else {
                 false
             }

--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -383,8 +383,6 @@ pub struct ServerZoneConfig {
     pub allow_update: Option<bool>,
     /// Allow AXFR (TODO: need auth)
     pub allow_axfr: Option<bool>,
-    /// Enable DnsSec TODO: should this move to StoreConfig?
-    pub enable_dnssec: Option<bool>,
     /// Keys for use by the zone
     #[serde(default)]
     pub keys: Vec<dnssec::KeyConfig>,
@@ -410,21 +408,18 @@ impl ServerZoneConfig {
     ///    [`ServerStoreConfig::File`] with the given path.
     /// * `allow_update` - enable dynamic updates
     /// * `allow_axfr` - enable AXFR transfers
-    /// * `enable_dnssec` - enable signing of the zone for DNSSEC
     /// * `keys` - list of private and public keys used to sign a zone
     /// * `nx_proof_kind` - the kind of non-existence proof provided by the nameserver
     pub fn new(
         file: String,
         allow_update: Option<bool>,
         allow_axfr: Option<bool>,
-        enable_dnssec: Option<bool>,
         keys: Vec<dnssec::KeyConfig>,
         #[cfg(feature = "dnssec")] nx_proof_kind: Option<NxProofKind>,
     ) -> Self {
         Self {
             allow_update,
             allow_axfr,
-            enable_dnssec,
             keys,
             #[cfg(feature = "dnssec")]
             nx_proof_kind,
@@ -465,7 +460,7 @@ impl ServerZoneConfig {
     pub fn is_dnssec_enabled(&self) -> bool {
         cfg_if! {
             if #[cfg(feature = "dnssec")] {
-                self.enable_dnssec.unwrap_or(false)
+                self.keys.iter().any(|key| key.is_zone_signing_key() || key.is_zone_update_auth())
             } else {
                 false
             }

--- a/bin/tests/integration/authority_battery/dnssec.rs
+++ b/bin/tests/integration/authority_battery/dnssec.rs
@@ -368,7 +368,7 @@ pub fn verify(records: &[&Record], rrsig_records: &[Record<RRSIG>], keys: &[DNSK
 }
 
 pub fn add_signers<A: DnssecAuthority>(authority: &mut A) -> Vec<DNSKEY> {
-    use hickory_dns::dnssec::KeyConfig;
+    use hickory_dns::dnssec::{KeyConfig, KeyPurpose};
     let signer_name = Name::from(authority.origin().to_owned());
 
     let mut keys = Vec::<DNSKEY>::new();
@@ -382,8 +382,7 @@ pub fn add_signers<A: DnssecAuthority>(authority: &mut A) -> Vec<DNSKEY> {
             password: None,
             algorithm: Algorithm::RSASHA512.to_string(),
             signer_name: Some(signer_name.to_string()),
-            is_zone_signing_key: Some(true),
-            is_zone_update_auth: Some(false),
+            purpose: KeyPurpose::ZoneSigning,
         };
 
         let signer = key_config
@@ -437,8 +436,7 @@ pub fn add_signers<A: DnssecAuthority>(authority: &mut A) -> Vec<DNSKEY> {
             password: None,
             algorithm: Algorithm::ED25519.to_string(),
             signer_name: Some(signer_name.to_string()),
-            is_zone_signing_key: Some(true),
-            is_zone_update_auth: Some(false),
+            purpose: KeyPurpose::ZoneSigning,
         };
 
         let signer = key_config

--- a/bin/tests/integration/authority_battery/dynamic_update.rs
+++ b/bin/tests/integration/authority_battery/dynamic_update.rs
@@ -8,7 +8,7 @@ use std::{
 
 use futures_executor::block_on;
 
-use hickory_dns::dnssec::KeyConfig;
+use hickory_dns::dnssec::{KeyConfig, KeyPurpose};
 use hickory_proto::{
     dnssec::{
         rdata::{key::KeyUsage, KEY},
@@ -787,8 +787,7 @@ pub fn add_auth<A: DnssecAuthority>(authority: &mut A) -> Vec<SigSigner> {
             password: None,
             algorithm: Algorithm::RSASHA512.to_string(),
             signer_name: Some(update_name.to_string()),
-            is_zone_signing_key: Some(true),
-            is_zone_update_auth: Some(false),
+            purpose: KeyPurpose::ZoneSigning,
         };
 
         let signer = key_config
@@ -848,8 +847,7 @@ pub fn add_auth<A: DnssecAuthority>(authority: &mut A) -> Vec<SigSigner> {
             password: None,
             algorithm: Algorithm::ED25519.to_string(),
             signer_name: Some(update_name.to_string()),
-            is_zone_signing_key: Some(true),
-            is_zone_update_auth: Some(false),
+            purpose: KeyPurpose::ZoneSigning,
         };
 
         let signer = key_config

--- a/bin/tests/integration/config_tests.rs
+++ b/bin/tests/integration/config_tests.rs
@@ -152,6 +152,7 @@ fn test_parse_toml() {
 #[cfg(feature = "dnssec")]
 #[test]
 fn test_parse_zone_keys() {
+    use hickory_dns::dnssec::KeyPurpose;
     use hickory_proto::dnssec::Algorithm;
     use hickory_proto::rr::Name;
 
@@ -170,14 +171,14 @@ key_path = \"/path/to/my_ed25519.pem\"
 algorithm = \"ED25519\"
 \
          signer_name = \"ns.example.com.\"
-is_zone_signing_key = false
-is_zone_update_auth = true
+purpose = \"ZoneUpdateAuth\"
 
 [[zones.keys]]
 key_path = \"/path/to/my_rsa.pem\"
 algorithm = \
          \"RSASHA256\"
 signer_name = \"ns.example.com.\"
+purpose = \"ZoneSigning\"
 ",
     )
     .unwrap();
@@ -196,8 +197,10 @@ signer_name = \"ns.example.com.\"
             .unwrap(),
         Name::parse("ns.example.com.", None).unwrap()
     );
-    assert!(!get_server_zone(&config, 0).keys()[0].is_zone_signing_key(),);
-    assert!(get_server_zone(&config, 0).keys()[0].is_zone_update_auth(),);
+    assert_eq!(
+        KeyPurpose::ZoneUpdateAuth,
+        get_server_zone(&config, 0).keys()[0].purpose()
+    );
 
     assert_eq!(
         get_server_zone(&config, 0).keys()[1].key_path(),
@@ -214,8 +217,10 @@ signer_name = \"ns.example.com.\"
             .unwrap(),
         Name::parse("ns.example.com.", None).unwrap()
     );
-    assert!(!get_server_zone(&config, 0).keys()[1].is_zone_signing_key(),);
-    assert!(!get_server_zone(&config, 0).keys()[1].is_zone_update_auth(),);
+    assert_eq!(
+        KeyPurpose::ZoneSigning,
+        get_server_zone(&config, 0).keys()[1].purpose(),
+    );
 }
 
 #[test]

--- a/bin/tests/integration/config_tests.rs
+++ b/bin/tests/integration/config_tests.rs
@@ -52,14 +52,20 @@ fn test_read_config() {
     assert_eq!(config.zones()[0].zone, "localhost");
     assert_eq!(config.zones()[0].zone_type, ZoneType::Primary);
     assert_eq!(
-        config.zones()[0].file.as_deref(),
+        config.zones()[0]
+            .file()
+            .as_deref()
+            .and_then(|path| path.to_str()),
         Some("default/localhost.zone")
     );
 
     assert_eq!(config.zones()[1].zone, "0.0.127.in-addr.arpa");
     assert_eq!(config.zones()[1].zone_type, ZoneType::Primary);
     assert_eq!(
-        config.zones()[1].file.as_deref(),
+        config.zones()[1]
+            .file()
+            .as_deref()
+            .and_then(|path| path.to_str()),
         Some("default/127.0.0.1.zone")
     );
 
@@ -69,21 +75,42 @@ fn test_read_config() {
     );
     assert_eq!(config.zones()[2].zone_type, ZoneType::Primary);
     assert_eq!(
-        config.zones()[2].file.as_deref(),
+        config.zones()[2]
+            .file()
+            .as_deref()
+            .and_then(|path| path.to_str()),
         Some("default/ipv6_1.zone")
     );
 
     assert_eq!(config.zones()[3].zone, "255.in-addr.arpa");
     assert_eq!(config.zones()[3].zone_type, ZoneType::Primary);
-    assert_eq!(config.zones()[3].file.as_deref(), Some("default/255.zone"));
+    assert_eq!(
+        config.zones()[3]
+            .file()
+            .as_deref()
+            .and_then(|path| path.to_str()),
+        Some("default/255.zone")
+    );
 
     assert_eq!(config.zones()[4].zone, "0.in-addr.arpa");
     assert_eq!(config.zones()[4].zone_type, ZoneType::Primary);
-    assert_eq!(config.zones()[4].file.as_deref(), Some("default/0.zone"));
+    assert_eq!(
+        config.zones()[4]
+            .file()
+            .as_deref()
+            .and_then(|path| path.to_str()),
+        Some("default/0.zone")
+    );
 
     assert_eq!(config.zones()[5].zone, "example.com");
     assert_eq!(config.zones()[5].zone_type, ZoneType::Primary);
-    assert_eq!(config.zones()[5].file.as_deref(), Some("example.com.zone"));
+    assert_eq!(
+        config.zones()[5]
+            .file()
+            .as_deref()
+            .and_then(|path| path.to_str()),
+        Some("example.com.zone")
+    );
 }
 
 #[test]
@@ -133,7 +160,9 @@ fn test_parse_zone_keys() {
 [[zones]]
 zone = \"example.com\"
 zone_type = \"Primary\"
-file = \"example.com.zone\"
+[zones.stores]
+type = \"file\"
+zone_file_path = \"example.com.zone\"
 
 \
          [[zones.keys]]
@@ -239,7 +268,6 @@ define_test_config!(dns_over_tls_rustls_and_openssl);
 define_test_config!(dns_over_tls);
 #[cfg(feature = "sqlite")]
 define_test_config!(dnssec_with_update);
-define_test_config!(dnssec_with_update_deprecated);
 define_test_config!(example);
 define_test_config!(ipv4_and_ipv6);
 define_test_config!(ipv4_only);

--- a/bin/tests/integration/named_test_rsa_dnssec.rs
+++ b/bin/tests/integration/named_test_rsa_dnssec.rs
@@ -195,39 +195,3 @@ fn test_dnssec_restart_with_update_journal() {
     // TODO: fix journal path so that it doesn't leave the dir dirty... this might make windows an option after that
     std::fs::remove_file(&journal).expect("failed to cleanup after test");
 }
-
-#[cfg(feature = "dnssec-ring")]
-#[cfg(feature = "sqlite")]
-#[test]
-fn test_dnssec_restart_with_update_journal_dep() {
-    // TODO: make journal path configurable, it should be in target/tests/...
-    let server_path = env::var("TDNS_WORKSPACE_ROOT").unwrap_or_else(|_| "..".to_owned());
-    let server_path = Path::new(&server_path);
-    let journal = server_path.join("tests/test-data/test_configs/example.com.jrnl");
-    std::fs::remove_file(&journal).ok();
-
-    generic_test(
-        "dnssec_with_update_deprecated.toml",
-        "tests/test-data/test_configs/dnssec/rsa_2048.pk8",
-        KeyFormat::Pkcs8,
-        Algorithm::RSASHA256,
-    );
-
-    // after running the above test, the journal file should exist
-    assert!(journal.exists());
-
-    // and all dnssec tests should still pass
-    generic_test(
-        "dnssec_with_update_deprecated.toml",
-        "tests/test-data/test_configs/dnssec/rsa_2048.pk8",
-        KeyFormat::Pkcs8,
-        Algorithm::RSASHA256,
-    );
-
-    // and journal should still exist
-    assert!(journal.exists());
-
-    // cleanup...
-    // TODO: fix journal path so that it doesn't leave the dir dirty... this might make windows an option after that
-    std::fs::remove_file(&journal).expect("failed to cleanup after test");
-}

--- a/conformance/packages/dns-test/src/templates/hickory.name-server.toml.jinja
+++ b/conformance/packages/dns-test/src/templates/hickory.name-server.toml.jinja
@@ -7,6 +7,7 @@ zone_type = "Primary"
 file = "/etc/zones/main.zone"
 nx_proof_kind = { nsec3 = { iterations = 1 } }
 
+{% if use_dnssec %}
 [[zones.keys]]
 {% if use_pkcs8 %}
 key_path = "/etc/zones/zsk.pk8"
@@ -14,7 +15,8 @@ key_path = "/etc/zones/zsk.pk8"
 key_path = "/etc/zones/zsk.key"
 {% endif %}
 algorithm = "RSASHA256"
-is_zone_signing_key = {{ use_dnssec }}
+purpose = "ZoneSigning"
+{% endif %}
 
 {% for zone in additional_zones -%}
 [[zones]]

--- a/conformance/packages/dns-test/src/templates/hickory.name-server.toml.jinja
+++ b/conformance/packages/dns-test/src/templates/hickory.name-server.toml.jinja
@@ -5,7 +5,6 @@ group = "nogroup"
 zone = "{{ fqdn }}"
 zone_type = "Primary"
 file = "/etc/zones/main.zone"
-enable_dnssec = {{ use_dnssec }}
 nx_proof_kind = { nsec3 = { iterations = 1 } }
 
 [[zones.keys]]
@@ -15,7 +14,7 @@ key_path = "/etc/zones/zsk.pk8"
 key_path = "/etc/zones/zsk.key"
 {% endif %}
 algorithm = "RSASHA256"
-is_zone_signing_key = true
+is_zone_signing_key = {{ use_dnssec }}
 
 {% for zone in additional_zones -%}
 [[zones]]

--- a/tests/test-data/test_configs/all_supported_dnssec.toml
+++ b/tests/test-data/test_configs/all_supported_dnssec.toml
@@ -37,8 +37,6 @@ zone_type = "Primary"
 ## file: this is relative to the directory above
 file = "example.com.zone"
 
-enable_dnssec = true
-
 [[zones.keys]]
 key_path = "../tests/test-data/test_configs/dnssec/rsa_2048.pk8"
 ## specify the algorithm

--- a/tests/test-data/test_configs/all_supported_dnssec.toml
+++ b/tests/test-data/test_configs/all_supported_dnssec.toml
@@ -42,7 +42,7 @@ key_path = "../tests/test-data/test_configs/dnssec/rsa_2048.pk8"
 ## specify the algorithm
 algorithm = "RSASHA256"
 ## this key should be used to sign the zone
-is_zone_signing_key = true
+purpose = "ZoneSigning"
 ## this key is authorized for dynamic update access to the zone via SIG0
 # is_zone_update_auth = true
 ## create the key if it is not found
@@ -51,22 +51,22 @@ is_zone_signing_key = true
 [[zones.keys]]
 key_path = "../tests/test-data/test_configs/dnssec/rsa_2048.pk8"
 algorithm = "RSASHA512"
-is_zone_signing_key = true
+purpose = "ZoneSigning"
 
 [[zones.keys]]
 # Requires --features=ring
 key_path = "../tests/test-data/test_configs/dnssec/ecdsa_p256.pk8"
 algorithm = "ECDSAP256SHA256"
-is_zone_signing_key = true
+purpose = "ZoneSigning"
 
 [[zones.keys]]
 # Requires --features=ring
 key_path = "../tests/test-data/test_configs/dnssec/ecdsa_p384.pk8"
 algorithm = "ECDSAP384SHA384"
-is_zone_signing_key = true
+purpose = "ZoneSigning"
 
 [[zones.keys]]
 # Requires --features=ring
 key_path = "../tests/test-data/test_configs/dnssec/ed25519.pk8"
 algorithm = "ED25519"
-is_zone_signing_key = true
+purpose = "ZoneSigning"

--- a/tests/test-data/test_configs/dnssec_with_update.toml
+++ b/tests/test-data/test_configs/dnssec_with_update.toml
@@ -34,13 +34,12 @@ zone = "example.com"
 ## zone_type: Primary, Secondary, Hint, Forward
 zone_type = "Primary"
 
-## if true, looks to see if a chained pem file exists at $file.pem (see
-## supported_algorithms below).
+## if at least one zone signing key has been configured, looks to see if a
+## chained pem file exists at $file.pem (see supported_algorithms below).
 ## these keys will also be registered as authorities for update,
 ## meaning that SIG(0) updates can be established by initially using these
 ## keys. the zone will be signed with all specified keys, it may be desirable
 ## to limit this set for performance reasons.
-enable_dnssec = true
 
 ## An ordered list of stores
 stores = { type = "sqlite", zone_file_path = "example.com.zone", journal_file_path = "example.com_dnssec_update.jrnl", allow_update = true }

--- a/tests/test-data/test_configs/dnssec_with_update.toml
+++ b/tests/test-data/test_configs/dnssec_with_update.toml
@@ -49,7 +49,7 @@ key_path = "../tests/test-data/test_configs/dnssec/rsa_2048.pk8"
 ## specify the algorithm
 algorithm = "RSASHA256"
 ## this key should be used to sign the zone
-is_zone_signing_key = true
+purpose = "ZoneSigning"
 ## this key is authorized for dynamic update access to the zone via SIG0
 # is_zone_update_auth = true
 ## create the key if it is not found
@@ -58,5 +58,4 @@ is_zone_signing_key = true
 [[zones.keys]]
 key_path = "../tests/test-data/test_configs/dnssec/rsa_2048.pk8"
 algorithm = "RSASHA512"
-is_zone_signing_key = false
-is_zone_update_auth = true
+purpose = "ZoneUpdateAuth"

--- a/tests/test-data/test_configs/dnssec_with_update_deprecated.toml
+++ b/tests/test-data/test_configs/dnssec_with_update_deprecated.toml
@@ -42,13 +42,12 @@ file = "example.com.zone"
 ## if false, updates will not be allowed, default false
 allow_update = true
 
-## if true, looks to see if a chained pem file exists at $file.pem (see
-## supported_algorithms below).
+## if at least one zone signing key has been configured, looks to see if a
+## chained pem file exists at $file.pem (see supported_algorithms below).
 ## these keys will also be registered as authorities for update,
 ## meaning that SIG(0) updates can be established by initially using these
 ## keys. the zone will be signed with all specified keys, it may be desirable
 ## to limit this set for performance reasons.
-enable_dnssec = true
 
 [[zones.keys]]
 key_path = "../tests/test-data/test_configs/dnssec/rsa_2048.pk8"

--- a/tests/test-data/test_configs/dnssec_with_update_deprecated.toml
+++ b/tests/test-data/test_configs/dnssec_with_update_deprecated.toml
@@ -54,7 +54,7 @@ key_path = "../tests/test-data/test_configs/dnssec/rsa_2048.pk8"
 ## specify the algorithm
 algorithm = "RSASHA256"
 ## this key should be used to sign the zone
-is_zone_signing_key = true
+purpose = "ZoneSigning"
 ## this key is authorized for dynamic update access to the zone via SIG0
 # is_zone_update_auth = true
 ## create the key if it is not found
@@ -63,5 +63,4 @@ is_zone_signing_key = true
 [[zones.keys]]
 key_path = "../tests/test-data/test_configs/dnssec/rsa_2048.pk8"
 algorithm = "RSASHA512"
-is_zone_signing_key = false
-is_zone_update_auth = true
+purpose = "ZoneUpdateAuth"


### PR DESCRIPTION
This PR implements RFC #2195. More specifically it:

- Removes `ZoneConfig::file` as the following `ZoneConfig`
   ```rust
   ZoneConfig {
       file: "path1",
       stores: vec![
           FileConfig {
               zone_file_path: "path2",
           }
      ],
       ..
   }
   ```
   was considered valid even though it is ambiguous. However, custom deserializers are implemented so that the `file` field inside `named.toml` can still be used if it is not ambiguous and if it is set for the valid type of zone (Primary or Secondary).
- Splits `StoreConfig` so each `ZoneType` has its own set of valid stores. This also comes with a new enum `ZoneTypeConfig` that moves all the `ZoneConfig` fields inside the enum's variants. Making impossible to set configuration fields that are irrelevant for a specific `ZoneType`.

TODO:
- [x] Refactor the dnssec related fields so it is impossible to set `dnssec_enabled = false` and `[zones.keys]` at the same time.
- [x] Figure out if `enable_axfr` is valid for `Primary` servers or it is only relevant for `Secondary` servers.
