### PR TITLE
Encapsulate type bit maps, save original encoding, and improve fuzzer

### DIFF
--- a/crates/proto/src/dnssec/rdata/nsec.rs
+++ b/crates/proto/src/dnssec/rdata/nsec.rs
@@ -13,7 +13,7 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 
 use crate::error::*;
-use crate::rr::type_bit_map::{decode_type_bit_maps, encode_type_bit_maps};
+use crate::rr::type_bit_map::decode_type_bit_maps;
 use crate::rr::{Name, RData, RecordData, RecordDataDecodable, RecordType, RecordTypeSet};
 use crate::serialize::binary::*;
 
@@ -145,7 +145,9 @@ impl BinEncodable for NSEC {
     fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
         encoder.with_canonical_names(|encoder| {
             self.next_domain_name().emit(encoder)?;
-            encode_type_bit_maps(encoder, &self.type_bit_maps)
+            self.type_bit_maps.emit(encoder)?;
+
+            Ok(())
         })
     }
 }

--- a/crates/proto/src/dnssec/rdata/nsec3.rs
+++ b/crates/proto/src/dnssec/rdata/nsec3.rs
@@ -291,7 +291,7 @@ impl BinEncodable for NSEC3 {
         encoder.emit_vec(self.salt())?;
         encoder.emit(self.next_hashed_owner_name().len() as u8)?;
         encoder.emit_vec(self.next_hashed_owner_name())?;
-        encode_type_bit_maps(encoder, &self.type_bit_maps)?;
+        self.type_bit_maps.emit(encoder)?;
 
         Ok(())
     }

--- a/crates/proto/src/rr/mod.rs
+++ b/crates/proto/src/rr/mod.rs
@@ -18,7 +18,7 @@ pub mod resource;
 mod rr_key;
 mod rr_set;
 pub mod serial_number;
-pub mod type_bit_map;
+pub(crate) mod type_bit_map;
 
 use core::fmt::{Debug, Display};
 
@@ -36,6 +36,7 @@ pub use self::resource::Record;
 pub use self::rr_set::IntoRecordSet;
 pub use self::rr_set::RecordSet;
 pub use self::rr_set::RrsetRecords;
+pub(crate) use self::type_bit_map::RecordTypeSet;
 pub use lower_name::LowerName;
 pub use rr_key::RrKey;
 pub use serial_number::SerialNumber;

--- a/crates/proto/src/rr/rdata/csync.rs
+++ b/crates/proto/src/rr/rdata/csync.rs
@@ -17,7 +17,7 @@ use crate::{
     error::*,
     rr::{
         RData, RecordData, RecordDataDecodable, RecordType, RecordTypeSet,
-        type_bit_map::{decode_type_bit_maps, encode_type_bit_maps},
+        type_bit_map::decode_type_bit_maps,
     },
     serialize::binary::*,
 };
@@ -147,7 +147,7 @@ impl BinEncodable for CSYNC {
     fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
         encoder.emit_u32(self.soa_serial)?;
         encoder.emit_u16(self.flags())?;
-        encode_type_bit_maps(encoder, &self.type_bit_maps)?;
+        self.type_bit_maps.emit(encoder)?;
 
         Ok(())
     }

--- a/crates/proto/src/rr/type_bit_map.rs
+++ b/crates/proto/src/rr/type_bit_map.rs
@@ -15,7 +15,7 @@ use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::vec::Vec;
 
 use crate::error::*;
-use crate::rr::RecordType;
+use crate::rr::{RecordDataDecodable, RecordType};
 use crate::serialize::binary::*;
 
 /// A collection of record types.
@@ -114,125 +114,113 @@ impl BinEncodable for RecordTypeSet {
     }
 }
 
