### PR TITLE
Update TLS features used in conformance tests

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -33,8 +33,8 @@ jobs:
       - name: run conformance tests against hickory-dns
         run: just conformance-hickory
 
-      - name: run conformance tests against hickory-dns (with aws-lc-rs)
-        run: just conformance-hickory-aws-lc-rs
+      - name: run conformance tests against hickory-dns (with ring)
+        run: just conformance-hickory-ring
 
       - name: check that all the tests that now pass with hickory-dns are not marked as `#[ignore]`-d
         run: just conformance-ignored

--- a/justfile
+++ b/justfile
@@ -219,7 +219,7 @@ conformance-ignored:
 
     tmpfile="$(mktemp)"
     bash -c '[[ -n "$(git status -s)" ]] && echo "WARNING: uncommitted changes will NOT be tested" || true'
-    ( DNS_TEST_VERBOSE_DOCKER_BUILD=1 DNS_TEST_PEER=unbound DNS_TEST_SUBJECT="hickory {{justfile_directory()}} dnssec-ring" cargo test --manifest-path conformance/Cargo.toml -p conformance-tests --lib -- --ignored || true ) | tee "$tmpfile"
+    ( DNS_TEST_VERBOSE_DOCKER_BUILD=1 DNS_TEST_PEER=unbound DNS_TEST_SUBJECT="hickory {{justfile_directory()}} dnssec-aws-lc-rs" cargo test --manifest-path conformance/Cargo.toml -p conformance-tests --lib -- --ignored || true ) | tee "$tmpfile"
     grep -e 'test result: \(ok\|FAILED\). 0 passed' "$tmpfile" || ( echo "expected ALL tests to fail but at least one passed; the passing tests must be un-#[ignore]-d" && exit 1 )
     bash -c '[[ -n "$(git status -s)" ]] && echo "WARNING: uncommitted changes were NOT tested" || true'
 


### PR DESCRIPTION
This changes `conformance-ignored` to use `aws-lc-rs`, in order to match the `conformance-hickory` recipe. I noticed that we aren't currently running the `conformance-hickory-ring` recipe in CI, so I fixed that as well.