### PR TITLE
Use async test attribute macros

### DIFF
--- a/crates/async-std-resolver/src/tests.rs
+++ b/crates/async-std-resolver/src/tests.rs
@@ -1,7 +1,14 @@
 #![allow(clippy::extra_unused_type_parameters)]
 
 use hickory_resolver::name_server::GenericConnection;
-use hickory_resolver::testing;
+use hickory_resolver::testing::{
+    domain_search_test, fqdn_test, idna_test, ip_lookup_across_threads_test, ip_lookup_test,
+    large_ndots_test, localhost_ipv4_test, localhost_ipv6_test, lookup_test, ndots_test,
+    search_ipv4_large_ndots_test, search_ipv6_large_ndots_test, search_ipv6_name_parse_fails_test,
+    search_list_test,
+};
+#[cfg(feature = "system-config")]
+use hickory_resolver::testing::{hosts_lookup_test, system_lookup_test};
 use hickory_resolver::LookupFuture;
 use test_support::subscribe;
 
@@ -35,176 +42,116 @@ fn test_send_sync() {
     assert!(is_send_t::<LookupFuture<GenericConnection>>());
 }
 
-#[test]
-fn test_lookup_google() {
-    use testing::lookup_test;
-    let io_loop = AsyncStdConnectionProvider::new();
-
-    lookup_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
-        ResolverConfig::google(),
-        io_loop.clone(),
-        io_loop,
-    )
+#[async_std::test]
+async fn test_lookup_google() {
+    subscribe();
+    lookup_test(ResolverConfig::google(), AsyncStdConnectionProvider::new()).await;
 }
 
-#[test]
-fn test_lookup_cloudflare() {
-    use testing::lookup_test;
-    let io_loop = AsyncStdConnectionProvider::new();
-    lookup_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
+#[async_std::test]
+async fn test_lookup_cloudflare() {
+    subscribe();
+    lookup_test(
         ResolverConfig::cloudflare(),
-        io_loop.clone(),
-        io_loop,
+        AsyncStdConnectionProvider::new(),
     )
+    .await;
 }
 
-#[test]
-fn test_ip_lookup() {
-    use testing::ip_lookup_test;
-    let io_loop = AsyncStdConnectionProvider::new();
-    ip_lookup_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
-        io_loop.clone(),
-        io_loop,
-    )
+#[async_std::test]
+async fn test_ip_lookup() {
+    subscribe();
+    ip_lookup_test(AsyncStdConnectionProvider::new()).await;
 }
 
 #[test]
 fn test_ip_lookup_across_threads() {
-    use testing::ip_lookup_across_threads_test;
-    let io_loop = AsyncStdConnectionProvider::new();
-    ip_lookup_across_threads_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(io_loop)
-}
-
-#[test]
-#[ignore]
-#[cfg(any(unix, target_os = "windows"))]
-#[cfg(feature = "system-config")]
-fn test_system_lookup() {
-    use testing::system_lookup_test;
-    let io_loop = AsyncStdConnectionProvider::new();
-    system_lookup_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
-        io_loop.clone(),
-        io_loop,
+    subscribe();
+    ip_lookup_across_threads_test::<AsyncStdConnectionProvider, _>(
+        AsyncStdConnectionProvider::new(),
     );
 }
 
-#[test]
+#[async_std::test]
+#[ignore]
+#[cfg(any(unix, target_os = "windows"))]
+#[cfg(feature = "system-config")]
+async fn test_system_lookup() {
+    subscribe();
+    system_lookup_test(AsyncStdConnectionProvider::new()).await;
+}
+
+#[async_std::test]
 #[ignore]
 #[cfg(feature = "system-config")]
 // these appear to not work on CI, test on macos with `10.1.0.104  a.com`
 #[cfg(unix)]
-fn test_hosts_lookup() {
-    use testing::hosts_lookup_test;
-    let io_loop = AsyncStdConnectionProvider::new();
-    hosts_lookup_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
-        io_loop.clone(),
-        io_loop,
-    );
-}
-
-#[test]
-fn test_fqdn() {
-    use testing::fqdn_test;
-    let io_loop = AsyncStdConnectionProvider::new();
-    fqdn_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(io_loop.clone(), io_loop);
-}
-
-#[test]
-fn test_ndots() {
-    use testing::ndots_test;
-    let io_loop = AsyncStdConnectionProvider::new();
-    ndots_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(io_loop.clone(), io_loop);
-}
-
-#[test]
-fn test_large_ndots() {
-    use testing::large_ndots_test;
-    let io_loop = AsyncStdConnectionProvider::new();
-    large_ndots_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
-        io_loop.clone(),
-        io_loop,
-    );
-}
-
-#[test]
-fn test_domain_search() {
-    use testing::domain_search_test;
+async fn test_hosts_lookup() {
     subscribe();
-    let io_loop = AsyncStdConnectionProvider::new();
-    domain_search_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
-        io_loop.clone(),
-        io_loop,
-    );
+    hosts_lookup_test(AsyncStdConnectionProvider::new()).await;
 }
 
-#[test]
-fn test_search_list() {
-    use testing::search_list_test;
-    let io_loop = AsyncStdConnectionProvider::new();
-    search_list_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
-        io_loop.clone(),
-        io_loop,
-    );
+#[async_std::test]
+async fn test_fqdn() {
+    subscribe();
+    fqdn_test(AsyncStdConnectionProvider::new()).await;
 }
 
