### PR TITLE
proto: treat the TSigner::signer_name as fully qualified

### DIFF
--- a/crates/proto/src/dnssec/tsig.rs
+++ b/crates/proto/src/dnssec/tsig.rs
@@ -54,9 +54,10 @@ impl TSigner {
     pub fn new(
         key: Vec<u8>,
         algorithm: TsigAlgorithm,
-        signer_name: Name,
+        mut signer_name: Name,
         fudge: u16,
     ) -> Result<Self, DnsSecError> {
+        signer_name.set_fqdn(true);
         if algorithm.supported() {
             Ok(Self(Arc::new(TSignerInner {
                 key,


### PR DESCRIPTION
Fixes #2816.

Alternatively, we could have `TSigner::new()` error out if the `signer_name` is not fully qualified already, but not sure if that makes sense here?

We should probably have a proper test for this.

cc @jcgruenhage 