### PR TITLE
Fix test failures due to example.com changes

### DIFF
--- a/bin/tests/integration/forwarder.rs
+++ b/bin/tests/integration/forwarder.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "resolver")]
 
-use std::net::Ipv4Addr;
 use std::str::FromStr;
 
 use tokio::runtime::Runtime;
@@ -26,7 +25,8 @@ fn test_lookup() {
         ))
         .unwrap();
 
-    let address = lookup.iter().next().expect("no addresses returned!");
-    let address = address.data().as_a().expect("not an A record");
-    assert_eq!(*address, Ipv4Addr::new(93, 184, 215, 14).into());
+    assert!(
+        lookup.iter().any(|record| record.data().as_a().is_some()),
+        "no addresses returned!"
+    );
 }

--- a/bin/tests/integration/named_tests.rs
+++ b/bin/tests/integration/named_tests.rs
@@ -256,7 +256,6 @@ fn test_server_continues_on_bad_data_tcp() {
 #[cfg(feature = "resolver")]
 fn test_forward() {
     use crate::server_harness::query_message;
-    use hickory_proto::rr::rdata::A;
 
     subscribe();
     let provider = TokioRuntimeProvider::new();
@@ -279,10 +278,10 @@ fn test_forward() {
         )
         .unwrap();
 
-        assert_eq!(
-            *response.answers()[0].data().as_a().unwrap(),
-            A::new(93, 184, 215, 14)
-        );
+        assert!(response
+            .answers()
+            .iter()
+            .any(|record| record.data().as_a().is_some()));
 
         // just tests that multiple queries work
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
@@ -299,10 +298,10 @@ fn test_forward() {
             RecordType::A,
         )
         .unwrap();
-        assert_eq!(
-            *response.answers()[0].data().as_a().unwrap(),
-            A::new(93, 184, 215, 14)
-        );
+        assert!(response
+            .answers()
+            .iter()
+            .any(|record| record.data().as_a().is_some()));
         assert!(!response.header().authoritative());
     })
 }

--- a/crates/async-std-resolver/src/lib.rs
+++ b/crates/async-std-resolver/src/lib.rs
@@ -64,12 +64,7 @@
 //!
 //!   // There can be many addresses associated with the name,
 //!   //  this can return IPv4 and/or IPv6 addresses
-//!   let address = response.iter().next().expect("no addresses returned!");
-//!   if address.is_ipv4() {
-//!     assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 215, 14)));
-//!   } else {
-//!     assert_eq!(address, IpAddr::V6(Ipv6Addr::new(0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c)));
-//!   }
+//!   let _address = response.iter().next().expect("no addresses returned!");
 //! }
 //! ```
 //!

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -22,10 +22,11 @@ The `client` is capable of DNSSEC validation as well as offering higher order fu
 ## Example
 
 ```rust
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::SocketAddr;
 use std::str::FromStr;
+
 use hickory_client::client::{Client, ClientHandle};
-use hickory_client::proto::rr::{rdata::A, DNSClass, Name, RData, Record, RecordType};
+use hickory_client::proto::rr::{DNSClass, Name, Record, RecordType};
 use hickory_client::proto::runtime::TokioRuntimeProvider;
 use hickory_client::proto::udp::UdpClientStream;
 use hickory_client::proto::xfer::DnsResponse;
@@ -54,11 +55,11 @@ let answers: &[Record] = response.answers();
 // Records are generic objects which can contain any data.
 //  In order to access it we need to first check what type of record it is
 //  In this case we are interested in A, IPv4 address
-if let RData::A(A(ref ip)) = answers[0].data() {
-    assert_eq!(*ip, Ipv4Addr::new(93, 184, 215, 14))
-} else {
-    panic!("unexpected result")
-}
+let a_data = answers
+    .iter()
+    .flat_map(|record| record.data().as_a())
+    .collect::<Vec<_>>();
+assert!(!a_data.is_empty());
 ```
 
 ## DNS-over-TLS and DNS-over-HTTPS

