### PR TITLE
Address two advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,7 +1457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2017,9 +2017,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.11"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",

--- a/justfile
+++ b/justfile
@@ -106,8 +106,10 @@ fmt:
 
 # Audit all depenedencies
 audit: init-audit (check '--all-features')
-    cargo audit --deny warnings --ignore RUSTSEC-2025-0007
-    cargo audit --file fuzz/Cargo.lock --deny warnings --ignore RUSTSEC-2025-0007
+    # RUSTSEC-2024-0436, regarding the maintenance status of `paste`, is being
+    # ignored for now. See issue #2833.
+    cargo audit --deny warnings --ignore RUSTSEC-2024-0436
+    cargo audit --file fuzz/Cargo.lock --deny warnings --ignore RUSTSEC-2024-0436
 
 # Task to run clippy, rustfmt, and audit on all crates
 cleanliness: clippy fmt audit


### PR DESCRIPTION
This updates `ring` and ignores another advisory. See #2833.