-/// Decodes the array of RecordTypes covered by this NSEC record
-///
-/// # Arguments
-///
-/// * `decoder` - decoder to read from
-/// * `bit_map_len` - the number bytes in the bit map
-///
-/// # Returns
-///
-/// The Array of covered types
-pub(crate) fn decode_type_bit_maps(
-    decoder: &mut BinDecoder<'_>,
-    bit_map_len: Restrict<usize>,
-) -> ProtoResult<RecordTypeSet> {
-    // 3.2.1.  Type Bit Maps Encoding
-    //
-    //  The encoding of the Type Bit Maps field is the same as that used by
-    //  the NSEC RR, described in [RFC4034].  It is explained and clarified
-    //  here for clarity.
-    //
-    //  The RR type space is split into 256 window blocks, each representing
-    //  the low-order 8 bits of the 16-bit RR type space.  Each block that
-    //  has at least one active RR type is encoded using a single octet
-    //  window number (from 0 to 255), a single octet bitmap length (from 1
-    //  to 32) indicating the number of octets used for the bitmap of the
-    //  window block, and up to 32 octets (256 bits) of bitmap.
-    //
-    //  Blocks are present in the NSEC3 RR RDATA in increasing numerical
-    //  order.
-    //
-    //     Type Bit Maps Field = ( Window Block # | Bitmap Length | Bitmap )+
-    //
-    //     where "|" denotes concatenation.
-    //
-    //  Each bitmap encodes the low-order 8 bits of RR types within the
-    //  window block, in network bit order.  The first bit is bit 0.  For
-    //  window block 0, bit 1 corresponds to RR type 1 (A), bit 2 corresponds
-    //  to RR type 2 (NS), and so forth.  For window block 1, bit 1
-    //  corresponds to RR type 257, bit 2 to RR type 258.  If a bit is set to
-    //  1, it indicates that an RRSet of that type is present for the
-    //  original owner name of the NSEC3 RR.  If a bit is set to 0, it
-    //  indicates that no RRSet of that type is present for the original
-    //  owner name of the NSEC3 RR.
-    //
-    //  Since bit 0 in window block 0 refers to the non-existing RR type 0,
-    //  it MUST be set to 0.  After verification, the validator MUST ignore
-    //  the value of bit 0 in window block 0.
-    //
-    //  Bits representing Meta-TYPEs or QTYPEs as specified in Section 3.1 of
-    //  [RFC2929] or within the range reserved for assignment only to QTYPEs
-    //  and Meta-TYPEs MUST be set to 0, since they do not appear in zone
-    //  data.  If encountered, they must be ignored upon reading.
-    //
-    //  Blocks with no types present MUST NOT be included.  Trailing zero
-    //  octets in the bitmap MUST be omitted.  The length of the bitmap of
-    //  each block is determined by the type code with the largest numerical
-    //  value, within that block, among the set of RR types present at the
-    //  original owner name of the NSEC3 RR.  Trailing octets not specified
-    //  MUST be interpreted as zero octets.
-    let mut record_types: BTreeSet<RecordType> = BTreeSet::new();
-    let mut state: BitMapReadState = BitMapReadState::Window;
+impl RecordDataDecodable<'_> for RecordTypeSet {
+    fn read_data(decoder: &mut BinDecoder<'_>, length: Restrict<u16>) -> ProtoResult<Self> {
+        // 3.2.1.  Type Bit Maps Encoding
+        //
+        //  The encoding of the Type Bit Maps field is the same as that used by
+        //  the NSEC RR, described in [RFC4034].  It is explained and clarified
+        //  here for clarity.
+        //
+        //  The RR type space is split into 256 window blocks, each representing
+        //  the low-order 8 bits of the 16-bit RR type space.  Each block that
+        //  has at least one active RR type is encoded using a single octet
+        //  window number (from 0 to 255), a single octet bitmap length (from 1
+        //  to 32) indicating the number of octets used for the bitmap of the
+        //  window block, and up to 32 octets (256 bits) of bitmap.
+        //
+        //  Blocks are present in the NSEC3 RR RDATA in increasing numerical
+        //  order.
+        //
+        //     Type Bit Maps Field = ( Window Block # | Bitmap Length | Bitmap )+
+        //
+        //     where "|" denotes concatenation.
+        //
+        //  Each bitmap encodes the low-order 8 bits of RR types within the
+        //  window block, in network bit order.  The first bit is bit 0.  For
+        //  window block 0, bit 1 corresponds to RR type 1 (A), bit 2 corresponds
+        //  to RR type 2 (NS), and so forth.  For window block 1, bit 1
+        //  corresponds to RR type 257, bit 2 to RR type 258.  If a bit is set to
+        //  1, it indicates that an RRSet of that type is present for the
+        //  original owner name of the NSEC3 RR.  If a bit is set to 0, it
+        //  indicates that no RRSet of that type is present for the original
+        //  owner name of the NSEC3 RR.
+        //
+        //  Since bit 0 in window block 0 refers to the non-existing RR type 0,
+        //  it MUST be set to 0.  After verification, the validator MUST ignore
+        //  the value of bit 0 in window block 0.
+        //
+        //  Bits representing Meta-TYPEs or QTYPEs as specified in Section 3.1 of
+        //  [RFC2929] or within the range reserved for assignment only to QTYPEs
+        //  and Meta-TYPEs MUST be set to 0, since they do not appear in zone
+        //  data.  If encountered, they must be ignored upon reading.
+        //
+        //  Blocks with no types present MUST NOT be included.  Trailing zero
+        //  octets in the bitmap MUST be omitted.  The length of the bitmap of
+        //  each block is determined by the type code with the largest numerical
+        //  value, within that block, among the set of RR types present at the
+        //  original owner name of the NSEC3 RR.  Trailing octets not specified
+        //  MUST be interpreted as zero octets.
+        let mut record_types: BTreeSet<RecordType> = BTreeSet::new();
+        let mut state: BitMapReadState = BitMapReadState::Window;
 
-    let bytes = decoder
-        .read_vec(bit_map_len.unverified(/*bounded over any length of u16*/))?
-        .unverified();
-    // loop through all the bytes in the bitmap
-    for current_byte in bytes.iter() {
-        state = match state {
-            BitMapReadState::Window => BitMapReadState::Len {
-                window: *current_byte,
-            },
-            BitMapReadState::Len { window } => BitMapReadState::RecordType {
-                window,
-                len: Restrict::new(*current_byte),
-                left: Restrict::new(*current_byte),
-            },
-            BitMapReadState::RecordType { window, len, left } => {
-                // window is the Window Block # from above
-                // len is the Bitmap Length
-                // current_byte is the Bitmap
-                let mut bit_map = *current_byte;
+        // loop through all the bytes in the bitmap
+        let bit_map_len = length.unverified();
+        let bytes = decoder.read_vec(bit_map_len as usize)?.unverified();
+        for current_byte in bytes.iter() {
+            state = match state {
+                BitMapReadState::Window => BitMapReadState::Len {
+                    window: *current_byte,
+                },
+                BitMapReadState::Len { window } => BitMapReadState::RecordType {
+                    window,
+                    len: Restrict::new(*current_byte),
+                    left: Restrict::new(*current_byte),
+                },
+                BitMapReadState::RecordType { window, len, left } => {
+                    // window is the Window Block # from above
+                    // len is the Bitmap Length
+                    // current_byte is the Bitmap
+                    let mut bit_map = *current_byte;
 
-                // for all the bits in the current_byte
-                for i in 0..8 {
-                    // if the current_bytes most significant bit is set
-                    if bit_map & 0b1000_0000 == 0b1000_0000 {
-                        // len - left is the block in the bitmap, times 8 for the bits, + the bit in the current_byte
-                        let low_byte: u8 = len
+                    // for all the bits in the current_byte
+                    for i in 0..8 {
+                        // if the current_bytes most significant bit is set
+                        if bit_map & 0b1000_0000 == 0b1000_0000 {
+                            // len - left is the block in the bitmap, times 8 for the bits, + the bit in the current_byte
+                            let low_byte: u8 = len
                             .checked_sub(left.unverified(/*will fail as param in this call if invalid*/))
                             .checked_mul(8)
                             .checked_add(i)
                             .map_err(|_| "block len or left out of bounds in NSEC(3)")?
                             .unverified(/*any u8 is valid at this point*/);
-                        let rr_type: u16 = (u16::from(window) << 8) | u16::from(low_byte);
-                        record_types.insert(RecordType::from(rr_type));
+                            let rr_type: u16 = (u16::from(window) << 8) | u16::from(low_byte);
+                            record_types.insert(RecordType::from(rr_type));
+                        }
+                        // shift left and look at the next bit
+                        bit_map <<= 1;
                     }
-                    // shift left and look at the next bit
-                    bit_map <<= 1;
-                }
 
-                // move to the next section of the bit_map
-                let left = left
-                    .checked_sub(1)
-                    .map_err(|_| ProtoError::from("block left out of bounds in NSEC(3)"))?;
-                if left.unverified(/*comparison is safe*/) == 0 {
-                    // we've exhausted this Window, move to the next
-                    BitMapReadState::Window
-                } else {
-                    // continue reading this Window
-                    BitMapReadState::RecordType { window, len, left }
+                    // move to the next section of the bit_map
+                    let left = left
+                        .checked_sub(1)
+                        .map_err(|_| ProtoError::from("block left out of bounds in NSEC(3)"))?;
+                    if left.unverified(/*comparison is safe*/) == 0 {
+                        // we've exhausted this Window, move to the next
+                        BitMapReadState::Window
+                    } else {
+                        // continue reading this Window
+                        BitMapReadState::RecordType { window, len, left }
+                    }
                 }
-            }
-        };
+            };
+        }
+
+        Ok(Self {
+            types: record_types,
+            original_encoding: Some(bytes),
+        })
     }
-
-    Ok(RecordTypeSet {
-        types: record_types,
-        original_encoding: Some(bytes),
-    })
 }
 
 enum BitMapReadState {
@@ -293,8 +281,9 @@ mod tests {
         let bytes = encoder.into_bytes();
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
-        let restrict = Restrict::new(bytes.len());
-        let read_bit_map = decode_type_bit_maps(&mut decoder, restrict).expect("Decoding error");
+        let restrict = Restrict::new(bytes.len() as u16);
+        let read_bit_map =
+            RecordTypeSet::read_data(&mut decoder, restrict).expect("Decoding error");
         assert_eq!(types, read_bit_map);
     }
 }

--- a/crates/proto/src/rr/type_bit_map.rs
+++ b/crates/proto/src/rr/type_bit_map.rs
@@ -14,18 +14,6 @@ use crate::error::*;
 use crate::rr::RecordType;
 use crate::serialize::binary::*;
 
-enum BitMapReadState {
-    Window,
-    Len {
-        window: u8,
-    },
-    RecordType {
-        window: u8,
-        len: Restrict<u8>,
-        left: Restrict<u8>,
-    },
-}
-
 /// Encode the bit map
 ///
 /// # Arguments
@@ -187,6 +175,18 @@ pub(crate) fn decode_type_bit_maps(
     }
 
     Ok(record_types)
+}
+
+enum BitMapReadState {
+    Window,
+    Len {
+        window: u8,
+    },
+    RecordType {
+        window: u8,
+        len: Restrict<u8>,
+        left: Restrict<u8>,
+    },
 }
 
 #[cfg(test)]

--- a/crates/proto/src/serialize/txt/parse_rdata.rs
+++ b/crates/proto/src/serialize/txt/parse_rdata.rs
@@ -138,6 +138,7 @@ mod tests {
     use crate::dnssec::rdata::DS;
     use crate::rr::domain::Name;
     use crate::rr::rdata::*;
+    use alloc::collections::BTreeSet;
     use core::str::FromStr;
 
     #[test]
@@ -208,7 +209,7 @@ mod tests {
                 123,
                 true,
                 false,
-                vec![RecordType::A, RecordType::NS]
+                BTreeSet::from([RecordType::A, RecordType::NS])
             ))
         );
     }
