### PR TITLE
Use PEER, not test_peer(), in conformance tests

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dns/rfc1035/truncation.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/rfc1035/truncation.rs
@@ -6,7 +6,7 @@
 use std::{fs, thread, time::Duration};
 
 use dns_test::{
-    FQDN, Implementation, Network, Resolver, Result,
+    FQDN, Implementation, Network, PEER, Resolver, Result,
     client::{Client, DigSettings, DigStatus},
     name_server::{Graph, NameServer},
     record::{Record, RecordType},
@@ -113,7 +113,7 @@ fn truncated_response_caching_udp_only() -> Result<()> {
 fn setup(script_path: &str) -> Result<(Resolver, Client, Graph)> {
     let network = Network::new()?;
 
-    let mut root_ns = NameServer::new(&Implementation::test_peer(), FQDN::ROOT, &network)?;
+    let mut root_ns = NameServer::new(&PEER, FQDN::ROOT, &network)?;
     let leaf_ns = NameServer::new(&Implementation::Dnslib, FQDN::TEST_TLD, &network)?;
     let script = fs::read_to_string(script_path)?;
     leaf_ns.cp("/script.py", &script)?;

--- a/conformance/packages/conformance-tests/src/resolver/dns/scenarios/packet_loss.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/scenarios/packet_loss.rs
@@ -3,7 +3,7 @@
 use std::{fs, net::Ipv4Addr};
 
 use dns_test::{
-    FQDN, Implementation, Network, Resolver, Result,
+    FQDN, Implementation, Network, PEER, Resolver, Result,
     client::{Client, DigSettings, DigStatus},
     name_server::NameServer,
     record::RecordType,
@@ -15,7 +15,7 @@ fn packet_loss_udp() -> Result<()> {
     let target_fqdn = FQDN("example.testing.")?;
     let network = Network::new()?;
 
-    let mut root_ns = NameServer::new(&Implementation::test_peer(), FQDN::ROOT, &network)?;
+    let mut root_ns = NameServer::new(&PEER, FQDN::ROOT, &network)?;
     let leaf_ns = NameServer::new(&Implementation::Dnslib, FQDN::TEST_TLD, &network)?;
     let script = fs::read_to_string("src/resolver/dns/scenarios/packet_loss.py")?;
     leaf_ns.cp("/script.py", &script)?;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/nsec3/does_not_cover/mod.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/nsec3/does_not_cover/mod.rs
@@ -1,7 +1,7 @@
 use std::{fs, net::Ipv4Addr};
 
 use dns_test::{
-    FQDN, Implementation, Network, Resolver, Result,
+    FQDN, Implementation, Network, PEER, Resolver, Result,
     client::{Client, DigSettings, DigStatus},
     name_server::NameServer,
     record::{A, RecordType},
@@ -30,12 +30,12 @@ fn does_not_cover() -> Result<()> {
 
     let leaf_ns = leaf_ns.sign(sign_settings.clone())?;
 
-    let mut tld_ns = NameServer::new(&Implementation::test_peer(), FQDN::TEST_TLD, &network)?;
+    let mut tld_ns = NameServer::new(&PEER, FQDN::TEST_TLD, &network)?;
     tld_ns.referral_nameserver(&leaf_ns);
     tld_ns.add(leaf_ns.ds().ksk.clone());
     let tld_ns = tld_ns.sign(sign_settings.clone())?;
 
-    let mut root_ns = NameServer::new(&Implementation::test_peer(), FQDN::ROOT, &network)?;
+    let mut root_ns = NameServer::new(&PEER, FQDN::ROOT, &network)?;
     root_ns.referral_nameserver(&tld_ns);
     root_ns.add(tld_ns.ds().ksk.clone());
     let root_ns = root_ns.sign(sign_settings)?;

--- a/conformance/packages/dns-test/src/implementation.rs
+++ b/conformance/packages/dns-test/src/implementation.rs
@@ -71,7 +71,9 @@ impl Implementation {
         }
     }
 
-    /// A test peer that cannot be changed using the `DNS_TEST_PEER` env variable
+    /// A test peer that cannot be changed using the `DNS_TEST_PEER` env variable.
+    ///
+    /// This is intended for use within `e2e-tests`, not `conformance-tests`.
     pub const fn test_peer() -> Implementation {
         Implementation::Unbound
     }


### PR DESCRIPTION
The `test_peer()` function should not be used in conformance tests, because the intent is that the peer implementation should be selectable via environment variables from the different justfile recipes. It should only be used in `e2e-tests`, which is not given any environment variables. This PR cleans up some stray usages, and adds a note to the doc comment.