### PR TITLE
bin: remove dns-over-tls in favor of dns-over-rustls

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -43,8 +43,7 @@ dns-over-https-rustls = ["dns-over-rustls", "hickory-server/dns-over-https-rustl
 dns-over-quic = ["dns-over-rustls", "hickory-server/dns-over-quic"]
 dns-over-h3 = ["dns-over-rustls", "hickory-server/dns-over-h3"]
 
-dns-over-rustls = ["dns-over-tls", "dep:rustls", "hickory-server/dns-over-rustls"]
-dns-over-tls = []
+dns-over-rustls = ["dep:rustls", "hickory-server/dns-over-rustls"]
 
 webpki-roots = ["hickory-server/webpki-roots"]
 rustls-platform-verifier = ["hickory-server/rustls-platform-verifier"]
@@ -95,5 +94,4 @@ workspace = true
 
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true
-denylist = ["dns-over-tls"]
 max_combination_size = 2

--- a/bin/src/hickory-dns.rs
+++ b/bin/src/hickory-dns.rs
@@ -59,7 +59,7 @@ use tracing_subscriber::{
 };
 
 use hickory_dns::Config;
-#[cfg(feature = "dns-over-tls")]
+#[cfg(feature = "dns-over-rustls")]
 use hickory_dns::TlsCertConfig;
 use hickory_server::{authority::Catalog, server::ServerFuture};
 
@@ -105,7 +105,7 @@ struct Cli {
 
     /// Listening port for DNS over TLS queries,
     /// overrides any value in config file
-    #[cfg(feature = "dns-over-tls")]
+    #[cfg(feature = "dns-over-rustls")]
     #[clap(long = "tls-port", value_name = "TLS-PORT")]
     pub(crate) tls_port: Option<u16>,
 
@@ -133,7 +133,7 @@ struct Cli {
 
     /// Disable TLS protocol,
     /// overrides any value in config file
-    #[cfg(feature = "dns-over-tls")]
+    #[cfg(feature = "dns-over-rustls")]
     #[clap(long = "disable-tls", conflicts_with = "tls_port")]
     pub(crate) disable_tls: bool,
 
@@ -242,7 +242,7 @@ fn run() -> Result<(), String> {
     let tcp_request_timeout = config.tcp_request_timeout();
 
     // now, run the server, based on the config
-    #[cfg_attr(not(feature = "dns-over-tls"), allow(unused_mut))]
+    #[cfg_attr(not(feature = "dns-over-rustls"), allow(unused_mut))]
     let mut server = ServerFuture::with_access(catalog, deny_networks, allow_networks);
 
     let _guard = runtime.enter();
@@ -290,12 +290,12 @@ fn run() -> Result<(), String> {
     }
 
     #[cfg(any(
-        feature = "dns-over-tls",
+        feature = "dns-over-rustls",
         feature = "dns-over-https-rustls",
         feature = "dns-over-quic"
     ))]
     if let Some(tls_cert_config) = config.tls_cert() {
-        #[cfg(feature = "dns-over-tls")]
+        #[cfg(feature = "dns-over-rustls")]
         if !args.disable_tls && !config.disable_tls() {
             // setup TLS listeners
             config_tls(
@@ -382,7 +382,7 @@ fn run() -> Result<(), String> {
     Ok(())
 }
 
-#[cfg(feature = "dns-over-tls")]
+#[cfg(feature = "dns-over-rustls")]
 fn config_tls(
     args: &Cli,
     server: &mut ServerFuture<Catalog>,

--- a/bin/tests/integration/config_tests.rs
+++ b/bin/tests/integration/config_tests.rs
@@ -206,7 +206,7 @@ purpose = \"ZoneSigning\"
 }
 
 #[test]
-#[cfg(feature = "dns-over-tls")]
+#[cfg(feature = "dns-over-rustls")]
 fn test_parse_tls() {
     // defaults
     let config = Config::from_toml("").unwrap();
@@ -256,9 +256,9 @@ define_test_config!(chained_blocklist);
 define_test_config!(consulting_blocklist);
 #[cfg(feature = "dns-over-https-rustls")]
 define_test_config!(dns_over_https);
-#[cfg(feature = "dns-over-tls")]
+#[cfg(feature = "dns-over-rustls")]
 define_test_config!(dns_over_tls_rustls_and_openssl);
-#[cfg(feature = "dns-over-tls")]
+#[cfg(feature = "dns-over-rustls")]
 define_test_config!(dns_over_tls);
 #[cfg(all(feature = "dnssec-ring", feature = "sqlite"))]
 define_test_config!(dnssec_with_update);
@@ -433,7 +433,7 @@ fn test_reject_unknown_fields() {
         let mut skip = false;
 
         #[cfg(not(any(
-            feature = "dns-over-tls",
+            feature = "dns-over-rustls",
             feature = "dns-over-https-rustls",
             feature = "dns-over-quic"
         )))]

--- a/bin/tests/integration/server_harness/mod.rs
+++ b/bin/tests/integration/server_harness/mod.rs
@@ -100,7 +100,7 @@ where
             "--zonedir={server_path}/tests/test-data/test_configs"
         ))
         .arg(format!("--port={}", 0));
-    #[cfg(feature = "dns-over-tls")]
+    #[cfg(feature = "dns-over-rustls")]
     command.arg(format!("--tls-port={}", 0));
     #[cfg(feature = "dns-over-https-rustls")]
     command.arg(format!("--https-port={}", 0));


### PR DESCRIPTION
This feature is now inaccurate/misleading.