### PR TITLE
[0.24] bump ring to 0.17.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
  "openssl",
  "quinn",
  "rand",
- "ring 0.16.20",
+ "ring 0.17.8",
  "rustls",
  "rustls-native-certs",
  "rustls-pemfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ rustls = "0.21.6"
 rustls-native-certs = "0.6.3"
 rustls-pemfile = "1.0.0"
 webpki-roots = "0.25.0"
-ring = "0.16"
+ring = "0.17"
 
 
 # net proto

--- a/crates/proto/src/rr/dnssec/key_format.rs
+++ b/crates/proto/src/rr/dnssec/key_format.rs
@@ -91,7 +91,8 @@ impl KeyFormat {
                     } else {
                         &ECDSA_P384_SHA384_FIXED_SIGNING
                     };
-                    let key = EcdsaKeyPair::from_pkcs8(ring_algorithm, bytes)?;
+                    let rng = ring::rand::SystemRandom::new();
+                    let key = EcdsaKeyPair::from_pkcs8(ring_algorithm, bytes, &rng)?;
 
                     Ok(KeyPair::from_ecdsa(key))
                 }

--- a/crates/proto/src/rr/dnssec/rdata/tsig.rs
+++ b/crates/proto/src/rr/dnssec/rdata/tsig.rs
@@ -635,9 +635,9 @@ impl TsigAlgorithm {
         use TsigAlgorithm::*;
 
         let len = match self {
-            HmacSha256 => hmac::HMAC_SHA256.digest_algorithm().output_len,
-            HmacSha384 => hmac::HMAC_SHA384.digest_algorithm().output_len,
-            HmacSha512 => hmac::HMAC_SHA512.digest_algorithm().output_len,
+            HmacSha256 => hmac::HMAC_SHA256.digest_algorithm().output_len(),
+            HmacSha384 => hmac::HMAC_SHA384.digest_algorithm().output_len(),
+            HmacSha512 => hmac::HMAC_SHA512.digest_algorithm().output_len(),
             _ => return Err(ProtoErrorKind::TsigUnsupportedMacAlgorithm(self.clone()).into()),
         };
 

--- a/tests/integration-tests/tests/client_tests.rs
+++ b/tests/integration-tests/tests/client_tests.rs
@@ -257,7 +257,7 @@ fn test_timeout_query_nonet() {
 
 #[test]
 fn test_timeout_query_udp() {
-    let addr: SocketAddr = ("203.0.113.0", 53)
+    let addr: SocketAddr = ("203.0.113.1", 53)
         .to_socket_addrs()
         .unwrap()
         .next()
@@ -272,7 +272,7 @@ fn test_timeout_query_udp() {
 fn test_timeout_query_tcp() {
     use std::time::Duration;
 
-    let addr: SocketAddr = ("203.0.113.0", 53)
+    let addr: SocketAddr = ("203.0.113.1", 53)
         .to_socket_addrs()
         .unwrap()
         .next()

--- a/tests/integration-tests/tests/client_tests.rs
+++ b/tests/integration-tests/tests/client_tests.rs
@@ -243,7 +243,7 @@ where
 
     if let ClientErrorKind::Timeout = err.kind() {
     } else {
-        panic!("expected timeout error")
+        panic!("expected timeout error: {err:?}")
     }
 }
 


### PR DESCRIPTION
Currently ring 0.16.x fails to build for Win on Aarch64/Arm64 and with no intent to address it for 0.16.x release [^1]. Users of the library must bump ring to 0.17.x to get a fix. With i.e. sccache looking to get rid of `openssl` as a dependency [^2], and having `hickory-dns` as a direct and hence affected ring as a transient dependency, I'd very much appreciate getting this merged, with the `0.25` seemingly still pending a refactor [^3].  

Context:

[^1]: https://github.com/briansmith/ring/issues/1167#issuecomment-1745560468
[^2]: https://github.com/mozilla/sccache/pull/2325
[^3]: https://github.com/hickory-dns/hickory-dns/issues/2206

