### PR TITLE
Add forwarder support to dns-test

### DIFF
--- a/conformance/packages/conformance-tests/src/forwarder.rs
+++ b/conformance/packages/conformance-tests/src/forwarder.rs
@@ -1,0 +1,2 @@
+mod dns;
+mod dnssec;

--- a/conformance/packages/conformance-tests/src/forwarder/dns.rs
+++ b/conformance/packages/conformance-tests/src/forwarder/dns.rs
@@ -1,0 +1,1 @@
+mod scenarios;

--- a/conformance/packages/conformance-tests/src/forwarder/dns/scenarios.rs
+++ b/conformance/packages/conformance-tests/src/forwarder/dns/scenarios.rs
@@ -1,0 +1,75 @@
+use std::net::Ipv4Addr;
+
+use dns_test::{
+    FQDN, Forwarder, Network, Resolver, Result,
+    client::{Client, DigSettings},
+    name_server::{Graph, NameServer, Sign},
+    record::{Record, RecordType},
+};
+
+#[test]
+fn noerror() -> Result<()> {
+    let network = Network::new()?;
+
+    let expected_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
+    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::TEST_DOMAIN, &network)?;
+    leaf_ns.add(Record::a(FQDN::EXAMPLE_SUBDOMAIN, expected_ipv4_addr));
+
+    let Graph {
+        nameservers: _nameservers,
+        root,
+        ..
+    } = Graph::build(leaf_ns, Sign::No)?;
+
+    let resolver = Resolver::new(&network, root).start_with_subject(&dns_test::PEER)?;
+    let forwarder = Forwarder::new(&network, &resolver).start()?;
+    let client = Client::new(&network)?;
+
+    let settings = *DigSettings::default().recurse();
+    let output = client.dig(
+        settings,
+        forwarder.ipv4_addr(),
+        RecordType::A,
+        &FQDN::EXAMPLE_SUBDOMAIN,
+    )?;
+
+    assert!(output.status.is_noerror(), "{:?}", output.status);
+
+    let [answer] = output.answer.try_into().unwrap();
+    let a = answer.try_into_a().unwrap();
+
+    assert_eq!(a.fqdn, FQDN::EXAMPLE_SUBDOMAIN);
+    assert_eq!(a.ipv4_addr, expected_ipv4_addr);
+
+    Ok(())
+}
+
+#[test]
+fn nxdomain() -> Result<()> {
+    let network = Network::new()?;
+
+    let leaf_ns = NameServer::new(&dns_test::PEER, FQDN::TEST_DOMAIN, &network)?;
+
+    let Graph {
+        nameservers: _nameservers,
+        root,
+        ..
+    } = Graph::build(leaf_ns, Sign::No)?;
+
+    let resolver = Resolver::new(&network, root).start_with_subject(&dns_test::PEER)?;
+    let forwarder = Forwarder::new(&network, &resolver).start()?;
+    let client = Client::new(&network)?;
+
+    let settings = *DigSettings::default().recurse();
+    let output = client.dig(
+        settings,
+        forwarder.ipv4_addr(),
+        RecordType::A,
+        &FQDN::EXAMPLE_SUBDOMAIN,
+    )?;
+
+    assert!(output.status.is_nxdomain(), "{:?}", output.status);
+    assert!(output.answer.is_empty(), "{:?}", output.answer);
+
+    Ok(())
+}

--- a/conformance/packages/conformance-tests/src/forwarder/dnssec.rs
+++ b/conformance/packages/conformance-tests/src/forwarder/dnssec.rs
@@ -1,0 +1,1 @@
+mod scenarios;

--- a/conformance/packages/conformance-tests/src/forwarder/dnssec/scenarios.rs
+++ b/conformance/packages/conformance-tests/src/forwarder/dnssec/scenarios.rs
@@ -8,6 +8,8 @@ use dns_test::{
     zone_file::SignSettings,
 };
 
