### PR TITLE
Fix validating forwarder

### DIFF
--- a/conformance/packages/conformance-tests/src/forwarder/dnssec/scenarios/bogus.rs
+++ b/conformance/packages/conformance-tests/src/forwarder/dnssec/scenarios/bogus.rs
@@ -1,8 +1,10 @@
+use std::{fs, net::Ipv4Addr};
+
 use dns_test::{
-    FQDN, Forwarder, Network, Resolver, Result, TrustAnchor,
-    client::{Client, DigSettings},
+    FQDN, Forwarder, Implementation, Network, PEER, Resolver, Result, TrustAnchor,
+    client::{Client, DigSettings, DigStatus},
     name_server::NameServer,
-    record::RecordType,
+    record::{A, RecordType},
     zone_file::SignSettings,
 };
 
@@ -59,6 +61,74 @@ fn wrong_key() -> Result<()> {
 
     let output = client.dig(settings, forwarder.ipv4_addr(), RecordType::SOA, &leaf_zone)?;
     assert!(output.status.is_servfail());
+
+    Ok(())
+}
+
+#[test]
+fn nsec3_does_not_cover() -> Result<()> {
+    let network = Network::new()?;
+    let sign_settings = SignSettings::default();
+
+    let mut leaf_ns = NameServer::new(&Implementation::Dnslib, FQDN::TEST_DOMAIN, &network)?;
+    let script =
+        fs::read_to_string("src/resolver/dnssec/scenarios/nsec3/does_not_cover/server.py")?;
+    leaf_ns.cp("/script.py", &script)?;
+
+    // Add many records with different owner names to reduce the range covered by each NSEC3 record
+    // in the chain.
+    for i in 0..100 {
+        leaf_ns.add(A {
+            fqdn: FQDN::TEST_DOMAIN.push_label(&format!("subdomain-{i}")),
+            ttl: 86400,
+            ipv4_addr: Ipv4Addr::LOCALHOST,
+        });
+    }
+
+    let leaf_ns = leaf_ns.sign(sign_settings.clone())?;
+
+    let mut tld_ns = NameServer::new(&PEER, FQDN::TEST_TLD, &network)?;
+    tld_ns.referral_nameserver(&leaf_ns);
+    tld_ns.add(leaf_ns.ds().ksk.clone());
+    let tld_ns = tld_ns.sign(sign_settings.clone())?;
+
+    let mut root_ns = NameServer::new(&PEER, FQDN::ROOT, &network)?;
+    root_ns.referral_nameserver(&tld_ns);
+    root_ns.add(tld_ns.ds().ksk.clone());
+    let root_ns = root_ns.sign(sign_settings)?;
+    let root_hint = root_ns.root_hint();
+    let trust_anchor = root_ns.trust_anchor();
+
+    let leaf_ns = leaf_ns.start()?;
+    let _tld_ns = tld_ns.start()?;
+    let _root_ns = root_ns.start()?;
+
+    let resolver = Resolver::new(&network, root_hint).start_with_subject(&PEER)?;
+    let forwarder = Forwarder::new(&network, &resolver)
+        .trust_anchor(&trust_anchor)
+        .start()?;
+    let client = Client::new(&network)?;
+    let dig_settings = *DigSettings::default().recurse().dnssec().tcp();
+
+    // These subdomains are not covered by the arbitrary NSEC3 record chosen by the server. This
+    // will be stable so long as the subdomains, NSEC3 algorithms, iterations, salt, and software
+    // versions are held constant. If the hashed names change, this test is unlikely to break,
+    // since there are so many more NSEC3 records in the chain than probed subdomains below.
+    for subdomain in 'a'..='d' {
+        let response = client.dig(
+            dig_settings,
+            forwarder.ipv4_addr(),
+            RecordType::A,
+            &FQDN::TEST_DOMAIN.push_label(&subdomain.to_string()),
+        )?;
+
+        if subdomain == 'a' {
+            println!("{}", forwarder.logs()?);
+            println!("{}", leaf_ns.logs()?);
+        }
+
+        assert_eq!(response.status, DigStatus::SERVFAIL);
+    }
 
     Ok(())
 }

--- a/conformance/packages/conformance-tests/src/forwarder/dnssec/scenarios/bogus.rs
+++ b/conformance/packages/conformance-tests/src/forwarder/dnssec/scenarios/bogus.rs
@@ -7,7 +7,6 @@ use dns_test::{
 };
 
 #[test]
