### PR TITLE
Cleanup features dns-over-native-tls/dns-over-openssl/dnssec-openssl documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,15 +102,19 @@ Support of TLS on the Server is managed through a pkcs12 der file. The documenta
 
 ## DNS-over-TLS and DNS-over-HTTPS
 
-DoT and DoH are supported. This is accomplished through the use of one of `native-tls`, `openssl`, or `rustls` (only `rustls` is currently supported for DoH). The Resolver requires valid DoT or DoH resolvers being registered in order to be used.
+The Resolver requires valid DoT or DoH resolvers being registered in order to be used.
 
 To use DoT or DoH with the `Client`, construct it with `TlsClientStream` or
 `HttpsClientStream`. Client authentication/mTLS is currently not supported,
 there are some issues still being worked on. TLS is useful for Server
 authentication and connection privacy.
 
-To enable DoT, one of the features `dns-over-native-tls`, `dns-over-openssl`, or
-`dns-over-rustls` must be enabled. `dns-over-https-rustls` is used for DoH.
+Some protocols are optionally supported:
+
+- Enable `dns-over-rustls` for DNS over TLS (DoT)
+- Enable `dns-over-https-rustls` for DNS over HTTP/2 (DoH)
+- Enable `dns-over-quic` for DNS over QUIC (DoQ)
+- Enable `dns-over-h3` for DNS over HTTP/3 (DoH3)
 
 ## DNSSEC status
 
@@ -118,7 +122,7 @@ The current root key is bundled into the system, and used by default. This gives
 validation of DNSKEY and DS records back to the root. NSEC and NSEC3 are
 implemented.
 
-Zones will be automatically resigned on any record updates via dynamic DNS. To enable DNSSEC, one of the features `dnssec-openssl` or `dnssec-ring` must be enabled.
+Zones will be automatically resigned on any record updates via dynamic DNS. To enable DNSSEC, enable the `dnssec-ring` feature.
 
 ## RFCs implemented
 
@@ -317,17 +321,8 @@ Success for query name: www.example.com. type: A class: IN
 
 The Client has a few features which can be disabled for different reasons when embedding in other software.
 
-- `dnssec-openssl`
-  Uses OpenSSL for DNSSEC validation.
-
 - `dnssec-ring`
   Ring support can be used for RSA and ED25519 DNSSEC validation.
-
-- `dns-over-native-tls`
-  Uses `native-tls` for DNS-over-TLS implementation, only supported in client and resolver, not server.
-
-- `dns-over-openssl`
-  Uses `openssl` for DNS-over-TLS implementation supported in server and client, resolver does not have default CA chains.
 
 - `dns-over-rustls`
   Uses `rustls` for DNS-over-TLS implementation. This is the best option where a pure Rust toolchain is desired. Supported in client, resolver, and server.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Support of TLS on the Server is managed through a pkcs12 der file. The documenta
 
 ## DNS-over-TLS and DNS-over-HTTPS
 
-The Resolver requires valid DoT or DoH resolvers being registered in order to be used.
+The Resolver supports DoT and DoH. These protocols can be selected and configured when forwarding to another server.
 
 To use DoT or DoH with the `Client`, construct it with `TlsClientStream` or
 `HttpsClientStream`. Client authentication/mTLS is currently not supported,

