### PR TITLE
proto: make Query fields public, remove QueryParts

### DIFF
--- a/crates/proto/src/op/query.rs
+++ b/crates/proto/src/op/query.rs
@@ -64,12 +64,20 @@ const MDNS_UNICAST_RESPONSE: u16 = 1 << 15;
 /// ```
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[non_exhaustive]
 pub struct Query {
-    name: Name,
-    query_type: RecordType,
-    query_class: DNSClass,
+    /// QNAME
+    pub name: Name,
+
+    /// QTYPE
+    pub query_type: RecordType,
+
+    /// QCLASS
+    pub query_class: DNSClass,
+
+    /// mDNS unicast-response bit set or not
     #[cfg(feature = "mdns")]
-    mdns_unicast_response: bool,
+    pub mdns_unicast_response: bool,
 }
 
 impl Default for Query {
@@ -164,66 +172,6 @@ impl Query {
     #[cfg(feature = "mdns")]
     pub fn mdns_unicast_response(&self) -> bool {
         self.mdns_unicast_response
-    }
-
-    /// Consumes `Query` and returns it's components
-    pub fn into_parts(self) -> QueryParts {
-        self.into()
-    }
-}
-
-/// Consumes `Query` giving public access to fields of `Query` so they can
-/// be destructured and taken by value.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct QueryParts {
-    /// QNAME
-    pub name: Name,
-    /// QTYPE
-    pub query_type: RecordType,
-    /// QCLASS
-    pub query_class: DNSClass,
-    /// mDNS unicast-response bit set or not
-    #[cfg(feature = "mdns")]
-    pub mdns_unicast_response: bool,
-}
-
-impl From<Query> for QueryParts {
-    fn from(q: Query) -> Self {
-        let Query {
-            name,
-            query_type,
-            query_class,
-            #[cfg(feature = "mdns")]
-            mdns_unicast_response,
-        } = q;
-
-        Self {
-            name,
-            query_type,
-            query_class,
-            #[cfg(feature = "mdns")]
-            mdns_unicast_response,
-        }
-    }
-}
-
-impl From<QueryParts> for Query {
-    fn from(p: QueryParts) -> Self {
-        let QueryParts {
-            name,
-            query_type,
-            query_class,
-            #[cfg(feature = "mdns")]
-            mdns_unicast_response,
-        } = p;
-
-        Self {
-            name,
-            query_type,
-            query_class,
-            #[cfg(feature = "mdns")]
-            mdns_unicast_response,
-        }
     }
 }
 

--- a/crates/proto/src/xfer/dns_handle.rs
+++ b/crates/proto/src/xfer/dns_handle.rs
@@ -76,9 +76,7 @@ fn build_request(mut query: Query, options: DnsRequestOptions) -> DnsRequest {
 
     if options.case_randomization {
         original_query = Some(query.clone());
-        let mut parts = query.into_parts();
-        parts.name.randomize_label_case();
-        query = parts.into();
+        query.name.randomize_label_case();
     }
 
     message


### PR DESCRIPTION
This is a follow-up to https://github.com/hickory-dns/hickory-dns/pull/2683#discussion_r1911010602 to remove the `QueryParts` struct.