-#[test]
-fn test_idna() {
-    use testing::idna_test;
-    let io_loop = AsyncStdConnectionProvider::new();
-    idna_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(io_loop.clone(), io_loop);
+#[async_std::test]
+async fn test_ndots() {
+    subscribe();
+    ndots_test(AsyncStdConnectionProvider::new()).await;
 }
 
-#[test]
-fn test_localhost_ipv4() {
-    use testing::localhost_ipv4_test;
-    let io_loop = AsyncStdConnectionProvider::new();
-
-    localhost_ipv4_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
-        io_loop.clone(),
-        io_loop,
-    );
+#[async_std::test]
+async fn test_large_ndots() {
+    subscribe();
+    large_ndots_test(AsyncStdConnectionProvider::new()).await;
 }
 
-#[test]
-fn test_localhost_ipv6() {
-    use testing::localhost_ipv6_test;
-    let io_loop = AsyncStdConnectionProvider::new();
-
-    localhost_ipv6_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
-        io_loop.clone(),
-        io_loop,
-    );
+#[async_std::test]
+async fn test_domain_search() {
+    subscribe();
+    domain_search_test(AsyncStdConnectionProvider::new()).await;
 }
 
-#[test]
-fn test_search_ipv4_large_ndots() {
-    use testing::search_ipv4_large_ndots_test;
-    let io_loop = AsyncStdConnectionProvider::new();
-
-    search_ipv4_large_ndots_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
-        io_loop.clone(),
-        io_loop,
-    );
+#[async_std::test]
+async fn test_search_list() {
+    subscribe();
+    search_list_test(AsyncStdConnectionProvider::new()).await;
 }
 
-#[test]
-fn test_search_ipv6_large_ndots() {
-    use testing::search_ipv6_large_ndots_test;
-    let io_loop = AsyncStdConnectionProvider::new();
-
-    search_ipv6_large_ndots_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
-        io_loop.clone(),
-        io_loop,
-    );
+#[async_std::test]
+async fn test_idna() {
+    subscribe();
+    idna_test(AsyncStdConnectionProvider::new()).await;
 }
 
-#[test]
-fn test_search_ipv6_name_parse_fails() {
-    use testing::search_ipv6_name_parse_fails_test;
-    let io_loop = AsyncStdConnectionProvider::new();
+#[async_std::test]
+async fn test_localhost_ipv4() {
+    subscribe();
+    localhost_ipv4_test(AsyncStdConnectionProvider::new()).await;
+}
 
-    search_ipv6_name_parse_fails_test::<AsyncStdConnectionProvider, AsyncStdConnectionProvider>(
-        io_loop.clone(),
-        io_loop,
-    );
+#[async_std::test]
+async fn test_localhost_ipv6() {
+    subscribe();
+    localhost_ipv6_test(AsyncStdConnectionProvider::new()).await;
+}
+
+#[async_std::test]
+async fn test_search_ipv4_large_ndots() {
+    subscribe();
+    search_ipv4_large_ndots_test(AsyncStdConnectionProvider::new()).await;
+}
+
+#[async_std::test]
+async fn test_search_ipv6_large_ndots() {
+    subscribe();
+    search_ipv6_large_ndots_test(AsyncStdConnectionProvider::new()).await;
+}
+
+#[async_std::test]
+async fn test_search_ipv6_name_parse_fails() {
+    search_ipv6_name_parse_fails_test(AsyncStdConnectionProvider::new()).await;
 }

--- a/crates/proto/src/multicast/mdns_stream.rs
+++ b/crates/proto/src/multicast/mdns_stream.rs
@@ -437,11 +437,10 @@ pub(crate) mod tests {
         Lazy::new(|| Ipv6Addr::new(0xFF02, 0, 0, 0, 0, 0, 0, 0x00FA).into());
 
     // one_shot tests are basically clones from the udp tests
-    #[test]
-    fn test_next_random_socket() {
+    #[tokio::test]
+    async fn test_next_random_socket() {
         subscribe();
 
-        let io_loop = runtime::Runtime::new().unwrap();
         let (stream, _) = MdnsStream::new(
             SocketAddr::new(*TEST_MDNS_IPV4, BASE_TEST_PORT),
             MdnsQueryType::OneShot,
@@ -449,7 +448,7 @@ pub(crate) mod tests {
             None,
             None,
         );
-        let result = io_loop.block_on(stream);
+        let result = stream.await;
 
         if let Err(error) = result {
             println!("Random address error: {error:#?}");

--- a/crates/proto/src/tcp/tcp_client_stream.rs
+++ b/crates/proto/src/tcp/tcp_client_stream.rs
@@ -111,27 +111,20 @@ where
 #[cfg(feature = "tokio-runtime")]
 mod tests {
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-    use tokio::runtime::Runtime;
 
     use crate::runtime::TokioRuntimeProvider;
     use crate::tests::tcp_client_stream_test;
-    #[test]
-    fn test_tcp_stream_ipv4() {
-        let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        tcp_client_stream_test::<Runtime>(
-            IpAddr::V4(Ipv4Addr::LOCALHOST),
-            io_loop,
-            TokioRuntimeProvider::new(),
-        )
+    #[tokio::test]
+    async fn test_tcp_stream_ipv4() {
+        tcp_client_stream_test(IpAddr::V4(Ipv4Addr::LOCALHOST), TokioRuntimeProvider::new()).await;
     }
 
-    #[test]
-    fn test_tcp_stream_ipv6() {
-        let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        tcp_client_stream_test::<Runtime>(
+    #[tokio::test]
+    async fn test_tcp_stream_ipv6() {
+        tcp_client_stream_test(
             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
-            io_loop,
             TokioRuntimeProvider::new(),
         )
+        .await;
     }
 }

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -384,28 +384,21 @@ impl<S: DnsTcpStream> Stream for TcpStream<S> {
 #[cfg(feature = "tokio-runtime")]
 mod tests {
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-    use tokio::runtime::Runtime;
 
     use crate::runtime::TokioRuntimeProvider;
     use crate::tests::tcp_stream_test;
 
-    #[test]
-    fn test_tcp_stream_ipv4() {
-        let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        tcp_stream_test::<Runtime>(
-            IpAddr::V4(Ipv4Addr::LOCALHOST),
-            io_loop,
-            TokioRuntimeProvider::new(),
-        )
+    #[tokio::test]
+    async fn test_tcp_stream_ipv4() {
+        tcp_stream_test(IpAddr::V4(Ipv4Addr::LOCALHOST), TokioRuntimeProvider::new()).await;
     }
 
-    #[test]
-    fn test_tcp_stream_ipv6() {
-        let io_loop = Runtime::new().expect("failed to create tokio runtime");
-        tcp_stream_test::<Runtime>(
+    #[tokio::test]
+    async fn test_tcp_stream_ipv6() {
+        tcp_stream_test(
             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
-            io_loop,
             TokioRuntimeProvider::new(),
         )
+        .await;
     }
 }

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -385,25 +385,18 @@ mod tests {
     use crate::{runtime::TokioRuntimeProvider, tests::udp_client_stream_test};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use test_support::subscribe;
-    use tokio::runtime::Runtime;
 
-    #[test]
-    fn test_udp_client_stream_ipv4() {
+    #[tokio::test]
+    async fn test_udp_client_stream_ipv4() {
         subscribe();
-        let io_loop = Runtime::new().expect("failed to create tokio runtime");
         let provider = TokioRuntimeProvider::new();
-        udp_client_stream_test(IpAddr::V4(Ipv4Addr::LOCALHOST), io_loop, provider)
+        udp_client_stream_test(IpAddr::V4(Ipv4Addr::LOCALHOST), provider).await;
     }
 
-    #[test]
-    fn test_udp_client_stream_ipv6() {
+    #[tokio::test]
+    async fn test_udp_client_stream_ipv6() {
         subscribe();
-        let io_loop = Runtime::new().expect("failed to create tokio runtime");
         let provider = TokioRuntimeProvider::new();
-        udp_client_stream_test(
-            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
-            io_loop,
-            provider,
-        )
+        udp_client_stream_test(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), provider).await;
     }
 }

--- a/crates/proto/src/udp/udp_stream.rs
+++ b/crates/proto/src/udp/udp_stream.rs
@@ -404,34 +404,27 @@ impl DnsUdpSocket for tokio::net::UdpSocket {
 #[cfg(feature = "tokio-runtime")]
 mod tests {
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-    use tokio::runtime::Runtime;
 
-    use crate::runtime::TokioRuntimeProvider;
+    use crate::{
+        runtime::TokioRuntimeProvider,
+        tests::{next_random_socket_test, udp_stream_test},
+    };
 
-    #[test]
-    fn test_next_random_socket() {
-        use crate::tests::next_random_socket_test;
-        let io_loop = Runtime::new().expect("failed to create tokio runtime");
+    #[tokio::test]
+    async fn test_next_random_socket() {
         let provider = TokioRuntimeProvider::new();
-        next_random_socket_test(io_loop, provider)
+        next_random_socket_test(provider).await;
     }
 
-    #[test]
-    fn test_udp_stream_ipv4() {
-        use crate::tests::udp_stream_test;
-        let io_loop = Runtime::new().expect("failed to create tokio runtime");
+    #[tokio::test]
+    async fn test_udp_stream_ipv4() {
         let provider = TokioRuntimeProvider::new();
-        io_loop.block_on(udp_stream_test(IpAddr::V4(Ipv4Addr::LOCALHOST), provider));
+        udp_stream_test(IpAddr::V4(Ipv4Addr::LOCALHOST), provider).await;
     }
 
-    #[test]
-    fn test_udp_stream_ipv6() {
-        use crate::tests::udp_stream_test;
-        let io_loop = Runtime::new().expect("failed to create tokio runtime");
+    #[tokio::test]
+    async fn test_udp_stream_ipv6() {
         let provider = TokioRuntimeProvider::new();
-        io_loop.block_on(udp_stream_test(
-            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
-            provider,
-        ));
+        udp_stream_test(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), provider).await;
     }
 }

--- a/crates/resolver/src/h3.rs
+++ b/crates/resolver/src/h3.rs
@@ -71,37 +71,35 @@ pub(crate) fn new_h3_stream_with_future(
 
 #[cfg(all(test, any(feature = "native-certs", feature = "webpki-roots")))]
 mod tests {
-    use tokio::runtime::Runtime;
-
     use crate::config::{ResolverConfig, ResolverOpts};
     use crate::name_server::TokioConnectionProvider;
     use crate::TokioResolver;
 
-    fn h3_test(config: ResolverConfig) {
-        let io_loop = Runtime::new().unwrap();
-
+    async fn h3_test(config: ResolverConfig) {
         let resolver = TokioResolver::new(
             config,
             ResolverOpts::default(),
             TokioConnectionProvider::default(),
         );
 
-        let response = io_loop
-            .block_on(resolver.lookup_ip("www.example.com."))
+        let response = resolver
+            .lookup_ip("www.example.com.")
+            .await
             .expect("failed to run lookup");
 
         assert_ne!(response.iter().count(), 0);
 
         // check if there is another connection created
-        let response = io_loop
-            .block_on(resolver.lookup_ip("www.example.com."))
+        let response = resolver
+            .lookup_ip("www.example.com.")
+            .await
             .expect("failed to run lookup");
 
         assert_ne!(response.iter().count(), 0);
     }
 
-    #[test]
-    fn test_google_h3() {
-        h3_test(ResolverConfig::google_h3())
+    #[tokio::test]
+    async fn test_google_h3() {
+        h3_test(ResolverConfig::google_h3()).await
     }
 }

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -488,9 +488,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_multi_use_conns() {
-        let io_loop = Runtime::new().unwrap();
+    #[tokio::test]
+    async fn test_multi_use_conns() {
         let conn_provider = TokioConnectionProvider::default();
 
         let tcp = NameServerConfig {
@@ -521,14 +520,13 @@ mod tests {
         let name = Name::from_str("www.example.com.").unwrap();
 
         // first lookup
-        let response = io_loop
-            .block_on(
-                pool.lookup(
-                    Query::query(name.clone(), RecordType::A),
-                    DnsRequestOptions::default(),
-                )
-                .first_answer(),
+        let response = pool
+            .lookup(
+                Query::query(name.clone(), RecordType::A),
+                DnsRequestOptions::default(),
             )
+            .first_answer()
+            .await
             .expect("lookup failed");
 
         assert!(!response.answers().is_empty());
@@ -539,14 +537,13 @@ mod tests {
         );
 
         // first lookup
-        let response = io_loop
-            .block_on(
-                pool.lookup(
-                    Query::query(name, RecordType::AAAA),
-                    DnsRequestOptions::default(),
-                )
-                .first_answer(),
+        let response = pool
+            .lookup(
+                Query::query(name, RecordType::AAAA),
+                DnsRequestOptions::default(),
             )
+            .first_answer()
+            .await
             .expect("lookup failed");
 
         assert!(!response.answers().is_empty());

--- a/crates/resolver/src/tls.rs
+++ b/crates/resolver/src/tls.rs
@@ -66,15 +66,11 @@ where
 #[cfg(any(feature = "webpki-roots", feature = "native-certs"))]
 #[cfg(test)]
 mod tests {
-    use tokio::runtime::Runtime;
-
     use crate::config::{ResolverConfig, ResolverOpts};
     use crate::name_server::TokioConnectionProvider;
     use crate::TokioResolver;
 
-    fn tls_test(config: ResolverConfig) {
-        let io_loop = Runtime::new().unwrap();
-
+    async fn tls_test(config: ResolverConfig) {
         let resolver = TokioResolver::new(
             config,
             ResolverOpts {
@@ -84,20 +80,21 @@ mod tests {
             TokioConnectionProvider::default(),
         );
 
-        let response = io_loop
-            .block_on(resolver.lookup_ip("www.example.com."))
+        let response = resolver
+            .lookup_ip("www.example.com.")
+            .await
             .expect("failed to run lookup");
 
         assert_ne!(response.iter().count(), 0);
     }
 
-    #[test]
-    fn test_google_tls() {
-        tls_test(ResolverConfig::google_tls())
+    #[tokio::test]
+    async fn test_google_tls() {
+        tls_test(ResolverConfig::google_tls()).await
     }
 
-    #[test]
-    fn test_cloudflare_tls() {
-        tls_test(ResolverConfig::cloudflare_tls())
+    #[tokio::test]
+    async fn test_cloudflare_tls() {
+        tls_test(ResolverConfig::cloudflare_tls()).await
     }
 }

--- a/crates/server/src/server/server_future.rs
+++ b/crates/server/src/server/server_future.rs
@@ -1309,19 +1309,16 @@ mod tests {
         reap_tasks(&mut joinset);
     }
 
-    #[test]
-    fn task_reap_on_nonempty_joinset() {
-        let runtime = tokio::runtime::Runtime::new().unwrap();
-        runtime.block_on(async {
-            let mut joinset = JoinSet::new();
-            let t = joinset.spawn(tokio::time::sleep(Duration::from_secs(2)));
+    #[tokio::test]
+    async fn task_reap_on_nonempty_joinset() {
+        let mut joinset = JoinSet::new();
+        let t = joinset.spawn(tokio::time::sleep(Duration::from_secs(2)));
 
-            // this should return immediately since no task is ready
-            reap_tasks(&mut joinset);
-            t.abort();
+        // this should return immediately since no task is ready
+        reap_tasks(&mut joinset);
+        t.abort();
 
-            // this should also return immediately since the task has been aborted
-            reap_tasks(&mut joinset);
-        });
+        // this should also return immediately since the task has been aborted
+        reap_tasks(&mut joinset);
     }
 }

--- a/tests/integration-tests/tests/integration/client_future_tests.rs
+++ b/tests/integration-tests/tests/integration/client_future_tests.rs
@@ -7,7 +7,6 @@ use futures::{Future, FutureExt, TryFutureExt};
 use test_support::subscribe;
 #[cfg(all(feature = "dnssec-ring", feature = "sqlite"))]
 use time::Duration;
-use tokio::runtime::Runtime;
 
 use hickory_client::{
     client::{Client, ClientHandle},
@@ -38,90 +37,83 @@ use hickory_proto::{
 };
 use hickory_server::authority::{Authority, Catalog};
 
-#[test]
-fn test_query_nonet() {
+#[tokio::test]
+async fn test_query_nonet() {
     subscribe();
 
     let authority = create_example();
     let mut catalog = Catalog::new();
     catalog.upsert(authority.origin().clone(), vec![Arc::new(authority)]);
 
-    let io_loop = Runtime::new().unwrap();
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
     let client = Client::new(stream, sender, None);
-    let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-    hickory_proto::runtime::spawn_bg(&io_loop, bg);
+    let (mut client, bg) = client.await.expect("client failed to connect");
+    tokio::spawn(bg);
 
-    io_loop.block_on(test_query(&mut client));
-    io_loop.block_on(test_query(&mut client));
+    test_query(&mut client).await;
+    test_query(&mut client).await;
 }
 
-#[test]
-fn test_query_udp_ipv4() {
-    let io_loop = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_query_udp_ipv4() {
     let stream = UdpClientStream::builder(GOOGLE_V4, TokioRuntimeProvider::new()).build();
     let client = Client::connect(stream);
-    let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-    hickory_proto::runtime::spawn_bg(&io_loop, bg);
+    let (mut client, bg) = client.await.expect("client failed to connect");
+    tokio::spawn(bg);
 
     // TODO: timeouts on these requests so that the test doesn't hang
-    io_loop.block_on(test_query(&mut client));
-    io_loop.block_on(test_query(&mut client));
-    io_loop.block_on(test_query_edns(&mut client));
+    test_query(&mut client).await;
+    test_query(&mut client).await;
+    test_query_edns(&mut client).await;
 }
 
-#[test]
+#[tokio::test]
 #[ignore]
-fn test_query_udp_ipv6() {
-    let io_loop = Runtime::new().unwrap();
+async fn test_query_udp_ipv6() {
     let stream = UdpClientStream::builder(GOOGLE_V6, TokioRuntimeProvider::new()).build();
     let client = Client::connect(stream);
-    let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-    hickory_proto::runtime::spawn_bg(&io_loop, bg);
+    let (mut client, bg) = client.await.expect("client failed to connect");
+    tokio::spawn(bg);
 
     // TODO: timeouts on these requests so that the test doesn't hang
-    io_loop.block_on(test_query(&mut client));
-    io_loop.block_on(test_query(&mut client));
-    io_loop.block_on(test_query_edns(&mut client));
+    test_query(&mut client).await;
+    test_query(&mut client).await;
+    test_query_edns(&mut client).await;
 }
 
-#[test]
-fn test_query_tcp_ipv4() {
-    let io_loop = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_query_tcp_ipv4() {
     let (stream, sender) = TcpClientStream::new(GOOGLE_V4, None, None, TokioRuntimeProvider::new());
     let client = Client::new(stream, sender, None);
-    let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-    hickory_proto::runtime::spawn_bg(&io_loop, bg);
+    let (mut client, bg) = client.await.expect("client failed to connect");
+    tokio::spawn(bg);
 
     // TODO: timeouts on these requests so that the test doesn't hang
-    io_loop.block_on(test_query(&mut client));
-    io_loop.block_on(test_query(&mut client));
+    test_query(&mut client).await;
+    test_query(&mut client).await;
 }
 
-#[test]
+#[tokio::test]
 #[ignore]
-fn test_query_tcp_ipv6() {
-    let io_loop = Runtime::new().unwrap();
+async fn test_query_tcp_ipv6() {
     let (stream, sender) = TcpClientStream::new(GOOGLE_V6, None, None, TokioRuntimeProvider::new());
     let client = Client::new(stream, sender, None);
-    let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-    hickory_proto::runtime::spawn_bg(&io_loop, bg);
+    let (mut client, bg) = client.await.expect("client failed to connect");
+    tokio::spawn(bg);
 
     // TODO: timeouts on these requests so that the test doesn't hang
-    io_loop.block_on(test_query(&mut client));
-    io_loop.block_on(test_query(&mut client));
+    test_query(&mut client).await;
+    test_query(&mut client).await;
 }
 
-#[test]
+#[tokio::test]
 #[cfg(feature = "dns-over-https-rustls")]
-fn test_query_https() {
+async fn test_query_https() {
     use hickory_integration::CLOUDFLARE_V4_TLS;
     use hickory_proto::h2::HttpsClientStreamBuilder;
     use rustls::{ClientConfig, RootCertStore};
 
     const ALPN_H2: &[u8] = b"h2";
-
-    let io_loop = Runtime::new().unwrap();
 
     // using the mozilla default root store
     let mut root_store = RootCertStore::empty();
@@ -144,12 +136,12 @@ fn test_query_https() {
         "cloudflare-dns.com".to_string(),
         "/dns-query".to_string(),
     ));
-    let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-    hickory_proto::runtime::spawn_bg(&io_loop, bg);
+    let (mut client, bg) = client.await.expect("client failed to connect");
+    tokio::spawn(bg);
 
     // TODO: timeouts on these requests so that the test doesn't hang
-    io_loop.block_on(test_query(&mut client));
-    io_loop.block_on(test_query(&mut client));
+    test_query(&mut client).await;
+    test_query(&mut client).await;
 }
 
 #[cfg(test)]
@@ -223,22 +215,22 @@ fn test_query_edns(client: &mut Client) -> impl Future<Output = ()> {
         .map(|r: Result<_, _>| r.expect("query failed"))
 }
 
-#[test]
-fn test_notify() {
-    let io_loop = Runtime::new().unwrap();
+#[tokio::test]
+async fn test_notify() {
     let authority = create_example();
     let mut catalog = Catalog::new();
     catalog.upsert(authority.origin().clone(), vec![Arc::new(authority)]);
 
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
     let client = Client::new(stream, sender, None);
-    let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-    hickory_proto::runtime::spawn_bg(&io_loop, bg);
+    let (mut client, bg) = client.await.expect("client failed to connect");
+    tokio::spawn(bg);
 
     let name = Name::from_str("ping.example.com.").unwrap();
 
-    let message =
-        io_loop.block_on(client.notify(name, DNSClass::IN, RecordType::A, None::<RecordSet>));
+    let message = client
+        .notify(name, DNSClass::IN, RecordType::A, None::<RecordSet>)
+        .await;
     assert!(message.is_ok());
     let message = message.unwrap();
     assert_eq!(
@@ -301,11 +293,10 @@ async fn create_sig0_ready_client() -> (
 }
 
 #[cfg(all(feature = "dnssec-ring", feature = "sqlite"))]
-#[test]
-fn test_create() {
-    let io_loop = Runtime::new().unwrap();
-    let ((mut client, bg), origin) = io_loop.block_on(create_sig0_ready_client());
-    hickory_proto::runtime::spawn_bg(&io_loop, bg);
+#[tokio::test]
+async fn test_create() {
+    let ((mut client, bg), origin) = create_sig0_ready_client().await;
+    tokio::spawn(bg);
 
     // create a record
     let record = Record::from_rdata(
@@ -314,16 +305,18 @@ fn test_create() {
         RData::A(A::new(100, 10, 100, 10)),
     );
 
-    let result = io_loop
-        .block_on(client.create(record.clone(), origin.clone()))
+    let result = client
+        .create(record.clone(), origin.clone())
+        .await
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
-    let result = io_loop
-        .block_on(client.query(
+    let result = client
+        .query(
             record.name().clone(),
             record.dns_class(),
             record.record_type(),
-        ))
+        )
+        .await
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
     assert_eq!(result.answers().len(), 1);
@@ -331,8 +324,9 @@ fn test_create() {
 
     // trying to create again should error
     // TODO: it would be cool to make this
-    let result = io_loop
-        .block_on(client.create(record.clone(), origin.clone()))
+    let result = client
+        .create(record.clone(), origin.clone())
+        .await
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::YXRRSet);
 
@@ -340,18 +334,15 @@ fn test_create() {
     let mut record = record;
     record.set_data(RData::A(A::new(101, 11, 101, 11)));
 
-    let result = io_loop
-        .block_on(client.create(record, origin))
-        .expect("create failed");
+    let result = client.create(record, origin).await.expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::YXRRSet);
 }
 
 #[cfg(all(feature = "dnssec-ring", feature = "sqlite"))]
-#[test]
-fn test_create_multi() {
-    let io_loop = Runtime::new().unwrap();
-    let ((mut client, bg), origin) = io_loop.block_on(create_sig0_ready_client());
-    hickory_proto::runtime::spawn_bg(&io_loop, bg);
+#[tokio::test]
+async fn test_create_multi() {
+    let ((mut client, bg), origin) = create_sig0_ready_client().await;
+    tokio::spawn(bg);
 
     // create a record
     let record = Record::from_rdata(
@@ -368,16 +359,18 @@ fn test_create_multi() {
     rrset.insert(record2.clone(), 0);
     let rrset = rrset;
 
-    let result = io_loop
-        .block_on(client.create(rrset.clone(), origin.clone()))
+    let result = client
+        .create(rrset.clone(), origin.clone())
+        .await
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
-    let result = io_loop
-        .block_on(client.query(
+    let result = client
+        .query(
             record.name().clone(),
             record.dns_class(),
             record.record_type(),
-        ))
+        )
+        .await
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
     assert_eq!(result.answers().len(), 2);
@@ -387,8 +380,9 @@ fn test_create_multi() {
 
     // trying to create again should error
     // TODO: it would be cool to make this
-    let result = io_loop
-        .block_on(client.create(rrset, origin.clone()))
+    let result = client
+        .create(rrset, origin.clone())
+        .await
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::YXRRSet);
 
@@ -396,18 +390,15 @@ fn test_create_multi() {
     let mut record = record;
     record.set_data(RData::A(A::new(101, 11, 101, 12)));
 
-    let result = io_loop
-        .block_on(client.create(record, origin))
-        .expect("create failed");
+    let result = client.create(record, origin).await.expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::YXRRSet);
 }
 
 #[cfg(all(feature = "dnssec-ring", feature = "sqlite"))]
-#[test]
-fn test_append() {
-    let io_loop = Runtime::new().unwrap();
-    let ((mut client, bg), origin) = io_loop.block_on(create_sig0_ready_client());
-    hickory_proto::runtime::spawn_bg(&io_loop, bg);
+#[tokio::test]
+async fn test_append() {
+    let ((mut client, bg), origin) = create_sig0_ready_client().await;
+    tokio::spawn(bg);
 
     // append a record
     let record = Record::from_rdata(
@@ -417,24 +408,27 @@ fn test_append() {
     );
 
     // first check the must_exist option
-    let result = io_loop
-        .block_on(client.append(record.clone(), origin.clone(), true))
+    let result = client
+        .append(record.clone(), origin.clone(), true)
+        .await
         .expect("append failed");
     assert_eq!(result.response_code(), ResponseCode::NXRRSet);
 
     // next append to a non-existent RRset
-    let result = io_loop
-        .block_on(client.append(record.clone(), origin.clone(), false))
+    let result = client
+        .append(record.clone(), origin.clone(), false)
+        .await
         .expect("append failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
     // verify record contents
-    let result = io_loop
-        .block_on(client.query(
+    let result = client
+        .query(
             record.name().clone(),
             record.dns_class(),
             record.record_type(),
-        ))
+        )
+        .await
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
     assert_eq!(result.answers().len(), 1);
@@ -445,17 +439,19 @@ fn test_append() {
     record2.set_data(RData::A(A::new(101, 11, 101, 11)));
     let record2 = record2;
 
-    let result = io_loop
-        .block_on(client.append(record2.clone(), origin.clone(), true))
+    let result = client
+        .append(record2.clone(), origin.clone(), true)
+        .await
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
-    let result = io_loop
-        .block_on(client.query(
+    let result = client
+        .query(
             record.name().clone(),
             record.dns_class(),
             record.record_type(),
-        ))
+        )
+        .await
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
     assert_eq!(result.answers().len(), 2);
@@ -464,28 +460,29 @@ fn test_append() {
     assert!(result.answers().iter().any(|rr| *rr == record2));
 
     // show that appending the same thing again is ok, but doesn't add any records
-    let result = io_loop
-        .block_on(client.append(record.clone(), origin, true))
+    let result = client
+        .append(record.clone(), origin, true)
+        .await
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
-    let result = io_loop
-        .block_on(client.query(
+    let result = client
+        .query(
             record.name().clone(),
             record.dns_class(),
             record.record_type(),
-        ))
+        )
+        .await
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
     assert_eq!(result.answers().len(), 2);
 }
 
 #[cfg(all(feature = "dnssec-ring", feature = "sqlite"))]
-#[test]
-fn test_append_multi() {
-    let io_loop = Runtime::new().unwrap();
-    let ((mut client, bg), origin) = io_loop.block_on(create_sig0_ready_client());
-    hickory_proto::runtime::spawn_bg(&io_loop, bg);
+#[tokio::test]
+async fn test_append_multi() {
+    let ((mut client, bg), origin) = create_sig0_ready_client().await;
+    tokio::spawn(bg);
 
     // append a record
     let record = Record::from_rdata(
@@ -495,24 +492,27 @@ fn test_append_multi() {
     );
 
     // first check the must_exist option
-    let result = io_loop
-        .block_on(client.append(record.clone(), origin.clone(), true))
+    let result = client
+        .append(record.clone(), origin.clone(), true)
+        .await
         .expect("append failed");
     assert_eq!(result.response_code(), ResponseCode::NXRRSet);
 
     // next append to a non-existent RRset
-    let result = io_loop
-        .block_on(client.append(record.clone(), origin.clone(), false))
+    let result = client
+        .append(record.clone(), origin.clone(), false)
+        .await
         .expect("append failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
     // verify record contents
-    let result = io_loop
-        .block_on(client.query(
+    let result = client
+        .query(
             record.name().clone(),
             record.dns_class(),
             record.record_type(),
-        ))
+        )
+        .await
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
     assert_eq!(result.answers().len(), 1);
@@ -528,17 +528,19 @@ fn test_append_multi() {
     let mut rrset = RecordSet::from(record2.clone());
     rrset.insert(record3.clone(), 0);
 
-    let result = io_loop
-        .block_on(client.append(rrset, origin.clone(), true))
+    let result = client
+        .append(rrset, origin.clone(), true)
+        .await
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
-    let result = io_loop
-        .block_on(client.query(
+    let result = client
+        .query(
             record.name().clone(),
             record.dns_class(),
             record.record_type(),
-        ))
+        )
+        .await
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
     assert_eq!(result.answers().len(), 3);
@@ -549,28 +551,29 @@ fn test_append_multi() {
 
     // show that appending the same thing again is ok, but doesn't add any records
     // TODO: technically this is a test for the Server, not client...
-    let result = io_loop
-        .block_on(client.append(record.clone(), origin, true))
+    let result = client
+        .append(record.clone(), origin, true)
+        .await
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
-    let result = io_loop
-        .block_on(client.query(
+    let result = client
+        .query(
             record.name().clone(),
             record.dns_class(),
             record.record_type(),
-        ))
+        )
+        .await
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
     assert_eq!(result.answers().len(), 3);
 }
 
 #[cfg(all(feature = "dnssec-ring", feature = "sqlite"))]
-#[test]
-fn test_compare_and_swap() {
-    let io_loop = Runtime::new().unwrap();
-    let ((mut client, bg), origin) = io_loop.block_on(create_sig0_ready_client());
-    hickory_proto::runtime::spawn_bg(&io_loop, bg);
+#[tokio::test]
+async fn test_compare_and_swap() {
+    let ((mut client, bg), origin) = create_sig0_ready_client().await;
+    tokio::spawn(bg);
 
     // create a record
     let record = Record::from_rdata(
@@ -579,8 +582,9 @@ fn test_compare_and_swap() {
         RData::A(A::new(100, 10, 100, 10)),
     );
 
-    let result = io_loop
-        .block_on(client.create(record.clone(), origin.clone()))
+    let result = client
+        .create(record.clone(), origin.clone())
+        .await
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
@@ -589,13 +593,15 @@ fn test_compare_and_swap() {
     new.set_data(RData::A(A::new(101, 11, 101, 11)));
     let new = new;
 
-    let result = io_loop
-        .block_on(client.compare_and_swap(current.clone(), new.clone(), origin.clone()))
+    let result = client
+        .compare_and_swap(current.clone(), new.clone(), origin.clone())
+        .await
         .expect("compare_and_swap failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
-    let result = io_loop
-        .block_on(client.query(new.name().clone(), new.dns_class(), new.record_type()))
+    let result = client
+        .query(new.name().clone(), new.dns_class(), new.record_type())
+        .await
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
     assert_eq!(result.answers().len(), 1);
@@ -607,13 +613,15 @@ fn test_compare_and_swap() {
     not.set_data(RData::A(A::new(102, 12, 102, 12)));
     let not = not;
 
-    let result = io_loop
-        .block_on(client.compare_and_swap(current, not.clone(), origin))
+    let result = client
+        .compare_and_swap(current, not.clone(), origin)
+        .await
         .expect("compare_and_swap failed");
     assert_eq!(result.response_code(), ResponseCode::NXRRSet);
 
-    let result = io_loop
-        .block_on(client.query(new.name().clone(), new.dns_class(), new.record_type()))
+    let result = client
+        .query(new.name().clone(), new.dns_class(), new.record_type())
+        .await
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
     assert_eq!(result.answers().len(), 1);
@@ -622,11 +630,10 @@ fn test_compare_and_swap() {
 }
 
 #[cfg(all(feature = "dnssec-ring", feature = "sqlite"))]
-#[test]
-fn test_compare_and_swap_multi() {
-    let io_loop = Runtime::new().unwrap();
-    let ((mut client, bg), origin) = io_loop.block_on(create_sig0_ready_client());
-    hickory_proto::runtime::spawn_bg(&io_loop, bg);
+#[tokio::test]
+async fn test_compare_and_swap_multi() {
+    let ((mut client, bg), origin) = create_sig0_ready_client().await;
+    tokio::spawn(bg);
 
     // create a record
     let mut current = RecordSet::with_ttl(
@@ -643,8 +650,9 @@ fn test_compare_and_swap_multi() {
         .clone();
     let current = current;
 
-    let result = io_loop
-        .block_on(client.create(current.clone(), origin.clone()))
+    let result = client
+        .create(current.clone(), origin.clone())
+        .await
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
@@ -653,13 +661,15 @@ fn test_compare_and_swap_multi() {
     let new2 = new.new_record(&RData::A(A::new(100, 10, 101, 11))).clone();
     let new = new;
 
-    let result = io_loop
-        .block_on(client.compare_and_swap(current.clone(), new.clone(), origin.clone()))
+    let result = client
+        .compare_and_swap(current.clone(), new.clone(), origin.clone())
+        .await
         .expect("compare_and_swap failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
-    let result = io_loop
-        .block_on(client.query(new.name().clone(), new.dns_class(), new.record_type()))
+    let result = client
+        .query(new.name().clone(), new.dns_class(), new.record_type())
+        .await
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
     assert_eq!(result.answers().len(), 2);
@@ -673,13 +683,15 @@ fn test_compare_and_swap_multi() {
     not.set_data(RData::A(A::new(102, 12, 102, 12)));
     let not = not;
 
-    let result = io_loop
-        .block_on(client.compare_and_swap(current, not.clone(), origin))
+    let result = client
+        .compare_and_swap(current, not.clone(), origin)
+        .await
         .expect("compare_and_swap failed");
     assert_eq!(result.response_code(), ResponseCode::NXRRSet);
 
-    let result = io_loop
-        .block_on(client.query(new.name().clone(), new.dns_class(), new.record_type()))
+    let result = client
+        .query(new.name().clone(), new.dns_class(), new.record_type())
+        .await
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
     assert_eq!(result.answers().len(), 2);
@@ -688,11 +700,10 @@ fn test_compare_and_swap_multi() {
 }
 
 #[cfg(all(feature = "dnssec-ring", feature = "sqlite"))]
-#[test]
-fn test_delete_by_rdata() {
-    let io_loop = Runtime::new().unwrap();
-    let ((mut client, bg), origin) = io_loop.block_on(create_sig0_ready_client());
-    hickory_proto::runtime::spawn_bg(&io_loop, bg);
+#[tokio::test]
+async fn test_delete_by_rdata() {
+    let ((mut client, bg), origin) = create_sig0_ready_client().await;
+    tokio::spawn(bg);
 
     // append a record
     let record1 = Record::from_rdata(
@@ -702,36 +713,41 @@ fn test_delete_by_rdata() {
     );
 
     // first check the must_exist option
-    let result = io_loop
-        .block_on(client.delete_by_rdata(record1.clone(), origin.clone()))
+    let result = client
+        .delete_by_rdata(record1.clone(), origin.clone())
+        .await
         .expect("delete failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
     // next create to a non-existent RRset
-    let result = io_loop
-        .block_on(client.create(record1.clone(), origin.clone()))
+    let result = client
+        .create(record1.clone(), origin.clone())
+        .await
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
     let mut record2 = record1.clone();
     record2.set_data(RData::A(A::new(101, 11, 101, 11)));
-    let result = io_loop
-        .block_on(client.append(record2.clone(), origin.clone(), true))
+    let result = client
+        .append(record2.clone(), origin.clone(), true)
+        .await
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
     // verify record contents
-    let result = io_loop
-        .block_on(client.delete_by_rdata(record2, origin))
+    let result = client
+        .delete_by_rdata(record2, origin)
+        .await
         .expect("delete failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
-    let result = io_loop
-        .block_on(client.query(
+    let result = client
+        .query(
             record1.name().clone(),
             record1.dns_class(),
             record1.record_type(),
-        ))
+        )
+        .await
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
     assert_eq!(result.answers().len(), 1);
@@ -739,11 +755,10 @@ fn test_delete_by_rdata() {
 }
 
 #[cfg(all(feature = "dnssec-ring", feature = "sqlite"))]
-#[test]
-fn test_delete_by_rdata_multi() {
-    let io_loop = Runtime::new().unwrap();
-    let ((mut client, bg), origin) = io_loop.block_on(create_sig0_ready_client());
-    hickory_proto::runtime::spawn_bg(&io_loop, bg);
+#[tokio::test]
+async fn test_delete_by_rdata_multi() {
+    let ((mut client, bg), origin) = create_sig0_ready_client().await;
+    tokio::spawn(bg);
 
     // append a record
     let mut rrset = RecordSet::with_ttl(
@@ -767,14 +782,16 @@ fn test_delete_by_rdata_multi() {
     let rrset = rrset;
 
     // first check the must_exist option
-    let result = io_loop
-        .block_on(client.delete_by_rdata(rrset.clone(), origin.clone()))
+    let result = client
+        .delete_by_rdata(rrset.clone(), origin.clone())
+        .await
         .expect("delete failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
     // next create to a non-existent RRset
-    let result = io_loop
-        .block_on(client.create(rrset, origin.clone()))
+    let result = client
+        .create(rrset, origin.clone())
+        .await
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
@@ -789,23 +806,26 @@ fn test_delete_by_rdata_multi() {
     let record3 = rrset.new_record(record3.data()).clone();
     let rrset = rrset;
 
-    let result = io_loop
-        .block_on(client.append(rrset.clone(), origin.clone(), true))
+    let result = client
+        .append(rrset.clone(), origin.clone(), true)
+        .await
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
     // verify record contents
-    let result = io_loop
-        .block_on(client.delete_by_rdata(rrset, origin))
+    let result = client
+        .delete_by_rdata(rrset, origin)
+        .await
         .expect("delete failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
-    let result = io_loop
-        .block_on(client.query(
+    let result = client
+        .query(
             record1.name().clone(),
             record1.dns_class(),
             record1.record_type(),
-        ))
+        )
+        .await
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
     assert_eq!(result.answers().len(), 2);
@@ -816,11 +836,10 @@ fn test_delete_by_rdata_multi() {
 }
 
 #[cfg(all(feature = "dnssec-ring", feature = "sqlite"))]
-#[test]
-fn test_delete_rrset() {
-    let io_loop = Runtime::new().unwrap();
-    let ((mut client, bg), origin) = io_loop.block_on(create_sig0_ready_client());
-    hickory_proto::runtime::spawn_bg(&io_loop, bg);
+#[tokio::test]
+async fn test_delete_rrset() {
+    let ((mut client, bg), origin) = create_sig0_ready_client().await;
+    tokio::spawn(bg);
 
     // append a record
     let mut record = Record::from_rdata(
@@ -830,48 +849,52 @@ fn test_delete_rrset() {
     );
 
     // first check the must_exist option
-    let result = io_loop
-        .block_on(client.delete_rrset(record.clone(), origin.clone()))
+    let result = client
+        .delete_rrset(record.clone(), origin.clone())
+        .await
         .expect("delete failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
     // next create to a non-existent RRset
-    let result = io_loop
-        .block_on(client.create(record.clone(), origin.clone()))
+    let result = client
+        .create(record.clone(), origin.clone())
+        .await
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
     record.set_data(RData::A(A::new(101, 11, 101, 11)));
-    let result = io_loop
-        .block_on(client.append(record.clone(), origin.clone(), true))
+    let result = client
+        .append(record.clone(), origin.clone(), true)
+        .await
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
     // verify record contents
-    let result = io_loop
-        .block_on(client.delete_rrset(record.clone(), origin))
+    let result = client
+        .delete_rrset(record.clone(), origin)
+        .await
         .expect("delete failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
-    let result = io_loop
-        .block_on(client.query(
+    let result = client
+        .query(
             record.name().clone(),
             record.dns_class(),
             record.record_type(),
-        ))
+        )
+        .await
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NXDomain);
     assert_eq!(result.answers().len(), 0);
 }
 
 #[cfg(all(feature = "dnssec-ring", feature = "sqlite"))]
-#[test]
-fn test_delete_all() {
+#[tokio::test]
+async fn test_delete_all() {
     use hickory_proto::rr::rdata::AAAA;
 
-    let io_loop = Runtime::new().unwrap();
-    let ((mut client, bg), origin) = io_loop.block_on(create_sig0_ready_client());
-    hickory_proto::runtime::spawn_bg(&io_loop, bg);
+    let ((mut client, bg), origin) = create_sig0_ready_client().await;
+    tokio::spawn(bg);
 
     // append a record
     let mut record = Record::from_rdata(
@@ -881,47 +904,54 @@ fn test_delete_all() {
     );
 
     // first check the must_exist option
-    let result = io_loop
-        .block_on(client.delete_all(record.name().clone(), origin.clone(), DNSClass::IN))
+    let result = client
+        .delete_all(record.name().clone(), origin.clone(), DNSClass::IN)
+        .await
         .expect("delete failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
     // next create to a non-existent RRset
-    let result = io_loop
-        .block_on(client.create(record.clone(), origin.clone()))
+    let result = client
+        .create(record.clone(), origin.clone())
+        .await
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
     record.set_data(RData::AAAA(AAAA::new(1, 2, 3, 4, 5, 6, 7, 8)));
-    let result = io_loop
-        .block_on(client.create(record.clone(), origin.clone()))
+    let result = client
+        .create(record.clone(), origin.clone())
+        .await
         .expect("create failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
     // verify record contents
-    let result = io_loop
-        .block_on(client.delete_all(record.name().clone(), origin, DNSClass::IN))
+    let result = client
+        .delete_all(record.name().clone(), origin, DNSClass::IN)
+        .await
         .expect("delete failed");
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
-    let result = io_loop
-        .block_on(client.query(record.name().clone(), record.dns_class(), RecordType::A))
+    let result = client
+        .query(record.name().clone(), record.dns_class(), RecordType::A)
+        .await
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NXDomain);
     assert_eq!(result.answers().len(), 0);
 
-    let result = io_loop
-        .block_on(client.query(record.name().clone(), record.dns_class(), RecordType::AAAA))
+    let result = client
+        .query(record.name().clone(), record.dns_class(), RecordType::AAAA)
+        .await
         .expect("query failed");
     assert_eq!(result.response_code(), ResponseCode::NXDomain);
     assert_eq!(result.answers().len(), 0);
 }
 
-fn test_timeout_query(mut client: Client, io_loop: Runtime) {
+async fn test_timeout_query(mut client: Client) {
     let name = Name::from_str("www.example.com").unwrap();
 
-    let err = io_loop
-        .block_on(client.query(name.clone(), DNSClass::IN, RecordType::A))
+    let err = client
+        .query(name.clone(), DNSClass::IN, RecordType::A)
+        .await
         .unwrap_err();
 
     println!("got error: {err:?}");
@@ -930,8 +960,9 @@ fn test_timeout_query(mut client: Client, io_loop: Runtime) {
         panic!("expected timeout error");
     }
 
-    io_loop
-        .block_on(client.query(name, DNSClass::IN, RecordType::AAAA))
+    client
+        .query(name, DNSClass::IN, RecordType::AAAA)
+        .await
         .unwrap_err();
 
     // test that we don't have any thing funky with registering new timeouts, etc...
@@ -943,37 +974,34 @@ fn test_timeout_query(mut client: Client, io_loop: Runtime) {
     // }
 }
 
-#[test]
-fn test_timeout_query_nonet() {
+#[tokio::test]
+async fn test_timeout_query_nonet() {
     subscribe();
-    let io_loop = Runtime::new().expect("failed to create Tokio Runtime");
     let (stream, sender) = NeverReturnsClientStream::new();
     let client = Client::with_timeout(stream, sender, std::time::Duration::from_millis(1), None);
-    let (client, bg) = io_loop.block_on(client).expect("client failed to connect");
-    hickory_proto::runtime::spawn_bg(&io_loop, bg);
+    let (client, bg) = client.await.expect("client failed to connect");
+    tokio::spawn(bg);
 
-    test_timeout_query(client, io_loop);
+    test_timeout_query(client).await;
 }
 
-#[test]
-fn test_timeout_query_udp() {
+#[tokio::test]
+async fn test_timeout_query_udp() {
     subscribe();
-    let io_loop = Runtime::new().unwrap();
     let stream = UdpClientStream::builder(TEST3_V4, TokioRuntimeProvider::new())
         .with_timeout(Some(std::time::Duration::from_millis(1)))
         .build();
 
     let client = Client::connect(stream);
-    let (client, bg) = io_loop.block_on(client).expect("client failed to connect");
-    hickory_proto::runtime::spawn_bg(&io_loop, bg);
+    let (client, bg) = client.await.expect("client failed to connect");
+    tokio::spawn(bg);
 
-    test_timeout_query(client, io_loop);
+    test_timeout_query(client).await;
 }
 
-#[test]
-fn test_timeout_query_tcp() {
+#[tokio::test]
+async fn test_timeout_query_tcp() {
     subscribe();
-    let io_loop = Runtime::new().unwrap();
 
     let (stream, sender) = TcpClientStream::new(
         TEST3_V4,
@@ -988,5 +1016,5 @@ fn test_timeout_query_tcp() {
         None,
     );
 
-    assert!(io_loop.block_on(client).is_err());
+    assert!(client.await.is_err());
 }


### PR DESCRIPTION
This changes most unit tests that currently manually construct Tokio/async-std runtimes to instead use attribute macros, making the whole test function async. I skipped some trickier tests, i.e. ignored tests that are currently failing, or tests that explicitly check functionality across two async runtime instances.

I also added `subscribe();` to the top of some tests, and fixed another `www.example.com` issue in an ignored test.