### PR TITLE
Add ede-dot-com tests that don't rely on internet name servers

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -42,6 +42,9 @@ jobs:
       - name: check public tests that use the `dns-test` framework
         run: just ede-dot-com-check
 
+      - name: run ede-dot-com tests against local nameservers
+        run: just ede-dot-com-run hermetic
+
       - name: lint code
         run: just conformance-clippy
 

--- a/conformance/packages/dns-test/src/docker/ede-dot-com/Dockerfile
+++ b/conformance/packages/dns-test/src/docker/ede-dot-com/Dockerfile
@@ -1,0 +1,25 @@
+# This is based on the dnssec-signzone Dockerfile from
+# https://github.com/yevheniya-nosyk/imc2023-ede.
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install BIND9 build dependencies and faketime.
+RUN apt-get update && apt-get install -y wget xz-utils build-essential libnghttp2-dev libcap-dev libssl-dev perl pkg-config faketime && rm -rf /var/lib/apt/lists/*
+
+# Download source code.
+# We use an older version of BIND in order to get a version of dnssec-keygen
+# that supports DSA and RSAMD5, and allows selecting how many additional
+# iterations to use in NSEC3.
+RUN cd /usr/bin && wget https://downloads.isc.org/isc/bind9/9.11.9/bind-9.11.9.tar.gz && tar -xf bind-9.11.9.tar.gz
+
+# Build and install
+# Python is disabled because the scripts are not compatible with Python 3.11 and later.
+RUN cd /usr/bin/bind-9.11.9 && ./configure --without-python && make && make install
+
+# Create configuration directory and working directory.
+RUN mkdir /etc/bind /var/cache/bind
+
+ADD configure_child.sh /
+ADD configure_parent.sh /
+RUN chmod a+x configure_child.sh configure_parent.sh

--- a/conformance/packages/dns-test/src/docker/ede-dot-com/configure_child.sh
+++ b/conformance/packages/dns-test/src/docker/ede-dot-com/configure_child.sh
@@ -1,0 +1,515 @@
+#!/bin/bash
+set -e
+
+# This is based on the configure_child.sh script from
+# https://github.com/yevheniya-nosyk/imc2023-ede.
+#
+# Note that the original setup uses a mixture of BIND 9.11.9 and a modern BIND
+# package from the VPS's distribution. BIND 9.11.9 is needed because its
+# version of dnssec-keygen and dnssec-signzone support obsolete signature
+# algorithms and arbitrary NSEC3 iteration counts. In the original scripts,
+# the modern version of BIND on the VPSes is used for generating all other
+# keys and signing all other zones that don't require those deprecated
+# features, and as the authoritative name server for the zones.
+#
+# In order to simplify the zone creation process, and reduce the number of
+# containers needed, this modified script is instead written to use the BIND
+# 9.11.9 version of dnssec-keygen and dnssec-signzone for all zones, and the
+# BIND 9.11.9 version of named is used to serve the zone out of the same
+# containers.
+#
+# The following changes have been made to this script.
+# - Robustness:
+#   - Added `set -e` to propagate errors.
+#   - Make the regular expressions used when deleting keys for no-zsk and
+#     no-ksk more strict, so that they can't have false positive matches on
+#     base64-encoded public keys.
+# - Integration with dns-test:
+#   - Removed modification of named.conf, because the custom configuration file
+#     dropped in the container already has the include directive added.
+#   - Removed `service bind9 restart` since named is run directly, and not as
+#     a service.
+#   - Run dnssec-signzone inside faketime when signing the rrsig-exp-all zone,
+#     so that we don't need to wait for the zone to expire. (dnssec-signzone
+#     does not itself support signing a zone with a backdated expiry)
+# - Replacing BIND 9.18/9.19 with BIND 9.11.9:
+#   - Generate files for the dsa, rsamd5, nsec3-iter-1, nsec3-iter-51,
+#     nsec3-iter-101, nsec3-iter-151, and nsec3-iter-200 zones here, instead
+#     of copying existing files.
+#   - Replace a hardcoded TTL of 600 in regular expressions with a more
+#     permissive pattern, since dnssec-signzone's default TTL has changed.
+#   - Delete DS records with the SHA-1 digest algorithm from dsset files, to
+#     match the output of modern dnssec-signzone versions. The commands for
+#     zones with corrupted DS records expect there to be only one DS record,
+#     using SHA-256.
+# - Performance:
+#   - Removed sleep.
+
+# Store the variables
+server_ip=$1
+domain=$2
+a_record=$3
+aaaa_record=$4
+
+# Create a directory to store zones or empty an existing one
+
+zones_dir="/etc/bind/zones_ede"
+if [ -d "$zones_dir" ]; then
+    rm -rf $zones_dir/*
+else
+    mkdir $zones_dir
+fi
+
+# Create a configuration file that will be included by the main configuration file
+local_conf="/etc/bind/named.conf.local-ede"
+> $local_conf
+
+# Loop through the array of subdomains
+
+subdomains=("valid" "rrsig-exp-all" "allow-query-none" "allow-query-localhost" "no-ds" "no-zsk" "no-ksk" "ds-bad-tag" "ds-bad-key-algo" "ds-unassigned-key-algo" "ds-reserved-key-algo" "ds-bogus-digest-value" "ds-unassigned-digest-algo" "rrsig-exp-a" "rrsig-not-yet-a" "rrsig-not-yet-all" "rrsig-no-a" "rrsig-no-all" "nsec3-missing" "nsec3param-missing" "no-nsec3param-nsec3" "bad-nsec3-hash" "bad-nsec3-next" "nsec3-rrsig-missing" "bad-nsec3-rrsig" "bad-nsec3param-salt" "v6-doc" "v4-doc" "bad-zsk" "bad-ksk" "no-rrsig-ksk" "no-rrsig-dnskey" "bad-rrsig-ksk" "bad-rrsig-dnskey" "ed448" "rrsig-exp-before-all" "rrsig-exp-before-a" "no-dnskey-256" "no-dnskey-257" "no-dnskey-256-257" "bad-zsk-algo" "unassigned-zsk-algo" "reserved-zsk-algo" "unsigned" "dsa" "nsec3-iter-1" "nsec3-iter-51" "nsec3-iter-101" "nsec3-iter-151" "nsec3-iter-200" "rsamd5" "not-auth")
+
+for subdomain in ${subdomains[@]}; do
+    # Store the full zone name
+    zone=$subdomain.$domain
+
+    # The below domains are not intended to be reachable,
+    # because the nameservers are set to documentation IPs
+    # Therefore, we do not need to create any zone files, only referrals and glues at the parent
+    if [[ $subdomain = "v4-doc" ]]; then
+        echo "$zone.      IN      NS     ns1.$zone." >> glues.txt
+        echo "ns1.$zone.  IN      A      198.51.100.0" >> glues.txt
+        continue
+    elif [[ $subdomain = "v6-doc" ]]; then
+        echo "$zone.      IN      NS      ns1.$zone." >> glues.txt
+        echo "ns1.$zone.  IN      AAAA      2001:db8::1" >> glues.txt
+        continue
+    # This domain name points to our nameservers, but we do not serve it
+    elif [[ $subdomain = "not-auth" ]]; then
+        echo "$zone.      IN      NS      ns1.$zone." >> glues.txt
+        echo "ns1.$zone.  IN      A       $server_ip" >> glues.txt
+        continue
+    fi
+
+    # For all the remaining subdomains we create zone files and (mis)configure them
+    output_dir=$zones_dir/$zone
+    mkdir -p $output_dir
+
+    # Create a basic (valid) zone file
+    echo "\$ORIGIN $zone." >> $output_dir/db.$zone
+    echo "\$TTL 600" >> $output_dir/db.$zone
+    echo "@	SOA	ns1.$zone.	hostmaster.$zone. (" >> $output_dir/db.$zone
+    echo "        $(date +%Y%m%d) ; serial" >> $output_dir/db.$zone
+    echo "        21600      ; refresh after 6 hours" >> $output_dir/db.$zone
+    echo "        3600       ; retry after 1 hour" >> $output_dir/db.$zone
+    echo "        604800     ; expire after 1 week" >> $output_dir/db.$zone
+    echo "        86400 )    ; minimum TTL of 1 day" >> $output_dir/db.$zone
+    echo "" >> $output_dir/db.$zone
+    echo "@               IN      NS      ns1.$zone." >> $output_dir/db.$zone
+    echo "ns1             IN      A       $server_ip" >> $output_dir/db.$zone
+    echo "@               IN      A       $a_record" >> $output_dir/db.$zone
+    echo "@               IN      AAAA    $aaaa_record " >> $output_dir/db.$zone
+
+
+    # First generate a KSK and a ZSK using RSASHA256 algorithm (number 8)
+    # and add both to zone files
+    # There are two exceptions: domains signed with other algorithms and the unsigned one
+    if [[ $subdomain = "ed448" ]]; then
+        dnssec-keygen -K $output_dir -a ED448 -n ZONE $zone
+        dnssec-keygen -K $output_dir -f KSK -a ED448 -n ZONE $zone
+    elif [[ $subdomain = "dsa" ]]; then
+        dnssec-keygen -K $output_dir -a DSA -b 1024 -n ZONE $zone
+        dnssec-keygen -K $output_dir -f KSK -a DSA -b 1024 -n ZONE $zone
+    elif [[ $subdomain = "rsamd5" ]]; then
+        dnssec-keygen -K $output_dir -a RSAMD5 -b 1024 -n ZONE $zone
+        dnssec-keygen -K $output_dir -f KSK -a RSAMD5 -b 1024 -n ZONE $zone
+    elif [[ $subdomain = "unsigned" ]]; then
+        # Do not create keys
+        true
+    else
+        dnssec-keygen -K $output_dir -a RSASHA256 -b 2048 -n ZONE $zone
+        dnssec-keygen -K $output_dir -f KSK -a RSASHA256 -b 2048 -n ZONE $zone
+    fi
+
+    # Add public keys into the zone file, unless the domain is unsigned
+    if [[ $subdomain != "unsigned" ]]; then
+        cat $output_dir/*.key >> $output_dir/db.$zone
+    fi
+
+    # Use no salt and 0 additional iterations for NSEC3, unless otherwise specified.
+    # Signatures will expire in almost half a year, unless otherwise specified.
+    if [[ $subdomain = "rrsig-exp-all" ]]; then
+        # Create an expired signature by running dnssec-signzone with a clock
+        # set in the past. Merely specifying an end time in the past causes
+        # problems with identifying the active KSK.
+        faketime -f -86400 dnssec-signzone -3 - -K $output_dir -e now+300 -o $zone $output_dir/db.$zone
+    elif [[ $subdomain = "unsigned" ]]; then
+        # Do not sign the zone
+        true
+    elif [[ $subdomain = "dsa" ]] || [[ $subdomain = "rsamd5" ]]; then
+        # These algorithms do not support NSEC3
+        dnssec-signzone -K $output_dir -e now+15000000 -o $zone $output_dir/db.$zone
+    elif [[ $subdomain = "nsec3-iter-1" ]]; then
+        dnssec-signzone -3 - -H 1 -K $output_dir -e now+15000000 -o $zone $output_dir/db.$zone
+    elif [[ $subdomain = "nsec3-iter-51" ]]; then
+        dnssec-signzone -3 - -H 51 -K $output_dir -e now+15000000 -o $zone $output_dir/db.$zone
+    elif [[ $subdomain = "nsec3-iter-101" ]]; then
+        dnssec-signzone -3 - -H 101 -K $output_dir -e now+15000000 -o $zone $output_dir/db.$zone
+    elif [[ $subdomain = "nsec3-iter-151" ]]; then
+        dnssec-signzone -3 - -H 151 -K $output_dir -e now+15000000 -o $zone $output_dir/db.$zone
+    elif [[ $subdomain = "nsec3-iter-200" ]]; then
+        dnssec-signzone -3 - -H 200 -K $output_dir -e now+15000000 -o $zone $output_dir/db.$zone
+    else
+        dnssec-signzone -3 - -K $output_dir -e now+15000000 -o $zone $output_dir/db.$zone
+    fi
+
+    # Configure subdomains that manipulate DNSKEY flags
+
+    # Set the ZSK Zone Key flag to 0
+    if [[ $subdomain = "no-dnskey-256" ]]; then
+        sed -i "s/DNSKEY.*256.*3.*8/DNSKEY	0 3 8/g" $output_dir/db.$zone.signed
+    # Set the KSK Zone Key flag to 0
+    elif [[ $subdomain = "no-dnskey-257" ]]; then
+        sed -i "s/DNSKEY.*257.*3.*8/DNSKEY	0 3 8/g" $output_dir/db.$zone.signed
+    elif [[ $subdomain = "no-dnskey-256-257" ]]; then
+        sed -i "s/DNSKEY.*256.*3.*8/DNSKEY	0 3 8/g" $output_dir/db.$zone.signed
+        sed -i "s/DNSKEY.*257.*3.*8/DNSKEY	0 3 8/g" $output_dir/db.$zone.signed
+    fi
+
+    # Configure subdomains that manipulate DNSKEYs
+
+    # Comment out the ZSK DNSKEY
+    if [[ $subdomain = "no-zsk" ]]; then
+        # Find numbers of lines where the key is located
+        line_start=$(grep -n 'DNSKEY.*256' $output_dir/db.$zone.signed | cut -f1 -d:)
+        line_end=$(grep -n ' ZSK;' $output_dir/db.$zone.signed | cut -f1 -d:)
+        sed -i "${line_start},${line_end}d" $output_dir/db.$zone.signed
+    # Edit the part of the ZSK
+    elif [[ $subdomain = "bad-zsk" ]]; then
+        # Find the first line with the ZSK
+        line_key=$(grep -A 1 'DNSKEY.*256' $output_dir/db.$zone.signed | tail -1 | xargs )
+        rand_substring=$(head -c 1000 /dev/urandom | sha1sum | cut -b 1-5)
+        line_key_new=$rand_substring${line_key:5}
+        sed -i "s@$line_key@$line_key_new@g" $output_dir/db.$zone.signed
+    # Set the wrong algorithm number for the ZSK
+    elif [[ $subdomain = "bad-zsk-algo" ]]; then
+        sed -i "s/DNSKEY.*256.*3.*8/DNSKEY	256 3 7/g" $output_dir/db.$zone.signed
+    # Set the unassigned algorithm number for the ZSK
+    elif [[ $subdomain = "unassigned-zsk-algo" ]]; then
+        sed -i "s/DNSKEY.*256.*3.*8/DNSKEY	256 3 100/g" $output_dir/db.$zone.signed
+    # Set the reserved algorithm number for the ZSK
+    elif [[ $subdomain = "reserved-zsk-algo" ]]; then
+        sed -i "s/DNSKEY.*256.*3.*8/DNSKEY	256 3 200/g" $output_dir/db.$zone.signed
+    # Edit the part of the KSK
+    elif [[ $subdomain = "bad-ksk" ]]; then
+        # Find the first line with the KSK
+        line_key=$(grep -A 1 'DNSKEY.*257' $output_dir/db.$zone.signed | tail -1 | xargs )
+        rand_substring=$(head -c 1000 /dev/urandom | sha1sum | cut -b 1-5)
+        line_key_new=$rand_substring${line_key:5}
+        sed -i "s@$line_key@$line_key_new@g" $output_dir/db.$zone.signed
+    # Comment out the KSK DNSKEY
+    elif [[ $subdomain = "no-ksk" ]]; then
+        # Find numbers of lines where the key is located
+        line_start=$(grep -n 'DNSKEY.*257' $output_dir/db.$zone.signed | cut -f1 -d:)
+        line_end=$(grep -n ' KSK;' $output_dir/db.$zone.signed | cut -f1 -d:)
+        sed -i "${line_start},${line_end}d" $output_dir/db.$zone.signed
+    fi
+
+    # Configure subdomains that manipulate RRSIGs
+
+    # Remove the signature over the KSK
+    if [[ $subdomain = "no-rrsig-ksk" ]]; then
+        # Find the ID of the key signing key
+        ksk_id=$(grep "KSK;" $output_dir/db.$zone.signed | awk -F' = ' '{print $NF}')
+        # Find the line containing the signature over KSK DNSKEY as well as where it starts and ends
+        line_rrsig_middle=$(grep  -n "$ksk_id.*no-rrsig-ksk.*" $output_dir/db.$zone.signed | cut -f1 -d:)
+        line_rrsig_start_num=$((line_rrsig_middle-1))
+        line_rrsig_end=$(tail -n +$line_rrsig_start_num $output_dir/db.$zone.signed | grep -m 1 ")")
+        line_rrsig_end_num=$(grep -n "$line_rrsig_end" $output_dir/db.$zone.signed | cut -f1 -d:)
+        sed -i "${line_rrsig_start_num},${line_rrsig_end_num}d" $output_dir/db.$zone.signed
+    # Remove both DNSKEY signatures
+    elif [[ $subdomain = "no-rrsig-dnskey" ]]; then
+        # First delete the signature over the KSK
+        ksk_id=$(grep "KSK;" $output_dir/db.$zone.signed | awk -F' = ' '{print $NF}')
+        # Find the line containing the signature over KSK DNSKEY as well as where it starts and ends
+        line_rrsig_middle=$(grep  -n "$ksk_id.*no-rrsig-dnskey.*" $output_dir/db.$zone.signed | cut -f1 -d:)
+        line_rrsig_start_num=$((line_rrsig_middle-1))
+        line_rrsig_end=$(tail -n +$line_rrsig_start_num $output_dir/db.$zone.signed | grep -m 1 ")")
+        line_rrsig_end_num=$(grep -n "$line_rrsig_end" $output_dir/db.$zone.signed | cut -f1 -d:)
+        sed -i "${line_rrsig_start_num},${line_rrsig_end_num}d" $output_dir/db.$zone.signed
+        # Next delete the signature over the ZSK
+        line_rrsig_start_num=$(grep -n "RRSIG.*DNSKEY.*8.*3.*[0-9]\+" $output_dir/db.$zone.signed | cut -f1 -d:)
+        line_rrsig_end=$(tail -n +$line_rrsig_start_num $output_dir/db.$zone.signed | grep -m 1 ")")
+        line_rrsig_end_num=$(grep -n "$line_rrsig_end" $output_dir/db.$zone.signed | cut -f1 -d:)
+        sed -i "${line_rrsig_start_num},${line_rrsig_end_num}d" $output_dir/db.$zone.signed
+    # Edit the signature over the KSK
+    elif [[ $subdomain = "bad-rrsig-ksk" ]]; then
+        # Find the ID of the key signing key
+        ksk_id=$(grep "KSK;" $output_dir/db.$zone.signed | awk -F' = ' '{print $NF}')
+        # Find the first line of the KSK signature
+        line_rrsig=$(grep -A2 'RRSIG.*DNSKEY.*8.*3' $output_dir/db.$zone.signed | grep -A1 ".*${ksk_id}.*" | tail -1 | xargs)
+        rand_substring=$(head -c 1000 /dev/urandom | sha1sum | cut -b 1-5)
+        line_rrsig_new=$rand_substring${line_rrsig:5}
+        sed -i "s@$line_rrsig@$line_rrsig_new@g" $output_dir/db.$zone.signed
+    # Edit both DNSKEY RRSIGs
+    elif [[ $subdomain = "bad-rrsig-dnskey" ]]; then
+        # Find the ID of the key signing key
+        ksk_id=$(grep "KSK;" $output_dir/db.$zone.signed | awk -F' = ' '{print $NF}')
+        # Find the ID of the zone signing key
+        zsk_id=$(grep "ZSK;" $output_dir/db.$zone.signed | awk -F' = ' '{print $NF}')
+        # Edit the KSK signature
+        rand_substring=$(head -c 1000 /dev/urandom | sha1sum | cut -b 1-5)
+        line_ksk_rrsig=$(grep -A2 'RRSIG.*DNSKEY.*8.*3' $output_dir/db.$zone.signed | grep -A1 ".*${ksk_id}.*" | tail -1 | xargs)
+        line_ksk_rrsig_new=$rand_substring${line_ksk_rrsig:5}
+        sed -i "s@$line_ksk_rrsig@$line_ksk_rrsig_new@g" $output_dir/db.$zone.signed
+        # Edit the ZSK signature
+        line_zsk_rrsig=$(grep -A2 'RRSIG.*DNSKEY.*8.*3' $output_dir/db.$zone.signed | grep -A1 ".*${zsk_id}.*" | tail -1 | xargs)
+        line_zsk_rrsig_new=$rand_substring${line_zsk_rrsig:5}
+        sed -i "s@$line_zsk_rrsig@$line_zsk_rrsig_new@g" $output_dir/db.$zone.signed
+    # Manipulate RRSIGs
+    elif [[ $subdomain = "rrsig-exp-a" ]]; then
+        # Find line number with a signature over A RRset
+        sig_start_line=$(grep -n "RRSIG\sA 8 3" $output_dir/db.$zone.signed | cut -f1 -d:)
+        sig_dates_line=$((sig_start_line+1))
+        # Get current timestamps
+        expiry_date=$(awk "NR==$sig_dates_line" $output_dir/db.$zone.signed | grep -oP "\d{14}" | head -1)
+        start_date=$(awk "NR==$sig_dates_line" $output_dir/db.$zone.signed | grep -oP "\d{14}" | tail -1)
+        # Compute the last year
+        this_year=$(date +'%Y')
+        last_year=$((this_year-1))
+        # Compute new timestamps
+        expiry_date_new="$(echo $last_year)$(echo $expiry_date | cut -c 5-)"
+        start_date_new="$(echo $last_year)$(echo $start_date | cut -c 5-)"
+        # Replace
+        sed -i "${sig_dates_line}s/$expiry_date/$expiry_date_new/" $output_dir/db.$zone.signed
+        sed -i "${sig_dates_line}s/$start_date/$start_date_new/" $output_dir/db.$zone.signed
+    elif [[ $subdomain = "rrsig-not-yet-a" ]]; then
+        # Find line number with a signature over A RRset
+        sig_start_line=$(grep -n "RRSIG\sA 8 3" $output_dir/db.$zone.signed | cut -f1 -d:)
+        sig_dates_line=$((sig_start_line+1))
+        # Get current timestamps
+        expiry_date=$(awk "NR==$sig_dates_line" $output_dir/db.$zone.signed | grep -oP "\d{14}" | head -1)
+        start_date=$(awk "NR==$sig_dates_line" $output_dir/db.$zone.signed | grep -oP "\d{14}" | tail -1)
+        # Compute the next year
+        this_year=$(date +'%Y')
+        next_year=$((this_year+1))
+        in_two_years=$((this_year+2))
+        # Compute new timestamps
+        expiry_date_new="$(echo $in_two_years)$(echo $expiry_date | cut -c 5-)"
+        start_date_new="$(echo $next_year)$(echo $start_date | cut -c 5-)"
+        # Replace
+        sed -i "${sig_dates_line}s/$expiry_date/$expiry_date_new/" $output_dir/db.$zone.signed
+        sed -i "${sig_dates_line}s/$start_date/$start_date_new/" $output_dir/db.$zone.signed
+    elif [[ $subdomain = "rrsig-not-yet-all" ]]; then
+        # Find line number with a signature over A RRset
+        sig_start_line=$(grep -n "RRSIG\sA 8 3" $output_dir/db.$zone.signed | cut -f1 -d:)
+        sig_dates_line=$((sig_start_line+1))
+        # Get current timestamps
+        expiry_date=$(awk "NR==$sig_dates_line" $output_dir/db.$zone.signed | grep -oP "\d{14}" | head -1)
+        start_date=$(awk "NR==$sig_dates_line" $output_dir/db.$zone.signed | grep -oP "\d{14}" | tail -1)
+        # Compute the next year
+        this_year=$(date +'%Y')
+        next_year=$((this_year+1))
+        in_two_years=$((this_year+2))
+        # Compute new timestamps
+        expiry_date_new="$(echo $in_two_years)$(echo $expiry_date | cut -c 5-)"
+        start_date_new="$(echo $next_year)$(echo $start_date | cut -c 5-)"
+        # Replace all the signatures
+        sed -i "s/$expiry_date/$expiry_date_new/g" $output_dir/db.$zone.signed
+        sed -i "s/$start_date/$start_date_new/g" $output_dir/db.$zone.signed
+    elif [[ $subdomain = "rrsig-exp-before-all" ]]; then
+        # Find line number with a signature over A RRset
+        sig_start_line=$(grep -n "RRSIG\sA 8 3" $output_dir/db.$zone.signed | cut -f1 -d:)
+        sig_dates_line=$((sig_start_line+1))
+        # Get current timestamps
+        expiry_date=$(awk "NR==$sig_dates_line" $output_dir/db.$zone.signed | grep -oP "\d{14}" | head -1)
+        start_date=$(awk "NR==$sig_dates_line" $output_dir/db.$zone.signed | grep -oP "\d{14}" | tail -1)
+        # Compute various years
+        this_year=$(date +'%Y')
+        before_2_years=$((this_year-2))
+        after_2_years=$((this_year+2))
+        # Compute new timestamps
+        expiry_date_new="$(echo $before_2_years)$(echo $expiry_date | cut -c 5-)"
+        start_date_new="$(echo $after_2_years)$(echo $start_date | cut -c 5-)"
+        # Replace all the signatures
+        sed -i "s/$expiry_date/$expiry_date_new/g" $output_dir/db.$zone.signed
+        sed -i "s/$start_date/$start_date_new/g" $output_dir/db.$zone.signed
+     elif [[ $subdomain = "rrsig-exp-before-a" ]]; then
+        # Find line number with a signature over A RRset
+        sig_start_line=$(grep -n "RRSIG\sA 8 3" $output_dir/db.$zone.signed | cut -f1 -d:)
+        sig_dates_line=$((sig_start_line+1))
+        # Get current timestamps
+        expiry_date=$(awk "NR==$sig_dates_line" $output_dir/db.$zone.signed | grep -oP "\d{14}" | head -1)
+        start_date=$(awk "NR==$sig_dates_line" $output_dir/db.$zone.signed | grep -oP "\d{14}" | tail -1)
+        # Compute various years
+        this_year=$(date +'%Y')
+        before_2_years=$((this_year-2))
+        after_2_years=$((this_year+2))
+        # Compute new timestamps
+        expiry_date_new="$(echo $before_2_years)$(echo $expiry_date | cut -c 5-)"
+        start_date_new="$(echo $after_2_years)$(echo $start_date | cut -c 5-)"
+        # Replace
+        sed -i "${sig_dates_line}s/$expiry_date/$expiry_date_new/" $output_dir/db.$zone.signed
+        sed -i "${sig_dates_line}s/$start_date/$start_date_new/" $output_dir/db.$zone.signed
+    elif [[ $subdomain = "rrsig-no-a" ]]; then
+        line_rrsig_start_num=$(grep -n "RRSIG\sA\s8\s3" $output_dir/db.$zone.signed | cut -f1 -d:)
+        line_rrsig_end=$(tail -n +$line_rrsig_start_num $output_dir/db.$zone.signed | grep -m 1 ")")
+        line_rrsig_end_num=$(grep -n "$line_rrsig_end" $output_dir/db.$zone.signed | cut -f1 -d:)
+        sed -i "${line_rrsig_start_num},${line_rrsig_end_num}d" $output_dir/db.$zone.signed
+    elif [[ $subdomain = "rrsig-no-all" ]]; then
+        while grep "0.*RRSIG.*" $output_dir/db.$zone.signed > /dev/null; do
+            # Delete signatures one by one
+            line_rrsig_start_num=$(grep -n "0.*RRSIG.*" $output_dir/db.$zone.signed | head -1 | cut -f1 -d:)
+            line_rrsig_end=$(tail -n +$line_rrsig_start_num $output_dir/db.$zone.signed | grep -m 1 ")")
+            line_rrsig_end_num=$(grep -n "$line_rrsig_end" $output_dir/db.$zone.signed | cut -f1 -d:)
+            sed -i "${line_rrsig_start_num},${line_rrsig_end_num}d" $output_dir/db.$zone.signed
+        done
+    fi
+
+    # Configure subdomains that manipulate NSEC3 resource records
+    # Note that we need to query non-existing subdomains to trigger their modified behavior
+
+    # Remove NSEC3 records
+    if [[ $subdomain = "nsec3-missing" ]]; then
+        while grep "IN.*NSEC3.*" $output_dir/db.$zone.signed > /dev/null; do
+            # Delete NSEC3 records one by one
+            line_start_num=$(grep -n "IN.*NSEC3.*" $output_dir/db.$zone.signed | head -1 | cut -f1 -d:)
+            line_end=$(tail -n +$line_start_num $output_dir/db.$zone.signed | grep -m 1 ")")
+            line_end_num=$(grep -n "$line_end" $output_dir/db.$zone.signed | cut -f1 -d:)
+            sed -i "${line_start_num},${line_end_num}d" $output_dir/db.$zone.signed
+        done
+    elif [[ $subdomain = "bad-nsec3param-salt" ]]; then
+        # Find NSEC3PARAM line number
+        nsec3param_line=$(grep -n "0\sNSEC3PARAM" $output_dir/db.$zone.signed | cut -f1 -d:)
+        # Find the salt value
+        nsec3param_salt=$(grep "0\sNSEC3PARAM" $output_dir/db.$zone.signed | awk '{print $NF}')
+        # Update the salt value
+        # Change hashed subdomains
+        nsec3param_salt_new="573461ade8fcdabb"
+        sed -i "${nsec3param_line}s/$nsec3param_salt/$nsec3param_salt_new/" $output_dir/db.$zone.signed
+    elif [[ $subdomain = "bad-nsec3-rrsig" ]]; then
+        rand_substring=$(head -c 1000 /dev/urandom | sha1sum | cut -b 1-5)
+        for rrsig in $(grep -n "RRSIG.*NSEC3\s8" $output_dir/db.$zone.signed | cut -f1 -d:); do
+            line_rrsig_start_num=$rrsig
+            line_rrsig_end=$(tail -n +$line_rrsig_start_num $output_dir/db.$zone.signed | grep ")" | head -1 | xargs)
+            line_rrsig_end_num=$(grep -n "$line_rrsig_end" $output_dir/db.$zone.signed | cut -f1 -d:)
+            line_rrsig_end_new=$rand_substring${line_rrsig_end:5}
+            sed -i "s@$line_rrsig_end@$line_rrsig_end_new@g" $output_dir/db.$zone.signed
+        done
+    # Remove NSEC3 RRSIG records
+    elif [[ $subdomain = "nsec3-rrsig-missing" ]]; then
+        while grep "RRSIG.*NSEC3\s8" $output_dir/db.$zone.signed > /dev/null; do
+            # Delete signatures one by one
+            line_rrsig_start_num=$(grep -n "RRSIG.*NSEC3\s8" $output_dir/db.$zone.signed | head -1 | cut -f1 -d:)
+            line_rrsig_end=$(tail -n +$line_rrsig_start_num $output_dir/db.$zone.signed | grep -m 1 ")")
+            line_rrsig_end_num=$(grep -n "$line_rrsig_end" $output_dir/db.$zone.signed | cut -f1 -d:)
+            sed -i "${line_rrsig_start_num},${line_rrsig_end_num}d" $output_dir/db.$zone.signed
+        done
+    # Make wrong NSEC3 records
+    elif [[ $subdomain = "bad-nsec3-hash" ]]; then
+        # Locate NSEC3 records
+        nsec3_domain_1=$(grep ".$zone.\s[0-9]\+\sIN\sNSEC3" $output_dir/db.$zone.signed | head -1 | awk '{print $1}')
+        nsec3_domain_2=$(grep ".$zone.\s[0-9]\+\sIN\sNSEC3" $output_dir/db.$zone.signed | tail -1 | awk '{print $1}')
+        # Change hashed subdomains
+        rand_substring=$(head -c 1000 /dev/urandom | sha1sum | cut -b 1-3 | tr '[:lower:]' '[:upper:]')
+        new_nsec3_domain_1=$rand_substring${nsec3_domain_1:3}
+        new_nsec3_domain_2=$rand_substring${nsec3_domain_2:3}
+        # Replace in the zone file
+        sed -i "s/$nsec3_domain_1/$new_nsec3_domain_1/g" $output_dir/db.$zone.signed
+        sed -i "s/$nsec3_domain_2/$new_nsec3_domain_2/g" $output_dir/db.$zone.signed
+    # Make wrong Next Hashed Owner Name field in NSEC3
+    elif [[ $subdomain = "bad-nsec3-next" ]]; then
+        # Find NSEC3 hashes
+        nsec3_hash_1=$(grep ".$zone.\s[0-9]\+\sIN\sNSEC3" $output_dir/db.$zone.signed | head -1 | awk '{print $1}' | awk -F'.' '{print $1}')
+        nsec3_hash_2=$(grep ".$zone.\s[0-9]\+\sIN\sNSEC3" $output_dir/db.$zone.signed | tail -1 | awk '{print $1}' | awk -F'.' '{print $1}')
+        # Change next hashed owners
+        rand_substring=$(head -c 1000 /dev/urandom | sha1sum | cut -b 1-3 | tr '[:lower:]' '[:upper:]')
+        nsec3_hash_1_new=$rand_substring${nsec3_hash_1:3}
+        nsec3_hash_2_new=$rand_substring${nsec3_hash_2:3}
+        # Replace in the zone file
+        sed -i "s/$nsec3_hash_1$/$nsec3_hash_1_new/g" $output_dir/db.$zone.signed
+        sed -i "s/$nsec3_hash_2$/$nsec3_hash_2_new/g" $output_dir/db.$zone.signed
+    # Remove NSEC3PARAM records
+    elif [[ $subdomain = "nsec3param-missing" ]]; then
+        sed -i '/NSEC3PARAM.*1/d' $output_dir/db.$zone.signed
+    # Remove both NSEC3 and NSEC3PARAM records
+    elif [[ $subdomain = "no-nsec3param-nsec3" ]]; then
+        # Delete NSEC3 records one by one
+        while grep "IN.*NSEC3.*" $output_dir/db.$zone.signed > /dev/null; do
+            line_start_num=$(grep -n "IN.*NSEC3.*" $output_dir/db.$zone.signed | head -1 | cut -f1 -d:)
+            line_end=$(tail -n +$line_start_num $output_dir/db.$zone.signed | grep -m 1 ")")
+            line_end_num=$(grep -n "$line_end" $output_dir/db.$zone.signed | cut -f1 -d:)
+            sed -i "${line_start_num},${line_end_num}d" $output_dir/db.$zone.signed
+        done
+        # Delete the NSEC3PARAM resource record
+        sed -i '/NSEC3PARAM.*1/d' $output_dir/db.$zone.signed
+    fi
+
+    # Configure subdomains that manipulate DS resource records
+
+    # Start by removing DS records with the SHA-1 digest algorithm, to keep
+    # them from interfering with the effects of crafted DS records
+    if [[ $subdomain != "unsigned" ]]; then
+        sed -i '/8 1 /d' dsset-$zone.
+    fi
+
+    # Change the key tag to 0000 in DS record for "ds-bad-tag" subdomain
+    if [[ $subdomain = "ds-bad-tag" ]]; then
+        sed -i 's/DS.*8 2/DS 0000 8 2/g' dsset-$zone.
+    # Set a different DNSKEY algorithm (8 -> 7)
+    elif [[ $subdomain = "ds-bad-key-algo" ]]; then
+        sed -i 's/8 2/7 2/g' dsset-$zone.
+    # Set an unassigned DNSKEY algorithm (8 -> 100)
+    elif [[ $subdomain = "ds-unassigned-key-algo" ]]; then
+        sed -i 's/8 2/100 2/g' dsset-$zone.
+    # Set an unassigned digest algorithm (2 -> 100)
+    elif [[ $subdomain = "ds-unassigned-digest-algo" ]]; then
+        sed -i 's/8 2/8 100/g' dsset-$zone.
+    # Set a reserved DNSKEY algorithm (8 -> 200)
+    elif [[ $subdomain = "ds-reserved-key-algo" ]]; then
+        sed -i 's/8 2/200 2/g' dsset-$zone.
+    # Change the digest value
+    elif [[ $subdomain = "ds-bogus-digest-value" ]]; then
+        sed -i "s/ 8 2.*/ 8 2 $(echo -n 'I am not a real DNSKEY digest' | sha256sum | cut -d' ' -f1)/" dsset-$zone.
+    fi
+
+    # Once all the domain names are configured, we need to correctly
+    # serve them and prepare glues/DS records for the parent zone
+
+    # Generate the text file with DS records to be uploaded at the parent
+    if [[ $subdomain != "no-ds" && $subdomain != "unsigned" ]]; then
+        cat dsset-$zone. >> dsset_for_parent.txt
+    fi
+    if [[ $subdomain != "unsigned" ]]; then
+            mv dsset-$zone. $output_dir/dsset-$zone.
+    fi
+
+    # Generate the text file with glue records to be uploaded at the parent
+    echo "$zone.      IN      NS      ns1.$zone." >> glues.txt
+    echo "ns1.$zone.  IN      A      $server_ip" >> glues.txt
+
+    # Fill in the local configuration file
+    if [[ $subdomain = "allow-query-none" ]]; then
+        echo "zone \"$zone\" {" >> $local_conf
+        echo "        type master;" >> $local_conf
+        echo "        file \"$zones_dir/$zone/db.$zone.signed\";" >> $local_conf
+        echo "        allow-query { none; };" >> $local_conf
+        echo "};" >> $local_conf
+    elif [[ $subdomain = "allow-query-localhost" ]]; then
+        echo "zone \"$zone\" {" >> $local_conf
+        echo "        type master;" >> $local_conf
+        echo "        file \"$zones_dir/$zone/db.$zone.signed\";" >> $local_conf
+        echo "        allow-query { localhost; };" >> $local_conf
+        echo "};" >> $local_conf
+    elif [[ $subdomain = "unsigned" ]]; then
+        echo "zone \"$zone\" {" >> $local_conf
+        echo "        type master;" >> $local_conf
+        echo "        file \"$zones_dir/$zone/db.$zone\";" >> $local_conf
+        echo "};" >> $local_conf
+    else
+        echo "zone \"$zone\" {" >> $local_conf
+        echo "        type master;" >> $local_conf
+        echo "        file \"$zones_dir/$zone/db.$zone.signed\";" >> $local_conf
+        echo "};" >> $local_conf
+    fi
+
+done