--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -8,11 +8,11 @@
 // Keep this in sync with the example in the README.
 #[tokio::test]
 async fn readme_example() {
-    use std::net::{Ipv4Addr, SocketAddr};
+    use std::net::SocketAddr;
     use std::str::FromStr;
 
     use crate::client::{Client, ClientHandle};
-    use crate::proto::rr::{rdata::A, DNSClass, Name, RData, Record, RecordType};
+    use crate::proto::rr::{DNSClass, Name, Record, RecordType};
     use crate::proto::runtime::TokioRuntimeProvider;
     use crate::proto::udp::UdpClientStream;
     use crate::proto::xfer::DnsResponse;
@@ -41,9 +41,9 @@ async fn readme_example() {
     // Records are generic objects which can contain any data.
     //  In order to access it we need to first check what type of record it is
     //  In this case we are interested in A, IPv4 address
-    if let RData::A(A(ref ip)) = answers[0].data() {
-        assert_eq!(*ip, Ipv4Addr::new(93, 184, 215, 14))
-    } else {
-        panic!("unexpected result")
-    }
+    let a_data = answers
+        .iter()
+        .flat_map(|record| record.data().as_a())
+        .collect::<Vec<_>>();
+    assert!(!a_data.is_empty());
 }

--- a/crates/resolver/README.md
+++ b/crates/resolver/README.md
@@ -22,7 +22,6 @@ This library contains implementations for IPv4 (A) and IPv6 (AAAA) resolution, m
 ## Example
 
 ```rust
-use std::net::*;
 use hickory_resolver::Resolver;
 use hickory_resolver::name_server::TokioConnectionProvider;
 use hickory_resolver::config::*;
@@ -42,12 +41,7 @@ let response = resolver.lookup_ip("www.example.com.").await.unwrap();
 
 // There can be many addresses associated with the name,
 //  this can return IPv4 and/or IPv6 addresses
-let address = response.iter().next().expect("no addresses returned!");
-if address.is_ipv4() {
-    assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 215, 14)));
-} else {
-    assert_eq!(address, IpAddr::V6(Ipv6Addr::new(0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c)));
-}
+let _address = response.iter().next().expect("no addresses returned!");
 ```
 
 ## DNS-over-TLS and DNS-over-HTTPS

--- a/crates/resolver/examples/custom_provider.rs
+++ b/crates/resolver/examples/custom_provider.rs
@@ -10,7 +10,7 @@ use {
     },
     std::future::Future,
     std::io,
-    std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    std::net::SocketAddr,
     std::pin::Pin,
     std::time::Duration,
     tokio::net::{TcpSocket, TcpStream, UdpSocket},
@@ -83,19 +83,7 @@ impl RuntimeProvider for PrintProvider {
 async fn lookup_test<R: ConnectionProvider>(resolver: Resolver<R>) {
     let response = resolver.lookup_ip("www.example.com.").await.unwrap();
 
-    // There can be many addresses associated with the name,
-    //  this can return IPv4 and/or IPv6 addresses
-    let address = response.iter().next().expect("no addresses returned!");
-    if address.is_ipv4() {
-        assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 215, 14)));
-    } else {
-        assert_eq!(
-            address,
-            IpAddr::V6(Ipv6Addr::new(
-                0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c
-            ))
-        );
-    }
+    assert_ne!(response.iter().count(), 0, "no addresses returned!");
 }
 
 #[cfg(any(feature = "webpki-roots", feature = "native-certs"))]

--- a/crates/resolver/src/h2.rs
+++ b/crates/resolver/src/h2.rs
@@ -74,8 +74,6 @@ where
 #[cfg(any(feature = "webpki-roots", feature = "native-certs"))]
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-
     use tokio::runtime::Runtime;
 
     use crate::config::{ResolverConfig, ResolverOpts};
@@ -98,38 +96,14 @@ mod tests {
             .block_on(resolver.lookup_ip("www.example.com."))
             .expect("failed to run lookup");
 
-        assert_eq!(response.iter().count(), 1);
-        for address in response.iter() {
-            if address.is_ipv4() {
-                assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 215, 14)));
-            } else {
-                assert_eq!(
-                    address,
-                    IpAddr::V6(Ipv6Addr::new(
-                        0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c,
-                    ))
-                );
-            }
-        }
+        assert_ne!(response.iter().count(), 0);
 
         // check if there is another connection created
         let response = io_loop
             .block_on(resolver.lookup_ip("www.example.com."))
             .expect("failed to run lookup");
 
-        assert_eq!(response.iter().count(), 1);
-        for address in response.iter() {
-            if address.is_ipv4() {
-                assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 215, 14)));
-            } else {
-                assert_eq!(
-                    address,
-                    IpAddr::V6(Ipv6Addr::new(
-                        0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c,
-                    ))
-                );
-            }
-        }
+        assert_ne!(response.iter().count(), 0);
     }
 
     #[test]

