### PR TITLE
Move uses of std to core and alloc in proto crate

### DIFF
--- a/crates/proto/src/async_std.rs
+++ b/crates/proto/src/async_std.rs
@@ -1,11 +1,12 @@
 //! async-std runtime implementation.
 
-use std::future::Future;
+use alloc::boxed::Box;
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use core::time::Duration;
 use std::io;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::Duration;
 
 use async_std::future::timeout;
 use async_trait::async_trait;

--- a/crates/proto/src/dnssec/algorithm.rs
+++ b/crates/proto/src/dnssec/algorithm.rs
@@ -9,8 +9,8 @@
 //   this issue in rustc would help narrow the statement: https://github.com/rust-lang/rust/issues/62398
 #![allow(deprecated, clippy::use_self)]
 
-use std::fmt;
-use std::fmt::{Display, Formatter};
+use alloc::fmt;
+use core::fmt::{Display, Formatter};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/proto/src/dnssec/crypto.rs
+++ b/crates/proto/src/dnssec/crypto.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, sync::Arc};
+use alloc::{borrow::Cow, boxed::Box, sync::Arc, vec::Vec};
 
 use rustls_pki_types::{PrivateKeyDer, PrivatePkcs1KeyDer, PrivatePkcs8KeyDer};
 

--- a/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
@@ -7,11 +7,10 @@
 
 //! The `DnssecDnsHandle` is used to validate all DNS responses for correct DNSSEC signatures.
 
