### PR TITLE
Try passing --no-remove-dev-deps to cargo ws publish

### DIFF
--- a/justfile
+++ b/justfile
@@ -149,7 +149,7 @@ generate-test-certs: init-openssl
 
 # Publish all crates
 publish:
-    cargo ws publish --publish-as-is --token $CRATES_IO_TOKEN
+    cargo ws publish --publish-as-is --no-remove-dev-deps --token $CRATES_IO_TOKEN
 
 # Removes the target directories cleaning all built artifacts
 clean:


### PR DESCRIPTION
This passes `--no-remove-dev-deps` to `cargo ws publish` in an effort to prevent it from dirtying various `Cargo.toml` files during publishing.