### PR TITLE
Fix and diagnose flaky tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
-      RUST_LOG: info,hickory_proto::udp::udp_stream=trace # Extra logging for issue #2649
+      RUST_LOG: info
     steps:
       - uses: actions/checkout@v4
 
@@ -114,6 +114,8 @@ jobs:
             dnssec-ring,
             doc,
           ]
+    env:
+      RUST_LOG: info
     steps:
       - uses: actions/checkout@v4
 

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
@@ -48,6 +48,7 @@ fn on_clients_ds_query_it_queries_the_parent_zone() -> Result<()> {
     tshark.wait_for_capture()?;
 
     let captures = tshark.terminate()?;
+    println!("captured {} packets", captures.len());
 
     // check that we were able to retrieve the DS record
     assert!(output.status.is_noerror());
@@ -64,6 +65,7 @@ fn on_clients_ds_query_it_queries_the_parent_zone() -> Result<()> {
                 let queries = message.as_value()["Queries"]
                     .as_object()
                     .expect("expected Object");
+                println!("outgoing query: {queries:?}");
                 for query in queries.keys() {
                     if query.contains("type DS") {
                         // the domain name in the query omits the last `.` so strip it from


### PR DESCRIPTION
This addresses or helps investigate some more flaky tests. We had some `www.example.com` tests with bad expectations that were inside retry loops, ignoring SERVFAIL responses. These are updated to match similar tests. (Google Public DNS returns a SERVFAIL response when we don't include the EDNS(0) OPT record in the request most of the time. The retry loop thus would ignore all three responses. However, in CI, we sometimes get a NOERROR response, and the test then fails because the web server IP addresses have changed.) I also added logging to the `on_clients_ds_query_it_queries_the_parent_zone` test, so we can see what iterative queries were captured, and set the `RUST_LOG` environment variable in another CI job to help debug `test_multi_use_conns` and others.