### PR TITLE
ci: remove specific Windows features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,11 +47,7 @@ jobs:
         run: cargo binstall cargo-workspaces -y --version ${{ env.CARGO_WS_VERSION }}
 
       - name: just all-features
-        if: matrix.os != 'windows-latest'
         run: just all-features
-      - name: just windows-features
-        if: matrix.os == 'windows-latest'
-        run: just windows-features
 
       - name: just test-docs
         if: ${{ !cancelled() && matrix.os != 'windows-latest' }} # uses all features, avoid openssl

--- a/bin/src/hickory-dns.rs
+++ b/bin/src/hickory-dns.rs
@@ -771,5 +771,7 @@ fn check_drop_privs(user: &str, group: &str) -> Result<(), String> {
     Ok(())
 }
 
+#[cfg(target_family = "unix")]
 static DEFAULT_USER: &str = "nobody";
+#[cfg(target_family = "unix")]
 static DEFAULT_GROUP: &str = "nobody";

--- a/crates/server/src/store/blocklist/authority.rs
+++ b/crates/server/src/store/blocklist/authority.rs
@@ -212,7 +212,7 @@ impl BlocklistAuthority {
             return Err(e);
         }
 
-        for mut entry in contents.split('\n') {
+        for mut entry in contents.lines() {
             // Strip comments
             if let Some((item, _)) = entry.split_once('#') {
                 entry = item.trim();
@@ -458,6 +458,7 @@ mod test {
         },
         store::blocklist::BlocklistConsultAction,
     };
+    use test_support::subscribe;
 
     enum TestResult {
         Break,
@@ -466,6 +467,7 @@ mod test {
 
     #[tokio::test]
     async fn test_blocklist_basic() {
+        subscribe();
         let config = super::BlocklistConfig {
             wildcard_match: true,
             min_wildcard_depth: 2,
@@ -528,6 +530,7 @@ mod test {
 
     #[tokio::test]
     async fn test_blocklist_wildcard_disabled() {
+        subscribe();
         let config = super::BlocklistConfig {
             min_wildcard_depth: 2,
             wildcard_match: false,
@@ -579,6 +582,7 @@ mod test {
     #[tokio::test]
     #[should_panic]
     async fn test_blocklist_wrong_block_message() {
+        subscribe();
         let config = super::BlocklistConfig {
             min_wildcard_depth: 2,
             wildcard_match: false,

--- a/justfile
+++ b/justfile
@@ -24,11 +24,6 @@ default feature='' ignore='': (check feature ignore) (build feature ignore) (tes
 # Check, build, and test all crates with all-features enabled
 all-features: (default "--all-features")
 
-# Check, build, and test a sizable cross-section of crates/features that don't depend on OpenSSL
-# All features will be applied independently to all crates, so the crates/features tested here
-# need to avoid crates that don't expose the features and features that are only defined in a few crates.
-windows-features: (default "--features=dns-over-rustls,dns-over-https-rustls,dns-over-quic,dnssec-ring" "--ignore=\\{async-std-resolver,hickory-client,hickory-compatibility,test-support\\}")
-
 # Check, build, and test all crates with no-default-features
 no-default-features: (default "--no-default-features" "--ignore=\\{hickory-compatibility\\}")
 


### PR DESCRIPTION
These should no longer be needed now that we don't support OpenSSL.