### PR TITLE
Add SIGTERM signal handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1869,7 +1869,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2081,7 +2081,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2268,6 +2268,15 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "slab"
@@ -2476,6 +2485,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -83,7 +83,7 @@ serde = { workspace = true, features = ["derive"] }
 time.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-tokio = { workspace = true, features = ["time", "rt"] }
+tokio = { workspace = true, features = ["time", "rt", "signal"] }
 toml.workspace = true
 hickory-client.workspace = true
 hickory-proto.workspace = true

--- a/crates/server/src/server/server_future.rs
+++ b/crates/server/src/server/server_future.rs
@@ -733,6 +733,14 @@ impl<T: RequestHandler> ServerFuture<T> {
         block_until_done(&mut self.join_set).await
     }
 
+    /// Returns a reference to the [`CancellationToken`] used to gracefully shut down the server.
+    ///
+    /// Once cancellation is requested, all background tasks will stop accepting new connections,
+    /// and `block_until_done()` will complete once all tasks have terminated.
+    pub fn shutdown_token(&self) -> &CancellationToken {
+        &self.shutdown_token
+    }
+
     /// This will run until all background tasks complete. If one or more tasks return an error,
     /// one will be chosen as the returned error for this future.
     pub async fn block_until_done(&mut self) -> Result<(), ProtoError> {


### PR DESCRIPTION
This adds a SIGTERM signal handler in the binary crate. This is useful when running in a container as root, since the default SIGTERM signal handler doesn't kill programs running as root. This also makes use of the existing graceful shutdown feature, to finish handling in-flight queries over TCP, HTTP, etc.