### PR TITLE
Fix AAAA record's RecordData::record_type() to return RecordType::AAAA

### DIFF
--- a/crates/proto/src/rr/rdata/aaaa.rs
+++ b/crates/proto/src/rr/rdata/aaaa.rs
@@ -64,7 +64,7 @@ impl RecordData for AAAA {
     }
 
     fn record_type(&self) -> RecordType {
-        RecordType::A
+        RecordType::AAAA
     }
 
     fn into_rdata(self) -> RData {


### PR DESCRIPTION
I couldn't find anyone calling this method which is why it's probably been unnoticed.