### PR TITLE
server: defer FORMERR when QDCOUNT!=1

### DIFF
--- a/conformance/packages/conformance-tests/src/name_server/rfc8906/basic.rs
+++ b/conformance/packages/conformance-tests/src/name_server/rfc8906/basic.rs
@@ -144,7 +144,6 @@ fn test_8_1_3_4_header_bits_recursive_query() -> Result<()> {
 }
 
 #[test]
-#[ignore = "hickory returns FORMERR"]
 fn test_8_1_4_unknown_opcodes() -> Result<()> {
     let (_network, ns, client) = setup()?;
 

--- a/crates/server/src/server/request_handler.rs
+++ b/crates/server/src/server/request_handler.rs
@@ -9,6 +9,8 @@
 
 use std::net::SocketAddr;
 
+use hickory_proto::ProtoError;
+
 use crate::{
     authority::MessageRequest,
     proto::{
@@ -42,13 +44,15 @@ impl Request {
     }
 
     /// Return just the header and request information from the Request Message
-    pub fn request_info(&self) -> RequestInfo<'_> {
-        RequestInfo {
+    ///
+    /// Returns an error if there is not exactly one query
+    pub fn request_info(&self) -> Result<RequestInfo<'_>, ProtoError> {
+        Ok(RequestInfo {
             src: self.src,
             protocol: self.protocol,
             header: self.message.header(),
-            query: self.message.query(),
-        }
+            query: self.message.raw_queries().try_as_query()?,
+        })
     }
 
     /// The IP address from which the request originated.


### PR DESCRIPTION
This makes some changes to the server crate to more gracefully handle messages with zero queries, and let us return `NOTIMP` with a higher precedence in such cases if the opcode is unrecognized. Fixes #2723. In particular:

- `MessageRequest` now contains a `Queries` instead of a `WireQuery`
  - Updated methods to reflect this change
  - Cleaned up helpers that are now dead code
- `MessageResponse` and `MessageResponseBuilder` take `&Queries` instead of `Option<&WireQuery>`
- `Request::request_info()` is now fallible
- `UpdateRequest::zone()` is now fallible
- Logging statements in server_future.rs were split in two to separately handle the case where QDCOUNT!=1 (and QNAME/QTYPE/QCLASS are not well defined)