### PR TITLE
ci: pass GITHUB_TOKEN to cargo binstall

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,8 @@ jobs:
       uses: cargo-bins/cargo-binstall@v1.10.20
     - name: install cargo-workspaces
       run: cargo binstall cargo-workspaces -y --version ${{ env.CARGO_WS_VERSION }}
-
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: just publish
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,8 @@ jobs:
         uses: cargo-bins/cargo-binstall@v1.10.20
       - name: install cargo-workspaces
         run: cargo binstall cargo-workspaces -y --version ${{ env.CARGO_WS_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: just all-features
         run: just all-features
@@ -125,6 +127,8 @@ jobs:
         uses: cargo-bins/cargo-binstall@v1.10.20
       - name: install cargo-workspaces
         run: cargo binstall cargo-workspaces -y --version ${{ env.CARGO_WS_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: just
         run: just ${{ matrix.feature }}
@@ -176,6 +180,8 @@ jobs:
         uses: cargo-bins/cargo-binstall@v1.10.20
       - name: install cargo-workspaces
         run: cargo binstall cargo-workspaces -y --version ${{ env.CARGO_WS_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: just no-default-features
         run: just no-default-features
@@ -214,6 +220,8 @@ jobs:
         uses: cargo-bins/cargo-binstall@v1.10.20
       - name: install cargo-workspaces
         run: cargo binstall cargo-workspaces -y --version ${{ env.CARGO_WS_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Clippy
       - name: just clippy


### PR DESCRIPTION
This implements the suggestion from https://github.com/hickory-dns/hickory-dns/pull/2767#issuecomment-2650419373, to pass a GitHub token in an environment variable to get higher rate limits when requesting releases, etc.