### PR TITLE
Handle unknown digest types and delete operations in CDS/CDNSKEY records

### DIFF
--- a/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
@@ -568,7 +568,7 @@ where
     if ds_records
         .iter()
         .filter(|ds| ds.proof().is_secure() || ds.proof().is_insecure())
-        .all(|ds| !ds.data().algorithm().is_supported())
+        .all(|ds| !ds.data().algorithm().is_supported() || !ds.data().digest_type().is_supported())
         && !ds_records.is_empty()
     {
         debug!("all dnskeys use unsupported algorithms and there are no supported DS records in the parent zone");
@@ -801,7 +801,8 @@ where
             let mut all_unknown = None;
             for record in all_records {
                 // A chain can be either SECURE or INSECURE, but we should not trust BOGUS or other records
-                if !record.data().algorithm().is_supported()
+                if (!record.data().algorithm().is_supported()
+                    || !record.data().digest_type().is_supported())
                     && (record.proof().is_secure() || record.proof().is_insecure())
                 {
                     all_unknown.get_or_insert(true);

--- a/crates/proto/src/dnssec/mod.rs
+++ b/crates/proto/src/dnssec/mod.rs
@@ -79,17 +79,17 @@ pub enum DigestType {
     /// [RFC 6605](https://tools.ietf.org/html/rfc6605)
     #[cfg_attr(feature = "serde", serde(rename = "SHA-384"))]
     SHA384,
+    /// An unknown digest type
+    Unknown(u8),
 }
 
-impl TryFrom<u8> for DigestType {
-    type Error = ProtoError;
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
+impl From<u8> for DigestType {
+    fn from(value: u8) -> Self {
         match value {
-            1 => Ok(Self::SHA1),
-            2 => Ok(Self::SHA256),
-            4 => Ok(Self::SHA384),
-            _ => Err(ProtoErrorKind::UnknownAlgorithmTypeValue(value).into()),
+            1 => Self::SHA1,
+            2 => Self::SHA256,
+            4 => Self::SHA384,
+            _ => Self::Unknown(value),
         }
     }
 }
@@ -100,6 +100,7 @@ impl From<DigestType> for u8 {
             DigestType::SHA1 => 1,
             DigestType::SHA256 => 2,
             DigestType::SHA384 => 4,
+            DigestType::Unknown(other) => other,
         }
     }
 }

--- a/crates/proto/src/dnssec/mod.rs
+++ b/crates/proto/src/dnssec/mod.rs
@@ -83,6 +83,12 @@ pub enum DigestType {
     Unknown(u8),
 }
 
+impl DigestType {
+    fn is_supported(&self) -> bool {
+        !matches!(self, Self::Unknown(_))
+    }
+}
+
 impl From<u8> for DigestType {
     fn from(value: u8) -> Self {
         match value {

--- a/crates/proto/src/dnssec/nsec3.rs
+++ b/crates/proto/src/dnssec/nsec3.rs
@@ -159,7 +159,7 @@ impl Nsec3HashAlgorithm {
                     name.to_lowercase().emit(&mut encoder)?;
                 }
 
-                Ok(Digest::iterated(salt, &buf, DigestType::SHA1, iterations))
+                Digest::iterated(salt, &buf, DigestType::SHA1, iterations)
             }
         }
     }

--- a/crates/proto/src/dnssec/rdata/cdnskey.rs
+++ b/crates/proto/src/dnssec/rdata/cdnskey.rs
@@ -7,41 +7,148 @@
 
 //! CDNSKEY type and related implementations
 
-use std::{fmt, ops::Deref};
+use std::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    dnssec::{Algorithm, PublicKey, PublicKeyBuf},
     error::ProtoResult,
     rr::{RData, RecordData, RecordDataDecodable, RecordType},
-    serialize::binary::{BinDecoder, BinEncodable, BinEncoder, Restrict},
+    serialize::binary::{
+        BinDecodable, BinDecoder, BinEncodable, BinEncoder, Restrict, RestrictedMath,
+    },
+    ProtoError, ProtoErrorKind,
 };
 
-use super::{DNSSECRData, DNSKEY};
+use super::DNSSECRData;
 
 /// Child DNSKEY. See RFC 8078.
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
-pub struct CDNSKEY(DNSKEY);
+pub struct CDNSKEY {
+    flags: u16,
+    public_key: PublicKeyBuf,
+}
 
-impl Deref for CDNSKEY {
-    type Target = DNSKEY;
+impl CDNSKEY {
+    /// Construct a new CDNSKEY RData
+    ///
+    /// # Arguments
+    ///
+    /// * `zone_key` - this key is used to sign Zone resource records
+    /// * `secure_entry_point` - this key is used to sign DNSKeys that sign the Zone records
+    /// * `revoke` - this key has been revoked
+    /// * `public_key` - the public key
+    ///
+    /// # Return
+    ///
+    /// A new CDNSKEY RData for use in a Resource Record
+    pub fn new(
+        zone_key: bool,
+        secure_entry_point: bool,
+        revoke: bool,
+        public_key: PublicKeyBuf,
+    ) -> Self {
+        let mut flags: u16 = 0;
+        if zone_key {
+            flags |= 0b0000_0001_0000_0000;
+        }
+        if secure_entry_point {
+            flags |= 0b0000_0000_0000_0001;
+        }
+        if revoke {
+            flags |= 0b0000_0000_1000_0000;
+        }
+        Self::with_flags(flags, public_key)
+    }
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    /// Construct a new CDNSKEY RData
+    ///
+    /// # Arguments
+    ///
+    /// * `flags` - flags associated with this key
+    /// * `public_key` - the public key
+    ///
+    /// # Return
+    ///
+    /// A new CDNSKEY RData for use in a Resource Record
+    pub fn with_flags(flags: u16, public_key: PublicKeyBuf) -> Self {
+        Self { flags, public_key }
+    }
+
+    /// Returns the value of the Zone Key flag
+    pub fn zone_key(&self) -> bool {
+        self.flags & 0b0000_0001_0000_0000 != 0
+    }
+
+    /// Returns the value of the Secure Entry Point flag
+    pub fn secure_entry_point(&self) -> bool {
+        self.flags & 0b0000_0000_0000_0001 != 0
+    }
+
+    /// Returns the value of the Revoke flag.
+    pub fn revoke(&self) -> bool {
+        self.flags & 0b0000_0000_1000_0000 != 0
+    }
+
+    /// Returns the public key
+    pub fn public_key(&self) -> &PublicKeyBuf {
+        &self.public_key
+    }
+
+    /// Returns the Flags field
+    pub fn flags(&self) -> u16 {
+        self.flags
+    }
+}
+
+impl From<CDNSKEY> for RData {
+    fn from(value: CDNSKEY) -> Self {
+        Self::DNSSEC(DNSSECRData::CDNSKEY(value))
     }
 }
 
 impl BinEncodable for CDNSKEY {
     fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
-        self.0.emit(encoder)
+        encoder.emit_u16(self.flags())?;
+        encoder.emit(3)?; // always 3 for now
+        self.public_key.algorithm().emit(encoder)?;
+        encoder.emit_vec(self.public_key.public_bytes())?;
+
+        Ok(())
     }
 }
 
 impl<'r> RecordDataDecodable<'r> for CDNSKEY {
     fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> ProtoResult<Self> {
-        DNSKEY::read_data(decoder, length).map(Self)
+        let flags = decoder.read_u16()?.unverified(/* used as a bitfield, this is safe */);
+
+        // protocol is defined to only be '3' right now
+        let _protocol = decoder
+            .read_u8()?
+            .verify_unwrap(|protocol| *protocol == 3)
+            .map_err(|protocol| ProtoError::from(ProtoErrorKind::DnsKeyProtocolNot3(protocol)))?;
+
+        let algorithm = Algorithm::read(decoder)?;
+
+        // The public key is the remaining bytes, excluding the first four bytes for the above
+        // fields. This subtraction is safe, as the first three fields must have been in the RDATA,
+        // otherwise there would have been an earlier return.
+        let key_len = length
+            .map(|u| u as usize)
+            .checked_sub(4)
+            .map_err(|_| ProtoError::from("invalid rdata length in DNSKEY"))?
+            .unverified(/* used only as length safely */);
+        let public_key = decoder
+            .read_vec(key_len)?
+            .unverified(/* signature verification will fail if the public key is invalid */);
+
+        Ok(Self::with_flags(
+            flags,
+            PublicKeyBuf::new(public_key, algorithm),
+        ))
     }
 }
 
@@ -71,6 +178,48 @@ impl RecordData for CDNSKEY {
 
 impl fmt::Display for CDNSKEY {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", self.0)
+        write!(
+            f,
+            "{flags} 3 {alg} {key}",
+            flags = self.flags,
+            alg = u8::from(self.public_key.algorithm()),
+            key = data_encoding::BASE64.encode(self.public_key.public_bytes())
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use crate::{
+        dnssec::{Algorithm, PublicKeyBuf},
+        rr::RecordDataDecodable,
+        serialize::binary::{BinDecoder, BinEncodable, BinEncoder, Restrict},
+    };
+
+    use super::CDNSKEY;
+
+    #[test]
+    fn test() {
+        let rdata = CDNSKEY::new(
+            true,
+            true,
+            false,
+            PublicKeyBuf::new(vec![1u8, 2u8, 3u8, 4u8], Algorithm::ECDSAP256SHA256),
+        );
+
+        let mut bytes = Vec::new();
+        let mut encoder = BinEncoder::new(&mut bytes);
+        rdata.emit(&mut encoder).expect("error encoding");
+        let bytes = encoder.into_bytes();
+
+        println!("bytes: {bytes:?}");
+
+        let mut decoder = BinDecoder::new(bytes);
+        let read_rdata = CDNSKEY::read_data(&mut decoder, Restrict::new(bytes.len() as u16))
+            .expect("error decoding");
+
+        assert_eq!(rdata, read_rdata);
     }
 }

--- a/crates/proto/src/dnssec/rdata/dnskey.rs
+++ b/crates/proto/src/dnssec/rdata/dnskey.rs
@@ -271,7 +271,7 @@ impl DNSKEY {
             }
         }
 
-        Ok(Digest::new(&buf, digest_type))
+        Digest::new(&buf, digest_type)
     }
 
     /// The key tag is calculated as a hash to more quickly lookup a DNSKEY.

--- a/crates/proto/src/dnssec/rdata/ds.rs
+++ b/crates/proto/src/dnssec/rdata/ds.rs
@@ -208,7 +208,7 @@ impl DS {
 impl BinEncodable for DS {
     fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
         encoder.emit_u16(self.key_tag())?;
-        self.algorithm().emit(encoder)?; // always 3 for now
+        self.algorithm().emit(encoder)?;
         encoder.emit(self.digest_type().into())?;
         encoder.emit_vec(self.digest())?;
 

--- a/crates/proto/src/dnssec/rdata/ds.rs
+++ b/crates/proto/src/dnssec/rdata/ds.rs
@@ -222,9 +222,8 @@ impl<'r> RecordDataDecodable<'r> for DS {
 
         let key_tag: u16 = decoder.read_u16()?.unverified(/*key_tag is valid as any u16*/);
         let algorithm: Algorithm = Algorithm::read(decoder)?;
-        let digest_type = DigestType::try_from(
-            decoder.read_u8()?.unverified(/*DigestType is verified as safe*/),
-        )?;
+        let digest_type =
+            DigestType::from(decoder.read_u8()?.unverified(/*DigestType is verified as safe*/));
 
         let bytes_read = decoder.index() - start_idx;
         let left: usize = length

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -211,6 +211,10 @@ pub enum ProtoErrorKind {
     #[error("algorithm type value unknown: {0}")]
     UnknownAlgorithmTypeValue(u8),
 
+    /// An unknown digest type was found
+    #[error("digest type value unknown: {0}")]
+    UnknownDigestTypeValue(u8),
+
     /// An unknown dns class was found
     #[error("dns class string unknown: {0}")]
     UnknownDnsClassStr(String),
@@ -769,6 +773,7 @@ impl Clone for ProtoErrorKind {
                 proof,
             },
             UnknownAlgorithmTypeValue(value) => UnknownAlgorithmTypeValue(value),
+            UnknownDigestTypeValue(value) => UnknownDigestTypeValue(value),
             UnknownDnsClassStr(ref value) => UnknownDnsClassStr(value.clone()),
             UnknownDnsClassValue(value) => UnknownDnsClassValue(value),
             UnknownRecordTypeStr(ref value) => UnknownRecordTypeStr(value.clone()),

--- a/crates/proto/src/serialize/txt/rdata_parsers/ds.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/ds.rs
@@ -50,7 +50,7 @@ pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResu
         "PRIVATEOID" => Algorithm::Unknown(254),
         _ => Algorithm::from_u8(algorithm_str.parse()?),
     };
-    let digest_type = DigestType::try_from(u8::from_str(digest_type_str)?)?;
+    let digest_type = DigestType::from(u8::from_str(digest_type_str)?);
     let digest_str: String = tokens.collect();
     if digest_str.is_empty() {
         return Err(ParseError::from(ParseErrorKind::Message(

--- a/tests/ede-dot-com/src/lib.rs
+++ b/tests/ede-dot-com/src/lib.rs
@@ -165,13 +165,11 @@ fn hermetic_ds_reserved_key_algo() -> Result<()> {
 }
 
 #[test]
-#[ignore = "hickory can't decode unassigned DS digest algorithms (issue #2695)"]
 fn ds_unassigned_digest_algo() -> Result<()> {
     compare("ds-unassigned-digest-algo").map(drop)
 }
 
 #[test]
-#[ignore = "hickory can't decode unassigned DS digest algorithms (issue #2695)"]
 fn hermetic_ds_unassigned_digest_algo() -> Result<()> {
     hermetic_compare("ds-unassigned-digest-algo").map(drop)
 }


### PR DESCRIPTION
This adds a variant to `DigestType` for unknown digest types, updates the unsupported algorithm logic to also consider digest type when deciding to treat a zone as insecure, and adds special handling to CDS and CDNSKEY records for delete operations, represented by a signature algorithm field of zero.

This closes #2695 and closes #2734.