### PR TITLE
resolver: never use truncated UDP response

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dns/rfc1035/truncation.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/rfc1035/truncation.rs
@@ -64,7 +64,6 @@ fn truncated_response_caching_with_tcp_fallback() -> Result<()> {
 /// Verify that resolvers will not cache a truncated response received via UDP if the authoritative
 /// server does not reply to TCP fallback queries.
 #[test]
-#[ignore = "hickory caches a truncated response if querying over TCP fails"]
 fn truncated_response_caching_udp_only() -> Result<()> {
     let target_fqdn = FQDN("example.testing.")?;
     let (resolver, client, _graph) = setup("src/resolver/dns/rfc1035/truncated_udp_only.py")?;

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -703,7 +703,7 @@ pub mod testing {
 
         let lookup_ip = response.unwrap();
         for record in lookup_ip.as_lookup().record_iter() {
-            assert!(record.proof().is_bogus())
+            assert!(record.proof().is_insecure());
         }
     }
 
@@ -1188,6 +1188,8 @@ mod tests {
     #[cfg(feature = "dnssec")]
     fn test_sec_lookup_fails() {
         use super::testing::sec_lookup_fails_test;
+        use test_support::subscribe;
+        subscribe();
         let io_loop = Runtime::new().expect("failed to create tokio runtime io_loop");
         let handle = TokioConnectionProvider::default();
         sec_lookup_fails_test::<Runtime, TokioConnectionProvider>(io_loop, handle);


### PR DESCRIPTION
This changes `NameServerPool` to only return data from a TCP response if the UDP response was truncated. This fixes #2608, and fixes NSEC/NSEC3 validation in some cases. I think we should not return truncated responses in this context, even if that's the only response available, because it is presently the cause of multiple correctness issues, and because this PR's behavior aligns with other implementations, like BIND and Unbound's recursive resolvers. There are some cases where it would be possible to implement optimizations making use of truncated responses, such as eagerly connecting to nameservers during iterative recursion before receiving complete referral responses, but I think we'd need to pierce existing encapsulation, and make more of the codebase truncation-aware. Plus, `ProtoError` makes reasoning about this behavior harder.

When handling a truncated UDP response for a query of an empty RRset, `ProtoError::from_response()` returns `Ok(response)`, because of a check for the truncation bit. `NameServerPool` also checks the truncation bit on the response, and sends a TCP query. Subsequently, `ProtoError::from_response()` turns the TCP response into `Err(ProtoErrorKind::NoRecordsFound { .. }.into())`. Between these two choices, the existing code will return the `Ok(...)` containing a truncated response over the complete `NoRecordsFound` error, which leads to later validation reporting that the NSEC/NSEC3/RRSIG records are bogus, since it is working from an incomplete RRset.