### PR TITLE
proto: remove DigestType::SHA512

### DIFF
--- a/crates/proto/src/dnssec/mod.rs
+++ b/crates/proto/src/dnssec/mod.rs
@@ -76,8 +76,6 @@ pub enum DigestType {
     SHA256,
     /// [RFC 6605](https://tools.ietf.org/html/rfc6605)
     SHA384,
-    /// Formally undefined
-    SHA512,
 }
 
 impl TryFrom<u8> for DigestType {
@@ -99,7 +97,6 @@ impl From<DigestType> for u8 {
             DigestType::SHA1 => 1,
             DigestType::SHA256 => 2,
             DigestType::SHA384 => 4,
-            DigestType::SHA512 => 255,
         }
     }
 }

--- a/crates/proto/src/dnssec/ring.rs
+++ b/crates/proto/src/dnssec/ring.rs
@@ -520,7 +520,6 @@ impl From<DigestType> for &'static digest::Algorithm {
             DigestType::SHA1 => &digest::SHA1_FOR_LEGACY_USE_ONLY,
             DigestType::SHA256 => &digest::SHA256,
             DigestType::SHA384 => &digest::SHA384,
-            DigestType::SHA512 => &digest::SHA512,
         }
     }
 }


### PR DESCRIPTION
This removes the `SHA512` variant from `DigestType`. As discussed in #2695, the conversion from `Algorithm` to `DigestType` is no longer used in RRSIG signing and verification, so this variant is no longer necessary. `DigestType` now only represents DS digest algorithms.