### PR TITLE
proto: hash lowercase names for DS and NSEC3

### DIFF
--- a/crates/proto/src/dnssec/nsec3.rs
+++ b/crates/proto/src/dnssec/nsec3.rs
@@ -156,7 +156,7 @@ impl Nsec3HashAlgorithm {
                 {
                     let mut encoder: BinEncoder<'_> = BinEncoder::new(&mut buf);
                     encoder.set_canonical_names(true);
-                    name.emit(&mut encoder)?;
+                    name.to_lowercase().emit(&mut encoder)?;
                 }
 
                 Self::sha1_recursive_hash(salt, buf, iterations)
@@ -237,6 +237,10 @@ mod tests {
             hash_with_base32("example"),
             "0p9mhaveqvm6t7vbl5lop2u3t2rp3tom"
         );
+        assert_eq!(
+            hash_with_base32("EXAMPLE"),
+            "0p9mhaveqvm6t7vbl5lop2u3t2rp3tom"
+        );
 
         // H(a.example)     = 35mthgpgcu1qg68fab165klnsnk3dpvl
         assert_eq!(
@@ -304,7 +308,7 @@ mod tests {
         use data_encoding::BASE32_DNSSEC;
 
         // NSEC3PARAM 1 0 12 aabbccdd
-        let known_name = Name::parse(name, Some(&Name::new())).unwrap();
+        let known_name = Name::from_ascii(name).unwrap();
         let known_salt = [0xAAu8, 0xBBu8, 0xCCu8, 0xDDu8];
         let hash = Nsec3HashAlgorithm::SHA1
             .hash(&known_salt, &known_name, 12)

--- a/crates/proto/src/dnssec/rdata/dnskey.rs
+++ b/crates/proto/src/dnssec/rdata/dnskey.rs
@@ -259,6 +259,7 @@ impl DNSKEY {
             let mut encoder: BinEncoder<'_> = BinEncoder::new(&mut buf);
             encoder.set_canonical_names(true);
             if let Err(e) = name
+                .to_lowercase()
                 .emit(&mut encoder)
                 .and_then(|_| self.emit(&mut encoder))
             {


### PR DESCRIPTION
This changes hash calculations for DS and NSEC3 to be over lowercase names, and adds a couple unit tests to confirm.

RFC 4034 section 5.1.4 and RFC 5155 section 5 both say that the canonical form of the name is hashed. RFC 4034 section 6.2 and RFC 5155 section 5 both say the canonical form has all ASCII uppercase letters replaced by corresponding lowercase letters.

I ran into this while working on #2683. Signature validation is fine already, see https://github.com/hickory-dns/hickory-dns/blob/ccf00381dc768366e7423f1231890df0ac59b5e4/crates/proto/src/dnssec/tbs.rs#L199.