### PR TITLE
resolver: simplify server ordering mechanics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ most impactful breaking changes in this release:
 * Top-level TLS configuration in the resolver crate has moved to the `ResolverOpts` type.
   Specific `NameServerConfig`s should implicitly set up the ALPN protocol appropriate for the DNS
   protocol.
+* The `ResolverOptions` fields `authentic_data` and `shuffle_dns_servers` were
+  removed. The former field didn't do anything; and should be covered by new DNSSEC API.
+  `shuffle_dns_servers` functionality has been subsumed into the `server_ordering_strategy` field.
 * The use of rustls-native-certs via the `native-certs` feature was replaced with
   rustls-platform-verifier.
 * The `tokio-runtime` feature was renamed to `tokio`.

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -827,8 +827,6 @@ pub struct ResolverOpts {
     ///
     /// This is true by default, disabling this is useful for requesting single records, but may prevent successful resolution.
     pub recursion_desired: bool,
-    /// Shuffle DNS servers before each query.
-    pub shuffle_dns_servers: bool,
     /// Local UDP ports to avoid when making outgoing queries
     pub avoid_local_udp_ports: Arc<HashSet<u16>>,
     /// Request UDP bind ephemeral ports directly from the OS
@@ -887,7 +885,6 @@ impl Default for ResolverOpts {
             try_tcp_on_error: false,
             server_ordering_strategy: ServerOrderingStrategy::default(),
             recursion_desired: true,
-            shuffle_dns_servers: false,
             avoid_local_udp_ports: Arc::new(HashSet::new()),
             os_port_selection: false,
             #[cfg(feature = "__tls")]

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -721,6 +721,7 @@ impl Default for LookupIpStrategy {
 /// The strategy for establishing the query order of name servers in a pool.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub enum ServerOrderingStrategy {
     /// Servers are ordered based on collected query statistics. The ordering
     /// may vary over time.

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -270,19 +270,8 @@ where
         let count = conns.len().min(opts.num_concurrent_reqs.max(1));
 
         // Shuffe DNS NameServers to avoid overloads to the first configured ones
-        if opts.shuffle_dns_servers {
-            for _ in 0..count {
-                let idx = rand::random_range(0..conns.len());
-
-                // UNWRAP: swap_remove has an implicit panicking bounds check. This should
-                // never fail because we check that conns is not empty and generate the idx
-                // to explicitly be in range.
-                par_conns.push(conns.swap_remove(idx));
-            }
-        } else {
-            for conn in conns.drain(..count) {
-                par_conns.push(conn);
-            }
+        for conn in conns.drain(..count) {
+            par_conns.push(conn);
         }
 
         if par_conns.is_empty() {


### PR DESCRIPTION
Remove the `ResolverOpts::shuffle_dns_servers` option in favor of the `ServerOrderingStrategy`. From my analysis in #2402, it doesn't feel like the `bool` option is addign much value. Make `ServerOrderingStrategy` `non_exhaustive` so that we can add more strategies without the need for a semver-incompatible bump.

Fixes #2402.