+mod bogus;
+
 #[test]
 fn noerror() -> Result<()> {
     let network = Network::new()?;

--- a/conformance/packages/conformance-tests/src/forwarder/dnssec/scenarios.rs
+++ b/conformance/packages/conformance-tests/src/forwarder/dnssec/scenarios.rs
@@ -1,0 +1,96 @@
+use std::net::Ipv4Addr;
+
+use dns_test::{
+    FQDN, Forwarder, Network, Resolver, Result,
+    client::{Client, DigSettings},
+    name_server::{Graph, NameServer, Sign},
+    record::{Record, RecordType},
+    zone_file::SignSettings,
+};
+
+#[test]
+fn noerror() -> Result<()> {
+    let network = Network::new()?;
+
+    let expected_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
+    let mut leaf_ns = NameServer::new(&dns_test::PEER, FQDN::TEST_DOMAIN, &network)?;
+    leaf_ns.add(Record::a(FQDN::EXAMPLE_SUBDOMAIN, expected_ipv4_addr));
+
+    let Graph {
+        nameservers: _nameservers,
+        root,
+        trust_anchor,
+    } = Graph::build(
+        leaf_ns,
+        Sign::Yes {
+            settings: SignSettings::default(),
+        },
+    )?;
+    let trust_anchor = trust_anchor.unwrap();
+
+    let resolver = Resolver::new(&network, root)
+        .trust_anchor(&trust_anchor)
+        .start_with_subject(&dns_test::PEER)?;
+    let forwarder = Forwarder::new(&network, &resolver)
+        .trust_anchor(&trust_anchor)
+        .start()?;
+    let client = Client::new(&network)?;
+
+    let settings = *DigSettings::default().recurse();
+    let output = client.dig(
+        settings,
+        forwarder.ipv4_addr(),
+        RecordType::A,
+        &FQDN::EXAMPLE_SUBDOMAIN,
+    )?;
+
+    assert!(output.status.is_noerror(), "{:?}", output.status);
+
+    let [answer] = output.answer.try_into().unwrap();
+    let a = answer.try_into_a().unwrap();
+
+    assert_eq!(a.fqdn, FQDN::EXAMPLE_SUBDOMAIN);
+    assert_eq!(a.ipv4_addr, expected_ipv4_addr);
+
+    Ok(())
+}
+
+#[test]
+fn nxdomain() -> Result<()> {
+    let network = Network::new()?;
+
+    let leaf_ns = NameServer::new(&dns_test::PEER, FQDN::TEST_DOMAIN, &network)?;
+
+    let Graph {
+        nameservers: _nameservers,
+        root,
+        trust_anchor,
+    } = Graph::build(
+        leaf_ns,
+        Sign::Yes {
+            settings: SignSettings::default(),
+        },
+    )?;
+    let trust_anchor = trust_anchor.unwrap();
+
+    let resolver = Resolver::new(&network, root)
+        .trust_anchor(&trust_anchor)
+        .start_with_subject(&dns_test::PEER)?;
+    let forwarder = Forwarder::new(&network, &resolver)
+        .trust_anchor(&trust_anchor)
+        .start()?;
+    let client = Client::new(&network)?;
+
+    let settings = *DigSettings::default().recurse();
+    let output = client.dig(
+        settings,
+        forwarder.ipv4_addr(),
+        RecordType::A,
+        &FQDN::EXAMPLE_SUBDOMAIN,
+    )?;
+
+    assert!(output.status.is_nxdomain(), "{:?}", output.status);
+    assert!(output.answer.is_empty(), "{:?}", output.answer);
+
+    Ok(())
+}

--- a/conformance/packages/conformance-tests/src/forwarder/dnssec/scenarios/bogus.rs
+++ b/conformance/packages/conformance-tests/src/forwarder/dnssec/scenarios/bogus.rs
@@ -1,0 +1,65 @@
+use dns_test::{
+    FQDN, Forwarder, Network, Resolver, Result, TrustAnchor,
+    client::{Client, DigSettings},
+    name_server::NameServer,
+    record::RecordType,
+    zone_file::SignSettings,
+};
+
+#[test]
+#[ignore = "hickory does not correctly reflect validation status in forwarder responses"]
+fn wrong_key() -> Result<()> {
+    let network = Network::new()?;
+    let sign_settings = SignSettings::default();
+    let leaf_zone = FQDN::TEST_TLD.push_label("wrong-key");
+    let peer = &dns_test::PEER;
+
+    let wrong_key_ns = NameServer::new(peer, leaf_zone.clone(), &network)?;
+    let wrong_key_ns = wrong_key_ns.sign(sign_settings.clone())?;
+    let wrong_ds = wrong_key_ns.ds().ksk.clone();
+    drop(wrong_key_ns);
+
+    let mut root_ns = NameServer::new(peer, FQDN::ROOT, &network)?;
+    let mut tld_ns = NameServer::new(peer, FQDN::TEST_TLD, &network)?;
+    let mut nameservers_ns = NameServer::new(peer, FQDN::TEST_DOMAIN, &network)?;
+    let leaf_ns = NameServer::new(peer, leaf_zone.clone(), &network)?;
+
+    root_ns.referral_nameserver(&tld_ns);
+    tld_ns.referral_nameserver(&nameservers_ns);
+    tld_ns.referral_nameserver(&leaf_ns);
+
+    nameservers_ns.add(root_ns.a());
+    nameservers_ns.add(tld_ns.a());
+
+    let nameservers_ns = nameservers_ns.sign(sign_settings.clone())?;
+    let leaf_ns = leaf_ns.sign(sign_settings.clone())?;
+
+    tld_ns.add(nameservers_ns.ds().ksk.clone());
+    tld_ns.add(wrong_ds);
+
+    let tld_ns = tld_ns.sign(sign_settings.clone())?;
+    root_ns.add(tld_ns.ds().ksk.clone());
+
+    let root_ns = root_ns.sign(sign_settings)?;
+    let mut trust_anchor = TrustAnchor::empty();
+    trust_anchor.add(root_ns.key_signing_key().clone());
+    let root_hint = root_ns.root_hint();
+
+    let _root_ns = root_ns.start()?;
+    let _tld_ns = tld_ns.start()?;
+    let _nameservers_ns = nameservers_ns.start()?;
+    let _leaf_ns = leaf_ns.start()?;
+
+    let resolver = Resolver::new(&network, root_hint).start_with_subject(peer)?;
+    let forwarder = Forwarder::new(&network, &resolver)
+        .trust_anchor(&trust_anchor)
+        .start()?;
+
+    let client = Client::new(&network)?;
+    let settings = *DigSettings::default().recurse().authentic_data();
+
+    let output = client.dig(settings, forwarder.ipv4_addr(), RecordType::SOA, &leaf_zone)?;
+    assert!(output.status.is_servfail());
+
+    Ok(())
+}

--- a/conformance/packages/conformance-tests/src/lib.rs
+++ b/conformance/packages/conformance-tests/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg(test)]
 
