### PR TITLE
Add trust anchor field to forwarder config file

### DIFF
--- a/crates/proto/src/serialize/txt/rdata_parsers/dnskey.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/dnskey.rs
@@ -48,7 +48,7 @@ mod tests {
     use alloc::string::ToString;
 
     use super::*;
-    #[cfg(feature = "dnssec-ring")]
+    #[cfg(feature = "__dnssec")]
     use crate::dnssec::crypto::EcdsaSigningKey;
     use crate::dnssec::{PublicKey, SigningKey};
 

--- a/crates/proto/src/serialize/txt/trust_anchor.rs
+++ b/crates/proto/src/serialize/txt/trust_anchor.rs
@@ -266,7 +266,7 @@ impl From<Token> for LexToken {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "dnssec-ring")]
+    #[cfg(feature = "__dnssec")]
     use crate::dnssec::crypto::EcdsaSigningKey;
     use crate::dnssec::{Algorithm, PublicKey, PublicKeyBuf, SigningKey, rdata::DNSKEY};
 

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -12,6 +12,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::ops::{Deref, DerefMut};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -856,6 +857,12 @@ pub struct ResolverOpts {
     /// This implements the mechanism described in
     /// [draft-vixie-dnsext-dns0x20-00](https://datatracker.ietf.org/doc/html/draft-vixie-dnsext-dns0x20-00).
     pub case_randomization: bool,
+    /// Path to a DNSSEC trust anchor file.
+    ///
+    /// `validate` must be set as well for this to take effect. If no trust anchor path is
+    /// provided, and `validate` is set to true, then the built-in trust anchor will be used by
+    /// default.
+    pub trust_anchor: Option<PathBuf>,
 }
 
 impl Default for ResolverOpts {
@@ -891,6 +898,7 @@ impl Default for ResolverOpts {
             #[cfg(feature = "__tls")]
             tls_config: client_config(),
             case_randomization: false,
+            trust_anchor: None,
         }
     }
 }

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -859,9 +859,7 @@ pub struct ResolverOpts {
     pub case_randomization: bool,
     /// Path to a DNSSEC trust anchor file.
     ///
-    /// `validate` must be set as well for this to take effect. If no trust anchor path is
-    /// provided, and `validate` is set to true, then the built-in trust anchor will be used by
-    /// default.
+    /// If this is provided, `validate` will automatically be set to `true`, enabling DNSSEC validation.
     pub trust_anchor: Option<PathBuf>,
 }
 

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -52,7 +52,8 @@ impl<P: ConnectionProvider> ForwardAuthorityBuilder<P> {
         self
     }
 
-    /// Set the DNSSEC trust anchors to be used by the forward authority.
+    /// Enables DNSSEC validation, and sets the DNSSEC trust anchors to be used by the forward
+    /// authority.
     ///
     /// This overrides the trust anchor path in the `ResolverOpts`.
     #[cfg(feature = "__dnssec")]
@@ -128,11 +129,13 @@ impl<P: ConnectionProvider> ForwardAuthorityBuilder<P> {
         #[cfg(feature = "__dnssec")]
         match (trust_anchor, &options.trust_anchor) {
             (Some(trust_anchor), _) => {
-                resolver_builder = resolver_builder.with_trust_anchor(trust_anchor)
+                resolver_builder = resolver_builder.with_trust_anchor(trust_anchor);
+                options.validate = true;
             }
             (None, Some(path)) => {
                 let trust_anchor = TrustAnchor::read_from_file(path)?;
                 resolver_builder = resolver_builder.with_trust_anchor(Arc::new(trust_anchor));
+                options.validate = true;
             }
             (None, None) => {}
         }

--- a/crates/server/src/store/recursor/config.rs
+++ b/crates/server/src/store/recursor/config.rs
@@ -21,10 +21,7 @@ use serde::Deserialize;
 
 use crate::error::ConfigError;
 #[cfg(feature = "__dnssec")]
-use crate::proto::{
-    dnssec::{TrustAnchor, Verifier},
-    serialize::txt::trust_anchor::{self, Entry},
-};
+use crate::proto::dnssec::TrustAnchor;
 use crate::proto::{
     rr::{Name, RData, Record, RecordSet},
     serialize::txt::Parser,
@@ -151,7 +148,7 @@ impl DnssecPolicyConfig {
             Self::ValidateWithStaticKey { path } => DnssecPolicy::ValidateWithStaticKey {
                 trust_anchor: path
                     .as_ref()
-                    .map(|path| read_trust_anchor(path))
+                    .map(|path| TrustAnchor::read_from_file(path))
                     .transpose()?
                     .map(Arc::new),
             },
@@ -159,45 +156,10 @@ impl DnssecPolicyConfig {
     }
 }
 
-#[cfg(feature = "__dnssec")]
-fn read_trust_anchor(path: &Path) -> Result<TrustAnchor, String> {
-    use std::fs;
-
-    let contents = fs::read_to_string(path).map_err(|e| e.to_string())?;
-
-    parse_trust_anchor(&contents)
-}
-
-#[cfg(feature = "__dnssec")]
-fn parse_trust_anchor(input: &str) -> Result<TrustAnchor, String> {
-    let parser = trust_anchor::Parser::new(input);
-    let entries = parser.parse().map_err(|e| e.to_string())?;
-
-    let mut trust_anchor = TrustAnchor::new();
-    for entry in entries {
-        if let Entry::DNSKEY(record) = entry {
-            let dnskey = record.data();
-            // XXX should we filter based on `dnskey.flags()`?
-            let key = dnskey.key().map_err(|e| e.to_string())?;
-            trust_anchor.insert_trust_anchor(&*key);
-        }
-    }
-
-    Ok(trust_anchor)
-}
-
 #[cfg(test)]
 mod tests {
+    #[cfg(all(feature = "__dnssec", feature = "toml"))]
     use super::*;
-
-    #[cfg(feature = "__dnssec")]
-    #[test]
-    fn can_load_trust_anchor_file() {
-        let input = include_str!("../../../../proto/tests/test-data/root.key");
-
-        let trust_anchor = parse_trust_anchor(input).unwrap();
-        assert_eq!(3, trust_anchor.len());
-    }
 
     #[cfg(all(feature = "__dnssec", feature = "toml"))]
     #[test]


### PR DESCRIPTION
This adds a field to the forwarder's configuration file to provide a set of trust anchors. This is a prerequisite for conformance tests of the forwarder using DNSSEC.