### PR TITLE
Reformat large inline tables in config files

### DIFF
--- a/conformance/packages/dns-test/src/templates/hickory.resolver.toml.jinja
+++ b/conformance/packages/dns-test/src/templates/hickory.resolver.toml.jinja
@@ -4,4 +4,13 @@ group = "nogroup"
 [[zones]]
 zone = "."
 zone_type = "Hint"
-stores = { type = "recursor" , roots = "/etc/root.hints" {% if use_dnssec %}, dnssec_policy.ValidateWithStaticKey.path = "/etc/trusted-key.key" {% else %}, dnssec_policy = "ValidationDisabled" {% endif %} , allow_server = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"] }
+
+[zones.stores]
+type = "recursor"
+roots = "/etc/root.hints"
+{% if use_dnssec %}
+dnssec_policy.ValidateWithStaticKey.path = "/etc/trusted-key.key"
+{% else %}
+dnssec_policy = "ValidationDisabled"
+{% endif %}
+allow_server = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]

--- a/tests/test-data/test_configs/dns_over_https.toml
+++ b/tests/test-data/test_configs/dns_over_https.toml
@@ -1,6 +1,10 @@
 listen_addrs_ipv4 = ["0.0.0.0"]
 
-tls_cert = { path = "sec/example.cert.pem", endpoint_name = "ns.example.com", cert_type = "pem", private_key = "sec/example.key" }
+[tls_cert]
+path = "sec/example.cert.pem"
+endpoint_name = "ns.example.com"
+cert_type = "pem"
+private_key = "sec/example.key"
 
 [[zones]]
 zone = "example.com"

--- a/tests/test-data/test_configs/dns_over_quic.toml
+++ b/tests/test-data/test_configs/dns_over_quic.toml
@@ -1,6 +1,10 @@
 listen_addrs_ipv4 = ["0.0.0.0"]
 
-tls_cert = { path = "sec/example.cert.pem", endpoint_name = "ns.example.com", cert_type = "pem", private_key = "sec/example.key" }
+[tls_cert]
+path = "sec/example.cert.pem"
+endpoint_name = "ns.example.com"
+cert_type = "pem"
+private_key = "sec/example.key"
 
 [[zones]]
 zone = "example.com"

--- a/tests/test-data/test_configs/dns_over_tls.toml
+++ b/tests/test-data/test_configs/dns_over_tls.toml
@@ -1,6 +1,9 @@
 listen_addrs_ipv4 = ["0.0.0.0"]
 
-tls_cert = { path = "sec/example.p12", endpoint_name = "ns.example.com", password = "mypass" }
+[tls_cert]
+path = "sec/example.p12"
+endpoint_name = "ns.example.com"
+password = "mypass"
 
 [[zones]]
 zone = "example.com"

--- a/tests/test-data/test_configs/dns_over_tls_rustls_and_openssl.toml
+++ b/tests/test-data/test_configs/dns_over_tls_rustls_and_openssl.toml
@@ -1,7 +1,11 @@
 listen_addrs_ipv4 = ["0.0.0.0"]
 
 # endpoint 
-tls_cert = { path = "sec/example.cert.pem", endpoint_name = "ns.example.com", cert_type = "pem", private_key = "sec/example.key" }
+[tls_cert]
+path = "sec/example.cert.pem"
+endpoint_name = "ns.example.com"
+cert_type = "pem"
+private_key = "sec/example.key"
 
 [[zones]]
 zone = "example.com"

--- a/tests/test-data/test_configs/dnssec_with_update.toml
+++ b/tests/test-data/test_configs/dnssec_with_update.toml
@@ -43,7 +43,11 @@ zone_type = "Primary"
 enable_dnssec = true
 
 ## An ordered list of stores
-stores = { type = "sqlite", zone_file_path = "example.com.zone", journal_file_path = "example.com_dnssec_update.jrnl", allow_update = true }
+[zones.stores]
+type = "sqlite"
+zone_file_path = "example.com.zone"
+journal_file_path = "example.com_dnssec_update.jrnl"
+allow_update = true
 
 [[zones.keys]]
 key_path = "../tests/test-data/test_configs/dnssec/rsa_2048.pk8"

--- a/tests/test-data/test_configs/example_forwarder.toml
+++ b/tests/test-data/test_configs/example_forwarder.toml
@@ -37,5 +37,15 @@ zone_type = "Forward"
 
 ## remember the port, defaults: 53 for Udp & Tcp, 853 for Tls and 443 for Https.
 ##   Tls and/or Https require features dns-over-tls and/or dns-over-https
-stores = { type = "forward", name_servers = [{ socket_addr = "8.8.8.8:53", protocol = "udp", trust_negative_responses = false },
-                                             { socket_addr = "8.8.8.8:53", protocol = "tcp", trust_negative_responses = false }] }
+[zones.stores]
+type = "forward"
+
+[[zones.stores.name_servers]]
+socket_addr = "8.8.8.8:53"
+protocol = "udp"
+trust_negative_responses = false
+
+[[zones.stores.name_servers]]
+socket_addr = "8.8.8.8:53"
+protocol = "tcp"
+trust_negative_responses = false


### PR DESCRIPTION
This replaces some inline tables in configuration files with equivalent normal tables, for readability.