### PR TITLE
Add test for handling of unknown record types

### DIFF
--- a/conformance/Cargo.lock
+++ b/conformance/Cargo.lock
@@ -167,6 +167,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "ctrlc",
+ "hex",
  "lazy_static",
  "minijinja",
  "pretty_assertions",

--- a/conformance/packages/conformance-tests/src/resolver/dns.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns.rs
@@ -1,5 +1,6 @@
 //! plain DNS functionality
 
 mod rfc1035;
+mod rfc3597;
 mod rfc8906;
 mod scenarios;

--- a/conformance/packages/conformance-tests/src/resolver/dns/rfc3597.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/rfc3597.rs
@@ -1,0 +1,55 @@
+use dns_test::{
+    FQDN, Network, PEER, Resolver, Result,
+    client::{Client, DigSettings},
+    name_server::{Graph, NameServer, Sign},
+    record::{Record, RecordType, UnknownRdata},
+};
+
+/// See RFC 3597, section 3, "Transparency":
+///
+/// "To enable new RR types to be deployed without server changes, name servers and resolvers MUST
+/// handle RRs of unknown type transparently. That is, they must treat the RDATA section of such RRs
+/// as unstructured binary data, storing and transmitting it without change."
+#[test]
+fn unknown_type_transparency() -> Result<()> {
+    let network = Network::new()?;
+
+    let mut leaf_ns = NameServer::new(&PEER, FQDN::TEST_DOMAIN, &network)?;
+    leaf_ns.add(Record::Unknown(UnknownRdata {
+        zone: FQDN::TEST_DOMAIN,
+        ttl: 86400,
+        r#type: 1234,
+        rdata: [0xde, 0xad, 0xbe, 0xef].to_vec(),
+    }));
+    println!("{}", leaf_ns.zone_file());
+
+    let Graph {
+        nameservers: _nameservers,
+        root,
+        ..
+    } = Graph::build(leaf_ns, Sign::No)?;
+
+    let resolver = Resolver::new(&network, root).start()?;
+    let client = Client::new(&network)?;
+
+    let settings = *DigSettings::default().recurse();
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::Unknown(1234),
+        &FQDN::TEST_DOMAIN,
+    )?;
+    dbg!(&output);
+
+    assert!(output.status.is_noerror(), "{:?}", output.status);
+
+    let [answer] = output.answer.try_into().unwrap();
+    let Record::Unknown(record) = answer else {
+        panic!("unexpected record type: {answer:?}");
+    };
+    assert_eq!(record.zone, FQDN::TEST_DOMAIN);
+    assert_eq!(record.r#type, 1234);
+    assert_eq!(record.rdata, [0xde, 0xad, 0xbe, 0xef]);
+
+    Ok(())
+}

--- a/conformance/packages/dns-test/Cargo.toml
+++ b/conformance/packages/dns-test/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 base64 = "0.22.1"
+hex = "0.4.3"
 lazy_static = "1.4.0"
 minijinja = "2"
 serde = { version = "1.0.196", features = ["derive"] }

--- a/tests/e2e-tests/Cargo.lock
+++ b/tests/e2e-tests/Cargo.lock
@@ -133,6 +133,7 @@ name = "dns-test"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "hex",
  "lazy_static",
  "minijinja",
  "serde",

--- a/tests/ede-dot-com/Cargo.lock
+++ b/tests/ede-dot-com/Cargo.lock
@@ -136,6 +136,7 @@ name = "dns-test"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "hex",
  "lazy_static",
  "minijinja",
  "serde",


### PR DESCRIPTION
This extends `dns-test`'s support for records of unknown types, and adds a test checking that resolvers can transparently handle a record with an unknown record type.