--- a/crates/resolver/src/h3.rs
+++ b/crates/resolver/src/h3.rs
@@ -71,8 +71,6 @@ pub(crate) fn new_h3_stream_with_future(
 
 #[cfg(all(test, any(feature = "native-certs", feature = "webpki-roots")))]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-
     use tokio::runtime::Runtime;
 
     use crate::config::{ResolverConfig, ResolverOpts};
@@ -92,38 +90,14 @@ mod tests {
             .block_on(resolver.lookup_ip("www.example.com."))
             .expect("failed to run lookup");
 
-        assert_eq!(response.iter().count(), 1);
-        for address in response.iter() {
-            if address.is_ipv4() {
-                assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 215, 14)));
-            } else {
-                assert_eq!(
-                    address,
-                    IpAddr::V6(Ipv6Addr::new(
-                        0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c,
-                    ))
-                );
-            }
-        }
+        assert_ne!(response.iter().count(), 0);
 
         // check if there is another connection created
         let response = io_loop
             .block_on(resolver.lookup_ip("www.example.com."))
             .expect("failed to run lookup");
 
-        assert_eq!(response.iter().count(), 1);
-        for address in response.iter() {
-            if address.is_ipv4() {
-                assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 215, 14)));
-            } else {
-                assert_eq!(
-                    address,
-                    IpAddr::V6(Ipv6Addr::new(
-                        0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c,
-                    ))
-                );
-            }
-        }
+        assert_ne!(response.iter().count(), 0);
     }
 
     #[test]

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -83,12 +83,7 @@
 //!
 //! // There can be many addresses associated with the name,
 //! //  this can return IPv4 and/or IPv6 addresses
-//! let address = response.iter().next().expect("no addresses returned!");
-//! if address.is_ipv4() {
-//!     assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 215, 14)));
-//! } else {
-//!     assert_eq!(address, IpAddr::V6(Ipv6Addr::new(0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c)));
-//! }
+//! let _address = response.iter().next().expect("no addresses returned!");
 //! # }
 //! # }
 //! ```

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -400,7 +400,7 @@ impl Stream for Local {
 #[cfg(test)]
 #[cfg(feature = "tokio-runtime")]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::str::FromStr;
 
     use tokio::runtime::Runtime;
@@ -531,13 +531,7 @@ mod tests {
             )
             .expect("lookup failed");
 
-        assert_eq!(
-            *response.answers()[0]
-                .data()
-                .as_a()
-                .expect("no a record available"),
-            Ipv4Addr::new(93, 184, 215, 14).into()
-        );
+        assert!(!response.answers().is_empty());
 
         assert!(
             name_servers[0].is_connected(),
@@ -555,13 +549,7 @@ mod tests {
             )
             .expect("lookup failed");
 
-        assert_eq!(
-            *response.answers()[0]
-                .data()
-                .as_aaaa()
-                .expect("no aaaa record available"),
-            Ipv6Addr::new(0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c).into()
-        );
+        assert!(!response.answers().is_empty());
 
         assert!(
             name_servers[0].is_connected(),

--- a/crates/resolver/src/quic.rs
+++ b/crates/resolver/src/quic.rs
@@ -70,7 +70,7 @@ pub(crate) fn new_quic_stream_with_future(
 
 #[cfg(all(test, any(feature = "native-certs", feature = "webpki-roots")))]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use std::net::IpAddr;
     use std::sync::Arc;
 
     use tokio::runtime::Runtime;
@@ -95,38 +95,14 @@ mod tests {
             .block_on(resolver.lookup_ip("www.example.com."))
             .expect("failed to run lookup");
 
-        assert_eq!(response.iter().count(), 1);
-        for address in response.iter() {
-            if address.is_ipv4() {
-                assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 215, 14)));
-            } else {
-                assert_eq!(
-                    address,
-                    IpAddr::V6(Ipv6Addr::new(
-                        0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c,
-                    ))
-                );
-            }
-        }
+        assert_ne!(response.iter().count(), 0);
 
         // check if there is another connection created
         let response = io_loop
             .block_on(resolver.lookup_ip("www.example.com."))
             .expect("failed to run lookup");
 
-        assert_eq!(response.iter().count(), 1);
-        for address in response.iter() {
-            if address.is_ipv4() {
-                assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 215, 14)));
-            } else {
-                assert_eq!(
-                    address,
-                    IpAddr::V6(Ipv6Addr::new(
-                        0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c,
-                    ))
-                );
-            }
-        }
+        assert_ne!(response.iter().count(), 0);
     }
 
     #[test]

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -550,19 +550,7 @@ pub mod testing {
             .block_on(resolver.lookup_ip("www.example.com."))
             .expect("failed to run lookup");
 
-        assert_eq!(response.iter().count(), 1);
-        for address in response.iter() {
-            if address.is_ipv4() {
-                assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 215, 14)));
-            } else {
-                assert_eq!(
-                    address,
-                    IpAddr::V6(Ipv6Addr::new(
-                        0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c,
-                    ))
-                );
-            }
-        }
+        assert_ne!(response.iter().count(), 0);
     }
 
     /// Test IP lookup from IP literals.
