### PR TITLE
DNSSEC validation cleanup

### DIFF
--- a/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
@@ -545,7 +545,7 @@ where
     let mut all_unsupported = None;
     let mut dnskey_proofs =
         Vec::<(Proof, Option<u32>, Option<usize>)>::with_capacity(rrset.records().len());
-    dnskey_proofs.resize(rrset.records().len(), (Proof::Indeterminate, None, None));
+    dnskey_proofs.resize(rrset.records().len(), (Proof::Bogus, None, None));
 
     // check if the DNSKEYs are in the root store
     for (r, proof) in rrset.records().iter().zip(dnskey_proofs.iter_mut()) {
@@ -677,7 +677,7 @@ where
 ///
 /// # Returns
 ///
-/// Proof::Secure if registered in the root store, Proof::Indeterminate if not
+/// Proof::Secure if registered in the root store, Proof::Bogus if not
 fn is_dnskey_in_root_store<H>(handle: &DnssecDnsHandle<H>, rr: &RecordRef<'_, DNSKEY>) -> Proof
 where
     H: DnsHandle + Sync + Unpin,
@@ -696,7 +696,7 @@ where
 
         Proof::Secure
     } else {
-        Proof::Indeterminate
+        Proof::Bogus
     }
 }
 
@@ -960,7 +960,7 @@ where
                 .lookup(query.clone(), options)
                 .first_answer()
                 .map_err(|proto| {
-                    ProofError::new(Proof::Indeterminate, ProofErrorKind::Proto { query, proto })
+                    ProofError::new(Proof::Bogus, ProofErrorKind::Proto { query, proto })
                 })
                 .map_ok(move |message| {
                     let mut tag_count = HashMap::<u16, usize>::new();


### PR DESCRIPTION
This cleans up the DNSSEC validation logic after recent fixes.

The first commit removes dead code in three places. These branches are never taken because an `Rrset` is never empty, and `find_ds_records()` never returns `Ok` with an empty vector.

The second commit replaces all remaining uses of `Proof::Indeterminate` with `Proof::Bogus`. I don't fully understand the RFC 4035 definition of Indeterminate, but the RFC 4033 definition says "There is no trust anchor that woud indicate that a specific portion of the tree is secure. This is the default operation mode." These days, the root zone is signed, so islands of security are much less common. Hickory DNS only has support for specifying a trust anchor for the root zone, so we shouldn't be using this status when operating in a validating mode. This has no impact on `verify_dnskey_rrset()` which was only checking `is_secure()` on the proofs. This may change the behavior of `verify_default_rrset()` if all DNSKEY lookups return an error.

The third commit removes logic checking whether all DNSKEY records use unsupported signature algorithms. We separately check if all DS records use unsupported signature algorithms, and only the DS records are authenticated at this point. Thus, looking at the DNSKEY RRset is redundant and not sound.