### PR TITLE
Validating forwarder tests

### DIFF
--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -431,11 +431,9 @@ impl ZoneConfig {
                         }
                         #[cfg(feature = "resolver")]
                         ExternalStoreConfig::Forward(config) => {
-                            let forwarder = ForwardAuthority::try_from_config(
-                                zone_name.clone(),
-                                zone_type,
-                                config,
-                            )?;
+                            let forwarder = ForwardAuthority::builder_tokio(config.clone())
+                                .with_origin(zone_name.clone())
+                                .build()?;
 
                             Arc::new(forwarder)
                         }

--- a/bin/tests/integration/forwarder.rs
+++ b/bin/tests/integration/forwarder.rs
@@ -17,7 +17,9 @@ fn test_lookup() {
     subscribe();
 
     let runtime = Runtime::new().expect("failed to create Tokio Runtime");
-    let forwarder = ForwardAuthority::new(TokioConnectionProvider::default())
+    let forwarder = ForwardAuthority::builder(TokioConnectionProvider::default())
+        .unwrap()
+        .build()
         .expect("failed to create forwarder");
 
     let lookup = runtime

--- a/crates/resolver/examples/custom_provider.rs
+++ b/crates/resolver/examples/custom_provider.rs
@@ -4,7 +4,7 @@
 use {
     hickory_resolver::{
         Resolver,
-        config::{ResolverConfig, ResolverOpts},
+        config::ResolverConfig,
         name_server::{ConnectionProvider, GenericConnector},
         proto::runtime::{RuntimeProvider, TokioHandle, TokioTime, iocompat::AsyncIoTokioAsStd},
     },
@@ -95,20 +95,20 @@ async fn main() {
 
 #[cfg(any(feature = "webpki-roots", feature = "rustls-platform-verifier"))]
 async fn run() {
-    let resolver = Resolver::new(
+    let resolver = Resolver::builder_with_config(
         ResolverConfig::google(),
-        ResolverOpts::default(),
         GenericConnector::new(PrintProvider::default()),
-    );
+    )
+    .build();
     lookup_test(resolver).await;
 
     #[cfg(feature = "__https")]
     {
-        let resolver2 = Resolver::new(
+        let resolver2 = Resolver::builder_with_config(
             ResolverConfig::cloudflare_https(),
-            ResolverOpts::default(),
             GenericConnector::new(PrintProvider::default()),
-        );
+        )
+        .build();
         lookup_test(resolver2).await;
     }
 

--- a/crates/resolver/examples/flush_cache.rs
+++ b/crates/resolver/examples/flush_cache.rs
@@ -16,9 +16,11 @@ async fn tokio_main() {
             use hickory_resolver::{TokioResolver, name_server::TokioConnectionProvider};
 
             // use the system resolver configuration
-            TokioResolver::from_system_conf(TokioConnectionProvider::default())
-                .map(Arc::new)
-                .expect("failed to create resolver")
+            Arc::new(
+                TokioResolver::builder(TokioConnectionProvider::default())
+                    .expect("failed to create resolver")
+                    .build(),
+            )
         }
 
         // For other operating systems, we can use one of the preconfigured definitions

--- a/crates/resolver/examples/global_resolver.rs
+++ b/crates/resolver/examples/global_resolver.rs
@@ -34,7 +34,8 @@ static GLOBAL_DNS_RESOLVER: Lazy<TokioResolver> = Lazy::new(|| {
             #[cfg(any(unix, windows))]
             {
                 // use the system resolver configuration
-                TokioResolver::from_system_conf(TokioConnectionProvider::default())
+                TokioResolver::builder(TokioConnectionProvider::default())
+                    .map(|builder| builder.build())
             }
 
             // For other operating systems, we can use one of the preconfigured definitions

--- a/crates/resolver/examples/multithreaded_runtime.rs
+++ b/crates/resolver/examples/multithreaded_runtime.rs
@@ -21,8 +21,9 @@ fn run() {
             use hickory_resolver::{TokioResolver, name_server::TokioConnectionProvider};
 
             // use the system resolver configuration
-            TokioResolver::from_system_conf(TokioConnectionProvider::default())
+            TokioResolver::builder(TokioConnectionProvider::default())
                 .expect("failed to create resolver")
+                .build()
         }
 
         // For other operating systems, we can use one of the preconfigured definitions

--- a/crates/resolver/src/h2.rs
+++ b/crates/resolver/src/h2.rs
@@ -58,18 +58,14 @@ mod tests {
     use test_support::subscribe;
 
     use crate::TokioResolver;
-    use crate::config::{ResolverConfig, ResolverOpts};
+    use crate::config::ResolverConfig;
     use crate::name_server::TokioConnectionProvider;
 
     async fn https_test(config: ResolverConfig) {
-        let resolver = TokioResolver::new(
-            config,
-            ResolverOpts {
-                try_tcp_on_error: true,
-                ..ResolverOpts::default()
-            },
-            TokioConnectionProvider::default(),
-        );
+        let mut resolver_builder =
+            TokioResolver::builder_with_config(config, TokioConnectionProvider::default());
+        resolver_builder.options_mut().try_tcp_on_error = true;
+        let resolver = resolver_builder.build();
 
         let response = resolver
             .lookup_ip("www.example.com.")

--- a/crates/resolver/src/h3.rs
+++ b/crates/resolver/src/h3.rs
@@ -52,15 +52,12 @@ mod tests {
     use test_support::subscribe;
 
     use crate::TokioResolver;
-    use crate::config::{ResolverConfig, ResolverOpts};
+    use crate::config::ResolverConfig;
     use crate::name_server::TokioConnectionProvider;
 
     async fn h3_test(config: ResolverConfig) {
-        let resolver = TokioResolver::new(
-            config,
-            ResolverOpts::default(),
-            TokioConnectionProvider::default(),
-        );
+        let resolver =
+            TokioResolver::builder_with_config(config, TokioConnectionProvider::default()).build();
 
         let response = resolver
             .lookup_ip("www.example.com.")

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -44,7 +44,7 @@
 //! # use hickory_resolver::Resolver;
 //! // Use the host OS'es `/etc/resolv.conf`
 //! # #[cfg(unix)]
-//! let resolver = Resolver::tokio_from_system_conf().unwrap();
+//! let resolver = Resolver::builder_tokio().unwrap().build();
 //! # #[cfg(unix)]
 //! let response = resolver.lookup_ip("www.example.com.").await.unwrap();
 //! # }
@@ -59,7 +59,8 @@
 //! # {
 //! use std::net::*;
 //! use tokio::runtime::Runtime;
-//! use hickory_resolver::TokioResolver;
+//! use hickory_resolver::Resolver;
+//! use hickory_resolver::name_server::TokioConnectionProvider;
 //! use hickory_resolver::config::*;
 //!
 //! // We need a Tokio Runtime to run the resolver
@@ -67,11 +68,10 @@
 //! let mut io_loop = Runtime::new().unwrap();
 //!
 //! // Construct a new Resolver with default configuration options
-//! let resolver = io_loop.block_on(async {
-//!     TokioResolver::tokio(
-//!         ResolverConfig::default(),
-//!         ResolverOpts::default())
-//! });
+//! let resolver = Resolver::builder_with_config(
+//!     ResolverConfig::default(),
+//!     TokioConnectionProvider::default()
+//! ).build();
 //!
 //! // Lookup the IP addresses associated with a name.
 //! // This returns a future that will lookup the IP addresses, it must be run in the Core to
@@ -97,17 +97,17 @@
 //! # {
 //! # use std::net::*;
 //! # use tokio::runtime::Runtime;
-//! # use hickory_resolver::TokioResolver;
+//! # use hickory_resolver::Resolver;
+//! # use hickory_resolver::name_server::TokioConnectionProvider;
 //! # use hickory_resolver::config::*;
 //! # use futures_util::TryFutureExt;
 //! #
 //! # let mut io_loop = Runtime::new().unwrap();
 //! #
-//! # let resolver = io_loop.block_on(async {
-//! #    TokioResolver::tokio(
-//! #        ResolverConfig::default(),
-//! #        ResolverOpts::default())
-//! # });
+//! # let resolver = Resolver::builder_with_config(
+//! #     ResolverConfig::default(),
+//! #     TokioConnectionProvider::default()
+//! # ).build();
 //! #
 //! let ips = io_loop.block_on(resolver.lookup_ip("www.example.com.")).unwrap();
 //!
@@ -151,12 +151,16 @@
 //! # fn main() {
 //! # #[cfg(feature = "tokio")]
 //! # {
-//! use hickory_resolver::TokioResolver;
+//! use hickory_resolver::Resolver;
+//! use hickory_resolver::name_server::TokioConnectionProvider;
 //! use hickory_resolver::config::*;
 //!
 //! // Construct a new Resolver with default configuration options
 //! # #[cfg(feature = "__tls")]
-//! let mut resolver = TokioResolver::tokio(ResolverConfig::cloudflare_tls(), ResolverOpts::default());
+//! let mut resolver = Resolver::builder_with_config(
+//!     ResolverConfig::cloudflare_tls(),
+//!     TokioConnectionProvider::default(),
+//! ).build();
 //!
 //! // see example above...
 //! # }
@@ -215,9 +219,9 @@ use name_server::TokioConnectionProvider;
 mod quic;
 mod resolver;
 pub use resolver::LookupFuture;
-pub use resolver::Resolver;
 #[cfg(feature = "tokio")]
 pub use resolver::TokioResolver;
+pub use resolver::{Resolver, ResolverBuilder};
 pub mod system_conf;
 #[cfg(test)]
 mod tests;

--- a/crates/resolver/src/quic.rs
+++ b/crates/resolver/src/quic.rs
@@ -54,19 +54,15 @@ mod tests {
     use test_support::subscribe;
 
     use crate::TokioResolver;
-    use crate::config::{NameServerConfigGroup, ResolverConfig, ResolverOpts};
+    use crate::config::{NameServerConfigGroup, ResolverConfig};
     use crate::name_server::TokioConnectionProvider;
 
     async fn quic_test(config: ResolverConfig, tls_config: rustls::ClientConfig) {
-        let resolver = TokioResolver::new(
-            config,
-            ResolverOpts {
-                try_tcp_on_error: true,
-                tls_config,
-                ..ResolverOpts::default()
-            },
-            TokioConnectionProvider::default(),
-        );
+        let mut resolver_builder =
+            TokioResolver::builder_with_config(config, TokioConnectionProvider::default());
+        resolver_builder.options_mut().try_tcp_on_error = true;
+        resolver_builder.options_mut().tls_config = tls_config;
+        let resolver = resolver_builder.build();
 
         let response = resolver
             .lookup_ip("www.example.com.")

--- a/crates/resolver/src/tests.rs
+++ b/crates/resolver/src/tests.rs
@@ -12,11 +12,11 @@ async fn readme_example() {
     use crate::name_server::TokioConnectionProvider;
 
     // Construct a new Resolver with default configuration options
-    let resolver = Resolver::new(
+    let resolver = Resolver::builder_with_config(
         ResolverConfig::default(),
-        ResolverOpts::default(),
         TokioConnectionProvider::default(),
-    );
+    )
+    .build();
 
     // On Unix/Posix systems, this will read the /etc/resolv.conf
     // let resolver = Resolver::from_system_conf(TokioConnectionProvider::default()).unwrap();
@@ -38,11 +38,11 @@ fn readme_tls() {
     use crate::name_server::TokioConnectionProvider;
 
     // Construct a new Resolver with default configuration options
-    let resolver = Resolver::new(
+    let resolver = Resolver::builder_with_config(
         ResolverConfig::cloudflare_tls(),
-        ResolverOpts::default(),
         TokioConnectionProvider::default(),
-    );
+    )
+    .build();
 
     let _ = resolver;
 }

--- a/crates/resolver/src/tls.rs
+++ b/crates/resolver/src/tls.rs
@@ -46,18 +46,14 @@ mod tests {
     use test_support::subscribe;
 
     use crate::TokioResolver;
-    use crate::config::{ResolverConfig, ResolverOpts};
+    use crate::config::ResolverConfig;
     use crate::name_server::TokioConnectionProvider;
 
     async fn tls_test(config: ResolverConfig) {
-        let resolver = TokioResolver::new(
-            config,
-            ResolverOpts {
-                try_tcp_on_error: true,
-                ..ResolverOpts::default()
-            },
-            TokioConnectionProvider::default(),
-        );
+        let mut resolver_builder =
+            TokioResolver::builder_with_config(config, TokioConnectionProvider::default());
+        resolver_builder.options_mut().try_tcp_on_error = true;
+        let resolver = resolver_builder.build();
 
         let response = resolver
             .lookup_ip("www.example.com.")

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -40,8 +40,9 @@ pub struct ForwardAuthority<P: ConnectionProvider = TokioConnectionProvider> {
 impl<P: ConnectionProvider> ForwardAuthority<P> {
     #[doc(hidden)]
     pub fn new(runtime: P) -> Result<Self, String> {
-        let resolver = Resolver::from_system_conf(runtime)
-            .map_err(|e| format!("error constructing new Resolver: {e}"))?;
+        let resolver = Resolver::builder(runtime)
+            .map_err(|e| format!("error constructing new Resolver: {e}"))?
+            .build();
 
         Ok(Self {
             origin: Name::root().into(),
@@ -88,7 +89,7 @@ impl<P: ConnectionProvider> ForwardAuthority<P> {
 
         let config = ResolverConfig::from_parts(None, vec![], name_servers);
 
-        let resolver = Resolver::new(config, options, runtime);
+        let resolver = Resolver::builder_with_config(config, runtime).build();
 
         info!("forward resolver configured: {}: ", origin);
 

--- a/crates/server/src/store/forwarder/mod.rs
+++ b/crates/server/src/store/forwarder/mod.rs
@@ -14,7 +14,7 @@ use serde::Deserialize;
 use crate::resolver::config::{NameServerConfigGroup, ResolverOpts};
 
 mod authority;
-pub use authority::{ForwardAuthority, ForwardLookup};
+pub use authority::{ForwardAuthority, ForwardAuthorityBuilder, ForwardLookup};
 
 /// Configuration for file based zones
 #[derive(Clone, Deserialize, Debug)]

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -118,7 +118,7 @@ tracing.workspace = true
 hickory-client.workspace = true
 hickory-proto = { workspace = true, features = ["testing"] }
 hickory-resolver = { workspace = true, features = ["tokio"] }
-hickory-server = { workspace = true, features = ["testing"] }
+hickory-server = { workspace = true, features = ["testing", "resolver"] }
 webpki-roots = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/tests/integration-tests/tests/integration/main.rs
+++ b/tests/integration-tests/tests/integration/main.rs
@@ -10,3 +10,4 @@ mod retry_dns_handle_tests;
 mod server_future_tests;
 mod sqlite_authority_tests;
 mod truncation_tests;
+mod validating_forwarder_tests;

--- a/tests/integration-tests/tests/integration/validating_forwarder_tests.rs
+++ b/tests/integration-tests/tests/integration/validating_forwarder_tests.rs
@@ -1,0 +1,194 @@
+#![cfg(feature = "__dnssec")]
+
+//! Test DNSSEC validation in the forwarder.
+//!
+//! Note that these tests configure an authoritative name server as the forwarder's name server, not
+//! a recursive name server. This happens to work out because we only query the root zone. Any more
+//! sophisticated tests would require setting up a recursive name server, which in turn would
+//! require a virtual network of authoritative name servers to contact.
+
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
+
+use hickory_client::client::{Client, ClientHandle};
+use hickory_proto::{
+    dnssec::{
+        PublicKeyBuf, SigSigner, SigningKey, TrustAnchor, crypto::Ed25519SigningKey, rdata::DNSKEY,
+    },
+    op::ResponseCode,
+    rr::{DNSClass, RData, Record, RecordType, rdata::A},
+    runtime::TokioRuntimeProvider,
+    udp::UdpClientStream,
+    xfer::Protocol,
+};
+use hickory_resolver::{
+    Name,
+    config::{NameServerConfig, NameServerConfigGroup, ResolverOpts},
+};
+use hickory_server::{
+    ServerFuture,
+    authority::{Catalog, ZoneType},
+    store::{
+        forwarder::{ForwardAuthority, ForwardConfig},
+        in_memory::InMemoryAuthority,
+    },
+};
+use test_support::subscribe;
+use tokio::{net::UdpSocket, spawn};
+
+#[tokio::test]
+async fn query_validate_true_signed_zone() {
+    subscribe();
+
+    let (name_server_addr, _name_server_future, public_key) =
+        setup_authoritative_server(true).await;
+    let (mut client, _forwarder_future) =
+        setup_client_forwarder(name_server_addr, &public_key, true).await;
+    let response = client
+        .query(Name::root(), DNSClass::IN, RecordType::A)
+        .await
+        .unwrap();
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+    assert!(response.answers().iter().any(|record| {
+        record
+            .data()
+            .as_a()
+            .is_some_and(|a| a.0 == Ipv4Addr::new(1, 2, 3, 4))
+    }));
+}
+
+#[tokio::test]
+#[ignore = "validation failure is not translated into SERVFAIL response"]
+async fn query_validate_true_unsigned_zone() {
+    subscribe();
+
+    let (name_server_addr, _name_server_future, public_key) =
+        setup_authoritative_server(false).await;
+    let (mut client, _forwarder_future) =
+        setup_client_forwarder(name_server_addr, &public_key, true).await;
+    let response = client
+        .query(Name::root(), DNSClass::IN, RecordType::A)
+        .await
+        .unwrap();
+    assert_eq!(response.response_code(), ResponseCode::ServFail);
+    assert!(response.answers().is_empty());
+}
+
+#[tokio::test]
+async fn query_validate_false_signed_zone() {
+    subscribe();
+
+    let (name_server_addr, _name_server_future, public_key) =
+        setup_authoritative_server(true).await;
+    let (mut client, _forwarder_future) =
+        setup_client_forwarder(name_server_addr, &public_key, false).await;
+    let response = client
+        .query(Name::root(), DNSClass::IN, RecordType::A)
+        .await
+        .unwrap();
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+    assert!(response.answers().iter().any(|record| {
+        record
+            .data()
+            .as_a()
+            .is_some_and(|a| a.0 == Ipv4Addr::new(1, 2, 3, 4))
+    }));
+}
+
+#[tokio::test]
+async fn query_validate_false_unsigned_zone() {
+    subscribe();
+
+    let (name_server_addr, _name_server_future, public_key) =
+        setup_authoritative_server(false).await;
+    let (mut client, _forwarder_future) =
+        setup_client_forwarder(name_server_addr, &public_key, false).await;
+    let response = client
+        .query(Name::root(), DNSClass::IN, RecordType::A)
+        .await
+        .unwrap();
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+    assert!(response.answers().iter().any(|record| {
+        record
+            .data()
+            .as_a()
+            .is_some_and(|a| a.0 == Ipv4Addr::new(1, 2, 3, 4))
+    }));
+}
+
+async fn setup_authoritative_server(
+    signed: bool,
+) -> (SocketAddr, ServerFuture<Catalog>, PublicKeyBuf) {
+    // Zone setup
+    let key = Ed25519SigningKey::from_pkcs8(&Ed25519SigningKey::generate_pkcs8().unwrap()).unwrap();
+    let public_key = key.to_public_key().unwrap();
+    let mut authority = InMemoryAuthority::empty(
+        Name::root(),
+        ZoneType::Primary,
+        false,
+        Some(hickory_server::dnssec::NxProofKind::Nsec),
+    );
+    authority.upsert_mut(
+        Record::from_rdata(Name::root(), 3600, RData::A(A(Ipv4Addr::new(1, 2, 3, 4)))),
+        0,
+    );
+    if signed {
+        authority
+            .add_zone_signing_key_mut(SigSigner::dnssec(
+                DNSKEY::from_key(&key.to_public_key().unwrap()),
+                Box::new(key),
+                Name::root(),
+                Duration::from_secs(86400),
+            ))
+            .unwrap();
+        authority.secure_zone_mut().unwrap();
+    }
+
+    // Server setup
+    let udp_socket = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let local_addr = udp_socket.local_addr().unwrap();
+    let mut catalog = Catalog::new();
+    catalog.upsert(Name::root().into(), vec![Arc::new(authority)]);
+    let mut server = ServerFuture::new(catalog);
+    server.register_socket(udp_socket);
+
+    (local_addr, server, public_key)
+}
+
+async fn setup_client_forwarder(
+    name_server_addr: SocketAddr,
+    public_key: &PublicKeyBuf,
+    validate: bool,
+) -> (Client, ServerFuture<Catalog>) {
+    // Server setup
+    let mut trust_anchor = TrustAnchor::new();
+    trust_anchor.insert_trust_anchor(public_key);
+    let mut options = ResolverOpts::default();
+    options.validate = validate;
+    let authority = ForwardAuthority::builder_tokio(ForwardConfig {
+        name_servers: NameServerConfigGroup::from(vec![NameServerConfig::new(
+            name_server_addr,
+            Protocol::Udp,
+        )]),
+        options: Some(options),
+    })
+    .with_trust_anchor(Arc::new(trust_anchor))
+    .build()
+    .unwrap();
+    let udp_socket = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let local_addr = udp_socket.local_addr().unwrap();
+    let mut catalog = Catalog::new();
+    catalog.upsert(Name::root().into(), vec![Arc::new(authority)]);
+    let mut server = ServerFuture::new(catalog);
+    server.register_socket(udp_socket);
+
+    // Client setup
+    let stream = UdpClientStream::builder(local_addr, TokioRuntimeProvider::new()).build();
+    let (client, bg) = Client::connect(stream).await.unwrap();
+    spawn(bg);
+
+    (client, server)
+}

--- a/util/src/bin/resolve.rs
+++ b/util/src/bin/resolve.rs
@@ -44,6 +44,7 @@ use hickory_resolver::{
     ResolveError, TokioResolver,
     config::{NameServerConfig, NameServerConfigGroup, ResolverConfig, ResolverOpts},
     lookup::Lookup,
+    name_server::TokioConnectionProvider,
 };
 
 /// A CLI interface for the hickory-resolver.
@@ -335,7 +336,10 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         options.ip_strategy = hickory_resolver::config::LookupIpStrategy::Ipv4AndIpv6;
     }
 
-    let resolver_arc = Arc::new(TokioResolver::tokio(config, options));
+    let mut resolver_builder =
+        TokioResolver::builder_with_config(config, TokioConnectionProvider::default());
+    *resolver_builder.options_mut() = options;
+    let resolver_arc = Arc::new(resolver_builder.build());
 
     if let Some(domainname) = &opts.domainname {
         log_query(domainname, opts.ty, &name_servers, &opts);


### PR DESCRIPTION
This adds new constructors for `Resolver` and `ForwardAuthority` that allow using trust anchors other than the bundled keys, and adds an ignored test for #2428, making use of the new constructors.