--- a/conformance/packages/dns-test/src/docker/ede-dot-com/configure_parent.sh
+++ b/conformance/packages/dns-test/src/docker/ede-dot-com/configure_parent.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -e
+
+# This is based on the configure_parent.sh script from
+# https://github.com/yevheniya-nosyk/imc2023-ede. The following changes have
+# been made to this script.
+# - Robustness:
+#   - Added `set -e` to propagate errors.
+# - Integration with dns-test:
+#   - Removed modification of named.conf, because the custom configuration file
+#     dropped in the container already has the include directive added.
+#   - Removed `service bind9 restart` since named is run directly, and not as
+#     a service.
+
+# Store the variables
+server_ip=$1
+domain=$2
+a_record=$3
+aaaa_record=$4
+
+# Create a directory to store the zone or empty an existing one
+
+zone_dir="/etc/bind/zone_ede"
+if [ -d "$zone_dir" ]; then
+    rm -rf $zone_dir/*
+else
+    mkdir $zone_dir
+fi
+
+# Create a configuration file that will be included by the main configuration file
+local_conf="/etc/bind/named.conf.local-ede"
+> $local_conf
+
+# Store the full zone name
+zone=$domain
+
+# Create the output directory
+output_dir=$zone_dir/$zone
+mkdir -p $output_dir
+
+# Create a basic (valid) zone file
+echo "\$ORIGIN $zone." >> $output_dir/db.$zone
+echo "\$TTL 600" >> $output_dir/db.$zone
+echo "@	SOA	ns1.$zone.	hostmaster.$zone. (" >> $output_dir/db.$zone
+echo "        $(date +%Y%m%d) ; serial" >> $output_dir/db.$zone
+echo "        21600      ; refresh after 6 hours" >> $output_dir/db.$zone
+echo "        3600       ; retry after 1 hour" >> $output_dir/db.$zone
+echo "        604800     ; expire after 1 week" >> $output_dir/db.$zone
+echo "        86400 )    ; minimum TTL of 1 day" >> $output_dir/db.$zone
+echo "" >> $output_dir/db.$zone
+echo "@               IN      NS      ns1.$zone." >> $output_dir/db.$zone
+echo "ns1             IN      A       $server_ip" >> $output_dir/db.$zone
+echo "@               IN      A       $a_record" >> $output_dir/db.$zone
+echo "@               IN      AAAA    $aaaa_record " >> $output_dir/db.$zone
+
+# Next we need to add all the delegations and DS records of child zones
+cat dsset_for_parent.txt >> $output_dir/db.$zone
+cat glues.txt >> $output_dir/db.$zone
+
+# First generate a KSK and a ZSK using RSASHA256 algorithm (number 8)
+dnssec-keygen -K $output_dir -a RSASHA256 -b 2048 -n ZONE $zone
+dnssec-keygen -K $output_dir -f KSK -a RSASHA256 -b 2048 -n ZONE $zone
+
+# Add public keys into the zone file
+cat $output_dir/*.key >> $output_dir/db.$zone
+
+# Sign the zone
+dnssec-signzone -3 - -K $output_dir -e now+15000000 -o $zone $output_dir/db.$zone
+
+# Move the DS records to the zone directory
+mv dsset-$zone. $output_dir/dsset-$zone.
+
+# Write to the named.conf.local the location of the signed zone file
+echo "zone \"$zone\" {" >> $local_conf
+echo "    type master;" >> $local_conf
+echo "    file \"$zone_dir/$zone/db.$zone.signed\";" >> $local_conf
+echo "};" >> $local_conf

--- a/conformance/packages/dns-test/src/fqdn.rs
+++ b/conformance/packages/dns-test/src/fqdn.rs
@@ -34,6 +34,14 @@ impl FQDN {
         inner: Cow::Borrowed("testing."),
     };
 
+    pub const COM_TLD: FQDN = FQDN {
+        inner: Cow::Borrowed("com."),
+    };
+
+    pub const EDE_DOT_COM: FQDN = FQDN {
+        inner: Cow::Borrowed("extended-dns-errors.com."),
+    };
+
     pub const TEST_DOMAIN: FQDN = FQDN {
         inner: Cow::Borrowed("hickory-dns.testing."),
     };

--- a/conformance/packages/dns-test/src/name_server.rs
+++ b/conformance/packages/dns-test/src/name_server.rs
@@ -476,6 +476,10 @@ impl<S> NameServer<S> {
         self.container.name()
     }
 
+    pub fn container(&self) -> &Container {
+        &self.container
+    }
+
     pub fn ipv4_addr(&self) -> Ipv4Addr {
         self.container.ipv4_addr()
     }
@@ -574,6 +578,8 @@ fn expand_zone(zone: &FQDN) -> String {
     } else if zone.num_labels() == 1 {
         if *zone == FQDN::TEST_TLD {
             FQDN::TEST_DOMAIN.as_str().to_string()
+        } else if *zone == FQDN::COM_TLD {
+            "nameservers.com.".to_string()
         } else {
             unimplemented!()
         }

--- a/conformance/packages/dns-test/src/templates/named.ede-dot-com.conf
+++ b/conformance/packages/dns-test/src/templates/named.ede-dot-com.conf
@@ -1,0 +1,13 @@
+options {
+    directory "/var/cache/bind";
+    pid-file "/tmp/named.pid";
+    recursion no;
+    dnssec-validation no;
+    allow-transfer { none; };
+    # significantly reduces noise in logs
+    empty-zones-enable no;
+};
+
+# Include the configuration file produced by the setup scripts. This contains
+# multiple zone blocks.
+include "/etc/bind/named.conf.local-ede";

--- a/tests/ede-dot-com/src/lib.rs
+++ b/tests/ede-dot-com/src/lib.rs
@@ -91,6 +91,7 @@ fn ds_reserved_key_algo() -> Result<()> {
 }
 
 #[test]
+#[ignore = "hickory can't decode unassigned DS digest algorithms (issue #2695)"]
 fn ds_unassigned_digest_algo() -> Result<()> {
     compare("ds-unassigned-digest-algo").map(drop)
 }

--- a/tests/ede-dot-com/src/lib.rs
+++ b/tests/ede-dot-com/src/lib.rs
@@ -6,8 +6,9 @@
 
 use dns_test::{
     client::{Client, DigOutput, DigSettings},
-    record::RecordType,
-    zone_file::Root,
+    name_server::{Graph, NameServer},
+    record::{RecordType, DS},
+    zone_file::{Root, SignSettings},
     Implementation, Network, Resolver, Result, TrustAnchor, FQDN,
 };
 
@@ -19,8 +20,18 @@ fn allow_query_localhost() -> Result<()> {
 }
 
 #[test]
+fn hermetic_allow_query_localhost() -> Result<()> {
+    hermetic_compare("allow-query-localhost").map(drop)
+}
+
+#[test]
 fn allow_query_none() -> Result<()> {
     compare("allow-query-none").map(drop)
+}
+
+#[test]
+fn hermetic_allow_query_none() -> Result<()> {
+    hermetic_compare("allow-query-none").map(drop)
 }
 
 #[test]
@@ -29,8 +40,18 @@ fn bad_ksk() -> Result<()> {
 }
 
 #[test]
+fn hermetic_bad_ksk() -> Result<()> {
+    hermetic_compare("bad-ksk").map(drop)
+}
+
+#[test]
 fn bad_nsec3_hash() -> Result<()> {
     compare("bad-nsec3-hash").map(drop)
+}
+
+#[test]
+fn hermetic_bad_nsec3_hash() -> Result<()> {
+    hermetic_compare("bad-nsec3-hash").map(drop)
 }
 
 #[test]
@@ -39,8 +60,18 @@ fn bad_nsec3_next() -> Result<()> {
 }
 
 #[test]
+fn hermetic_bad_nsec3_next() -> Result<()> {
+    hermetic_compare("bad-nsec3-next").map(drop)
+}
+
+#[test]
 fn bad_nsec3_rrsig() -> Result<()> {
     compare("bad-nsec3-rrsig").map(drop)
+}
+
+#[test]
+fn hermetic_bad_nsec3_rrsig() -> Result<()> {
+    hermetic_compare("bad-nsec3-rrsig").map(drop)
 }
 
 #[test]
@@ -49,8 +80,18 @@ fn bad_nsec3param_salt() -> Result<()> {
 }
 
 #[test]
+fn hermetic_bad_nsec3param_salt() -> Result<()> {
+    hermetic_compare("bad-nsec3param-salt").map(drop)
+}
+
+#[test]
 fn bad_rrsig_dnskey() -> Result<()> {
     compare("bad-rrsig-dnskey").map(drop)
+}
+
+#[test]
+fn hermetic_bad_rrsig_dnskey() -> Result<()> {
+    hermetic_compare("bad-rrsig-dnskey").map(drop)
 }
 
 #[test]
@@ -59,8 +100,18 @@ fn bad_rrsig_ksk() -> Result<()> {
 }
 
 #[test]
+fn hermetic_bad_rrsig_ksk() -> Result<()> {
+    hermetic_compare("bad-rrsig-ksk").map(drop)
+}
+
+#[test]
 fn bad_zsk() -> Result<()> {
     compare("bad-zsk").map(drop)
+}
+
+#[test]
+fn hermetic_bad_zsk() -> Result<()> {
+    hermetic_compare("bad-zsk").map(drop)
 }
 
 #[test]
@@ -69,8 +120,18 @@ fn bad_zsk_algo() -> Result<()> {
 }
 
 #[test]
+fn hermetic_bad_zsk_algo() -> Result<()> {
+    hermetic_compare("bad-zsk-algo").map(drop)
+}
+
+#[test]
 fn ds_bad_key_algo() -> Result<()> {
     compare("ds-bad-key-algo").map(drop)
+}
+
+#[test]
+fn hermetic_ds_bad_key_algo() -> Result<()> {
+    hermetic_compare("ds-bad-key-algo").map(drop)
 }
 
 #[test]
@@ -79,13 +140,28 @@ fn ds_bad_tag() -> Result<()> {
 }
 
 #[test]
+fn hermetic_ds_bad_tag() -> Result<()> {
+    hermetic_compare("ds-bad-tag").map(drop)
+}
+
+#[test]
 fn ds_bogus_digest_value() -> Result<()> {
     compare("ds-bogus-digest-value").map(drop)
 }
 
 #[test]
+fn hermetic_ds_bogus_digest_value() -> Result<()> {
+    hermetic_compare("ds-bogus-digest-value").map(drop)
+}
+
+#[test]
 fn ds_reserved_key_algo() -> Result<()> {
     compare("ds-reserved-key-algo").map(drop)
+}
+
+#[test]
+fn hermetic_ds_reserved_key_algo() -> Result<()> {
+    hermetic_compare("ds-reserved-key-algo").map(drop)
 }
 
 #[test]
@@ -95,13 +171,29 @@ fn ds_unassigned_digest_algo() -> Result<()> {
 }
 
 #[test]
+#[ignore = "hickory can't decode unassigned DS digest algorithms (issue #2695)"]
+fn hermetic_ds_unassigned_digest_algo() -> Result<()> {
+    hermetic_compare("ds-unassigned-digest-algo").map(drop)
+}
+
+#[test]
 fn ds_unassigned_key_algo() -> Result<()> {
     compare("ds-unassigned-key-algo").map(drop)
 }
 
 #[test]
+fn hermetic_ds_unassigned_key_algo() -> Result<()> {
+    hermetic_compare("ds-unassigned-key-algo").map(drop)
+}
+
+#[test]
 fn dsa() -> Result<()> {
     compare("dsa").map(drop)
+}
+
+#[test]
+fn hermetic_dsa() -> Result<()> {
+    hermetic_compare("dsa").map(drop)
 }
 
 #[test]
@@ -111,8 +203,19 @@ fn ed448() -> Result<()> {
 }
 
 #[test]
+#[ignore]
+fn hermetic_ed448() -> Result<()> {
+    hermetic_compare("ed448").map(drop)
+}
+
+#[test]
 fn no_dnskey_256() -> Result<()> {
     compare("no-dnskey-256").map(drop)
+}
+
+#[test]
+fn hermetic_no_dnskey_256() -> Result<()> {
+    hermetic_compare("no-dnskey-256").map(drop)
 }
 
 #[test]
@@ -121,8 +224,18 @@ fn no_dnskey_256_257() -> Result<()> {
 }
 
 #[test]
+fn hermetic_no_dnskey_256_257() -> Result<()> {
+    hermetic_compare("no-dnskey-256-257").map(drop)
+}
+
+#[test]
 fn no_dnskey_257() -> Result<()> {
     compare("no-dnskey-257").map(drop)
+}
+
+#[test]
+fn hermetic_no_dnskey_257() -> Result<()> {
+    hermetic_compare("no-dnskey-257").map(drop)
 }
 
 #[test]
@@ -132,8 +245,19 @@ fn no_ds() -> Result<()> {
 }
 
 #[test]
+#[ignore]
+fn hermetic_no_ds() -> Result<()> {
+    hermetic_compare("no-ds").map(drop)
+}
+
+#[test]
 fn no_ksk() -> Result<()> {
     compare("no-ksk").map(drop)
+}
+
+#[test]
+fn hermetic_no_ksk() -> Result<()> {
+    hermetic_compare("no-ksk").map(drop)
 }
 
 #[test]
@@ -142,8 +266,18 @@ fn no_nsec3param_nsec3() -> Result<()> {
 }
 
 #[test]
+fn hermetic_no_nsec3param_nsec3() -> Result<()> {
+    hermetic_compare("no-nsec3param-nsec3").map(drop)
+}
+
+#[test]
 fn no_rrsig_dnskey() -> Result<()> {
     compare("no-rrsig-dnskey").map(drop)
+}
+
+#[test]
+fn hermetic_no_rrsig_dnskey() -> Result<()> {
+    hermetic_compare("no-rrsig-dnskey").map(drop)
 }
 
 #[test]
@@ -152,8 +286,18 @@ fn no_rrsig_ksk() -> Result<()> {
 }
 
 #[test]
+fn hermetic_no_rrsig_ksk() -> Result<()> {
+    hermetic_compare("no-rrsig-ksk").map(drop)
+}
+
+#[test]
 fn no_zsk() -> Result<()> {
     compare("no-zsk").map(drop)
+}
+
+#[test]
+fn hermetic_no_zsk() -> Result<()> {
+    hermetic_compare("no-zsk").map(drop)
 }
 
 #[test]
@@ -162,8 +306,18 @@ fn not_auth() -> Result<()> {
 }
 
 #[test]
+fn hermetic_not_auth() -> Result<()> {
+    hermetic_compare("not-auth").map(drop)
+}
+
+#[test]
 fn nsec3_iter_1() -> Result<()> {
     compare("nsec3-iter-1").map(drop)
+}
+
+#[test]
+fn hermetic_nsec3_iter_1() -> Result<()> {
+    hermetic_compare("nsec3-iter-1").map(drop)
 }
 
 #[test]
@@ -172,8 +326,18 @@ fn nsec3_iter_51() -> Result<()> {
 }
 
 #[test]
+fn hermetic_nsec3_iter_51() -> Result<()> {
+    hermetic_compare("nsec3-iter-51").map(drop)
+}
+
+#[test]
 fn nsec3_iter_101() -> Result<()> {
     compare("nsec3-iter-101").map(drop)
+}
+
+#[test]
+fn hermetic_nsec3_iter_101() -> Result<()> {
+    hermetic_compare("nsec3-iter-101").map(drop)
 }
 
 #[test]
@@ -182,8 +346,18 @@ fn nsec3_iter_151() -> Result<()> {
 }
 
 #[test]
+fn hermetic_nsec3_iter_151() -> Result<()> {
+    hermetic_compare("nsec3-iter-151").map(drop)
+}
+
+#[test]
 fn nsec3_iter_200() -> Result<()> {
     compare("nsec3-iter-200").map(drop)
+}
+
+#[test]
+fn hermetic_nsec3_iter_200() -> Result<()> {
+    hermetic_compare("nsec3-iter-200").map(drop)
 }
 
 #[test]
@@ -192,8 +366,18 @@ fn nsec3_missing() -> Result<()> {
 }
 
 #[test]
+fn hermetic_nsec3_missing() -> Result<()> {
+    hermetic_compare("nsec3-missing").map(drop)
+}
+
+#[test]
 fn nsec3_rrsig_missing() -> Result<()> {
     compare("nsec3-rrsig-missing").map(drop)
+}
+
+#[test]
+fn hermetic_nsec3_rrsig_missing() -> Result<()> {
+    hermetic_compare("nsec3-rrsig-missing").map(drop)
 }
 
 #[test]
@@ -202,8 +386,18 @@ fn nsec3param_missing() -> Result<()> {
 }
 
 #[test]
+fn hermetic_nsec3param_missing() -> Result<()> {
+    hermetic_compare("nsec3param-missing").map(drop)
+}
+
+#[test]
 fn reserved_zsk_algo() -> Result<()> {
     compare("reserved-zsk-algo").map(drop)
+}
+
+#[test]
+fn hermetic_reserved_zsk_algo() -> Result<()> {
+    hermetic_compare("reserved-zsk-algo").map(drop)
 }
 
 #[test]
@@ -212,8 +406,18 @@ fn rrsig_exp_a() -> Result<()> {
 }
 
 #[test]
+fn hermetic_rrsig_exp_a() -> Result<()> {
+    hermetic_compare("rrsig-exp-a").map(drop)
+}
+
+#[test]
 fn rrsig_exp_all() -> Result<()> {
     compare("rrsig-exp-all").map(drop)
+}
+
+#[test]
+fn hermetic_rrsig_exp_all() -> Result<()> {
+    hermetic_compare("rrsig-exp-all").map(drop)
 }
 
 #[test]
@@ -222,8 +426,18 @@ fn rrsig_exp_before_a() -> Result<()> {
 }
 
 #[test]
+fn hermetic_rrsig_exp_before_a() -> Result<()> {
+    hermetic_compare("rrsig-exp-before-a").map(drop)
+}
+
+#[test]
 fn rrsig_exp_before_all() -> Result<()> {
     compare("rrsig-exp-before-all").map(drop)
+}
+
+#[test]
+fn hermetic_rrsig_exp_before_all() -> Result<()> {
+    hermetic_compare("rrsig-exp-before-all").map(drop)
 }
 
 #[test]
@@ -232,8 +446,18 @@ fn rrsig_no_a() -> Result<()> {
 }
 
 #[test]
+fn hermetic_rrsig_no_a() -> Result<()> {
+    hermetic_compare("rrsig-no-a").map(drop)
+}
+
+#[test]
 fn rrsig_no_all() -> Result<()> {
     compare("rrsig-no-all").map(drop)
+}
+
+#[test]
+fn hermetic_rrsig_no_all() -> Result<()> {
+    hermetic_compare("rrsig-no-all").map(drop)
 }
 
 #[test]
@@ -242,8 +466,18 @@ fn rrsig_not_yet_a() -> Result<()> {
 }
 
 #[test]
+fn hermetic_rrsig_not_yet_a() -> Result<()> {
+    hermetic_compare("rrsig-not-yet-a").map(drop)
+}
+
+#[test]
 fn rrsig_not_yet_all() -> Result<()> {
     compare("rrsig-not-yet-all").map(drop)
+}
+
+#[test]
+fn hermetic_rrsig_not_yet_all() -> Result<()> {
+    hermetic_compare("rrsig-not-yet-all").map(drop)
 }
 
 #[test]
@@ -252,8 +486,18 @@ fn rsamd5() -> Result<()> {
 }
 
 #[test]
+fn hermetic_rsamd5() -> Result<()> {
+    hermetic_compare("rsamd5").map(drop)
+}
+
+#[test]
 fn unassigned_zsk_algo() -> Result<()> {
     compare("unassigned-zsk-algo").map(drop)
+}
+
+#[test]
+fn hermetic_unassigned_zsk_algo() -> Result<()> {
+    hermetic_compare("unassigned-zsk-algo").map(drop)
 }
 
 #[test]
@@ -263,8 +507,19 @@ fn unsigned() -> Result<()> {
 }
 
 #[test]
+#[ignore]
+fn hermetic_unsigned() -> Result<()> {
+    hermetic_compare("unsigned").map(drop)
+}
+
+#[test]
 fn v4_doc() -> Result<()> {
     compare("v4-doc").map(drop)
+}
+
+#[test]
+fn hermetic_v4_doc() -> Result<()> {
+    hermetic_compare("v4-doc").map(drop)
 }
 
 #[test]
@@ -273,13 +528,23 @@ fn v6_doc() -> Result<()> {
 }
 
 #[test]
+fn hermetic_v6_doc() -> Result<()> {
+    hermetic_compare("v6-doc").map(drop)
+}
+
+#[test]
 fn valid() -> Result<()> {
     compare("valid").map(drop)
 }
 
-/// compares hickory's response to unbound's response
+#[test]
+fn hermetic_valid() -> Result<()> {
+    hermetic_compare("valid").map(drop)
+}
+
+/// compares hickory's response to unbound's response, using internet nameservers
 ///
-/// this compares STATUS and flags but not EDE
+/// this compares RCODE and flags but not EDE
 fn compare(subdomain: &str) -> Result<DigOutput> {
     let network = Network::with_internet_access()?;
     let domain = FQDN(format!("{subdomain}.extended-dns-errors.com."))?;
@@ -312,4 +577,144 @@ fn compare(subdomain: &str) -> Result<DigOutput> {
     assert_eq!(unbound_response.flags, hickory_response.flags);
 
     Ok(unbound_response)
+}
+
+/// compares hickory's response to unbound's response, using local nameservers
+///
+/// this compares RCODE and flags but not EDE
+fn hermetic_compare(subdomain: &str) -> Result<DigOutput> {
+    let network = Network::new()?;
+    let subdomain_fqdn = FQDN(format!("{subdomain}.extended-dns-errors.com."))?;
+    let graph = setup_hermetic_network(subdomain_fqdn.clone(), &network)?;
+
+    let unbound = Resolver::new(&network, graph.root.clone())
+        .trust_anchor(graph.trust_anchor.as_ref().unwrap())
+        .start_with_subject(&Implementation::Unbound)?;
+    let hickory = Resolver::new(&network, graph.root.clone())
+        .trust_anchor(graph.trust_anchor.as_ref().unwrap())
+        .start_with_subject(&Implementation::hickory())?;
+
+    let client = Client::new(&network)?;
+    let settings = *DigSettings::default().recurse().authentic_data();
+    let hickory_response = client.dig(
+        settings,
+        hickory.ipv4_addr(),
+        RecordType::A,
+        &subdomain_fqdn,
+    )?;
+    let unbound_response = client.dig(
+        settings,
+        unbound.ipv4_addr(),
+        RecordType::A,
+        &subdomain_fqdn,
+    )?;
+
+    dbg!(&unbound_response);
+    dbg!(&hickory_response);
+
+    assert_eq!(unbound_response.status, hickory_response.status);
+    assert_eq!(unbound_response.flags, hickory_response.flags);
+
+    Ok(unbound_response)
+}
+
+/// Creates a Docker network with nameservers for *.extended-dns-errors.com and all parent zones.
+fn setup_hermetic_network(subdomain_fqdn: FQDN, network: &Network) -> Result<Graph> {
+    let mut root_ns = NameServer::new(&Implementation::Bind, FQDN::ROOT, network)?;
+    let mut tld_ns = NameServer::new(&Implementation::Bind, FQDN::COM_TLD, network)?;
+    let parent_ns = NameServer::new(&Implementation::EdeDotCom, FQDN::EDE_DOT_COM, network)?;
+    let child_ns = NameServer::new(&Implementation::EdeDotCom, subdomain_fqdn, network)?;
+
+    let child_output = child_ns.container().output(&[
+        "/configure_child.sh",
+        &format!("{}", child_ns.ipv4_addr()),
+        "extended-dns-errors.com",
+        "65.21.183.116",
+        "2a01:4f9:c012:6b60::1",
+    ])?;
+    if !child_output.status.success() {
+        panic!(
+            "configuring child server failed\nSTDOUT:\n{}\nSTDERR:\n{}",
+            child_output.stdout, child_output.stderr
+        );
+    }
+    let mut child_dsset = child_ns
+        .container()
+        .stdout(&["cat", "/dsset_for_parent.txt"])?;
+    let mut glues = child_ns.container().stdout(&["cat", "/glues.txt"])?;
+    // Add back newlines stripped by `Output`.
+    child_dsset.push('\n');
+    glues.push('\n');
+
+    parent_ns.cp("/dsset_for_parent.txt", &child_dsset)?;
+    parent_ns.cp("/glues.txt", &glues)?;
+    let parent_output = parent_ns.container().output(&[
+        "/configure_parent.sh",
+        &format!("{}", parent_ns.ipv4_addr()),
+        "extended-dns-errors.com",
+        "65.21.183.116",
+        "2a01:4f9:c012:6b60::1",
+    ])?;
+    if !parent_output.status.success() {
+        panic!(
+            "configuring parent server failed\nSTDOUT:\n{}\nSTDERR:\n{}",
+            parent_output.stdout, parent_output.stderr
+        );
+    }
+    let parent_dsset = parent_ns.container().stdout(&[
+        "cat",
+        "/etc/bind/zone_ede/extended-dns-errors.com/dsset-extended-dns-errors.com.",
+    ])?;
+
+    tld_ns.referral(
+        FQDN::EDE_DOT_COM,
+        FQDN("ns1.extended-dns-errors.com.")?,
+        parent_ns.ipv4_addr(),
+    );
+    for parent_ds in parse_dnssec_signzone_dsset(&parent_dsset)? {
+        tld_ns.add(parent_ds);
+    }
+
+    let tld_ns = tld_ns.sign(SignSettings::default())?;
+
+    root_ns.referral(
+        FQDN::COM_TLD,
+        FQDN("primary.nameservers.com.")?,
+        tld_ns.ipv4_addr(),
+    );
+    root_ns.add(tld_ns.ds().ksk.clone());
+
+    let root_ns = root_ns.sign(SignSettings::default())?;
+    let trust_anchor = Some(root_ns.trust_anchor());
+
+    let root_ns = root_ns.start()?;
+    let tld_ns = tld_ns.start()?;
+    let parent_ns = parent_ns.start()?;
+    let child_ns = child_ns.start()?;
+
+    let root = root_ns.root_hint();
+
+    let nameservers = vec![child_ns, parent_ns, tld_ns, root_ns];
+
+    Ok(Graph {
+        nameservers,
+        root,
+        trust_anchor,
+    })
+}
+
+fn parse_dnssec_signzone_dsset(input: &str) -> Result<Vec<DS>> {
+    let mut ds_records = Vec::new();
+    for line in input.split('\n') {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let mut tokens = line.split_ascii_whitespace().collect::<Vec<_>>();
+        // Insert a TTL, since dnssec-signzone does not include one in DS records, and our FromStr
+        // implementations do not support this.
+        tokens.insert(1, "86400");
+        let ds: DS = tokens.join(" ").parse()?;
+        ds_records.push(ds);
+    }
+    Ok(ds_records)
 }

--- a/tests/ede-dot-com/src/lib.rs
+++ b/tests/ede-dot-com/src/lib.rs
@@ -159,6 +159,31 @@ fn no_zsk() -> Result<()> {
 }
 
 #[test]
+fn not_auth() -> Result<()> {
+    compare("not-auth").map(drop)
+}
+
+#[test]
+fn nsec3_iter_1() -> Result<()> {
+    compare("nsec3-iter-1").map(drop)
+}
+
+#[test]
+fn nsec3_iter_51() -> Result<()> {
+    compare("nsec3-iter-51").map(drop)
+}
+
+#[test]
+fn nsec3_iter_101() -> Result<()> {
+    compare("nsec3-iter-101").map(drop)
+}
+
+#[test]
+fn nsec3_iter_151() -> Result<()> {
+    compare("nsec3-iter-151").map(drop)
+}
+
+#[test]
 fn nsec3_iter_200() -> Result<()> {
     compare("nsec3-iter-200").map(drop)
 }
@@ -247,103 +272,8 @@ fn v4_doc() -> Result<()> {
 
 #[test]
 #[ignore]
-fn v4_hex() -> Result<()> {
-    compare("v4-hex").map(drop)
-}
-
-#[test]
-#[ignore]
-fn v4_link_local() -> Result<()> {
-    compare("v4-link-local").map(drop)
-}
-
-#[test]
-#[ignore]
-fn v4_loopback() -> Result<()> {
-    compare("v4-loopback").map(drop)
-}
-
-#[test]
-#[ignore]
-fn v4_private_10() -> Result<()> {
-    compare("v4-private-10").map(drop)
-}
-
-#[test]
-#[ignore]
-fn v4_private_172() -> Result<()> {
-    compare("v4-private-172").map(drop)
-}
-
-#[test]
-#[ignore]
-fn v4_private_192() -> Result<()> {
-    compare("v4-private-192").map(drop)
-}
-
-#[test]
-#[ignore]
-fn v4_reserved() -> Result<()> {
-    compare("v4-reserved").map(drop)
-}
-
-#[test]
-#[ignore]
-fn v4_this_host() -> Result<()> {
-    compare("v4-this-host").map(drop)
-}
-
-#[test]
-#[ignore]
 fn v6_doc() -> Result<()> {
     compare("v6-doc").map(drop)
-}
-
-#[test]
-#[ignore]
-fn v6_link_local() -> Result<()> {
-    compare("v6-link-local").map(drop)
-}
-
-#[test]
-#[ignore]
-fn v6_localhost() -> Result<()> {
-    compare("v6-localhost").map(drop)
-}
-
-#[test]
-#[ignore]
-fn v6_mapped() -> Result<()> {
-    compare("v6-mapped").map(drop)
-}
-
-#[test]
-#[ignore]
-fn v6_mapped_dep() -> Result<()> {
-    compare("v6-mapped-dep").map(drop)
-}
-
-#[test]
-#[ignore]
-fn v6_multicast() -> Result<()> {
-    compare("v6-multicast").map(drop)
-}
-
-#[test]
-#[ignore]
-fn v6_nat64() -> Result<()> {
-    compare("v6-nat64").map(drop)
-}
-
-#[test]
-#[ignore]
-fn v6_unique_local() -> Result<()> {
-    compare("v6-unique-local").map(drop)
-}
-
-#[test]
-fn v6_unspecified() -> Result<()> {
-    compare("v6-unspecified").map(drop)
 }
 
 #[test]

--- a/tests/ede-dot-com/src/lib.rs
+++ b/tests/ede-dot-com/src/lib.rs
@@ -14,13 +14,11 @@ use dns_test::{
 mod sanity_check;
 
 #[test]
-#[ignore]
 fn allow_query_localhost() -> Result<()> {
     compare("allow-query-localhost").map(drop)
 }
 
 #[test]
-#[ignore]
 fn allow_query_none() -> Result<()> {
     compare("allow-query-none").map(drop)
 }
@@ -265,13 +263,11 @@ fn unsigned() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn v4_doc() -> Result<()> {
     compare("v4-doc").map(drop)
 }
 
 #[test]
-#[ignore]
 fn v6_doc() -> Result<()> {
     compare("v6-doc").map(drop)
 }

--- a/tests/ede-dot-com/src/lib.rs
+++ b/tests/ede-dot-com/src/lib.rs
@@ -197,13 +197,13 @@ fn hermetic_dsa() -> Result<()> {
 }
 
 #[test]
-#[ignore]
+#[ignore = "hickory doesn't support ED448"]
 fn ed448() -> Result<()> {
     compare("ed448").map(drop)
 }
 
 #[test]
-#[ignore]
+#[ignore = "hickory doesn't support ED448"]
 fn hermetic_ed448() -> Result<()> {
     hermetic_compare("ed448").map(drop)
 }
@@ -239,13 +239,13 @@ fn hermetic_no_dnskey_257() -> Result<()> {
 }
 
 #[test]
-#[ignore]
+#[ignore = "hickory incorrectly produces a bogus validation result, instead of insecure"]
 fn no_ds() -> Result<()> {
     compare("no-ds").map(drop)
 }
 
 #[test]
-#[ignore]
+#[ignore = "hickory incorrectly produces a bogus validation result, instead of insecure"]
 fn hermetic_no_ds() -> Result<()> {
     hermetic_compare("no-ds").map(drop)
 }
@@ -501,13 +501,13 @@ fn hermetic_unassigned_zsk_algo() -> Result<()> {
 }
 
 #[test]
-#[ignore]
+#[ignore = "hickory incorrectly produces a bogus validation result, instead of insecure"]
 fn unsigned() -> Result<()> {
     compare("unsigned").map(drop)
 }
 
 #[test]
-#[ignore]
+#[ignore = "hickory incorrectly produces a bogus validation result, instead of insecure"]
 fn hermetic_unsigned() -> Result<()> {
     hermetic_compare("unsigned").map(drop)
 }

--- a/tests/ede-dot-com/src/sanity_check.rs
+++ b/tests/ede-dot-com/src/sanity_check.rs
@@ -16,6 +16,18 @@ fn valid() -> Result<()> {
 }
 
 #[test]
+fn hermetic_valid() -> Result<()> {
+    let response = crate::hermetic_compare("valid")?;
+
+    dbg!(&response);
+
+    assert!(response.status.is_noerror());
+    assert!(response.flags.authenticated_data);
+
+    Ok(())
+}
+
+#[test]
 fn dns_test_vars_are_not_set() {
     for var in ["DNS_TEST_SUBJECT", "DNS_TEST_PEER"] {
         assert!(


### PR DESCRIPTION
Closes #2491. This adds a separate Dockerfile that builds an older version of BIND, and sets up a Docker network that mirrors `extended-dns-errors.com` using modified versions of the same shell scripts. Separate tests are added to test recursors against subdomains hosted by these locally-run name servers. The offline-only tests are now run in CI, to catch future regressions.