### PR TITLE
recursor: drop type aliases

### DIFF
--- a/crates/recursor/src/recursor_dns_handle.rs
+++ b/crates/recursor/src/recursor_dns_handle.rs
@@ -34,13 +34,10 @@ use crate::{
     Error, ErrorKind,
 };
 
-/// Set of nameservers by the zone name
-type NameServerCache<P> = LruCache<Name, RecursorPool<P>>;
-
 #[derive(Clone)]
 pub(crate) struct RecursorDnsHandle {
     roots: RecursorPool<TokioRuntimeProvider>,
-    name_server_cache: Arc<Mutex<NameServerCache<TokioRuntimeProvider>>>,
+    name_server_cache: Arc<Mutex<LruCache<Name, RecursorPool<TokioRuntimeProvider>>>>,
     record_cache: DnsLru,
     recursion_limit: Option<u8>,
     ns_recursion_limit: Option<u8>,
@@ -76,7 +73,7 @@ impl RecursorDnsHandle {
         let roots =
             GenericNameServerPool::from_config(roots, opts, TokioConnectionProvider::default());
         let roots = RecursorPool::from(Name::root(), roots);
-        let name_server_cache = Arc::new(Mutex::new(NameServerCache::new(ns_cache_size)));
+        let name_server_cache = Arc::new(Mutex::new(LruCache::new(ns_cache_size)));
         let record_cache = DnsLru::new(record_cache_size, ttl_config);
 
         let mut deny_server_v4 = PrefixSet::new();


### PR DESCRIPTION
In most cases, IMO type aliases add more obfuscation rather than anything else -- they certainly don't add any type safety. All of these have relatively few usages and are better off as direct types, IMO.