@@ -224,7 +225,7 @@ mod tests {
                 123,
                 true,
                 false,
-                vec![RecordType::A, RecordType::NS]
+                BTreeSet::from([RecordType::A, RecordType::NS])
             ))
         );
     }

--- a/crates/proto/src/serialize/txt/rdata_parsers/csync.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/csync.rs
@@ -7,8 +7,8 @@
 
 //! CSYNC record for synchronizing information to the parent zone
 
+use alloc::collections::BTreeSet;
 use alloc::string::ToString;
-use alloc::vec::Vec;
 use core::str::FromStr;
 
 use crate::rr::RecordType;
@@ -35,11 +35,11 @@ pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResu
     let immediate: bool = flags & 0b0000_0001 == 0b0000_0001;
     let soa_minimum: bool = flags & 0b0000_0010 == 0b0000_0010;
 
-    let mut record_types: Vec<RecordType> = Vec::new();
+    let mut record_types: BTreeSet<RecordType> = BTreeSet::new();
 
     for token in tokens {
         let record_type: RecordType = RecordType::from_str(token)?;
-        record_types.push(record_type);
+        record_types.insert(record_type);
     }
 
     Ok(CSYNC::new(soa_serial, immediate, soa_minimum, record_types))
@@ -51,7 +51,7 @@ fn test_parsing() {
 
     assert_eq!(
         parse(vec!["123", "3", "NS"].into_iter()).expect("failed to parse CSYNC"),
-        CSYNC::new(123, true, true, vec![RecordType::NS]),
+        CSYNC::new(123, true, true, BTreeSet::from([RecordType::NS])),
     );
 }
 

