### PR TITLE
server: fix DNSSEC MSRV

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -82,7 +82,7 @@ pub mod dnssec {
             #[serde(default)]
             algorithm: Nsec3HashAlgorithm,
             /// The salt used for hashing.
-            #[serde(default)]
+            #[serde(default = "default_salt")]
             salt: Arc<[u8]>,
             /// The number of hashing iterations.
             #[serde(default)]
@@ -91,6 +91,11 @@ pub mod dnssec {
             #[serde(default)]
             opt_out: bool,
         },
+    }
+
+    // MSRV: works in 1.80, fails in 1.78
+    fn default_salt() -> Arc<[u8]> {
+        Arc::new([])
     }
 }
 


### PR DESCRIPTION
Fixes #2422.

I guess this might be related to 1.79's [inline const expressions](https://blog.rust-lang.org/2024/06/13/Rust-1.79.0.html#inline-const-expressions)? Not entirely sure.

With this change, I can run `cargo +1.71.1 c --no-default-features --features dnssec-aws-lc-rs,h3-aws-lc-rs,tokio` without errors which should cover a decent amount of ground.