### PR TITLE
Add conformance test support for dnssec-aws-lc-rs

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -33,6 +33,9 @@ jobs:
       - name: run conformance tests against hickory-dns
         run: just conformance-hickory
 
+      - name: run conformance tests against hickory-dns (with aws-lc-rs)
+        run: just conformance-hickory-aws-lc-rs
+
       - name: check that all the tests that now pass with hickory-dns are not marked as `#[ignore]`-d
         run: just conformance-ignored
 

--- a/conformance/packages/dns-test/src/implementation.rs
+++ b/conformance/packages/dns-test/src/implementation.rs
@@ -253,12 +253,14 @@ impl Implementation {
 /// A Hickory DNS Cargo feature used to enable DNSSEC with a particular cryptography library.
 #[derive(Debug, Clone, Copy)]
 pub enum HickoryDnssecFeature {
+    AwsLcRs,
     Ring,
 }
 
 impl fmt::Display for HickoryDnssecFeature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
+            Self::AwsLcRs => "dnssec-aws-lc-rs",
             Self::Ring => "dnssec-ring",
         })
     }
@@ -269,6 +271,7 @@ impl FromStr for HickoryDnssecFeature {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
+            "dnssec-aws-lc-rs" => Ok(Self::AwsLcRs),
             "dnssec-ring" => Ok(Self::Ring),
             _ => {
                 Err(format!("invalid value for DNSSEC_FEATURE: {s}, expected  dnssec-ring").into())

--- a/justfile
+++ b/justfile
@@ -183,6 +183,11 @@ conformance-bind filter='':
 # runs the conformance test suite against the latest local hickory-dns commit -- changes that have not been commited will be ignored!
 conformance-hickory: (conformance-hickory-ring)
 
+conformance-hickory-aws-lc-rs filter='':
+    @ bash -c '[[ -n "$(git status -s)" ]] && echo "WARNING: uncommitted changes will NOT be tested" || true'
+    DNS_TEST_VERBOSE_DOCKER_BUILD=1 DNS_TEST_PEER=unbound DNS_TEST_SUBJECT="hickory {{justfile_directory()}} dnssec-aws-lc-rs" cargo t --manifest-path conformance/Cargo.toml -p conformance-tests -- {{filter}}
+    @ bash -c '[[ -n "$(git status -s)" ]] && echo "WARNING: uncommitted changes were NOT tested" || true'
+
 conformance-hickory-ring filter='':
     @ bash -c '[[ -n "$(git status -s)" ]] && echo "WARNING: uncommitted changes will NOT be tested" || true'
     DNS_TEST_VERBOSE_DOCKER_BUILD=1 DNS_TEST_PEER=unbound DNS_TEST_SUBJECT="hickory {{justfile_directory()}} dnssec-ring" cargo t --manifest-path conformance/Cargo.toml -p conformance-tests -- {{filter}}


### PR DESCRIPTION
Not sure we should additional conformance runs for this in CI -- conformance is already very slow. More likely, given the maintenance state of ring, we should switch the default in CI over to aws-lc-rs soonish (after we can use aws-lc-rs for TLS, too).

(But, `just conformance-hickory-aws-lc-rs` passes for me locally.)