--- a/crates/server/src/store/in_memory/authority.rs
+++ b/crates/server/src/store/in_memory/authority.rs
@@ -8,7 +8,7 @@
 //! In-memory authority
 
 #[cfg(feature = "__dnssec")]
-use std::collections::{HashMap, hash_map::Entry};
+use std::collections::{BTreeSet, HashMap, hash_map::Entry};
 #[cfg(all(feature = "__dnssec", feature = "testing"))]
 use std::ops::Deref;
 use std::{
@@ -705,12 +705,12 @@ impl InnerInMemory {
         let mut records: Vec<Record> = vec![];
 
         {
-            let mut nsec_info: Option<(&Name, Vec<RecordType>)> = None;
+            let mut nsec_info: Option<(&Name, BTreeSet<RecordType>)> = None;
             for key in self.records.keys() {
                 match &mut nsec_info {
-                    None => nsec_info = Some((&key.name, vec![key.record_type])),
+                    None => nsec_info = Some((&key.name, BTreeSet::from([key.record_type]))),
                     Some((name, vec)) if LowerName::new(name) == key.name => {
-                        vec.push(key.record_type);
+                        vec.insert(key.record_type);
                     }
                     Some((name, vec)) => {
                         // names aren't equal, create the NSEC record
@@ -719,7 +719,7 @@ impl InnerInMemory {
                         records.push(record.into_record_of_rdata());
 
                         // new record...
-                        nsec_info = Some((&key.name, vec![key.record_type]))
+                        nsec_info = Some((&key.name, BTreeSet::from([key.record_type])))
                     }
                 }
             }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -202,6 +202,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,7 +249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -364,6 +370,7 @@ version = "0.0.0"
 dependencies = [
  "hickory-proto",
  "libfuzzer-sys",
+ "pretty_assertions",
 ]
 
 [[package]]
@@ -691,6 +698,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,7 +817,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1174,6 +1191,12 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +61,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dabb68eb3a7aa08b46fddfd59a3d55c978243557a90ab804769f7e20e67d2b01"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbe221bbf523b625a4dd8585c7f38166e31167ec2ca98051dbcb4c3b6e825d2"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +97,29 @@ dependencies = [
  "object",
  "rustc-demangle",
  "windows-targets",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+ "which",
 ]
 
 [[package]]
@@ -96,16 +152,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "displaydoc"
@@ -117,6 +211,18 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "enum-as-inner"
@@ -131,6 +237,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +254,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -198,6 +320,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +337,8 @@ version = "0.25.0"
 dependencies = [
  "async-recursion",
  "async-trait",
+ "aws-lc-rs",
+ "bitflags",
  "cfg-if",
  "data-encoding",
  "enum-as-inner",
@@ -219,7 +349,9 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand",
+ "rustls-pki-types",
  "thiserror",
+ "time",
  "tinyvec",
  "tokio",
  "tracing",
@@ -232,6 +364,15 @@ version = "0.0.0"
 dependencies = [
  "hickory-proto",
  "libfuzzer-sys",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -380,6 +521,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +537,18 @@ checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -405,16 +567,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
+name = "log"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -433,8 +623,24 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "object"
@@ -470,12 +676,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy 0.7.35",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -528,10 +750,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "serde"
@@ -581,7 +857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -633,6 +909,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,7 +965,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -722,6 +1017,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,10 +1061,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
@@ -938,6 +1260,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zerovec"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-hickory-proto = { path = "../crates/proto", features = ["std"] }
+hickory-proto = { path = "../crates/proto", features = ["std", "dnssec-aws-lc-rs"] }
 
 [[bin]]
 name = "message"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,6 +12,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 hickory-proto = { path = "../crates/proto", features = ["std", "dnssec-aws-lc-rs"] }
+pretty_assertions = "1.4.1"
 
 [[bin]]
 name = "message"

--- a/fuzz/fuzz_targets/message.rs
+++ b/fuzz/fuzz_targets/message.rs
@@ -3,7 +3,7 @@ use libfuzzer_sys::fuzz_target;
 
 use hickory_proto::{
     op::Message,
-    rr::{Record, RecordType},
+    rr::Record,
     serialize::binary::{BinDecodable, BinEncodable},
 };
 
@@ -85,13 +85,6 @@ fn record_equal(record1: &Record, record2: &Record) -> bool {
 
     if record1.record_type() != record2.record_type() {
         return false;
-    }
-
-    // FIXME: evaluate why these don't work
-    // record types we're skipping for now
-    match record1.record_type() {
-        RecordType::CSYNC => return true,
-        _ => (),
     }
 
     // if the record data matches, we're fine

--- a/fuzz/fuzz_targets/message.rs
+++ b/fuzz/fuzz_targets/message.rs
@@ -1,5 +1,6 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
+use pretty_assertions::assert_eq;
 
 use hickory_proto::{
     op::Message,
@@ -13,14 +14,6 @@ fuzz_target!(|data: &[u8]| {
         match Message::from_bytes(&reencoded) {
             Ok(reparsed) => {
                 if !messages_equal(&original, &reparsed) {
-                    for (m, r) in format!("{:#?}", original)
-                        .lines()
-                        .zip(format!("{:#?}", reparsed).lines())
-                    {
-                        if m != r {
-                            println!("{} -> {}", m, r);
-                        }
-                    }
                     assert_eq!(original, reparsed);
                 }
             }


### PR DESCRIPTION
This PR encapsulates type bit maps handling in a new struct. This stores record types in a sorted data structure, and saves the original encoding, if available, to be reused when emitting the record again.

In the fuzzer, `CSYNC` records are no longer ignored, and all DNSSEC records are now included, thanks to enabling the `dnssec-aws-lc-rs` Cargo feature. I replaced the line-based comparison printed upon failure with the `pretty_assertions` crate, which also provides context and ANSI color codes.

I've been running the fuzzer for about half an hour with this fix, and so far I haven't found any more round trip issues.

This closes #2815.