### PR TITLE
ci: upgrade cargo-workspaces

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
       - published
 
 env:
-  CARGO_WS_VERSION: "0.2.42"
+  CARGO_WS_VERSION: "0.3.6"
 
 jobs:
   publish:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ on:
     - cron: "0 3 * * 4"
 
 env:
-  CARGO_WS_VERSION: "0.2.44"
+  CARGO_WS_VERSION: "0.3.6"
 
 jobs:
   ## Run all default oriented feature sets across all platforms.

--- a/justfile
+++ b/justfile
@@ -152,7 +152,7 @@ generate-test-certs: init-openssl
 
 # Publish all crates
 publish:
-    cargo ws publish --from-git --token $CRATES_IO_TOKEN
+    cargo ws publish --publish-as-is --token $CRATES_IO_TOKEN
 
 # Removes the target directories cleaning all built artifacts
 clean:


### PR DESCRIPTION
This upgrades cargo-workspaces, and updates one command line flag that has been renamed in the intervening time. This should fix some warnings flagged by the GitHub Actions UI.