### PR TITLE
Fix key generation script

### DIFF
--- a/tests/test-data/test_configs/dnssec/gen-keys.sh
+++ b/tests/test-data/test_configs/dnssec/gen-keys.sh
@@ -9,7 +9,7 @@ RSA_2048=rsa_2048.pem
 [ -f ${RSA_2048:?} ] || ${OPENSSL:?} genrsa -des3 -out ${RSA_2048:?} 2048
 
 ECDSA_P256=ecdsa_p256.pem
-[ -f ${ECDSA_P256:?} ] || ${OPENSSL:?} ecparam -out ${ECDSA_P256} -name secp256k1 -genkey
+[ -f ${ECDSA_P256:?} ] || ${OPENSSL:?} ecparam -out ${ECDSA_P256} -name prime256v1 -genkey
 
 ECDSA_P384=ecdsa_p384.pem
 [ -f ${ECDSA_P384:?} ] || ${OPENSSL:?} ecparam -out ${ECDSA_P384} -name secp384r1 -genkey


### PR DESCRIPTION
This fixes a key generation script to use the correct curve. The key file itself was already fixed in #2621. See also #2752, which did the same on the 0.24 release branch.