### PR TITLE
fix(dnssec): Include NSEC3PARAM in the covered RRSet list

### DIFF
--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -776,6 +776,7 @@ impl InnerInMemory {
         // Store the record types of each domain name so we can generate NSEC3 records for each
         // domain name.
         let mut record_types = HashMap::new();
+        record_types.insert(origin.clone(), ([RecordType::NSEC3PARAM].into(), true));
 
         for key in self.records.keys() {
             // Store the type of the current record under its domain name


### PR DESCRIPTION
When using NSEC3, the server returns a `NSEC3` entry with a list of covered RRSet. But, as the `NSEC3PARAM` entry is dynamically generated, it's missing from the list.

When testing a zone with [zonemaster](https://www.zonemaster.net), it complains with :
> NSEC3 record for the zone apex with incorrect type list. Fetched from name servers "...". 

In the detailed test procedure, this fails (6.5.3.5.2.1) :
>If the type list in the NSEC record matches at least one of the following criteria then add name server IP to the *NSEC Incorrect Type List* set:
>
>    1. At least one of SOA, NS, DNSKEY, NSEC or RRSIG is missing.
>    1. At least one of NSEC3PARAM or NSEC3 is included.
>
> *Source: [DNSSEC10](https://doc.zonemaster.net/latest/specifications/tests/DNSSEC-TP/dnssec10.html)*


This PR initializes the `record_types` list with the `NSEC3PARAM` RR that will be added at the end of the function, so it's included in the RRSet list.
