### PR TITLE
Lower the severity of "failed send_message response" log

### DIFF
--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -15,7 +15,7 @@ use std::task::{Context, Poll};
 use futures_channel::mpsc;
 use futures_util::future::FutureExt;
 use futures_util::stream::{Peekable, Stream, StreamExt};
-use tracing::{debug, warn};
+use tracing::debug;
 
 use crate::error::*;
 use crate::runtime::Time;
@@ -212,7 +212,7 @@ where
                     match serial_response.send_response(io_stream.send_message(dns_request)) {
                         Ok(()) => (),
                         Err(_) => {
-                            warn!("failed to associate send_message response to the sender");
+                            debug!("failed to associate send_message response to the sender");
                         }
                     }
                 }


### PR DESCRIPTION
I have a use case where I need to discard the async resolve requests and it leads to a flood of warnings:
`WARN hickory_proto::xfer::dns_exchange: failed to associate send_message response to the sender`

As the comment in the source code already says, it is benign and probably shouldn't be a warning.