@@ -661,24 +649,11 @@ pub mod testing {
             .block_on(resolver.lookup_ip("www.example.com."))
             .expect("failed to run lookup");
 
-        // TODO: this test is flaky, sometimes 1 is returned, sometimes 2...
-        //assert_eq!(response.iter().count(), 1);
-        for address in response.iter() {
-            if address.is_ipv4() {
-                assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 215, 14)));
-            } else {
-                assert_eq!(
-                    address,
-                    IpAddr::V6(Ipv6Addr::new(
-                        0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c,
-                    ))
-                );
-            }
-        }
-
-        for record in response.as_lookup().record_iter() {
-            assert!(record.proof().is_secure())
-        }
+        assert_ne!(response.iter().count(), 0);
+        assert!(response
+            .as_lookup()
+            .record_iter()
+            .any(|record| record.proof().is_secure()));
     }
 
     /// Test IP lookup from domains that exist but unsigned with DNSSEC validation.
@@ -779,13 +754,9 @@ pub mod testing {
             .block_on(resolver.lookup_ip("www.example.com."))
             .expect("failed to run lookup");
 
-        assert_eq!(response.iter().count(), 1);
+        assert_ne!(response.iter().count(), 0);
         for address in response.iter() {
-            if address.is_ipv4() {
-                assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 215, 14)));
-            } else {
-                panic!("should only be looking up IPv4");
-            }
+            assert!(address.is_ipv4(), "should only be looking up IPv4");
         }
     }
 
@@ -815,13 +786,9 @@ pub mod testing {
             .block_on(resolver.lookup_ip("www.example.com"))
             .expect("failed to run lookup");
 
-        assert_eq!(response.iter().count(), 1);
+        assert_ne!(response.iter().count(), 0);
         for address in response.iter() {
-            if address.is_ipv4() {
-                assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 215, 14)));
-            } else {
-                panic!("should only be looking up IPv4");
-            }
+            assert!(address.is_ipv4(), "should only be looking up IPv4");
         }
     }
 
@@ -854,13 +821,9 @@ pub mod testing {
             .block_on(resolver.lookup_ip("www.example.com"))
             .expect("failed to run lookup");
 
-        assert_eq!(response.iter().count(), 1);
+        assert_ne!(response.iter().count(), 0);
         for address in response.iter() {
-            if address.is_ipv4() {
-                assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 215, 14)));
-            } else {
-                panic!("should only be looking up IPv4");
-            }
+            assert!(address.is_ipv4(), "should only be looking up IPv4");
         }
     }
 
@@ -892,13 +855,9 @@ pub mod testing {
             .block_on(resolver.lookup_ip("www"))
             .expect("failed to run lookup");
 
-        assert_eq!(response.iter().count(), 1);
+        assert_ne!(response.iter().count(), 0);
         for address in response.iter() {
-            if address.is_ipv4() {
-                assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 215, 14)));
-            } else {
-                panic!("should only be looking up IPv4");
-            }
+            assert!(address.is_ipv4(), "should only be looking up IPv4");
         }
     }
 
@@ -931,13 +890,9 @@ pub mod testing {
             .block_on(resolver.lookup_ip("www"))
             .expect("failed to run lookup");
 
-        assert_eq!(response.iter().count(), 1);
+        assert_ne!(response.iter().count(), 0);
         for address in response.iter() {
-            if address.is_ipv4() {
-                assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 215, 14)));
-            } else {
-                panic!("should only be looking up IPv4");
-            }
+            assert!(address.is_ipv4(), "should only be looking up IPv4");
         }
     }
 

--- a/crates/resolver/src/tests.rs
+++ b/crates/resolver/src/tests.rs
@@ -2,8 +2,6 @@
 #[cfg(feature = "tokio-runtime")]
 #[tokio::test]
 async fn readme_example() {
-    use std::net::*;
-
     use crate::config::*;
     use crate::name_server::TokioConnectionProvider;
     use crate::Resolver;
@@ -23,17 +21,7 @@ async fn readme_example() {
 
     // There can be many addresses associated with the name,
     //  this can return IPv4 and/or IPv6 addresses
-    let address = response.iter().next().expect("no addresses returned!");
-    if address.is_ipv4() {
-        assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 215, 14)));
-    } else {
-        assert_eq!(
-            address,
-            IpAddr::V6(Ipv6Addr::new(
-                0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c
-            ))
-        );
-    }
+    let _address = response.iter().next().expect("no addresses returned!");
 }
 
 // Keep this in sync with the example in the README.

