### PR TITLE
conformance: avoid arithmetic overflow of key tag

### DIFF
--- a/conformance/packages/dns-test/src/zone_file/signer.rs
+++ b/conformance/packages/dns-test/src/zone_file/signer.rs
@@ -259,7 +259,7 @@ impl<'a> Signer<'a> {
         for _ in 0..100 {
             let (ksk, output) = self.gen_key(&ldns_keygen_ksk(&self.settings, zone))?;
             let ksk_keytag = ksk.rdata.calculate_key_tag();
-            if ksk_keytag != zsk_keytag && ksk_keytag != zsk_keytag + 1 {
+            if ksk_keytag != zsk_keytag && ksk_keytag != zsk_keytag.wrapping_add(1) {
                 return Ok((ksk, output));
             }
         }


### PR DESCRIPTION
This avoids a 1-in-65536 test flake in the ldns-signzone workaround rejection sampling loop.

```
thread 'resolver::dnssec::scenarios::insecure::deprecated_algorithm::rsamd5' panicked at packages/dns-test/src/zone_file/signer.rs:262:58:
attempt to add with overflow
```