### PR TITLE
Replace certificate and key pairs with `Arc<dyn ResolvesServerCert>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,9 +1949,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
+version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ pin-project-lite = "0.2"
 
 
 # ssl
-rustls = { version = "0.23.14", default-features = false, features = [
+rustls = { version = "0.23.23", default-features = false, features = [
     "logging",
     "std",
     "tls12",


### PR DESCRIPTION
I finally got around to implement this. As requested in #2718, I changed the method signatures to be incompatible with the old parameters. Since we needed the old functionality in the binary crate anyways and test code needed it too, I implemented a new `CertificateAndKey` struct that mimic's the internal behaviour of rustls, which is unfortunately not public.

Fixes #2718 