--- a/crates/resolver/src/tls.rs
+++ b/crates/resolver/src/tls.rs
@@ -66,8 +66,6 @@ where
 #[cfg(any(feature = "webpki-roots", feature = "native-certs"))]
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-
     use tokio::runtime::Runtime;
 
     use crate::config::{ResolverConfig, ResolverOpts};
@@ -90,19 +88,7 @@ mod tests {
             .block_on(resolver.lookup_ip("www.example.com."))
             .expect("failed to run lookup");
 
-        assert_eq!(response.iter().count(), 1);
-        for address in response.iter() {
-            if address.is_ipv4() {
-                assert_eq!(address, IpAddr::V4(Ipv4Addr::new(93, 184, 215, 14)));
-            } else {
-                assert_eq!(
-                    address,
-                    IpAddr::V6(Ipv6Addr::new(
-                        0x2606, 0x2800, 0x21f, 0xcb07, 0x6820, 0x80da, 0xaf6b, 0x8b2c,
-                    ))
-                );
-            }
-        }
+        assert_ne!(response.iter().count(), 0);
     }
 
     #[test]

--- a/tests/integration-tests/tests/integration/client_tests.rs
+++ b/tests/integration-tests/tests/integration/client_tests.rs
@@ -198,10 +198,7 @@ async fn test_query_edns(client: Client) {
         .name()
         .eq_case(&name));
 
-    let record = &response.answers()[0];
-    assert_eq!(record.name(), &name);
-    assert_eq!(record.record_type(), RecordType::A);
-    assert_eq!(record.dns_class(), DNSClass::IN);
+    assert!(!response.answers().is_empty());
     assert!(response.extensions().is_some());
     assert_eq!(
         response
@@ -212,12 +209,6 @@ async fn test_query_edns(client: Client) {
             .unwrap(),
         &EdnsOption::Subnet("1.2.0.0/16".parse().unwrap())
     );
-
-    if let RData::A(address) = *record.data() {
-        assert_eq!(address, A::new(93, 184, 215, 14))
-    } else {
-        panic!();
-    }
 }
 
 #[tokio::test]
@@ -260,16 +251,7 @@ async fn test_secure_query_example(mut client: DnssecClient) {
             .dnssec_ok
     );
 
-    let record = &response.answers()[0];
-    assert_eq!(record.name(), &name);
-    assert_eq!(record.record_type(), RecordType::A);
-    assert_eq!(record.dns_class(), DNSClass::IN);
-
-    if let RData::A(address) = *record.data() {
-        assert_eq!(address, A::new(93, 184, 215, 14))
-    } else {
-        panic!();
-    }
+    assert!(!response.answers().is_empty());
 }
 
 async fn test_timeout_query(mut client: Client) {

--- a/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
+++ b/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
@@ -7,11 +7,10 @@ use futures::executor::block_on;
 use tokio::runtime::Runtime;
 
 use hickory_client::client::{Client, ClientHandle, MemoizeClientHandle};
-use hickory_proto::dnssec::{DnssecDnsHandle, Proof, TrustAnchor};
+use hickory_proto::dnssec::{DnssecDnsHandle, TrustAnchor};
 use hickory_proto::op::ResponseCode;
-use hickory_proto::rr::rdata::A;
 use hickory_proto::rr::Name;
-use hickory_proto::rr::{DNSClass, RData, RecordType};
+use hickory_proto::rr::{DNSClass, RecordType};
 use hickory_proto::runtime::TokioRuntimeProvider;
 use hickory_proto::tcp::TcpClientStream;
 use hickory_proto::udp::UdpClientStream;
@@ -56,17 +55,6 @@ where
     );
 
     assert!(!response.answers().is_empty());
-    let record = &response.answers()[0];
-    assert_eq!(record.name(), &name);
-    assert_eq!(record.record_type(), RecordType::A);
-    assert_eq!(record.dns_class(), DNSClass::IN);
-    assert_eq!(record.proof(), Proof::Secure);
-
-    if let RData::A(address) = *record.data() {
-        assert_eq!(address, A::new(93, 184, 215, 14))
-    } else {
-        panic!();
-    }
 }
 
 #[test]


### PR DESCRIPTION
This removes or relaxes assertions about responses we get when querying `www.example.com.` in tests. It also sets the maximum buffer size in some low-level transport tests. We no longer check the IP address returned, since we could now get almost any Akamai server, instead we just check that we got at least one record, or at least one record of a particular type. Fixes #2724.