-#[ignore = "hickory does not correctly reflect validation status in forwarder responses"]
 fn wrong_key() -> Result<()> {
     let network = Network::new()?;
     let sign_settings = SignSettings::default();

--- a/crates/server/src/authority/auth_lookup.rs
+++ b/crates/server/src/authority/auth_lookup.rs
@@ -11,9 +11,6 @@ use std::sync::Arc;
 
 use cfg_if::cfg_if;
 
-#[cfg(feature = "__dnssec")]
-use crate::{authority::DnssecSummary, proto::dnssec::Proof};
-
 use crate::authority::{LookupObject, LookupOptions};
 use crate::proto::rr::{LowerName, Record, RecordSet, RecordType, RrsetRecords};
 
@@ -108,25 +105,6 @@ impl LookupObject for AuthLookup {
     fn take_additionals(&mut self) -> Option<Box<dyn LookupObject>> {
         let additionals = Self::take_additionals(self);
         additionals.map(|a| Box::new(a) as Box<dyn LookupObject>)
-    }
-
-    #[cfg(feature = "__dnssec")]
-    fn dnssec_summary(&self) -> DnssecSummary {
-        let mut all_secure = None;
-        for record in self {
-            match record.proof() {
-                Proof::Secure => {
-                    all_secure.get_or_insert(true);
-                }
-                Proof::Bogus => return DnssecSummary::Bogus,
-                _ => all_secure = Some(false),
-            }
-        }
-
-        match all_secure {
-            Some(true) => DnssecSummary::Secure,
-            _ => DnssecSummary::Insecure,
-        }
     }
 }
 

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -774,11 +774,14 @@ async fn build_forwarded_response(
                 id = request_header.id(),
                 "request disabled recursion, returning REFUSED"
             );
+            response_header.set_response_code(ResponseCode::Refused);
 
-            (
-                Answer::Normal(Box::new(EmptyLookup)),
-                Box::<AuthLookup>::default(),
-            )
+            return LookupSections {
+                answers: Box::new(EmptyLookup),
+                ns: Box::new(EmptyLookup),
+                soa: Box::new(EmptyLookup),
+                additionals: Box::new(EmptyLookup),
+            };
         }
         Ok(l) => (Answer::Normal(l), Box::<AuthLookup>::default()),
         Err(e) if e.is_no_records_found() || e.is_nx_domain() => {

--- a/crates/server/src/store/forwarder/authority.rs
+++ b/crates/server/src/store/forwarder/authority.rs
@@ -215,6 +215,11 @@ impl<P: ConnectionProvider> Authority for ForwardAuthority<P> {
         false
     }
 
+    /// Whether the authority can perform DNSSEC validation
+    fn can_validate_dnssec(&self) -> bool {
+        self.resolver.options().validate
+    }
+
     async fn update(&self, _update: &MessageRequest) -> UpdateResult<bool> {
         Err(ResponseCode::NotImp)
     }

--- a/tests/integration-tests/tests/integration/validating_forwarder_tests.rs
+++ b/tests/integration-tests/tests/integration/validating_forwarder_tests.rs
@@ -270,16 +270,17 @@ async fn setup_client_forwarder(
     trust_anchor.insert(public_key);
     let mut options = ResolverOpts::default();
     options.validate = validate;
-    let authority = ForwardAuthority::builder_tokio(ForwardConfig {
+    let mut authority_builder = ForwardAuthority::builder_tokio(ForwardConfig {
         name_servers: NameServerConfigGroup::from(vec![NameServerConfig::new(
             name_server_addr,
             Protocol::Udp,
         )]),
         options: Some(options),
-    })
-    .with_trust_anchor(Arc::new(trust_anchor))
-    .build()
-    .unwrap();
+    });
+    if validate {
+        authority_builder = authority_builder.with_trust_anchor(Arc::new(trust_anchor));
+    }
+    let authority = authority_builder.build().unwrap();
     let udp_socket = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
     let local_addr = udp_socket.local_addr().unwrap();
     let mut catalog = Catalog::new();

--- a/tests/integration-tests/tests/integration/validating_forwarder_tests.rs
+++ b/tests/integration-tests/tests/integration/validating_forwarder_tests.rs
@@ -85,7 +85,6 @@ async fn query_validate_true_signed_zone_no_soa() {
 }
 
 #[tokio::test]
-#[ignore = "validation failure is not translated into SERVFAIL response"]
 async fn query_validate_true_unsigned_zone_with_soa() {
     subscribe();
 
@@ -102,7 +101,6 @@ async fn query_validate_true_unsigned_zone_with_soa() {
 }
 
 #[tokio::test]
-#[ignore = "validation failure is not translated into SERVFAIL response"]
 async fn query_validate_true_unsigned_zone_no_soa() {
     subscribe();
 


### PR DESCRIPTION
This overrides `can_validate_dnssec()` on `ForwardAuthority`, adds a default implementation of `dnssec_summary()` on `LookupObject`, and makes the recursor and forwarder return `REFUSED` to queries with RD=0. Some additional tests are added, both in the integration tests and conformance tests. This fixes #2428. There may be additional room for hardening the validating forwarder, but I think this addresses the regression from 0.24.