### PR TITLE
proto: add algorithm identifier to TrustAnchor

### DIFF
--- a/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
@@ -707,7 +707,7 @@ where
     // Checks to see if the key is valid against the registered root certificates
     if handle
         .trust_anchor
-        .contains_dnskey_bytes(key_rdata.public_key())
+        .contains_dnskey_bytes(key_rdata.public_key(), key_rdata.algorithm())
     {
         debug!(
             "validated dnskey with trust_anchor: {}, {key_rdata}",

--- a/crates/proto/src/dnssec/public_key.rs
+++ b/crates/proto/src/dnssec/public_key.rs
@@ -37,6 +37,7 @@ pub trait PublicKey {
 }
 
 /// An owned variant of PublicKey
+#[derive(Clone)]
 pub struct PublicKeyBuf {
     key_buf: Vec<u8>,
     algorithm: Algorithm,


### PR DESCRIPTION
This changes the API of the `TrustAnchor` to take an algorithm as well, and compares both the encoded public key and algorithm identifier when testing membership. This prevents confusion between unrelated algorithms, or hash algorithm downgrades.

The trust anchor's current behavior isn't exploitable, because the three ECC algorithms all have different public key sizes, and downgrading from RSASHA256/RSASHA512 to RSASHA1 requires a SHA-1 second preimage attack for a complete break, which is impractical. As new algorithms are added, failing to check the algorithm type could get more dangerous.