### PR TITLE
Fix RFC 6975 behavior

### DIFF
--- a/bin/tests/integration/authority_battery/dnssec.rs
+++ b/bin/tests/integration/authority_battery/dnssec.rs
@@ -10,7 +10,7 @@ use futures_executor::block_on;
 use hickory_proto::{
     dnssec::{
         rdata::{DNSKEY, RRSIG},
-        verify_nsec, Algorithm, SupportedAlgorithms, Verifier,
+        verify_nsec, Algorithm, Verifier,
     },
     op::{Header, Query},
     rr::{DNSClass, Name, RData, Record, RecordType},
@@ -32,11 +32,7 @@ pub fn test_a_lookup<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DN
         &query,
     );
 
-    let lookup = block_on(authority.search(
-        request_info,
-        LookupOptions::for_dnssec(true, SupportedAlgorithms::new()),
-    ))
-    .unwrap();
+    let lookup = block_on(authority.search(request_info, LookupOptions::for_dnssec(true))).unwrap();
 
     let (a_records, other_records): (Vec<_>, Vec<_>) = lookup
         .into_iter()
@@ -54,9 +50,7 @@ pub fn test_a_lookup<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DN
 
 #[allow(clippy::unreadable_literal)]
 pub fn test_soa<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DNSKEY]) {
-    let lookup =
-        block_on(authority.soa_secure(LookupOptions::for_dnssec(true, SupportedAlgorithms::new())))
-            .unwrap();
+    let lookup = block_on(authority.soa_secure(LookupOptions::for_dnssec(true))).unwrap();
 
     let (soa_records, other_records): (Vec<_>, Vec<_>) = lookup
         .into_iter()
@@ -88,9 +82,7 @@ pub fn test_soa<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DNSKEY]
 }
 
 pub fn test_ns<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DNSKEY]) {
-    let lookup =
-        block_on(authority.ns(LookupOptions::for_dnssec(true, SupportedAlgorithms::new())))
-            .unwrap();
+    let lookup = block_on(authority.ns(LookupOptions::for_dnssec(true))).unwrap();
 
     let (ns_records, other_records): (Vec<_>, Vec<_>) = lookup
         .into_iter()
@@ -124,11 +116,7 @@ pub fn test_aname_lookup<A: Authority<Lookup = AuthLookup>>(authority: A, keys: 
         &query,
     );
 
-    let lookup = block_on(authority.search(
-        request_info,
-        LookupOptions::for_dnssec(true, SupportedAlgorithms::new()),
-    ))
-    .unwrap();
+    let lookup = block_on(authority.search(request_info, LookupOptions::for_dnssec(true))).unwrap();
 
     let (a_records, other_records): (Vec<_>, Vec<_>) = lookup
         .into_iter()
@@ -158,11 +146,8 @@ pub fn test_wildcard<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DN
         &query,
     );
 
-    let lookup = block_on(authority.search(
-        request_info,
-        LookupOptions::for_dnssec(true, SupportedAlgorithms::new()),
-    ))
-    .expect("lookup of www.wildcard.example.com. failed");
+    let lookup = block_on(authority.search(request_info, LookupOptions::for_dnssec(true)))
+        .expect("lookup of www.wildcard.example.com. failed");
 
     let (cname_records, other_records): (Vec<_>, Vec<_>) = lookup
         .into_iter()
