### PR TITLE
[0.24] Use cargo environment variables for path to executable

### DIFF
--- a/bin/tests/server_harness/mod.rs
+++ b/bin/tests/server_harness/mod.rs
@@ -41,7 +41,7 @@ where
     let server_path = env::var("TDNS_WORKSPACE_ROOT").unwrap_or_else(|_| "..".to_owned());
     println!("using server src path: {server_path}");
 
-    let mut command = Command::new(format!("{server_path}/target/debug/hickory-dns"));
+    let mut command = Command::new(env!("CARGO_BIN_EXE_hickory-dns"));
     command
         .stdout(Stdio::piped())
         .env(


### PR DESCRIPTION
Backport #2130 to 0.24. Without it, my automated tests for the release compilation fail as the binary then is located in `target/release` instead of `target/debug`.