### PR TITLE
Preserve fully qualified status of `Name` after `prepend_label`

### DIFF
--- a/crates/proto/src/rr/domain/name.rs
+++ b/crates/proto/src/rr/domain/name.rs
@@ -34,6 +34,9 @@ pub struct Name {
 }
 
 impl Name {
+    /// Maximum legal length of a domain name
+    pub const MAX_LENGTH: usize = 255;
+
     /// Create a new domain::Name, i.e. label
     pub fn new() -> Self {
         Self::default()
@@ -48,11 +51,15 @@ impl Name {
 
     /// Extend the name with the offered label, and ensure maximum name length is not exceeded.
     fn extend_name(&mut self, label: &[u8]) -> Result<(), ProtoError> {
+        let new_len = self.len() + label.len() + 1;
+
+        if new_len > Self::MAX_LENGTH {
+            return Err(ProtoErrorKind::DomainNameTooLong(new_len).into());
+        };
+
         self.label_data.extend_from_slice(label);
         self.label_ends.push(self.label_data.len() as u8);
-        if self.len() > 255 {
-            return Err(ProtoErrorKind::DomainNameTooLong(self.len()).into());
-        };
+
         Ok(())
     }
 


### PR DESCRIPTION
**make Name::prepend_label preserve fqdn**

Currently, if you have a fully qualified `Name` and you add a label with `prepend_label`, the resulting `Name` is not fully qualified. This change modifies the behavior so that if the fully qualified marker of the input `Name` is the same in the new `Name`.

**check length violation before mutation**

Currently, when appending a label to a name, the label is appended first, and then the length of the buffer is checked. This returns an error, but still leaves the buffer in an illegal state, potentially allowing further use if the Name is not disregarded after this point.

Instead the new length is checked before mutating the buffer, leaving it unmodified if the result would be too long.