+mod forwarder;
 mod name_server;
 mod resolver;

--- a/conformance/packages/dns-test/src/forwarder.rs
+++ b/conformance/packages/dns-test/src/forwarder.rs
@@ -1,0 +1,134 @@
+use std::net::Ipv4Addr;
+
+use crate::{
+    Implementation, Network, Resolver, Result, TrustAnchor,
+    container::{Child, Container},
+    implementation::{Config, Role},
+    record::DNSKEY,
+    tshark::Tshark,
+};
+
+pub struct Forwarder {
+    container: Container,
+    _child: Child,
+    implementation: Implementation,
+}
+
+impl Forwarder {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new<'a>(network: &Network, resolver: &'a Resolver) -> ForwarderSettings<'a> {
+        ForwarderSettings {
+            network: network.clone(),
+            resolver,
+            trust_anchor: TrustAnchor::empty(),
+        }
+    }
+
+    pub fn eavesdrop(&self) -> Result<Tshark> {
+        self.container.eavesdrop()
+    }
+
+    pub fn network(&self) -> &Network {
+        self.container.network()
+    }
+
+    pub fn container_id(&self) -> &str {
+        self.container.id()
+    }
+
+    pub fn container_name(&self) -> &str {
+        self.container.name()
+    }
+
+    pub fn ipv4_addr(&self) -> Ipv4Addr {
+        self.container.ipv4_addr()
+    }
+
+    /// Returns the logs collected so far
+    pub fn logs(&self) -> Result<String> {
+        if self.implementation.is_hickory() {
+            self.stdout()
+        } else {
+            self.stderr()
+        }
+    }
+
+    fn stdout(&self) -> Result<String> {
+        self.container
+            .stdout(&["cat", &self.implementation.stdout_logfile(Role::Forwarder)])
+    }
+
+    fn stderr(&self) -> Result<String> {
+        self.container
+            .stdout(&["cat", &self.implementation.stderr_logfile(Role::Forwarder)])
+    }
+}
+
+pub struct ForwarderSettings<'a> {
+    network: Network,
+    resolver: &'a Resolver,
+    trust_anchor: TrustAnchor,
+}
+
+impl ForwarderSettings<'_> {
+    /// Starts a DNS server in the forwarder role.
+    ///
+    /// The server uses the implementation chosen by the `$DNS_TEST_SUBJECT` environment variable.
+    pub fn start(&self) -> Result<Forwarder> {
+        self.start_with_subject(&crate::SUBJECT)
+    }
+
+    /// Starts a DNS server in the forwarder role.
+    pub fn start_with_subject(&self, implementation: &Implementation) -> Result<Forwarder> {
+        let image = implementation.clone().into();
+        let container = Container::run(&image, &self.network)?;
+
+        let use_dnssec = !self.trust_anchor.is_empty();
+        let config = Config::Forwarder {
+            use_dnssec,
+            resolver_ip: self.resolver.ipv4_addr(),
+        };
+        let config_contents = implementation.format_config(config);
+        if let Some(conf_file_path) = implementation.conf_file_path(Role::Forwarder) {
+            container.cp(conf_file_path, &config_contents)?;
+        }
+
+        if use_dnssec {
+            let path = if implementation.is_bind() {
+                "/etc/bind/bind.keys"
+            } else {
+                "/etc/trusted-key.key"
+            };
+
+            let contents = if implementation.is_bind() {
+                self.trust_anchor.delv()
+            } else {
+                self.trust_anchor.to_string()
+            };
+
+            container.cp(path, &contents)?;
+        }
+
+        let child = container.spawn(&implementation.cmd_args(Role::Forwarder))?;
+
+        Ok(Forwarder {
+            container,
+            _child: child,
+            implementation: implementation.clone(),
+        })
+    }
+
+    /// Adds a DNSKEY record to the trust anchor
+    pub fn trust_anchor_key(&mut self, key: DNSKEY) -> &mut Self {
+        self.trust_anchor.add(key.clone());
+        self
+    }
+
+    /// Adds all the keys in the `other` trust anchor to ours
+    pub fn trust_anchor(&mut self, other: &TrustAnchor) -> &mut Self {
+        for key in other.keys() {
+            self.trust_anchor.add(key.clone());
+        }
+        self
+    }
+}