--- a/bin/README.md
+++ b/bin/README.md
@@ -27,14 +27,18 @@ authentication method is under development).
 
 Support of TLS on the Server is managed through a pkcs12 der file. The documentation is captured in the example test config file, [example.toml](https://github.com/hickory-dns/hickory-dns/blob/main/tests/test-data/test_configs/example.toml). A registered certificate to the server can be pinned to the Client with the `add_ca()` method. Alternatively, as the client uses the rust-native-tls library, it should work with certificate signed by any standard CA.
 
-DoT and DoH are supported. This is accomplished through the use of one of `native-tls`, `openssl`, or `rustls` (only `rustls` is currently supported for DoH). The Resolver requires valid DoT or DoH resolvers being registered in order to be used.
+The Resolver requires valid DoT or DoH resolvers being registered in order to be used.
 
 Client authentication/mTLS is currently not supported, there are some issues
 still being worked on. TLS is useful for Server authentication and connection
 privacy.
 
-To enable DoT, one of the features `dns-over-native-tls`, `dns-over-openssl`, or
-`dns-over-rustls` must be enabled. `dns-over-https-rustls` is used for DoH.
+Some protocols are optionally supported:
+
+- Enable `dns-over-rustls` for DNS over TLS (DoT)
+- Enable `dns-over-https-rustls` for DNS over HTTP/2 (DoH)
+- Enable `dns-over-quic` for DNS over QUIC (DoQ)
+- Enable `dns-over-h3` for DNS over HTTP/3 (DoH3)
 
 ## DNSSEC status
 
@@ -42,7 +46,7 @@ The current root key is bundled into the system, and used by default. This gives
 validation of DNSKEY and DS records back to the root. NSEC and NSEC3 are
 implemented.
 
-Zones will be automatically resigned on any record updates via dynamic DNS. To enable DNSSEC, one of the features `dnssec-openssl` or `dnssec-ring` must be enabled.
+Zones will be automatically resigned on any record updates via dynamic DNS. To enable DNSSEC, enable the `dnssec-ring` feature.
 
 ## Future goals
 

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -64,15 +64,17 @@ assert!(!a_data.is_empty());
 
 ## DNS-over-TLS and DNS-over-HTTPS
 
-DoT and DoH are supported. This is accomplished through the use of one of `native-tls`, `openssl`, or `rustls` (only `rustls` is currently supported for DoH).
-
 To use DoT or DoH with the `Client`, construct it with `TlsClientStream` or
 `HttpsClientStream`. Client authentication/mTLS is currently not supported,
 there are some issues still being worked on. TLS is useful for Server
 authentication and connection privacy.
 
-To enable DoT, one of the features `dns-over-native-tls`, `dns-over-openssl`, or
-`dns-over-rustls` must be enabled. `dns-over-https-rustls` is used for DoH.
+Some protocols are optionally supported:
+
+- Enable `dns-over-rustls` for DNS over TLS (DoT)
+- Enable `dns-over-https-rustls` for DNS over HTTP/2 (DoH)
+- Enable `dns-over-quic` for DNS over QUIC (DoQ)
+- Enable `dns-over-h3` for DNS over HTTP/3 (DoH3)
 
 ## DNSSEC status
 
@@ -80,7 +82,7 @@ The current root key is bundled into the system, and used by default. This gives
 validation of DNSKEY and DS records back to the root. NSEC and NSEC3 are
 implemented.
 
-Zones will be automatically resigned on any record updates via dynamic DNS. To enable DNSSEC, one of the features `dnssec-openssl` or `dnssec-ring` must be enabled.
+Zones will be automatically resigned on any record updates via dynamic DNS. To enable DNSSEC, enable the `dnssec-ring` feature.
 
 ## Minimum Rust Version
 

--- a/crates/resolver/README.md
+++ b/crates/resolver/README.md
@@ -16,7 +16,7 @@ This library contains implementations for IPv4 (A) and IPv6 (AAAA) resolution, m
 - DNSSEC validation
 - Generic Record Type Lookup
 - CNAME chain resolution
-- DNS over TLS (utilizing `native-tls`, `rustls`, and `openssl`; `native-tls` or `rustls` are recommended)
+- DNS over TLS (utilizing `rustls`)
 - DNS over HTTPS (currently only supports `rustls`)
 
 ## Example
@@ -46,14 +46,18 @@ let _address = response.iter().next().expect("no addresses returned!");
 
 ## DNS-over-TLS and DNS-over-HTTPS
 
-DoT and DoH are supported. This is accomplished through the use of one of `native-tls`, `openssl`, or `rustls` (only `rustls` is currently supported for DoH). The Resolver requires valid DoT or DoH resolvers being registered in order to be used.
+The Resolver requires valid DoT or DoH resolvers being registered in order to be used.
 
 Client authentication/mTLS is currently not supported, there are some issues
 still being worked on. TLS is useful for Server authentication and connection
 privacy.
 
-To enable DoT, one of the features `dns-over-native-tls`, `dns-over-openssl`, or
-`dns-over-rustls` must be enabled. `dns-over-https-rustls` is used for DoH.
+Some protocols are optionally supported:
+
+- Enable `dns-over-rustls` for DNS over TLS (DoT)
+- Enable `dns-over-https-rustls` for DNS over HTTP/2 (DoH)
+- Enable `dns-over-quic` for DNS over QUIC (DoQ)
+- Enable `dns-over-h3` for DNS over HTTP/3 (DoH3)
 
 ### Example
 
@@ -82,8 +86,7 @@ The current root key is bundled into the system, and used by default. This gives
 validation of DNSKEY and DS records back to the root. NSEC and NSEC3 are
 implemented.
 
-To enable DNSSEC, one of the features `dnssec-openssl` or `dnssec-ring` must be
-enabled.
+To enable DNSSEC, enable the `dnssec-ring` feature.
 
 ## Testing the resolver via CLI with resolve
 

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -133,18 +133,13 @@
 //! implementations are available as addon libraries. *WARNING* The hickory-dns developers make no
 //! claims on the security and/or privacy guarantees of this implementation.
 //!
-//! To use DNS-over-TLS one of the `dns-over-tls` features must be enabled at compile time. There
-//! are three: `dns-over-openssl`, `dns-over-native-tls`, and `dns-over-rustls`. For DNS-over-HTTPS
+//! To use DNS-over-TLS `dns-over-rustls` feature must be enabled at compile time. For DNS-over-HTTPS
 //! only rustls is supported with the `dns-over-https-rustls`, this implicitly enables support for
 //! DNS-over-TLS as well. The reason for each is to make the Hickory DNS libraries flexible for
 //! different deployments, and/or security concerns. The easiest to use will generally be
 //! `dns-over-rustls` which utilizes the `*ring*` Rust cryptography library (a rework of the
 //! `boringssl` project), this should compile and be usable on most ARM and x86 platforms.
-//! `dns-over-native-tls` will utilize the hosts TLS implementation where available or fallback to
-//! `openssl` where not supported. `dns-over-openssl` will specify that `openssl` should be used
-//! (which is a perfectly fine option if required). If more than one is specified, the precedence
-//! will be in this order (i.e. only one can be used at a time) `dns-over-rustls`,
-//! `dns-over-native-tls`, and then `dns-over-openssl`. **NOTICE** the Hickory DNS developers are not
+//! **NOTICE** the Hickory DNS developers are not
 //! responsible for any choice of library that does not meet required security requirements.
 //!
 //! ### Example


### PR DESCRIPTION
These features are already removed in 0.25.0-alpha.5