+use alloc::{borrow::ToOwned, boxed::Box, string::ToString, sync::Arc, vec::Vec};
+use core::{clone::Clone, pin::Pin};
 use std::{
-    clone::Clone,
     collections::{HashMap, HashSet},
-    pin::Pin,
-    sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -1371,6 +1370,8 @@ fn proof_log_yield(proof: Proof, name: &Name, nsec_type: &str, msg: &str) -> Pro
 }
 
 mod rrset {
+    use alloc::vec::Vec;
+
     use crate::rr::{DNSClass, Name, Record, RecordType};
 
     // TODO: combine this with crate::rr::RecordSet?

--- a/crates/proto/src/dnssec/dnssec_dns_handle/nsec3_validation.rs
+++ b/crates/proto/src/dnssec/dnssec_dns_handle/nsec3_validation.rs
@@ -76,6 +76,8 @@
 //!     `wildcard_encloser` == `*.soa.name`
 //!
 
+use alloc::vec::Vec;
+
 use super::proof_log_yield;
 use crate::{
     dnssec::{Nsec3HashAlgorithm, Proof, rdata::NSEC3},

--- a/crates/proto/src/dnssec/mod.rs
+++ b/crates/proto/src/dnssec/mod.rs
@@ -7,7 +7,9 @@
 
 //! dns security extension related modules
 
-use std::fmt;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt;
 
 #[cfg(feature = "backtrace")]
 use backtrace::Backtrace;
@@ -138,7 +140,7 @@ pub enum KeyFormat {
 }
 
 /// An alias for dnssec results returned by functions of this crate
-pub type DnsSecResult<T> = ::std::result::Result<T, DnsSecError>;
+pub type DnsSecResult<T> = ::core::result::Result<T, DnsSecError>;
 
 /// The error type for dnssec errors that get returned in the crate
 #[derive(Debug, Clone, Error)]

--- a/crates/proto/src/dnssec/nsec3.rs
+++ b/crates/proto/src/dnssec/nsec3.rs
@@ -17,6 +17,8 @@
 
 //! NSEC3 related record types
 
+use alloc::vec::Vec;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -175,12 +177,13 @@ impl From<Nsec3HashAlgorithm> for u8 {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::String;
+    use core::str::FromStr;
+
     use super::*;
 
     #[test]
     fn test_hash() {
-        use std::str::FromStr;
-
         let name = Name::from_str("www.example.com").unwrap();
         let salt: Vec<u8> = vec![1, 2, 3, 4];
 

--- a/crates/proto/src/dnssec/proof.rs
+++ b/crates/proto/src/dnssec/proof.rs
@@ -7,7 +7,8 @@
 
 //! DNSSEC related Proof of record authenticity
 
-use std::{fmt, ops::BitOr};
+use alloc::string::String;
+use core::{fmt, ops::BitOr};
 
 use bitflags::bitflags;
 #[cfg(feature = "serde")]

--- a/crates/proto/src/dnssec/public_key.rs
+++ b/crates/proto/src/dnssec/public_key.rs
@@ -7,6 +7,8 @@
 
 //! Public Key implementations for supported key types
 
+use alloc::vec::Vec;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/crates/proto/src/dnssec/rdata/cdnskey.rs
+++ b/crates/proto/src/dnssec/rdata/cdnskey.rs
@@ -7,7 +7,8 @@
 
 //! CDNSKEY type and related implementations
 
-use std::fmt;
+use alloc::vec::Vec;
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -212,6 +213,9 @@ impl fmt::Display for CDNSKEY {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use alloc::vec::Vec;
+    use std::println;
 
     use crate::{
         dnssec::Algorithm,

--- a/crates/proto/src/dnssec/rdata/cds.rs
+++ b/crates/proto/src/dnssec/rdata/cds.rs
@@ -7,7 +7,8 @@
 
 //! CDS type and related implementations
 
-use std::fmt;
+use alloc::vec::Vec;
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -176,6 +177,9 @@ impl fmt::Display for CDS {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use alloc::vec::Vec;
+    use std::println;
 
     use crate::{
         dnssec::{Algorithm, DigestType},

--- a/crates/proto/src/dnssec/rdata/dnskey.rs
+++ b/crates/proto/src/dnssec/rdata/dnskey.rs
@@ -7,7 +7,8 @@
 
 //! public key record data for signing zone records
 
-use std::{fmt, sync::Arc};
+use alloc::{borrow::ToOwned, sync::Arc, vec::Vec};
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -498,6 +499,8 @@ impl fmt::Display for DNSKEY {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use std::println;
 
     use rustls_pki_types::PrivateKeyDer;
 

--- a/crates/proto/src/dnssec/rdata/ds.rs
+++ b/crates/proto/src/dnssec/rdata/ds.rs
@@ -7,7 +7,9 @@
 
 //! pointer record from parent zone to child zone for dnskey proof
 
-use std::fmt::{self, Display, Formatter};
+use alloc::borrow::ToOwned;
+use alloc::vec::Vec;
+use core::fmt::{self, Display, Formatter};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -389,6 +391,8 @@ fn key_tag(public_key: &[u8]) -> u16 {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use std::println;
 
     use super::*;
     use crate::dnssec::{PublicKeyBuf, SigningKey, crypto::EcdsaSigningKey, rdata::DNSKEY};

--- a/crates/proto/src/dnssec/rdata/key.rs
+++ b/crates/proto/src/dnssec/rdata/key.rs
@@ -8,7 +8,8 @@
 //! public key record data for signing zone records
 #![allow(clippy::use_self)]
 
-use std::{fmt, sync::Arc};
+use alloc::{sync::Arc, vec::Vec};
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -890,6 +891,8 @@ impl From<Protocol> for u8 {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use std::println;
 
     use super::*;
     use crate::dnssec::{SigningKey, crypto::EcdsaSigningKey};

--- a/crates/proto/src/dnssec/rdata/mod.rs
+++ b/crates/proto/src/dnssec/rdata/mod.rs
@@ -7,7 +7,7 @@
 
 //! All record data structures and related serialization methods
 
-use std::fmt;
+use alloc::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/proto/src/dnssec/rdata/nsec.rs
+++ b/crates/proto/src/dnssec/rdata/nsec.rs
@@ -6,7 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 
 //! NSEC record types
-use std::fmt;
+use alloc::vec::Vec;
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -234,12 +235,14 @@ impl fmt::Display for NSEC {
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
 
+    use std::println;
+
     use super::*;
 
     #[test]
     fn test() {
         use crate::rr::RecordType;
-        use std::str::FromStr;
+        use core::str::FromStr;
 
         let rdata = NSEC::new(
             Name::from_str("www.example.com.").unwrap(),

--- a/crates/proto/src/dnssec/rdata/nsec3.rs
+++ b/crates/proto/src/dnssec/rdata/nsec3.rs
@@ -7,7 +7,7 @@
 
 //! NSEC record types
 
-use std::fmt;
+use alloc::{fmt, string::ToString, vec::Vec};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize};
@@ -467,6 +467,8 @@ impl<'de> Deserialize<'de> for NSEC3 {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use std::println;
 
     use super::*;
     use crate::dnssec::rdata::RecordType;

--- a/crates/proto/src/dnssec/rdata/nsec3param.rs
+++ b/crates/proto/src/dnssec/rdata/nsec3param.rs
@@ -7,7 +7,8 @@
 
 //! parameters used for the nsec3 hash method
 
-use std::fmt;
+use alloc::{string::ToString, vec::Vec};
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -273,6 +274,8 @@ impl fmt::Display for NSEC3PARAM {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use std::println;
 
     use super::*;
 

--- a/crates/proto/src/dnssec/rdata/rrsig.rs
+++ b/crates/proto/src/dnssec/rdata/rrsig.rs
@@ -7,7 +7,8 @@
 
 //! RRSIG type and related implementations
 
-use std::{fmt, ops::Deref};
+use alloc::vec::Vec;
+use core::{fmt, ops::Deref};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/proto/src/dnssec/rdata/sig.rs
+++ b/crates/proto/src/dnssec/rdata/sig.rs
@@ -6,7 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 
 //! signature record for signing queries, updates, and responses
-use std::fmt;
+use alloc::vec::Vec;
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -645,11 +646,13 @@ impl fmt::Display for SIG {
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
 
+    use std::println;
+
     use super::*;
 
     #[test]
     fn test() {
-        use std::str::FromStr;
+        use core::str::FromStr;
 
         let rdata = SIG::new(
             RecordType::NULL,

--- a/crates/proto/src/dnssec/rdata/tsig.rs
+++ b/crates/proto/src/dnssec/rdata/tsig.rs
@@ -8,7 +8,8 @@
 //! TSIG for secret key authentication of transaction
 #![allow(clippy::use_self)]
 
-use std::{convert::TryInto, fmt};
+use alloc::vec::Vec;
+use core::{convert::TryInto, fmt};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -737,6 +738,8 @@ pub fn make_tsig_record(name: Name, rdata: TSIG) -> Record {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use std::println;
 
     use super::*;
     use crate::rr::Record;

--- a/crates/proto/src/dnssec/signer.rs
+++ b/crates/proto/src/dnssec/signer.rs
@@ -6,9 +6,10 @@
 // copied, modified, or distributed except according to those terms.
 
 //! signer is a structure for performing many of the signing processes of the DNSSEC specification
-use tracing::debug;
+use alloc::{boxed::Box, vec::Vec};
+use core::time::Duration;
 
-use std::time::Duration;
+use tracing::debug;
 
 use super::{DnsSecResult, SigningKey};
 use crate::{
@@ -536,6 +537,8 @@ impl MessageFinalizer for SigSigner {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use std::println;
 
     use rustls_pki_types::PrivatePkcs8KeyDer;
 

--- a/crates/proto/src/dnssec/supported_algorithm.rs
+++ b/crates/proto/src/dnssec/supported_algorithm.rs
@@ -16,7 +16,8 @@
 
 //! bitmap for expressing the set of supported algorithms in edns.
 
-use std::fmt::{self, Display, Formatter};
+use alloc::vec::Vec;
+use core::fmt::{self, Display, Formatter};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/proto/src/dnssec/tbs.rs
+++ b/crates/proto/src/dnssec/tbs.rs
@@ -7,6 +7,7 @@
 
 //! hash functions for DNSSEC operations
 
+use alloc::{borrow::ToOwned, vec::Vec};
 use time::OffsetDateTime;
 
 use super::Algorithm;

--- a/crates/proto/src/dnssec/trust_anchor.rs
+++ b/crates/proto/src/dnssec/trust_anchor.rs
@@ -16,6 +16,8 @@
 
 //! Allows for the root trust_anchor to either be added to or replaced for dns_sec validation.
 
+use alloc::{borrow::ToOwned, vec::Vec};
+
 use crate::dnssec::PublicKey;
 
 use super::{Algorithm, PublicKeyBuf};

--- a/crates/proto/src/dnssec/tsig.rs
+++ b/crates/proto/src/dnssec/tsig.rs
@@ -13,8 +13,11 @@
 //! - Mac checking don't support HMAC truncation with TSIG (pedantic constant time verification)
 //! - Time checking not in TSIG implementation but in caller
 
-use std::ops::Range;
-use std::sync::Arc;
+use alloc::boxed::Box;
+use alloc::string::ToString;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::ops::Range;
 
 use tracing::debug;
 

--- a/crates/proto/src/dnssec/verifier.rs
+++ b/crates/proto/src/dnssec/verifier.rs
@@ -7,7 +7,7 @@
 
 //! Verifier is a structure for performing many of the signing processes of the DNSSEC specification
 
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 use super::{
     Algorithm, PublicKey,

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -9,9 +9,14 @@
 
 #![deny(missing_docs)]
 
-use std::cmp::Ordering;
-use std::sync::Arc;
-use std::{fmt, io, sync};
+use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::fmt;
+use std::{io, sync};
 
 #[cfg(feature = "backtrace")]
 pub use backtrace::Backtrace as ExtBacktrace;
@@ -56,7 +61,7 @@ macro_rules! trace {
 }
 
 /// An alias for results returned by functions of this crate
-pub(crate) type ProtoResult<T> = ::std::result::Result<T, ProtoError>;
+pub(crate) type ProtoResult<T> = ::core::result::Result<T, ProtoError>;
 
 /// The error kind for errors that get returned in the crate
 #[derive(Debug, EnumAsInner, Error)]
@@ -275,15 +280,15 @@ pub enum ProtoErrorKind {
 
     /// A utf8 parsing error
     #[error("error parsing utf8 string")]
-    Utf8(#[from] std::str::Utf8Error),
+    Utf8(#[from] core::str::Utf8Error),
 
     /// A utf8 parsing error
     #[error("error parsing utf8 string")]
-    FromUtf8(#[from] std::string::FromUtf8Error),
+    FromUtf8(#[from] alloc::string::FromUtf8Error),
 
     /// An int parsing error
     #[error("error parsing int")]
-    ParseInt(#[from] std::num::ParseIntError),
+    ParseInt(#[from] core::num::ParseIntError),
 
     /// A Quinn (Quic) connection error occurred
     #[cfg(feature = "__quic")]

--- a/crates/proto/src/h2/h2_client_stream.rs
+++ b/crates/proto/src/h2/h2_client_stream.rs
@@ -5,15 +5,17 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::fmt::{self, Display};
-use std::future::Future;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::sync::Arc;
+use core::fmt::{self, Display};
+use core::future::Future;
+use core::ops::DerefMut;
+use core::pin::Pin;
+use core::str::FromStr;
+use core::task::{Context, Poll};
 use std::io;
 use std::net::SocketAddr;
-use std::ops::DerefMut;
-use std::pin::Pin;
-use std::str::FromStr;
-use std::sync::Arc;
-use std::task::{Context, Poll};
 
 use bytes::{Buf, Bytes, BytesMut};
 use futures_util::future::{FutureExt, TryFutureExt};
@@ -570,8 +572,8 @@ impl Future for HttpsClientResponse {
 #[cfg(any(feature = "webpki-roots", feature = "rustls-platform-verifier"))]
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
     use std::net::SocketAddr;
-    use std::str::FromStr;
 
     use rustls::KeyLogFile;
     use test_support::subscribe;

--- a/crates/proto/src/h2/h2_server.rs
+++ b/crates/proto/src/h2/h2_server.rs
@@ -7,9 +7,9 @@
 
 //! HTTPS related server items
 
-use std::fmt::Debug;
-use std::str::FromStr;
-use std::sync::Arc;
+use alloc::sync::Arc;
+use core::fmt::Debug;
+use core::str::FromStr;
 
 use bytes::{Bytes, BytesMut};
 use futures_util::stream::{Stream, StreamExt};
@@ -100,9 +100,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+    use core::pin::Pin;
+    use core::task::{Context, Poll};
     use futures_executor::block_on;
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
 
     use test_support::subscribe;
 

--- a/crates/proto/src/h3/h3_client_stream.rs
+++ b/crates/proto/src/h3/h3_client_stream.rs
@@ -5,13 +5,15 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::fmt::{self, Display};
-use std::future::{Future, poll_fn};
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::sync::Arc;
+use core::fmt::{self, Display};
+use core::future::{Future, poll_fn};
+use core::pin::Pin;
+use core::str::FromStr;
+use core::task::{Context, Poll};
 use std::net::SocketAddr;
-use std::pin::Pin;
-use std::str::FromStr;
-use std::sync::Arc;
-use std::task::{Context, Poll};
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use futures_util::future::FutureExt;
@@ -466,8 +468,10 @@ impl Future for H3ClientResponse {
     any(feature = "rustls-platform-verifier", feature = "webpki-roots")
 ))]
 mod tests {
+    use alloc::string::ToString;
+    use core::str::FromStr;
     use std::net::SocketAddr;
-    use std::str::FromStr;
+    use std::println;
 
     use rustls::KeyLogFile;
     use test_support::subscribe;

--- a/crates/proto/src/h3/h3_server.rs
+++ b/crates/proto/src/h3/h3_server.rs
@@ -7,7 +7,8 @@
 
 //! HTTP/3 related server items
 
-use std::{io, net::SocketAddr, sync::Arc};
+use alloc::sync::Arc;
+use std::{io, net::SocketAddr};
 
 use bytes::Bytes;
 use h3::server::{Connection, RequestStream};

--- a/crates/proto/src/http/error.rs
+++ b/crates/proto/src/http/error.rs
@@ -5,8 +5,9 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::num::ParseIntError;
-use std::{fmt, io};
+use alloc::{fmt, string::String};
+use core::num::ParseIntError;
+use std::io;
 
 use crate::error::ProtoError;
 use http::header::ToStrError;
@@ -16,7 +17,7 @@ use thiserror::Error;
 use crate::{ExtBacktrace, trace};
 
 /// An alias for results returned by functions of this crate
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = ::core::result::Result<T, Error>;
 
 // TODO: remove this and put in ProtoError
 #[derive(Debug, Error)]

--- a/crates/proto/src/http/request.rs
+++ b/crates/proto/src/http/request.rs
@@ -7,7 +7,7 @@
 
 //! HTTP request creation and validation
 
-use std::str::FromStr;
+use core::str::FromStr;
 
 use http::header::{ACCEPT, CONTENT_LENGTH, CONTENT_TYPE};
 use http::{Request, Uri, header, uri};

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -6,11 +6,15 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+#![no_std]
 // LIBRARY WARNINGS
 #![warn(
+    clippy::alloc_instead_of_core,
     clippy::default_trait_access,
     clippy::dbg_macro,
     clippy::print_stdout,
+    clippy::std_instead_of_core,
+    clippy::std_instead_of_alloc,
     clippy::unimplemented,
     clippy::use_self,
     missing_copy_implementations,
@@ -29,6 +33,11 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 //! Hickory DNS Protocol library
+
+extern crate std;
+
+#[macro_use]
+extern crate alloc;
 
 macro_rules! try_ready_stream {
     ($e:expr) => {{

--- a/crates/proto/src/multicast/mdns_client_stream.rs
+++ b/crates/proto/src/multicast/mdns_client_stream.rs
@@ -5,11 +5,12 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::fmt::{self, Display};
-use std::future::Future;
+use alloc::boxed::Box;
+use core::fmt::{self, Display};
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 use std::net::{Ipv4Addr, SocketAddr};
-use std::pin::Pin;
-use std::task::{Context, Poll};
 
 use futures_util::future::{FutureExt, TryFutureExt};
 use futures_util::stream::{Stream, StreamExt, TryStreamExt};

--- a/crates/proto/src/op/edns.rs
+++ b/crates/proto/src/op/edns.rs
@@ -7,7 +7,7 @@
 
 //! Extended DNS options
 
-use std::fmt;
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/proto/src/op/header.rs
+++ b/crates/proto/src/op/header.rs
@@ -7,7 +7,9 @@
 
 //! Message metadata
 
-use std::{convert::From, fmt};
+#[cfg(test)]
+use alloc::vec::Vec;
+use core::{convert::From, fmt};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/proto/src/op/lower_query.rs
+++ b/crates/proto/src/op/lower_query.rs
@@ -5,7 +5,7 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::fmt::{self, Display};
+use core::fmt::{self, Display};
 
 use crate::error::*;
 use crate::op::Query;

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -7,7 +7,8 @@
 
 //! Basic protocol message for DNS
 
-use std::{fmt, iter, mem, ops::Deref};
+use alloc::{boxed::Box, fmt, vec::Vec};
+use core::{iter, mem, ops::Deref};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/proto/src/op/op_code.rs
+++ b/crates/proto/src/op/op_code.rs
@@ -7,7 +7,7 @@
 
 //! Operation code for queries, updates, and responses
 
-use std::{convert::From, fmt};
+use core::{convert::From, fmt};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/proto/src/op/query.rs
+++ b/crates/proto/src/op/query.rs
@@ -16,8 +16,9 @@
 
 //! Query struct for looking up resource records
 
-use std::fmt;
-use std::fmt::{Display, Formatter};
+#[cfg(test)]
+use alloc::vec::Vec;
+use core::fmt::{self, Display, Formatter};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -321,7 +322,7 @@ fn test_read_and_emit() {
 #[test]
 fn test_mdns_unicast_response_bit_handling() {
     const QCLASS_OFFSET: usize = 1 /* empty name */ +
-        std::mem::size_of::<u16>() /* query_type */;
+        core::mem::size_of::<u16>() /* query_type */;
 
     let mut query = Query::new();
     query.set_mdns_unicast_response(true);

--- a/crates/proto/src/op/response_code.rs
+++ b/crates/proto/src/op/response_code.rs
@@ -18,8 +18,7 @@
 
 //! All defined response codes in DNS
 
-use std::fmt;
-use std::fmt::{Display, Formatter};
+use core::fmt::{self, Display, Formatter};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/proto/src/op/update_message.rs
+++ b/crates/proto/src/op/update_message.rs
@@ -7,7 +7,7 @@
 
 //! Update related operations for Messages
 
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use crate::{
     op::{Edns, Message, MessageType, OpCode, Query},

--- a/crates/proto/src/quic/quic_client_stream.rs
+++ b/crates/proto/src/quic/quic_client_stream.rs
@@ -5,15 +5,14 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::{
+use alloc::{boxed::Box, string::String, sync::Arc};
+use core::{
     fmt::{self, Display},
     future::Future,
-    io,
-    net::SocketAddr,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use std::{io, net::SocketAddr};
 
 use futures_util::{future::FutureExt, stream::Stream};
 use quinn::{

--- a/crates/proto/src/quic/quic_server.rs
+++ b/crates/proto/src/quic/quic_server.rs
@@ -5,7 +5,8 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::{io, net::SocketAddr, sync::Arc};
+use alloc::sync::Arc;
+use std::{io, net::SocketAddr};
 
 use quinn::crypto::rustls::QuicServerConfig;
 use quinn::{Connection, Endpoint, ServerConfig};

--- a/crates/proto/src/quic/tests.rs
+++ b/crates/proto/src/quic/tests.rs
@@ -7,7 +7,9 @@
 
 #![allow(clippy::print_stdout)] // this is a test module
 
-use std::{env, net::SocketAddr, path::Path, str::FromStr, sync::Arc};
+use alloc::{borrow::ToOwned, string::ToString, sync::Arc, vec::Vec};
+use core::str::FromStr;
+use std::{env, net::SocketAddr, path::Path, println};
 
 use futures_util::StreamExt;
 use rustls::{

--- a/crates/proto/src/rr/dns_class.rs
+++ b/crates/proto/src/rr/dns_class.rs
@@ -8,9 +8,12 @@
 //! class of DNS operations, in general always IN for internet
 #![allow(clippy::use_self)]
 
-use std::cmp::Ordering;
-use std::fmt::{self, Display, Formatter};
-use std::str::FromStr;
+use alloc::string::ToString;
+use core::{
+    cmp::Ordering,
+    fmt::{self, Display, Formatter},
+    str::FromStr,
+};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/proto/src/rr/domain/label.rs
+++ b/crates/proto/src/rr/domain/label.rs
@@ -9,10 +9,11 @@
 //!
 //! A label is stored internally as ascii, where all unicode characters are converted to punycode internally.
 
-use std::borrow::Borrow;
-use std::cmp::{Ordering, PartialEq};
-use std::fmt::{self, Debug, Display, Formatter, Write};
-use std::hash::{Hash, Hasher};
+use alloc::{string::String, vec::Vec};
+use core::borrow::Borrow;
+use core::cmp::{Ordering, PartialEq};
+use core::fmt::{self, Debug, Display, Formatter, Write};
+use core::hash::{Hash, Hasher};
 
 use idna::uts46::{AsciiDenyList, DnsLength, Hyphens, Uts46};
 use tinyvec::TinyVec;
@@ -364,6 +365,9 @@ impl IntoLabel for Vec<u8> {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use alloc::string::ToString;
+    use std::{eprintln, println};
 
     use super::*;
 

--- a/crates/proto/src/rr/domain/name.rs
+++ b/crates/proto/src/rr/domain/name.rs
@@ -7,12 +7,15 @@
 
 //! domain name, aka labels, implementation
 
-use std::char;
-use std::cmp::{Ordering, PartialEq};
-use std::fmt::{self, Write};
-use std::hash::{Hash, Hasher};
+#[cfg(feature = "serde")]
+use alloc::string::ToString;
+use alloc::{string::String, vec::Vec};
+use core::char;
+use core::cmp::{Ordering, PartialEq};
+use core::fmt::{self, Write};
+use core::hash::{Hash, Hasher};
+use core::str::FromStr;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use std::str::FromStr;
 
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 #[cfg(feature = "serde")]
@@ -874,19 +877,19 @@ impl Name {
         let first = iter
             .next()
             .ok_or_else(|| ProtoError::from("not an arpa address"))?;
-        if !"arpa".eq_ignore_ascii_case(std::str::from_utf8(first)?) {
+        if !"arpa".eq_ignore_ascii_case(core::str::from_utf8(first)?) {
             return Err("not an arpa address".into());
         }
         let second = iter
             .next()
             .ok_or_else(|| ProtoError::from("invalid arpa address"))?;
         let mut prefix_len: u8 = 0;
-        match &std::str::from_utf8(second)?.to_ascii_lowercase()[..] {
+        match &core::str::from_utf8(second)?.to_ascii_lowercase()[..] {
             "in-addr" => {
                 let mut octets: [u8; 4] = [0; 4];
                 for octet in octets.iter_mut() {
                     match iter.next() {
-                        Some(label) => *octet = std::str::from_utf8(label)?.parse()?,
+                        Some(label) => *octet = core::str::from_utf8(label)?.parse()?,
                         None => break,
                     }
                     prefix_len += 8;
@@ -905,7 +908,7 @@ impl Name {
                         Some(label) => {
                             if label.len() == 1 {
                                 prefix_len += 4;
-                                let hex = u8::from_str_radix(std::str::from_utf8(label)?, 16)?;
+                                let hex = u8::from_str_radix(core::str::from_utf8(label)?, 16)?;
                                 address |= u128::from(hex) << (128 - prefix_len);
                             } else {
                                 return Err("invalid label length for ip6.arpa".into());
@@ -1022,8 +1025,8 @@ impl Name {
     }
 }
 
-impl std::fmt::Debug for Name {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Name {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str("Name(\"")?;
         self.write_labels::<_, LabelEncUtf8>(f)?;
         f.write_str("\")")
@@ -1528,10 +1531,11 @@ impl<'de> Deserialize<'de> for Name {
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
 
-    use std::cmp::Ordering;
-    use std::collections::hash_map::DefaultHasher;
-    use std::iter;
-    use std::str::FromStr;
+    use alloc::string::ToString;
+    use core::cmp::Ordering;
+    use core::iter;
+    use core::str::FromStr;
+    use std::{collections::hash_map::DefaultHasher, println};
 
     use super::*;
 
@@ -2387,7 +2391,7 @@ mod tests {
 
     #[test]
     fn test_name_partialord_constraints() {
-        use std::cmp::Ordering::*;
+        use core::cmp::Ordering::*;
 
         let example_fqdn = Name::from_utf8("example.com.").unwrap();
         let foo_example_fqdn = Name::from_utf8("foo.example.com.").unwrap();
@@ -2453,7 +2457,7 @@ mod tests {
 
     #[test]
     fn test_name_ord_constraints() {
-        use std::cmp;
+        use core::cmp;
 
         let example_fqdn = Name::from_utf8("example.com.").unwrap();
         let foo_example_fqdn = Name::from_utf8("foo.example.com.").unwrap();

--- a/crates/proto/src/rr/domain/usage.rs
+++ b/crates/proto/src/rr/domain/usage.rs
@@ -9,7 +9,7 @@
 //!
 //! see [Special-Use Domain Names](https://tools.ietf.org/html/rfc6761), RFC 6761 February, 2013
 
-use std::ops::Deref;
+use core::ops::Deref;
 
 use once_cell::sync::Lazy;
 

--- a/crates/proto/src/rr/lower_name.rs
+++ b/crates/proto/src/rr/lower_name.rs
@@ -7,11 +7,13 @@
 
 //! domain name, aka labels, implementation
 
-use std::cmp::{Ordering, PartialEq};
-use std::fmt;
-use std::hash::{Hash, Hasher};
-use std::ops::Deref;
-use std::str::FromStr;
+#[cfg(feature = "serde")]
+use alloc::string::{String, ToString};
+use core::cmp::{Ordering, PartialEq};
+use core::fmt;
+use core::hash::{Hash, Hasher};
+use core::ops::Deref;
+use core::str::FromStr;
 
 use crate::error::*;
 #[cfg(feature = "serde")]

--- a/crates/proto/src/rr/mod.rs
+++ b/crates/proto/src/rr/mod.rs
@@ -20,7 +20,7 @@ mod rr_set;
 pub mod serial_number;
 pub mod type_bit_map;
 
-use std::fmt::{Debug, Display};
+use core::fmt::{Debug, Display};
 
 use crate::{
     error::ProtoResult,

--- a/crates/proto/src/rr/rdata/a.rs
+++ b/crates/proto/src/rr/rdata/a.rs
@@ -31,8 +31,9 @@
 //! "10.2.0.52" or "192.0.5.6").
 //! ```
 
+use core::{fmt, ops::Deref, str};
+use std::net::AddrParseError;
 pub use std::net::Ipv4Addr;
-use std::{fmt, net::AddrParseError, ops::Deref, str};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -151,6 +152,8 @@ impl str::FromStr for A {
 
 #[cfg(test)]
 mod mytests {
+    use alloc::vec::Vec;
+
     use super::*;
     use crate::serialize::binary::bin_tests::{test_emit_data_set, test_read_data_set};
 

--- a/crates/proto/src/rr/rdata/aaaa.rs
+++ b/crates/proto/src/rr/rdata/aaaa.rs
@@ -23,8 +23,10 @@
 //!   resource record in network byte order (high-order byte first).
 //! ```
 
+use core::{fmt, ops::Deref, str};
+use std::net::AddrParseError;
+
 pub use std::net::Ipv6Addr;
-use std::{fmt, net::AddrParseError, ops::Deref, str};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -153,7 +155,8 @@ impl str::FromStr for AAAA {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use alloc::vec::Vec;
+    use core::str::FromStr;
 
     use super::*;
     use crate::serialize::binary::bin_tests::{test_emit_data_set, test_read_data_set};

--- a/crates/proto/src/rr/rdata/caa.rs
+++ b/crates/proto/src/rr/rdata/caa.rs
@@ -21,7 +21,8 @@
 //! ```
 #![allow(clippy::use_self)]
 
-use std::{fmt, str};
+use alloc::{string::String, vec::Vec};
+use core::{fmt, str};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -859,7 +860,8 @@ impl fmt::Display for CAA {
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
 
-    use std::str;
+    use alloc::{str, string::ToString};
+    use std::{dbg, println};
 
     use super::*;
 

--- a/crates/proto/src/rr/rdata/cert.rs
+++ b/crates/proto/src/rr/rdata/cert.rs
@@ -6,7 +6,10 @@
 // copied, modified, or distributed except according to those terms.
 
 //! CERT record type for storing certificates in DNS
-use std::fmt;
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/proto/src/rr/rdata/csync.rs
+++ b/crates/proto/src/rr/rdata/csync.rs
@@ -7,7 +7,8 @@
 
 //! CSYNC record for synchronizing data from a child zone to the parent
 
-use std::fmt;
+use alloc::vec::Vec;
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -206,6 +207,8 @@ impl fmt::Display for CSYNC {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use std::println;
 
     use super::*;
 

--- a/crates/proto/src/rr/rdata/hinfo.rs
+++ b/crates/proto/src/rr/rdata/hinfo.rs
@@ -7,7 +7,8 @@
 
 //! HINFO record for storing host information
 
-use std::fmt;
+use alloc::{boxed::Box, string::String};
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -180,6 +181,9 @@ impl fmt::Display for HINFO {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use alloc::{string::ToString, vec::Vec};
+    use std::println;
 
     use super::*;
 

--- a/crates/proto/src/rr/rdata/https.rs
+++ b/crates/proto/src/rr/rdata/https.rs
@@ -7,7 +7,7 @@
 
 //! HTTPS type and related implementations
 
-use std::{fmt, ops::Deref};
+use core::{fmt, ops::Deref};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/proto/src/rr/rdata/mx.rs
+++ b/crates/proto/src/rr/rdata/mx.rs
@@ -7,7 +7,7 @@
 
 //! mail exchange, email, record
 
-use std::fmt;
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -177,11 +177,14 @@ impl fmt::Display for MX {
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
 
+    use alloc::vec::Vec;
+    use std::println;
+
     use super::*;
 
     #[test]
     fn test() {
-        use std::str::FromStr;
+        use core::str::FromStr;
 
         let rdata = MX::new(16, Name::from_str("mail.example.com.").unwrap());
 

--- a/crates/proto/src/rr/rdata/name.rs
+++ b/crates/proto/src/rr/rdata/name.rs
@@ -30,7 +30,7 @@
 //! the description of name server logic in [RFC-1034] for details.
 //! ```
 
-use std::{fmt, ops::Deref};
+use core::{fmt, ops::Deref};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -138,6 +138,9 @@ name_rdata!(ANAME);
 
 #[cfg(test)]
 mod tests {
+
+    use alloc::{string::ToString, vec::Vec};
+    use std::println;
 
     use super::*;
 

--- a/crates/proto/src/rr/rdata/naptr.rs
+++ b/crates/proto/src/rr/rdata/naptr.rs
@@ -7,7 +7,8 @@
 
 //! Dynamic Delegation Discovery System
 
-use std::fmt;
+use alloc::{boxed::Box, string::String};
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -298,10 +299,13 @@ impl fmt::Display for NAPTR {
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
 
+    use alloc::vec::Vec;
+    use std::println;
+
     use super::*;
     #[test]
     fn test() {
-        use std::str::FromStr;
+        use core::str::FromStr;
 
         let rdata = NAPTR::new(
             8,
@@ -326,7 +330,7 @@ mod tests {
 
     #[test]
     fn test_bad_data() {
-        use std::str::FromStr;
+        use core::str::FromStr;
 
         let rdata = NAPTR::new(
             8,

--- a/crates/proto/src/rr/rdata/null.rs
+++ b/crates/proto/src/rr/rdata/null.rs
@@ -6,7 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 
 //! null record type, generally not used except as an internal tool for representing null data
-use std::fmt;
+use alloc::vec::Vec;
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -117,6 +118,8 @@ impl fmt::Display for NULL {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use std::println;
 
     use super::*;
 

--- a/crates/proto/src/rr/rdata/openpgpkey.rs
+++ b/crates/proto/src/rr/rdata/openpgpkey.rs
@@ -6,7 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 
 //! OPENPGPKEY records for OpenPGP public keys
-use std::fmt;
+use alloc::vec::Vec;
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -8,13 +8,13 @@
 //! option record for passing protocol options between the client and server
 #![allow(clippy::use_self)]
 
-use std::fmt;
+use alloc::vec::Vec;
+use core::fmt;
+use core::str::FromStr;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use std::str::FromStr;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-
 use tracing::warn;
 
 use crate::{
@@ -781,6 +781,8 @@ impl FromStr for ClientSubnet {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use std::println;
 
     use super::*;
 

--- a/crates/proto/src/rr/rdata/soa.rs
+++ b/crates/proto/src/rr/rdata/soa.rs
@@ -7,7 +7,7 @@
 
 //! start of authority record defining ownership and defaults for the zone
 
-use std::fmt;
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -355,13 +355,16 @@ impl fmt::Display for SOA {
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
 
+    use alloc::vec::Vec;
+    use std::println;
+
     use crate::{rr::RecordDataDecodable, serialize::binary::Restrict};
 
     use super::*;
 
     #[test]
     fn test() {
-        use std::str::FromStr;
+        use core::str::FromStr;
 
         let rdata = SOA::new(
             Name::from_str("m.example.com.").unwrap(),

--- a/crates/proto/src/rr/rdata/srv.rs
+++ b/crates/proto/src/rr/rdata/srv.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 //! service records for identify port mapping for specific services on a host
-use std::fmt;
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -287,11 +287,14 @@ impl fmt::Display for SRV {
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
 
+    use alloc::vec::Vec;
+    use std::println;
+
     use super::*;
 
     #[test]
     fn test() {
-        use std::str::FromStr;
+        use core::str::FromStr;
 
         let rdata = SRV::new(1, 2, 3, Name::from_str("_dns._tcp.example.com.").unwrap());
 

--- a/crates/proto/src/rr/rdata/sshfp.rs
+++ b/crates/proto/src/rr/rdata/sshfp.rs
@@ -8,7 +8,8 @@
 //! SSHFP records for SSH public key fingerprints
 #![allow(clippy::use_self)]
 
-use std::fmt;
+use alloc::vec::Vec;
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/proto/src/rr/rdata/svcb.rs
+++ b/crates/proto/src/rr/rdata/svcb.rs
@@ -8,7 +8,8 @@
 //! SVCB records, see [RFC 9460 SVCB and HTTPS Resource Records, Nov 2023](https://datatracker.ietf.org/doc/html/rfc9460)
 #![allow(clippy::use_self)]
 
-use std::{
+use alloc::{string::String, vec::Vec};
+use core::{
     cmp::{Ord, Ordering, PartialOrd},
     convert::TryFrom,
     fmt,
@@ -302,7 +303,7 @@ impl fmt::Display for SvcParamKey {
     }
 }
 
-impl std::str::FromStr for SvcParamKey {
+impl core::str::FromStr for SvcParamKey {
     type Err = ProtoError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -1188,6 +1189,8 @@ impl fmt::Display for SVCB {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+
     use super::*;
 
     #[test]

--- a/crates/proto/src/rr/rdata/tlsa.rs
+++ b/crates/proto/src/rr/rdata/tlsa.rs
@@ -8,7 +8,8 @@
 //! TLSA records for storing TLS certificate validation information
 #![allow(clippy::use_self)]
 
-use std::fmt;
+use alloc::vec::Vec;
+use core::fmt;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -508,6 +509,8 @@ impl fmt::Display for TLSA {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use std::println;
 
     use super::*;
 

--- a/crates/proto/src/rr/rdata/txt.rs
+++ b/crates/proto/src/rr/rdata/txt.rs
@@ -6,8 +6,9 @@
 // copied, modified, or distributed except according to those terms.
 
 //! text records for storing arbitrary data
-use std::fmt;
-use std::slice::Iter;
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::fmt;
+use core::slice::Iter;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -177,6 +178,9 @@ impl fmt::Display for TXT {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use alloc::string::ToString;
+    use std::println;
 
     use super::*;
 

--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -8,18 +8,15 @@
 //! record data enum variants
 #![allow(deprecated, clippy::use_self)] // allows us to deprecate RData types
 
+use alloc::vec::Vec;
 #[cfg(test)]
-use std::convert::From;
-use std::{
-    cmp::Ordering,
-    fmt,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
-};
-
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
+use core::convert::From;
+use core::{cmp::Ordering, fmt};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use enum_as_inner::EnumAsInner;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use tracing::{trace, warn};
 
 use crate::{
@@ -1132,7 +1129,9 @@ impl From<Ipv6Addr> for RData {
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
 
-    use std::str::FromStr;
+    use alloc::string::ToString;
+    use core::str::FromStr;
+    use std::println;
 
     use super::*;
     use crate::rr::domain::Name;

--- a/crates/proto/src/rr/record_type.rs
+++ b/crates/proto/src/rr/record_type.rs
@@ -8,9 +8,10 @@
 //! record type definitions
 #![allow(clippy::use_self)]
 
-use std::cmp::Ordering;
-use std::fmt::{self, Display, Formatter};
-use std::str::FromStr;
+use alloc::string::ToString;
+use core::cmp::Ordering;
+use core::fmt::{self, Display, Formatter};
+use core::str::FromStr;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -458,6 +459,8 @@ impl Display for RecordType {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
+
+    use std::println;
 
     use super::*;
 

--- a/crates/proto/src/rr/resource.rs
+++ b/crates/proto/src/rr/resource.rs
@@ -7,7 +7,8 @@
 
 //! resource record implementation
 
-use std::{cmp::Ordering, convert::TryFrom, fmt};
+use alloc::borrow::ToOwned;
+use core::{cmp::Ordering, convert::TryFrom, fmt};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -820,8 +821,10 @@ impl<'a, R: RecordData> TryFrom<&'a Record> for RecordRef<'a, R> {
 mod tests {
     #![allow(clippy::dbg_macro, clippy::print_stdout)]
 
-    use std::cmp::Ordering;
-    use std::str::FromStr;
+    use alloc::vec::Vec;
+    use core::cmp::Ordering;
+    use core::str::FromStr;
+    use std::println;
 
     use super::*;
     use crate::rr::Name;
@@ -892,7 +895,7 @@ mod tests {
     #[test]
     fn test_mdns_cache_flush_bit_handling() {
         const RR_CLASS_OFFSET: usize = 1 /* empty name */ +
-            std::mem::size_of::<u16>() /* rr_type */;
+            core::mem::size_of::<u16>() /* rr_type */;
 
         let mut record = Record::<RData>::stub();
         record.set_mdns_cache_flush(true);

--- a/crates/proto/src/rr/rr_key.rs
+++ b/crates/proto/src/rr/rr_key.rs
@@ -5,7 +5,7 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 use crate::rr::{LowerName, RecordType};
 

--- a/crates/proto/src/rr/rr_set.rs
+++ b/crates/proto/src/rr/rr_set.rs
@@ -5,8 +5,9 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::{iter::Chain, slice::Iter, vec};
-
+use alloc::vec;
+use alloc::vec::Vec;
+use core::{iter::Chain, slice::Iter};
 use tracing::{info, warn};
 
 use crate::rr::{DNSClass, Name, RData, Record, RecordType};
@@ -543,8 +544,8 @@ impl<'r> Iterator for RrsetRecords<'r> {
 
 #[cfg(test)]
 mod test {
+    use core::str::FromStr;
     use std::net::Ipv4Addr;
-    use std::str::FromStr;
 
     use crate::rr::rdata::{CNAME, NS, SOA};
     use crate::rr::*;

--- a/crates/proto/src/rr/serial_number.rs
+++ b/crates/proto/src/rr/serial_number.rs
@@ -1,6 +1,6 @@
 //! Number type to support Serial Number Arithmetics
 
-use std::{cmp::Ordering, ops::Add};
+use core::{cmp::Ordering, ops::Add};
 
 /// Wrapper type to support Serial Number Arithmetics as defined
 /// in RFC 1982. The signaure fields (expireation, inception) defined in RFC 4034, section 3.1.5

--- a/crates/proto/src/rr/type_bit_map.rs
+++ b/crates/proto/src/rr/type_bit_map.rs
@@ -7,10 +7,12 @@
 
 //! type bit map helper definitions
 
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
+
 use crate::error::*;
 use crate::rr::RecordType;
 use crate::serialize::binary::*;
-use std::collections::BTreeMap;
 
 enum BitMapReadState {
     Window,

--- a/crates/proto/src/runtime.rs
+++ b/crates/proto/src/runtime.rs
@@ -1,13 +1,14 @@
 //! Abstractions to deal with different async runtimes.
 
-use std::future::Future;
-use std::io;
-use std::marker::Send;
-use std::net::SocketAddr;
-use std::pin::Pin;
+use alloc::boxed::Box;
 #[cfg(feature = "__quic")]
-use std::sync::Arc;
-use std::time::Duration;
+use alloc::sync::Arc;
+use core::future::Future;
+use core::marker::Send;
+use core::pin::Pin;
+use core::time::Duration;
+use std::io;
+use std::net::SocketAddr;
 
 use async_trait::async_trait;
 #[cfg(any(test, feature = "tokio"))]
@@ -31,9 +32,9 @@ pub fn spawn_bg<F: Future<Output = R> + Send + 'static, R: Send + 'static>(
 #[cfg(feature = "tokio")]
 #[doc(hidden)]
 pub mod iocompat {
+    use core::pin::Pin;
+    use core::task::{Context, Poll};
     use std::io;
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
 
     use futures_io::{AsyncRead, AsyncWrite};
     use tokio::io::{AsyncRead as TokioAsyncRead, AsyncWrite as TokioAsyncWrite, ReadBuf};
@@ -112,7 +113,8 @@ pub mod iocompat {
 #[cfg(feature = "tokio")]
 #[allow(unreachable_pub)]
 mod tokio_runtime {
-    use std::sync::{Arc, Mutex};
+    use alloc::sync::Arc;
+    use std::sync::Mutex;
 
     use futures_util::FutureExt;
     #[cfg(feature = "__quic")]

--- a/crates/proto/src/rustls/mod.rs
+++ b/crates/proto/src/rustls/mod.rs
@@ -7,7 +7,7 @@
 
 //! TLS protocol related components for DNS over TLS
 
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 #[cfg(not(feature = "rustls-platform-verifier"))]
 use rustls::RootCertStore;

--- a/crates/proto/src/rustls/tls_client_stream.rs
+++ b/crates/proto/src/rustls/tls_client_stream.rs
@@ -7,11 +7,13 @@
 
 //! DNS over TLS client implementation for Rustls
 
-use std::future::Future;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::sync::Arc;
+use core::future::Future;
+use core::pin::Pin;
 use std::io;
 use std::net::SocketAddr;
-use std::pin::Pin;
-use std::sync::Arc;
 
 use futures_util::TryFutureExt;
 use rustls::ClientConfig;

--- a/crates/proto/src/rustls/tls_stream.rs
+++ b/crates/proto/src/rustls/tls_stream.rs
@@ -7,11 +7,13 @@
 
 //! DNS over TLS I/O stream implementation for Rustls
 
-use std::future::Future;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::sync::Arc;
+use core::future::Future;
+use core::pin::Pin;
 use std::io;
 use std::net::SocketAddr;
-use std::pin::Pin;
-use std::sync::Arc;
 
 use rustls::ClientConfig;
 use rustls::pki_types::ServerName;

--- a/crates/proto/src/serialize/binary/bin_tests.rs
+++ b/crates/proto/src/serialize/binary/bin_tests.rs
@@ -15,9 +15,11 @@
  */
 #![allow(clippy::dbg_macro, clippy::print_stdout)]
 
+use core::fmt::Debug;
+use std::println;
+
 use super::*;
 use crate::error::*;
-use std::fmt::Debug;
 
 fn get_character_data() -> Vec<(&'static str, Vec<u8>)> {
     vec![

--- a/crates/proto/src/serialize/binary/decoder.rs
+++ b/crates/proto/src/serialize/binary/decoder.rs
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
-use crate::serialize::binary::Restrict;
+use alloc::{borrow::ToOwned, vec::Vec};
+
 use thiserror::Error;
+
+use crate::serialize::binary::Restrict;
 
 /// This is non-destructive to the inner buffer, b/c for pointer types we need to perform a reverse
 ///  seek to lookup names

--- a/crates/proto/src/serialize/binary/encoder.rs
+++ b/crates/proto/src/serialize/binary/encoder.rs
@@ -5,7 +5,9 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
+
+use alloc::vec::Vec;
 
 use crate::{
     error::{ProtoErrorKind, ProtoResult},
@@ -16,6 +18,8 @@ use super::BinEncodable;
 
 // this is private to make sure there is no accidental access to the inner buffer.
 mod private {
+    use alloc::vec::Vec;
+
     use crate::error::{ProtoErrorKind, ProtoResult};
 
     /// A wrapper for a buffer that guarantees writes never exceed a defined set of bytes
@@ -433,7 +437,7 @@ impl<'a> BinEncoder<'a> {
 
 /// A trait to return the size of a type as it will be encoded in DNS
 ///
-/// it does not necessarily equal `std::mem::size_of`, though it might, especially for primitives
+/// it does not necessarily equal `core::mem::size_of`, though it might, especially for primitives
 pub trait EncodedSize: BinEncodable {
     /// Return the size in bytes of the
     fn size_of() -> usize;
@@ -491,7 +495,7 @@ pub enum EncodeMode {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     use super::*;
     use crate::{

--- a/crates/proto/src/serialize/binary/mod.rs
+++ b/crates/proto/src/serialize/binary/mod.rs
@@ -11,6 +11,8 @@ mod decoder;
 mod encoder;
 mod restrict;
 
+use alloc::vec::Vec;
+
 pub use self::decoder::{BinDecoder, DecodeError};
 pub use self::encoder::BinEncoder;
 pub use self::encoder::EncodeMode;

--- a/crates/proto/src/serialize/txt/errors.rs
+++ b/crates/proto/src/serialize/txt/errors.rs
@@ -1,6 +1,5 @@
-use std::{fmt, io};
-
-use thiserror::Error;
+use alloc::{fmt, string::String};
+use std::io;
 
 #[cfg(feature = "backtrace")]
 use crate::trace;
@@ -9,11 +8,13 @@ use crate::{
     rr::RecordType,
     serialize::txt::Token,
 };
+
 #[cfg(feature = "backtrace")]
 use backtrace::Backtrace as ExtBacktrace;
+use thiserror::Error;
 
 /// An alias for parse results returned by functions of this crate
-pub type ParseResult<T> = ::std::result::Result<T, ParseError>;
+pub type ParseResult<T> = ::core::result::Result<T, ParseError>;
 
 /// The error kind for parse errors that get returned in the crate
 #[derive(Debug, Error)]
@@ -62,7 +63,7 @@ pub enum ParseErrorKind {
 
     /// A number parsing error
     #[error("error parsing number: {0}")]
-    ParseInt(#[from] std::num::ParseIntError),
+    ParseInt(#[from] core::num::ParseIntError),
 
     /// An error got returned by the hickory-proto crate
     #[error("proto error: {0}")]
@@ -186,8 +187,8 @@ impl From<LexerError> for ParseError {
     }
 }
 
-impl From<std::num::ParseIntError> for ParseError {
-    fn from(e: std::num::ParseIntError) -> Self {
+impl From<core::num::ParseIntError> for ParseError {
+    fn from(e: core::num::ParseIntError) -> Self {
         ParseErrorKind::from(e).into()
     }
 }
@@ -201,8 +202,8 @@ impl From<ProtoError> for ParseError {
     }
 }
 
-impl From<std::convert::Infallible> for ParseError {
-    fn from(_e: std::convert::Infallible) -> Self {
+impl From<core::convert::Infallible> for ParseError {
+    fn from(_e: core::convert::Infallible) -> Self {
         panic!("infallible")
     }
 }
@@ -217,7 +218,7 @@ impl From<ParseError> for io::Error {
 }
 
 /// An alias for lexer results returned by functions of this crate
-pub(crate) type LexerResult<T> = ::std::result::Result<T, LexerError>;
+pub(crate) type LexerResult<T> = core::result::Result<T, LexerError>;
 
 /// The error kind for lexer errors that get returned in the crate
 #[derive(Eq, PartialEq, Debug, Error, Clone)]

--- a/crates/proto/src/serialize/txt/parse_rdata.rs
+++ b/crates/proto/src/serialize/txt/parse_rdata.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 //! record data enum variants
+use alloc::vec::Vec;
 
 #[cfg(feature = "__dnssec")]
 use crate::dnssec::rdata::DNSSECRData;
@@ -137,7 +138,7 @@ mod tests {
     use crate::dnssec::rdata::DS;
     use crate::rr::domain::Name;
     use crate::rr::rdata::*;
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     #[test]
     fn test_a() {

--- a/crates/proto/src/serialize/txt/rdata_parsers/a.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/a.rs
@@ -16,8 +16,9 @@
 
 //! Parser for A text form
 
+use alloc::string::ToString;
+use core::str::FromStr;
 use std::net::Ipv4Addr;
-use std::str::FromStr;
 
 use crate::{
     rr::rdata::A,

--- a/crates/proto/src/serialize/txt/rdata_parsers/aaaa.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/aaaa.rs
@@ -16,8 +16,9 @@
 
 //! Parser for AAAA text form
 
+use alloc::string::ToString;
+use core::str::FromStr;
 use std::net::Ipv6Addr;
-use std::str::FromStr;
 
 use crate::{
     rr::rdata::AAAA,

--- a/crates/proto/src/serialize/txt/rdata_parsers/caa.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/caa.rs
@@ -16,6 +16,7 @@
 
 //! mail exchange, email, record
 
+use alloc::string::ToString;
 use tracing::warn;
 
 use crate::rr::rdata::CAA;
@@ -100,6 +101,8 @@ pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResu
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+
     use crate::rr::{Name, RData, RecordType, rdata::caa::KeyValue};
     use crate::serialize::txt::parse_rdata::RDataParser;
 

--- a/crates/proto/src/serialize/txt/rdata_parsers/csync.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/csync.rs
@@ -7,7 +7,9 @@
 
 //! CSYNC record for synchronizing information to the parent zone
 
-use std::str::FromStr;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use core::str::FromStr;
 
 use crate::rr::RecordType;
 use crate::rr::rdata::CSYNC;

--- a/crates/proto/src/serialize/txt/rdata_parsers/dnskey.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/dnskey.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use core::str::FromStr as _;
 
 use crate::dnssec::rdata::dnskey::DNSKEY;
@@ -44,6 +45,8 @@ pub(crate) fn parse<'i>(mut tokens: impl Iterator<Item = &'i str>) -> ParseResul
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+
     use super::*;
     #[cfg(feature = "dnssec-ring")]
     use crate::dnssec::crypto::EcdsaSigningKey;

--- a/crates/proto/src/serialize/txt/rdata_parsers/ds.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/ds.rs
@@ -1,6 +1,8 @@
 //! Parser for DS text form
 
-use std::str::FromStr;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::str::FromStr;
 
 use crate::dnssec::rdata::ds::DS;
 use crate::dnssec::{Algorithm, DigestType};

--- a/crates/proto/src/serialize/txt/rdata_parsers/hinfo.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/hinfo.rs
@@ -7,6 +7,8 @@
 
 //! HINFO record for storing host information
 
+use alloc::string::ToString;
+
 use crate::rr::rdata::HINFO;
 use crate::serialize::txt::errors::{ParseError, ParseErrorKind, ParseResult};
 

--- a/crates/proto/src/serialize/txt/rdata_parsers/mx.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/mx.rs
@@ -16,6 +16,8 @@
 
 //! mail exchange, email, record
 
+use alloc::string::ToString;
+
 use crate::rr::domain::Name;
 use crate::rr::rdata::MX;
 use crate::serialize::txt::errors::{ParseError, ParseErrorKind, ParseResult};

--- a/crates/proto/src/serialize/txt/rdata_parsers/name.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/name.rs
@@ -16,6 +16,8 @@
 
 //! Parse for Name text form
 
+use alloc::string::ToString;
+
 use crate::rr::domain::Name;
 use crate::serialize::txt::errors::{ParseError, ParseErrorKind, ParseResult};
 

--- a/crates/proto/src/serialize/txt/rdata_parsers/naptr.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/naptr.rs
@@ -7,7 +7,8 @@
 
 //! naptr records DDDS, RFC 3403
 
-use std::str::FromStr;
+use alloc::string::ToString;
+use core::str::FromStr;
 
 use crate::rr::Name;
 use crate::rr::rdata::naptr::{NAPTR, verify_flags};

--- a/crates/proto/src/serialize/txt/rdata_parsers/null.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/null.rs
@@ -16,6 +16,8 @@
 
 //! null record type, generally not used except as an internal tool for representing null data
 
+use alloc::string::ToString;
+
 use crate::rr::rdata::NULL;
 use crate::serialize::txt::errors::{ParseError, ParseErrorKind, ParseResult};
 

--- a/crates/proto/src/serialize/txt/rdata_parsers/openpgpkey.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/openpgpkey.rs
@@ -34,7 +34,7 @@ pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResu
 
 #[test]
 fn test_parsing() {
-    assert!(parse(::std::iter::empty()).is_err());
+    assert!(parse(core::iter::empty()).is_err());
     assert!(parse(vec!["äöüäööüä"].into_iter()).is_err());
     assert!(parse(vec!["ZmFpbGVk", "äöüäöüö"].into_iter()).is_err());
 

--- a/crates/proto/src/serialize/txt/rdata_parsers/soa.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/soa.rs
@@ -16,6 +16,8 @@
 
 //! Parser for SOA text form
 
+use alloc::string::ToString;
+
 use crate::{
     rr::{domain::Name, rdata::SOA},
     serialize::txt::{
@@ -77,7 +79,7 @@ pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(
 
 #[test]
 fn test_parse() {
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     let soa_tokens = vec![
         "hickory-dns.org.",

--- a/crates/proto/src/serialize/txt/rdata_parsers/srv.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/srv.rs
@@ -15,7 +15,8 @@
  */
 
 //! service records for identify port mapping for specific services on a host
-use std::str::FromStr;
+use alloc::string::ToString;
+use core::str::FromStr;
 
 use crate::rr::domain::Name;
 use crate::rr::rdata::SRV;

--- a/crates/proto/src/serialize/txt/rdata_parsers/sshfp.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/sshfp.rs
@@ -7,6 +7,9 @@
 
 //! SSHFP records for SSH public key fingerprints
 
+#[cfg(test)]
+use alloc::vec::Vec;
+
 use crate::rr::rdata::{SSHFP, sshfp};
 use crate::serialize::txt::errors::{ParseError, ParseErrorKind, ParseResult};
 
@@ -55,7 +58,7 @@ pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResu
 
 #[test]
 fn test_parsing() {
-    assert!(parse(::std::iter::empty()).is_err());
+    assert!(parse(core::iter::empty()).is_err());
     assert!(parse(vec!["51", "13"].into_iter()).is_err());
     assert!(parse(vec!["1", "-1"].into_iter()).is_err());
     assert!(parse(vec!["1", "1", "abcd", "foo"].into_iter()).is_err());

--- a/crates/proto/src/serialize/txt/rdata_parsers/svcb.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/svcb.rs
@@ -7,7 +7,11 @@
 
 //! SVCB records in presentation format
 
-use std::str::FromStr;
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::str::FromStr;
 
 use crate::{
     rr::{
@@ -362,6 +366,9 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloc::borrow::ToOwned;
+    use alloc::string::ToString;
+
     use crate::{
         rr::{RecordData, rdata::HTTPS},
         serialize::txt::Parser,

--- a/crates/proto/src/serialize/txt/rdata_parsers/tlsa.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/tlsa.rs
@@ -8,6 +8,8 @@
 
 //! tlsa records for storing TLS authentication records
 
+use alloc::string::String;
+
 use crate::rr::rdata::tlsa::CertUsage;
 use crate::rr::rdata::{TLSA, sshfp};
 use crate::serialize::txt::errors::{ParseError, ParseErrorKind, ParseResult};

--- a/crates/proto/src/serialize/txt/rdata_parsers/txt.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/txt.rs
@@ -16,6 +16,9 @@
 
 //! text records for storing arbitrary data
 
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
 use crate::rr::rdata::TXT;
 use crate::serialize::txt::errors::ParseResult;
 

--- a/crates/proto/src/serialize/txt/trust_anchor.rs
+++ b/crates/proto/src/serialize/txt/trust_anchor.rs
@@ -3,7 +3,8 @@
 //! A trust anchor file largely adheres to the syntax of a zone file but may only contain
 //! DNSKEY or DS records. DS records are currently unsupported
 
-use std::{borrow::Cow, str::FromStr as _};
+use alloc::{borrow::Cow, string::String, vec::Vec};
+use core::str::FromStr;
 
 use crate::{
     dnssec::rdata::DNSKEY,

--- a/crates/proto/src/serialize/txt/zone.rs
+++ b/crates/proto/src/serialize/txt/zone.rs
@@ -5,12 +5,16 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::{
+use alloc::{
     borrow::Cow,
     collections::BTreeMap,
-    fs, mem,
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::{mem, str::FromStr};
+use std::{
+    fs,
     path::{Path, PathBuf},
-    str::FromStr,
 };
 
 use crate::{
@@ -527,6 +531,8 @@ const MAX_INCLUDE_LEVEL: usize = 256;
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+
     use super::*;
 
     #[test]

--- a/crates/proto/src/serialize/txt/zone_lex.rs
+++ b/crates/proto/src/serialize/txt/zone_lex.rs
@@ -5,8 +5,10 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::borrow::Cow;
-use std::{char, iter::Peekable};
+use alloc::borrow::Cow;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::{char, iter::Peekable};
 
 use crate::serialize::txt::errors::{LexerError, LexerErrorKind, LexerResult};
 
@@ -394,6 +396,8 @@ pub enum Token {
 
 #[cfg(test)]
 mod lex_test {
+    use alloc::string::ToString;
+
     use super::*;
 
     #[allow(clippy::uninlined_format_args)]

--- a/crates/proto/src/tcp/tcp_client_stream.rs
+++ b/crates/proto/src/tcp/tcp_client_stream.rs
@@ -5,12 +5,13 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::fmt::{self, Display};
-use std::future::Future;
+use alloc::boxed::Box;
+use core::fmt::{self, Display};
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use core::time::Duration;
 use std::net::SocketAddr;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::Duration;
 
 use futures_util::{StreamExt, stream::Stream};
 use tracing::warn;

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -7,12 +7,13 @@
 
 //! This module contains all the TCP structures for demuxing TCP into streams of DNS packets.
 
+use alloc::vec::Vec;
+use core::mem;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use core::time::Duration;
 use std::io;
-use std::mem;
 use std::net::SocketAddr;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::Duration;
 
 use futures_io::{AsyncRead, AsyncWrite};
 use futures_util::stream::Stream;

--- a/crates/proto/src/tests/tcp.rs
+++ b/crates/proto/src/tests/tcp.rs
@@ -1,6 +1,9 @@
+use alloc::string::ToString;
+use alloc::sync::Arc;
+use core::sync::atomic::AtomicBool;
 use std::io::{Read, Write};
 use std::net::{IpAddr, SocketAddr};
-use std::sync::{Arc, atomic::AtomicBool};
+use std::println;
 
 use futures_util::stream::StreamExt;
 
@@ -24,8 +27,8 @@ fn tcp_server_setup(
         .spawn(move || {
             let succeeded = succeeded_clone;
             for _ in 0..15 {
-                std::thread::sleep(std::time::Duration::from_secs(1));
-                if succeeded.load(std::sync::atomic::Ordering::Relaxed) {
+                std::thread::sleep(core::time::Duration::from_secs(1));
+                if succeeded.load(core::sync::atomic::Ordering::Relaxed) {
                     return;
                 }
             }
@@ -47,10 +50,10 @@ fn tcp_server_setup(
             let (mut socket, _) = server.accept().expect("accept failed");
 
             socket
-                .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+                .set_read_timeout(Some(core::time::Duration::from_secs(5)))
                 .unwrap(); // should receive something within 5 seconds...
             socket
-                .set_write_timeout(Some(std::time::Duration::from_secs(5)))
+                .set_write_timeout(Some(core::time::Duration::from_secs(5)))
                 .unwrap(); // should receive something within 5 seconds...
 
             for _ in 0..SEND_RECV_TIMES {
@@ -111,7 +114,7 @@ pub async fn tcp_stream_test(server_addr: IpAddr, provider: impl RuntimeProvider
         assert_eq!(message.bytes(), TEST_BYTES);
     }
 
-    succeeded.store(true, std::sync::atomic::Ordering::Relaxed);
+    succeeded.store(true, core::sync::atomic::Ordering::Relaxed);
     server_handle.join().expect("server thread failed");
 }
 
@@ -141,6 +144,6 @@ pub async fn tcp_client_stream_test(server_addr: IpAddr, provider: impl RuntimeP
         assert_eq!(buffer.bytes(), TEST_BYTES);
     }
 
-    succeeded.store(true, std::sync::atomic::Ordering::Relaxed);
+    succeeded.store(true, core::sync::atomic::Ordering::Relaxed);
     server_handle.join().expect("server thread failed");
 }

--- a/crates/proto/src/tests/udp.rs
+++ b/crates/proto/src/tests/udp.rs
@@ -1,8 +1,10 @@
+use alloc::string::ToString;
+use alloc::sync::Arc;
+use core::str::FromStr;
+use core::sync::atomic::AtomicBool;
+use core::time::Duration;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs};
-use std::str::FromStr;
-use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
-use std::time::Duration;
+use std::println;
 
 use futures_util::stream::StreamExt;
 use tracing::debug;
@@ -36,8 +38,8 @@ pub async fn udp_stream_test<P: RuntimeProvider>(server_addr: IpAddr, provider: 
         .spawn(move || {
             let succeeded = succeeded_clone;
             for _ in 0..15 {
-                std::thread::sleep(std::time::Duration::from_secs(1));
-                if succeeded.load(std::sync::atomic::Ordering::Relaxed) {
+                std::thread::sleep(core::time::Duration::from_secs(1));
+                if succeeded.load(core::sync::atomic::Ordering::Relaxed) {
                     return;
                 }
             }
@@ -49,10 +51,10 @@ pub async fn udp_stream_test<P: RuntimeProvider>(server_addr: IpAddr, provider: 
 
     let server = std::net::UdpSocket::bind(SocketAddr::new(server_addr, 0)).unwrap();
     server
-        .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+        .set_read_timeout(Some(core::time::Duration::from_secs(5)))
         .unwrap(); // should receive something within 5 seconds...
     server
-        .set_write_timeout(Some(std::time::Duration::from_secs(5)))
+        .set_write_timeout(Some(core::time::Duration::from_secs(5)))
         .unwrap(); // should receive something within 5 seconds...
     let server_addr = server.local_addr().unwrap();
     println!("server listening on: {server_addr}");
@@ -116,7 +118,7 @@ pub async fn udp_stream_test<P: RuntimeProvider>(server_addr: IpAddr, provider: 
         assert_eq!(message.addr(), server_addr);
     }
 
-    succeeded.store(true, std::sync::atomic::Ordering::Relaxed);
+    succeeded.store(true, core::sync::atomic::Ordering::Relaxed);
     server_handle.join().expect("server thread failed");
 }
 
@@ -130,8 +132,8 @@ pub async fn udp_client_stream_test(server_addr: IpAddr, provider: impl RuntimeP
         .spawn(move || {
             let succeeded = succeeded_clone;
             for _ in 0..15 {
-                std::thread::sleep(std::time::Duration::from_secs(1));
-                if succeeded.load(std::sync::atomic::Ordering::Relaxed) {
+                std::thread::sleep(core::time::Duration::from_secs(1));
+                if succeeded.load(core::sync::atomic::Ordering::Relaxed) {
                     return;
                 }
             }
@@ -143,10 +145,10 @@ pub async fn udp_client_stream_test(server_addr: IpAddr, provider: impl RuntimeP
 
     let server = std::net::UdpSocket::bind(SocketAddr::new(server_addr, 0)).unwrap();
     server
-        .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+        .set_read_timeout(Some(core::time::Duration::from_secs(5)))
         .unwrap(); // should receive something within 5 seconds...
     server
-        .set_write_timeout(Some(std::time::Duration::from_secs(5)))
+        .set_write_timeout(Some(core::time::Duration::from_secs(5)))
         .unwrap(); // should receive something within 5 seconds...
     let server_addr = server.local_addr().unwrap();
 
@@ -230,7 +232,7 @@ pub async fn udp_client_stream_test(server_addr: IpAddr, provider: impl RuntimeP
         worked_once = true;
     }
 
-    succeeded.store(true, std::sync::atomic::Ordering::Relaxed);
+    succeeded.store(true, core::sync::atomic::Ordering::Relaxed);
     server_handle.join().expect("server thread failed");
 
     assert!(worked_once);

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -5,13 +5,16 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::fmt::{self, Display};
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use core::time::Duration;
 use std::collections::HashSet;
-use std::fmt::{self, Display};
 use std::net::SocketAddr;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use futures_util::{future::Future, stream::Stream};
 use tracing::{debug, trace, warn};

--- a/crates/proto/src/udp/udp_stream.rs
+++ b/crates/proto/src/udp/udp_stream.rs
@@ -5,13 +5,14 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use core::future::poll_fn;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 use std::collections::HashSet;
-use std::future::poll_fn;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
 
 use async_trait::async_trait;
 use futures_util::stream::Stream;

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -7,10 +7,10 @@
 
 //! This module contains all the types for demuxing DNS oriented streams.
 
-use std::future::Future;
-use std::marker::PhantomData;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use core::future::Future;
+use core::marker::PhantomData;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 
 use futures_channel::mpsc;
 use futures_util::future::FutureExt;

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -7,15 +7,18 @@
 
 //! `DnsMultiplexer` and associated types implement the state machines for sending DNS messages while using the underlying streams.
 
-use std::{
+use alloc::{boxed::Box, sync::Arc};
+use core::{
     borrow::Borrow,
-    collections::{HashMap, hash_map::Entry},
     fmt::{self, Display},
     marker::Unpin,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::Duration,
+};
+use std::{
+    collections::{HashMap, hash_map::Entry},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use futures_channel::mpsc;
@@ -428,6 +431,13 @@ where
 
 #[cfg(test)]
 mod test {
+    use alloc::vec::Vec;
+    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+
+    use futures_util::future;
+    use futures_util::stream::TryStreamExt;
+    use test_support::subscribe;
+
     use super::*;
     use crate::op::op_code::OpCode;
     use crate::op::{Message, MessageType, Query};
@@ -436,10 +446,6 @@ mod test {
     use crate::serialize::binary::BinEncodable;
     use crate::xfer::StreamReceiver;
     use crate::xfer::{DnsClientStream, DnsRequestOptions};
-    use futures_util::future;
-    use futures_util::stream::TryStreamExt;
-    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
-    use test_support::subscribe;
 
     struct MockClientStream {
         messages: Vec<Message>,

--- a/crates/proto/src/xfer/dns_request.rs
+++ b/crates/proto/src/xfer/dns_request.rs
@@ -7,7 +7,7 @@
 
 //! `DnsRequest` wraps a `Message` and associates a set of `DnsRequestOptions` for specifying different transfer options.
 
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 
 use crate::op::Message;
 

--- a/crates/proto/src/xfer/dns_response.rs
+++ b/crates/proto/src/xfer/dns_response.rs
@@ -7,14 +7,18 @@
 
 //! `DnsResponse` wraps a `Message` and any associated connection details
 
-use std::{
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::{
     convert::TryFrom,
-    future::Future,
-    io,
     ops::{Deref, DerefMut},
+};
+use core::{
+    future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
+use std::io;
 
 use futures_channel::mpsc;
 use futures_util::{ready, stream::Stream};

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -4,12 +4,13 @@
 //!
 //! TODO: this module needs some serious refactoring and normalization.
 
-use std::fmt::{self, Debug, Display};
-use std::future::Future;
+use core::fmt::Display;
+use core::fmt::{self, Debug};
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use core::time::Duration;
 use std::net::SocketAddr;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::Duration;
 
 use futures_channel::mpsc;
 use futures_channel::oneshot;
@@ -36,7 +37,8 @@ pub use self::dns_exchange::{
 pub use self::dns_handle::{DnsHandle, DnsStreamHandle};
 pub use self::dns_multiplexer::{DnsMultiplexer, DnsMultiplexerConnect};
 pub use self::dns_request::{DnsRequest, DnsRequestOptions};
-pub use self::dns_response::{DnsResponse, DnsResponseStream};
+pub use self::dns_response::DnsResponse;
+pub use self::dns_response::DnsResponseStream;
 pub use self::retry_dns_handle::RetryDnsHandle;
 pub use self::serial_message::SerialMessage;
 
@@ -146,7 +148,7 @@ pub struct BufDnsRequestStreamHandle {
 
 macro_rules! try_oneshot {
     ($expr:expr) => {{
-        use std::result::Result;
+        use core::result::Result;
 
         match $expr {
             Result::Ok(val) => val,

--- a/crates/proto/src/xfer/retry_dns_handle.rs
+++ b/crates/proto/src/xfer/retry_dns_handle.rs
@@ -7,8 +7,9 @@
 
 //! `RetryDnsHandle` allows for DnsQueries to be reattempted on failure
 
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use alloc::boxed::Box;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 
 use futures_util::stream::{Stream, StreamExt};
 
@@ -137,18 +138,17 @@ impl RetryableError for ProtoError {
 
 #[cfg(test)]
 mod test {
+    use alloc::sync::Arc;
+    use core::sync::atomic::{AtomicU16, Ordering};
+
     use super::*;
     use crate::error::*;
     use crate::op::*;
     use crate::xfer::FirstAnswer;
-    use DnsHandle;
+
     use futures_executor::block_on;
     use futures_util::future::{err, ok};
     use futures_util::stream::*;
-    use std::sync::{
-        Arc,
-        atomic::{AtomicU16, Ordering},
-    };
     use test_support::subscribe;
 
     #[derive(Clone)]

--- a/crates/proto/src/xfer/serial_message.rs
+++ b/crates/proto/src/xfer/serial_message.rs
@@ -5,6 +5,7 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use alloc::vec::Vec;
 use std::net::SocketAddr;
 
 use crate::error::ProtoResult;


### PR DESCRIPTION
This is a first step towards making the hickory-proto crate `no_std`.

The full/follow-up PR is here: #2104