### PR TITLE
Add initial std feature that keeps MSRV, the next step towards no_std

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,8 +191,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: just no-default-features
-        run: just no-default-features
+      - name: just std
+        run: just std
 
       - name: just build-bench
         if: contains( matrix.version, 'nightly' )

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ hickory-client = { version = "0.25", path = "crates/client", default-features = 
 hickory-recursor = { version = "0.25", path = "crates/recursor", default-features = false }
 hickory-resolver = { version = "0.25", path = "crates/resolver", default-features = false }
 hickory-server = { version = "0.25", path = "crates/server", default-features = false }
-hickory-proto = { version = "0.25", path = "crates/proto", default-features = false }
+hickory-proto = { version = "0.25", path = "crates/proto", default-features = false, features = ["std"] }
 test-support.path = "tests/test-support"
 
 

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -25,6 +25,8 @@ categories.workspace = true
 license.workspace = true
 
 [features]
+std = []
+
 async-std = ["dep:async-std", "dep:pin-utils", "dep:socket2"]
 
 tls-aws-lc-rs = ["tokio-rustls/aws-lc-rs", "__tls"]

--- a/crates/proto/src/rr/domain/name.rs
+++ b/crates/proto/src/rr/domain/name.rs
@@ -14,7 +14,10 @@ use core::char;
 use core::cmp::{Ordering, PartialEq};
 use core::fmt::{self, Write};
 use core::hash::{Hash, Hasher};
+#[cfg(not(feature = "std"))]
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use core::str::FromStr;
+#[cfg(feature = "std")]
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};

--- a/crates/proto/src/rr/rdata/a.rs
+++ b/crates/proto/src/rr/rdata/a.rs
@@ -31,8 +31,15 @@
 //! "10.2.0.52" or "192.0.5.6").
 //! ```
 
+#[cfg(not(feature = "std"))]
+use core::net::AddrParseError;
 use core::{fmt, ops::Deref, str};
+#[cfg(feature = "std")]
 use std::net::AddrParseError;
+
+#[cfg(not(feature = "std"))]
+pub use core::net::Ipv4Addr;
+#[cfg(feature = "std")]
 pub use std::net::Ipv4Addr;
 
 #[cfg(feature = "serde")]

--- a/crates/proto/src/rr/rdata/aaaa.rs
+++ b/crates/proto/src/rr/rdata/aaaa.rs
@@ -23,9 +23,15 @@
 //!   resource record in network byte order (high-order byte first).
 //! ```
 
+#[cfg(not(feature = "std"))]
+use core::net::AddrParseError;
 use core::{fmt, ops::Deref, str};
+#[cfg(feature = "std")]
 use std::net::AddrParseError;
 
+#[cfg(not(feature = "std"))]
+pub use core::net::Ipv6Addr;
+#[cfg(feature = "std")]
 pub use std::net::Ipv6Addr;
 
 #[cfg(feature = "serde")]

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -10,7 +10,10 @@
 
 use alloc::vec::Vec;
 use core::fmt;
+#[cfg(not(feature = "std"))]
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use core::str::FromStr;
+#[cfg(feature = "std")]
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 #[cfg(feature = "serde")]

--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -11,7 +11,10 @@
 use alloc::vec::Vec;
 #[cfg(test)]
 use core::convert::From;
+#[cfg(not(feature = "std"))]
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use core::{cmp::Ordering, fmt};
+#[cfg(feature = "std")]
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use enum_as_inner::EnumAsInner;

--- a/crates/proto/src/rr/record_type.rs
+++ b/crates/proto/src/rr/record_type.rs
@@ -556,7 +556,10 @@ mod tests {
         #[cfg(not(feature = "__dnssec"))]
         let dnssec_record_names = &[];
 
+        #[cfg(feature = "std")]
         let mut rtypes = std::collections::HashSet::new();
+        #[cfg(not(feature = "std"))]
+        let mut rtypes = alloc::collections::BTreeSet::new();
         for name in record_names.iter().chain(dnssec_record_names) {
             let rtype: RecordType = name.parse().unwrap();
             assert_eq!(rtype.to_string().to_ascii_uppercase().as_str(), *name);

--- a/crates/proto/src/rr/rr_set.rs
+++ b/crates/proto/src/rr/rr_set.rs
@@ -544,7 +544,10 @@ impl<'r> Iterator for RrsetRecords<'r> {
 
 #[cfg(test)]
 mod test {
+    #[cfg(not(feature = "std"))]
+    use core::net::Ipv4Addr;
     use core::str::FromStr;
+    #[cfg(feature = "std")]
     use std::net::Ipv4Addr;
 
     use crate::rr::rdata::{CNAME, NS, SOA};

--- a/crates/proto/src/serialize/txt/errors.rs
+++ b/crates/proto/src/serialize/txt/errors.rs
@@ -46,6 +46,13 @@ pub enum ParseErrorKind {
 
     // foreign
     /// An address parse error
+    #[cfg(not(feature = "std"))]
+    #[error("network address parse error: {0}")]
+    AddrParse(#[from] core::net::AddrParseError),
+
+    // foreign
+    /// An address parse error
+    #[cfg(feature = "std")]
     #[error("network address parse error: {0}")]
     AddrParse(#[from] std::net::AddrParseError),
 
@@ -160,6 +167,14 @@ impl From<String> for ParseError {
     }
 }
 
+#[cfg(not(feature = "std"))]
+impl From<core::net::AddrParseError> for ParseError {
+    fn from(e: core::net::AddrParseError) -> Self {
+        ParseErrorKind::from(e).into()
+    }
+}
+
+#[cfg(feature = "std")]
 impl From<std::net::AddrParseError> for ParseError {
     fn from(e: std::net::AddrParseError) -> Self {
         ParseErrorKind::from(e).into()

--- a/crates/proto/src/xfer/serial_message.rs
+++ b/crates/proto/src/xfer/serial_message.rs
@@ -6,6 +6,9 @@
 // copied, modified, or distributed except according to those terms.
 
 use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
+use core::net::SocketAddr;
+#[cfg(feature = "std")]
 use std::net::SocketAddr;
 
 use crate::error::ProtoResult;

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-hickory-proto = { path = "../crates/proto" }
+hickory-proto = { path = "../crates/proto", features = ["std"] }
 
 [[bin]]
 name = "message"

--- a/justfile
+++ b/justfile
@@ -27,6 +27,10 @@ all-features: (default "--all-features")
 # Check, build, and test all crates with no-default-features
 no-default-features: (default "--no-default-features" "--ignore=\\{hickory-compatibility\\}")
 
+# Check, build, and test all crates with no-default-features, but with std features enabled
+std: (default "--no-default-features" "--ignore=\\{hickory-compatibility,hickory-proto\\}")
+    cargo {{MSRV}} test --locked --package hickory-proto --no-default-features --features="std"
+
 # Check, build, and test all crates with tls-aws-lc-rs enabled
 tls-aws-lc-rs: (default "--features=tls-aws-lc-rs" "--ignore=\\{hickory-compatibility,test-support\\}")
 


### PR DESCRIPTION
This is the next step to make hickory no_std. Now, without the `std` feature, the MSRV will be 1.81.
The `std` feature is enabled for pretty much all use cases.
In the future, we can add proper no_std support now, in #2104