--- a/conformance/packages/dns-test/src/lib.rs
+++ b/conformance/packages/dns-test/src/lib.rs
@@ -8,6 +8,7 @@ use lazy_static::lazy_static;
 use name_server::{NameServer, Running};
 
 pub use crate::container::Network;
+pub use crate::forwarder::Forwarder;
 pub use crate::fqdn::FQDN;
 pub use crate::implementation::{HickoryDnssecFeature, Implementation, Repository};
 pub use crate::resolver::Resolver;
@@ -15,6 +16,7 @@ pub use crate::trust_anchor::TrustAnchor;
 
 pub mod client;
 pub mod container;
+mod forwarder;
 mod fqdn;
 mod implementation;
 pub mod name_server;
@@ -38,7 +40,12 @@ lazy_static! {
 
 /// Helper to prevent a unit test from immediately terminating so its associated containers can be
 /// manually inspected
-pub fn inspect(clients: &[Client], resolvers: &[Resolver], nameservers: &[NameServer<Running>]) {
+pub fn inspect(
+    clients: &[Client],
+    resolvers: &[Resolver],
+    nameservers: &[NameServer<Running>],
+    forwarders: &[Forwarder],
+) {
     use core::fmt::Write as _;
 
     let mut output = String::new();
@@ -76,6 +83,20 @@ pub fn inspect(clients: &[Client], resolvers: &[Resolver], nameservers: &[NameSe
             nameserver.container_id(),
             nameserver.ipv4_addr(),
             nameserver.zone(),
+        )
+        .unwrap();
+    }
+
+    if !forwarders.is_empty() {
+        output.push_str("\n\nFORWARDERS");
+    }
+
+    for forwarder in forwarders {
+        write!(
+            output,
+            "\n{} {}",
+            forwarder.container_id(),
+            forwarder.ipv4_addr()
         )
         .unwrap();
     }

--- a/conformance/packages/dns-test/src/templates/hickory.forwarder.toml.jinja
+++ b/conformance/packages/dns-test/src/templates/hickory.forwarder.toml.jinja
@@ -1,0 +1,19 @@
+user = "nobody"
+group = "nogroup"
+
+[[zones]]
+zone = "."
+zone_type = "External"
+
+[zones.stores]
+type = "forward"
+
+{% if use_dnssec %}
+[zones.stores.options]
+validate = true
+trust_anchor = "/etc/trusted-key.key"
+{% endif %}
+
+[[zones.stores.name_servers]]
+socket_addr = "{{ resolver_ip }}:53"
+protocol = "tcp"

--- a/conformance/packages/dns-test/src/templates/named.forwarder.conf.jinja
+++ b/conformance/packages/dns-test/src/templates/named.forwarder.conf.jinja
@@ -1,0 +1,12 @@
+options {
+    directory "/var/cache/bind";
+    pid-file "/tmp/named.pid";
+    recursion yes;
+    dnssec-validation {% if use_dnssec %} auto {% else %} no {% endif %};
+    # significantly reduces noise in logs
+    empty-zones-enable no;
+    forwarders {
+        {{ resolver_ip }};
+    };
+    forward only;
+};

--- a/conformance/packages/dns-test/src/templates/unbound.forwarder.conf.jinja
+++ b/conformance/packages/dns-test/src/templates/unbound.forwarder.conf.jinja
@@ -1,0 +1,20 @@
+server:
+    verbosity: 4
+    use-syslog: no
+    interface: 0.0.0.0
+    access-control: 0.0.0.0/0 allow
+    pidfile: /tmp/unbound.pid
+    cache-max-ttl: 60
+
+{% if use_dnssec %}
+    val-sig-skew-min: 3600
+    trust-anchor-file: /etc/trusted-key.key
+{% endif %}
+
+remote-control:
+    control-enable: yes
+    control-interface: /run/unbound.ctl
+
+forward-zone:
+    name: "."
+    forward-addr: {{ resolver_ip }}


### PR DESCRIPTION
This adds a forwarder role to the `dns-test` framework, and adds some very basic conformance tests exercising it.