@@ -185,11 +170,9 @@ pub fn test_wildcard<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DN
 pub fn test_nsec_nodata<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DNSKEY]) {
     // this should have a single nsec record that covers the type
     let name = Name::from_str("www.example.com.").unwrap();
-    let lookup = block_on(authority.get_nsec_records(
-        &name.clone().into(),
-        LookupOptions::for_dnssec(true, SupportedAlgorithms::all()),
-    ))
-    .unwrap();
+    let lookup =
+        block_on(authority.get_nsec_records(&name.clone().into(), LookupOptions::for_dnssec(true)))
+            .unwrap();
 
     let (nsec_records, _other_records): (Vec<_>, Vec<_>) = lookup
         .into_iter()
@@ -211,11 +194,9 @@ pub fn test_nsec_nodata<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &
 pub fn test_nsec_nxdomain_start<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DNSKEY]) {
     // tests between the SOA and first record in the zone, where bbb is the first zone record
     let name = Name::from_str("aaa.example.com.").unwrap();
-    let lookup = block_on(authority.get_nsec_records(
-        &name.clone().into(),
-        LookupOptions::for_dnssec(true, SupportedAlgorithms::all()),
-    ))
-    .unwrap();
+    let lookup =
+        block_on(authority.get_nsec_records(&name.clone().into(), LookupOptions::for_dnssec(true)))
+            .unwrap();
 
     let (nsec_records, _other_records): (Vec<_>, Vec<_>) = lookup
         .into_iter()
@@ -239,11 +220,9 @@ pub fn test_nsec_nxdomain_start<A: Authority<Lookup = AuthLookup>>(authority: A,
 pub fn test_nsec_nxdomain_middle<A: Authority<Lookup = AuthLookup>>(authority: A, keys: &[DNSKEY]) {
     // follows the first record, nsec should cover between ccc and www, where bbb is the first zone record
     let name = Name::from_str("ccc.example.com.").unwrap();
-    let lookup = block_on(authority.get_nsec_records(
-        &name.clone().into(),
-        LookupOptions::for_dnssec(true, SupportedAlgorithms::all()),
-    ))
-    .unwrap();
+    let lookup =
+        block_on(authority.get_nsec_records(&name.clone().into(), LookupOptions::for_dnssec(true)))
+            .unwrap();
 
     let (nsec_records, _other_records): (Vec<_>, Vec<_>) = lookup
         .into_iter()
@@ -269,11 +248,9 @@ pub fn test_nsec_nxdomain_wraps_end<A: Authority<Lookup = AuthLookup>>(
 ) {
     // wraps back to the beginning of the zone, where www is the last zone record
     let name = Name::from_str("zzz.example.com.").unwrap();
-    let lookup = block_on(authority.get_nsec_records(
-        &name.clone().into(),
-        LookupOptions::for_dnssec(true, SupportedAlgorithms::all()),
-    ))
-    .unwrap();
+    let lookup =
+        block_on(authority.get_nsec_records(&name.clone().into(), LookupOptions::for_dnssec(true)))
+            .unwrap();
 
     let (nsec_records, _other_records): (Vec<_>, Vec<_>) = lookup
         .into_iter()
@@ -291,43 +268,6 @@ pub fn test_nsec_nxdomain_wraps_end<A: Authority<Lookup = AuthLookup>>(
 
     let query = Query::query(name, RecordType::A);
     assert!(verify_nsec(&query, &Name::from_str("example.com.").unwrap(), &nsecs).is_secure());
-}
-
-pub fn test_rfc_6975_supported_algorithms<A: Authority<Lookup = AuthLookup>>(
-    authority: A,
-    keys: &[DNSKEY],
-) {
-    // for each key, see that supported algorithms are restricted to that individual key
-    for key in keys {
-        println!("key algorithm: {}", key.algorithm());
-
-        let query = Query::query(Name::from_str("www.example.com.").unwrap(), RecordType::A).into();
-        let request_info = RequestInfo::new(
-            SocketAddr::from((Ipv4Addr::LOCALHOST, 53)),
-            Protocol::Udp,
-            TEST_HEADER,
-            &query,
-        );
-
-        let lookup = block_on(authority.search(
-            request_info,
-            LookupOptions::for_dnssec(true, SupportedAlgorithms::from(key.algorithm())),
-        ))
-        .unwrap();
-
-        let (a_records, other_records): (Vec<_>, Vec<_>) = lookup
-            .into_iter()
-            .partition(|r| r.record_type() == RecordType::A);
-
-        let rrsig_records: Vec<_> = other_records
-            .into_iter()
-            .cloned()
-            .filter_map(|r| Record::<RRSIG>::try_from(r).ok())
-            .collect();
-
-        assert!(!rrsig_records.is_empty());
-        verify(&a_records, &rrsig_records, &[key.clone()]);
-    }
 }
 
 pub fn verify(records: &[&Record], rrsig_records: &[Record<RRSIG>], keys: &[DNSKEY]) {
@@ -458,7 +398,6 @@ macro_rules! dnssec_battery {
                     test_nsec_nxdomain_start,
                     test_nsec_nxdomain_middle,
                     test_nsec_nxdomain_wraps_end,
-                    test_rfc_6975_supported_algorithms,
                 );
             }
         }

--- a/bin/tests/integration/authority_battery/dynamic_update.rs
+++ b/bin/tests/integration/authority_battery/dynamic_update.rs
@@ -13,7 +13,7 @@ use hickory_dns::dnssec::{KeyConfig, KeyPurpose};
 use hickory_proto::{
     dnssec::{
         rdata::{key::KeyUsage, KEY},
-        Algorithm, PublicKey, SigSigner, SupportedAlgorithms, Verifier,
+        Algorithm, PublicKey, SigSigner, Verifier,
     },
     op::{update_message, Header, Message, Query, ResponseCode},
     rr::{

--- a/bin/tests/integration/named_test_rsa_dnssec.rs
+++ b/bin/tests/integration/named_test_rsa_dnssec.rs
@@ -8,9 +8,7 @@ use std::sync::Arc;
 
 use tokio::runtime::Runtime;
 
-use crate::server_harness::{
-    named_test_harness, query_a, query_all_dnssec_with_rfc6975, query_all_dnssec_wo_rfc6975,
-};
+use crate::server_harness::{named_test_harness, query_a, query_all_dnssec};
 use hickory_client::client::Client;
 use hickory_dns::dnssec::key_from_file;
 use hickory_proto::dnssec::{Algorithm, DnssecDnsHandle, TrustAnchor};
@@ -64,11 +62,7 @@ fn generic_test(config_toml: &str, key_path: &str, algorithm: Algorithm) {
         let client = standard_tcp_conn(tcp_port.expect("no tcp port"), provider.clone());
         let (client, bg) = io_loop.block_on(client);
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
-        query_all_dnssec_with_rfc6975(&mut io_loop, client, algorithm);
-        let client = standard_tcp_conn(tcp_port.expect("no tcp port"), provider.clone());
-        let (client, bg) = io_loop.block_on(client);
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
-        query_all_dnssec_wo_rfc6975(&mut io_loop, client, algorithm);
+        query_all_dnssec(&mut io_loop, client, algorithm);
 
         // test that request with Dnssec client is successful, i.e. validates chain
         let trust_anchor = trust_anchor(&server_path.join(key_path), algorithm);

--- a/bin/tests/integration/server_harness/mut_message_client.rs
+++ b/bin/tests/integration/server_harness/mut_message_client.rs
@@ -1,7 +1,7 @@
 use hickory_client::client::ClientHandle;
-use hickory_proto::xfer::{DnsHandle, DnsRequest};
 #[cfg(feature = "dnssec-ring")]
-use hickory_proto::{op::Edns, rr::rdata::opt::EdnsOption};
+use hickory_proto::op::Edns;
+use hickory_proto::xfer::{DnsHandle, DnsRequest};
 #[cfg(feature = "dnssec-ring")]
 use hickory_server::authority::LookupOptions;
 
@@ -39,8 +39,6 @@ impl<C: ClientHandle + Unpin> DnsHandle for MutMessageHandle<C> {
             // mutable block
             let edns = request.extensions_mut().get_or_insert_with(Edns::new);
             edns.set_dnssec_ok(true);
-            edns.options_mut()
-                .insert(EdnsOption::DAU(self.lookup_options.supported_algorithms()));
         }
 
         println!("sending message");

--- a/crates/proto/src/dnssec/supported_algorithm.rs
+++ b/crates/proto/src/dnssec/supported_algorithm.rs
@@ -31,7 +31,7 @@ use crate::serialize::binary::{BinEncodable, BinEncoder};
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct SupportedAlgorithms {
-    // right now the number of Algorithms supported are fewer than 16..
+    // right now the number of Algorithms supported are fewer than 8.
     bit_map: u8,
 }
 

--- a/crates/proto/src/op/edns.rs
+++ b/crates/proto/src/op/edns.rs
@@ -121,8 +121,6 @@ impl Edns {
     }
 
     /// Set the default algorithms which are supported by this handle
-    ///
-    /// Set both Algorithms Understood (DAU) and Hash Understood (DHU) to the same algorithms.
     #[cfg(feature = "dnssec-ring")]
     pub fn set_default_algorithms(&mut self) -> &mut Self {
         let mut algorithms = SupportedAlgorithms::new();
@@ -134,10 +132,8 @@ impl Edns {
         algorithms.set(Algorithm::RSASHA256);
 
         let dau = EdnsOption::DAU(algorithms);
-        let dhu = EdnsOption::DHU(algorithms);
 
         self.options_mut().insert(dau);
-        self.options_mut().insert(dhu);
         self
     }
 

--- a/crates/proto/src/op/edns.rs
+++ b/crates/proto/src/op/edns.rs
@@ -125,11 +125,16 @@ impl Edns {
     pub fn set_default_algorithms(&mut self) -> &mut Self {
         let mut algorithms = SupportedAlgorithms::new();
 
-        #[cfg(feature = "dnssec-ring")]
-        algorithms.set(Algorithm::ED25519);
-        algorithms.set(Algorithm::ECDSAP256SHA256);
-        algorithms.set(Algorithm::ECDSAP384SHA384);
-        algorithms.set(Algorithm::RSASHA256);
+        for algorithm in [
+            Algorithm::RSASHA256,
+            Algorithm::ECDSAP256SHA256,
+            Algorithm::ECDSAP384SHA384,
+            Algorithm::ED25519,
+        ] {
+            if algorithm.is_supported() {
+                algorithms.set(algorithm);
+            }
+        }
 
         let dau = EdnsOption::DAU(algorithms);
 

--- a/crates/proto/src/op/edns.rs
+++ b/crates/proto/src/op/edns.rs
@@ -127,6 +127,7 @@ impl Edns {
 
         for algorithm in [
             Algorithm::RSASHA256,
+            Algorithm::RSASHA512,
             Algorithm::ECDSAP256SHA256,
             Algorithm::ECDSAP384SHA384,
             Algorithm::ED25519,

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -469,14 +469,6 @@ pub enum EdnsOption {
     #[cfg(feature = "dnssec-ring")]
     DAU(SupportedAlgorithms),
 
-    /// [RFC 6975, DS Hash Understood](https://tools.ietf.org/html/rfc6975)
-    #[cfg(feature = "dnssec-ring")]
-    DHU(SupportedAlgorithms),
-
-    /// [RFC 6975, NSEC3 Hash Understood](https://tools.ietf.org/html/rfc6975)
-    #[cfg(feature = "dnssec-ring")]
-    N3U(SupportedAlgorithms),
-
     /// [RFC 7871, Client Subnet, Optional](https://tools.ietf.org/html/rfc7871)
     Subnet(ClientSubnet),
 
@@ -489,9 +481,7 @@ impl EdnsOption {
     pub fn len(&self) -> u16 {
         match self {
             #[cfg(feature = "dnssec-ring")]
-            EdnsOption::DAU(algorithms)
-            | EdnsOption::DHU(algorithms)
-            | EdnsOption::N3U(algorithms) => algorithms.len(),
+            EdnsOption::DAU(algorithms) => algorithms.len(),
             EdnsOption::Subnet(subnet) => subnet.len(),
             EdnsOption::Unknown(_, data) => data.len() as u16, // TODO: should we verify?
         }
@@ -501,9 +491,7 @@ impl EdnsOption {
     pub fn is_empty(&self) -> bool {
         match self {
             #[cfg(feature = "dnssec-ring")]
-            EdnsOption::DAU(algorithms)
-            | EdnsOption::DHU(algorithms)
-            | EdnsOption::N3U(algorithms) => algorithms.is_empty(),
+            EdnsOption::DAU(algorithms) => algorithms.is_empty(),
             EdnsOption::Subnet(subnet) => subnet.is_empty(),
             EdnsOption::Unknown(_, data) => data.is_empty(),
         }
@@ -514,9 +502,7 @@ impl BinEncodable for EdnsOption {
     fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
         match self {
             #[cfg(feature = "dnssec-ring")]
-            EdnsOption::DAU(algorithms)
-            | EdnsOption::DHU(algorithms)
-            | EdnsOption::N3U(algorithms) => algorithms.emit(encoder),
+            EdnsOption::DAU(algorithms) => algorithms.emit(encoder),
             EdnsOption::Subnet(subnet) => subnet.emit(encoder),
             EdnsOption::Unknown(_, data) => encoder.emit_vec(data), // gah, clone needed or make a crazy api.
         }
@@ -532,10 +518,6 @@ impl<'a> TryFrom<(EdnsCode, &'a [u8])> for EdnsOption {
         Ok(match value.0 {
             #[cfg(feature = "dnssec-ring")]
             EdnsCode::DAU => Self::DAU(value.1.into()),
-            #[cfg(feature = "dnssec-ring")]
-            EdnsCode::DHU => Self::DHU(value.1.into()),
-            #[cfg(feature = "dnssec-ring")]
-            EdnsCode::N3U => Self::N3U(value.1.into()),
             EdnsCode::Subnet => Self::Subnet(value.1.try_into()?),
             _ => Self::Unknown(value.0.into(), value.1.to_vec()),
         })
@@ -548,9 +530,7 @@ impl<'a> TryFrom<&'a EdnsOption> for Vec<u8> {
     fn try_from(value: &'a EdnsOption) -> Result<Self, Self::Error> {
         Ok(match value {
             #[cfg(feature = "dnssec-ring")]
-            EdnsOption::DAU(algorithms)
-            | EdnsOption::DHU(algorithms)
-            | EdnsOption::N3U(algorithms) => algorithms.into(),
+            EdnsOption::DAU(algorithms) => algorithms.into(),
             EdnsOption::Subnet(subnet) => subnet.try_into()?,
             EdnsOption::Unknown(_, data) => data.clone(), // gah, clone needed or make a crazy api.
         })
@@ -562,10 +542,6 @@ impl<'a> From<&'a EdnsOption> for EdnsCode {
         match value {
             #[cfg(feature = "dnssec-ring")]
             EdnsOption::DAU(..) => Self::DAU,
-            #[cfg(feature = "dnssec-ring")]
-            EdnsOption::DHU(..) => Self::DHU,
-            #[cfg(feature = "dnssec-ring")]
-            EdnsOption::N3U(..) => Self::N3U,
             EdnsOption::Subnet(..) => Self::Subnet,
             EdnsOption::Unknown(code, _) => (*code).into(),
         }

--- a/crates/server/src/authority/auth_lookup.rs
+++ b/crates/server/src/authority/auth_lookup.rs
@@ -293,7 +293,7 @@ impl<'r> Iterator for AnyRecordsIter<'r> {
                     self.records = Some(
                         self.rrset
                             .expect("rrset should not be None at this point")
-                            .records(self.lookup_options.dnssec_ok(), self.lookup_options.supported_algorithms()),
+                            .records(self.lookup_options.dnssec_ok()),
                     );
                 } else {
                     self.records = Some(self.rrset.expect("rrset should not be None at this point").records_without_rrsigs());
@@ -310,7 +310,7 @@ pub enum LookupRecords {
     Empty,
     /// The associate records
     Records {
-        /// LookupOptions for the request, e.g. dnssec and supported algorithms
+        /// LookupOptions for the request, e.g. dnssec
         lookup_options: LookupOptions,
         /// the records found based on the query
         records: Arc<RecordSet>,
@@ -368,12 +368,10 @@ impl<'a> IntoIterator for &'a LookupRecords {
             LookupRecords::Records {
                 lookup_options,
                 records,
-            } => LookupRecordsIter::RecordsIter(
-                lookup_options.rrset_with_supported_algorithms(records),
-            ),
+            } => LookupRecordsIter::RecordsIter(lookup_options.rrset_with_rrigs(records)),
             LookupRecords::ManyRecords(lookup_options, r) => LookupRecordsIter::ManyRecordsIter(
                 r.iter()
-                    .map(|r| lookup_options.rrset_with_supported_algorithms(r))
+                    .map(|r| lookup_options.rrset_with_rrigs(r))
                     .collect(),
                 None,
             ),

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -14,14 +14,7 @@ use cfg_if::cfg_if;
 use tracing::{debug, error, info, trace, warn};
 
 #[cfg(feature = "dnssec-ring")]
-use crate::{
-    authority::Nsec3QueryInfo,
-    dnssec::NxProofKind,
-    proto::{
-        dnssec::SupportedAlgorithms,
-        rr::rdata::opt::{EdnsCode, EdnsOption},
-    },
-};
+use crate::{authority::Nsec3QueryInfo, dnssec::NxProofKind};
 use crate::{
     authority::{
         authority_object::DnssecSummary, AuthLookup, AuthorityObject, EmptyLookup,
@@ -512,15 +505,7 @@ fn lookup_options_for_edns(edns: Option<&Edns>) -> LookupOptions {
 
     cfg_if! {
         if #[cfg(feature = "dnssec-ring")] {
-            let supported_algorithms = if let Some(&EdnsOption::DAU(algs)) = edns.option(EdnsCode::DAU)
-            {
-               algs
-            } else {
-               debug!("no DAU in request, used default SupportAlgorithms");
-               SupportedAlgorithms::default()
-            };
-
-            LookupOptions::for_dnssec(edns.flags().dnssec_ok, supported_algorithms)
+            LookupOptions::for_dnssec(edns.flags().dnssec_ok)
         } else {
             LookupOptions::default()
         }

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -30,7 +30,7 @@ use crate::{
     proto::{
         dnssec::{
             rdata::{key::KEY, DNSSECRData, DNSKEY, NSEC, NSEC3, NSEC3PARAM, RRSIG},
-            DnsSecResult, Nsec3HashAlgorithm, SigSigner, SupportedAlgorithms, TBS,
+            DnsSecResult, Nsec3HashAlgorithm, SigSigner, TBS,
         },
         ProtoError,
     },
@@ -435,7 +435,7 @@ impl InnerInMemory {
                 cfg_if! {
                     if #[cfg(feature = "dnssec-ring")] {
                         let (records_tmp, rrsigs_tmp) = rrset
-                            .records(lookup_options.dnssec_ok(), lookup_options.supported_algorithms())
+                            .records(lookup_options.dnssec_ok())
                             .partition(|r| r.record_type() != RecordType::RRSIG);
                         records = records_tmp;
                         _rrsigs = rrsigs_tmp;
@@ -1450,7 +1450,7 @@ impl Authority for InMemoryAuthority {
                 .find(|rr_set| {
                     // there should only be one record
                     rr_set
-                        .records(false, SupportedAlgorithms::default())
+                        .records(false)
                         .next()
                         .map(Record::data)
                         .and_then(RData::as_dnssec)

--- a/tests/integration-tests/tests/integration/sqlite_authority_tests.rs
+++ b/tests/integration-tests/tests/integration/sqlite_authority_tests.rs
@@ -7,7 +7,6 @@ use std::str::FromStr;
 use hickory_proto::rr::LowerName;
 use rusqlite::*;
 
-use hickory_proto::dnssec::SupportedAlgorithms;
 use hickory_proto::op::{Header, LowerQuery, Message, MessageType, OpCode, Query, ResponseCode};
 use hickory_proto::rr::rdata::{A, AAAA, NS, TXT};
 use hickory_proto::rr::{DNSClass, Name, RData, Record, RecordType};
@@ -805,7 +804,7 @@ async fn test_zone_signing() {
         .lookup(
             authority.origin(),
             RecordType::AXFR,
-            LookupOptions::for_dnssec(true, SupportedAlgorithms::all()),
+            LookupOptions::for_dnssec(true),
         )
         .await
         .unwrap();
@@ -821,7 +820,7 @@ async fn test_zone_signing() {
         .lookup(
             authority.origin(),
             RecordType::AXFR,
-            LookupOptions::for_dnssec(true, SupportedAlgorithms::all()),
+            LookupOptions::for_dnssec(true),
         )
         .await
         .unwrap();
@@ -838,7 +837,7 @@ async fn test_zone_signing() {
             .lookup(
                 authority.origin(),
                 RecordType::AXFR,
-                LookupOptions::for_dnssec(true, SupportedAlgorithms::all()),
+                LookupOptions::for_dnssec(true),
             )
             .await
             .unwrap();
@@ -870,10 +869,7 @@ async fn test_get_nsec() {
     let lower_name = LowerName::from(name.clone());
 
     let results = authority
-        .get_nsec_records(
-            &lower_name,
-            LookupOptions::for_dnssec(true, SupportedAlgorithms::all()),
-        )
+        .get_nsec_records(&lower_name, LookupOptions::for_dnssec(true))
         .await
         .unwrap();
 
@@ -1041,10 +1037,6 @@ async fn test_recovery() {
 async fn test_axfr() {
     let mut authority = create_example();
     authority.set_allow_axfr(true);
-
-    // query: &'q LowerQuery,
-    //         is_secure: bool,
-    //         supported_algorithms: SupportedAlgorithms,
 
     let query = LowerQuery::from(Query::query(
         Name::from_str("example.com.").unwrap(),


### PR DESCRIPTION
This fixes #2638 and makes some related improvements. RRSIG filtering behavior is removed. The DHU option is no longer emitted, because we were previously sending signature algorithm numbers in this option. The `EdnsOption::DHU` and `EdnsOption::N3U` are removed, because they currently use a bit field that is specialized for signature algorithm numbers. RSASHA512 is added to outgoing DAU options.