### PR TITLE
Fuzzer for preservation of RDATA

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dns/rfc3597.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/rfc3597.rs
@@ -2,7 +2,8 @@ use dns_test::{
     FQDN, Network, PEER, Resolver, Result,
     client::{Client, DigSettings},
     name_server::{Graph, NameServer, Sign},
-    record::{Record, RecordType, UnknownRdata},
+    record::{CAA, Record, RecordType, UnknownRdata},
+    zone_file::SignSettings,
 };
 
 /// See RFC 3597, section 3, "Transparency":
@@ -50,6 +51,65 @@ fn unknown_type_transparency() -> Result<()> {
     assert_eq!(record.zone, FQDN::TEST_DOMAIN);
     assert_eq!(record.r#type, 1234);
     assert_eq!(record.rdata, [0xde, 0xad, 0xbe, 0xef]);
+
+    Ok(())
+}
+
+/// See RFC 3597, section 3, "Transparency":
+///
+/// "To ensure the correct operation of ... the DNSSEC canonical form (section 7) when an RR type is
+/// known to some but not all of the servers involved, servers MUST also exactly preserve the RDATA
+/// of RRs of known type, except for changes due to compression or decompression where allowed by
+/// section 4 of this memo."
+#[test]
+#[ignore = "hickory adds a semicolon if issue-value is empty"]
+fn caa_issue_empty_value_dnssec() -> Result<()> {
+    let network = Network::new()?;
+
+    let mut leaf_ns = NameServer::new(&PEER, FQDN::TEST_DOMAIN, &network)?;
+    leaf_ns.add(Record::CAA(CAA {
+        zone: FQDN::TEST_DOMAIN,
+        ttl: 86400,
+        flags: 0,
+        tag: "issue".to_string(),
+        value: "".to_string(),
+    }));
+
+    let settings = SignSettings::default();
+    let Graph {
+        nameservers: _nameservers,
+        root,
+        trust_anchor,
+    } = Graph::build(leaf_ns, Sign::Yes { settings })?;
+    let trust_anchor = trust_anchor.unwrap();
+
+    let resolver = Resolver::new(&network, root)
+        .trust_anchor(&trust_anchor)
+        .start()?;
+    let client = Client::new(&network)?;
+
+    let settings = *DigSettings::default().dnssec().recurse();
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::CAA,
+        &FQDN::TEST_DOMAIN,
+    )?;
+    dbg!(&output);
+
+    assert!(output.status.is_noerror(), "{:?}", output.status);
+    assert!(output.flags.authenticated_data);
+
+    let caa = output
+        .answer
+        .into_iter()
+        .filter_map(|record| record.try_into_caa().ok())
+        .next()
+        .expect("did not find CAA record in response");
+    assert_eq!(caa.zone, FQDN::TEST_DOMAIN);
+    assert_eq!(caa.flags, 0);
+    assert_eq!(caa.tag, "issue");
+    assert_eq!(caa.value, "");
 
     Ok(())
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,14 +20,9 @@ path = "fuzz_targets/message.rs"
 test = false
 doc = false
 
-# [[bin]]
-# name = "name"
-# path = "fuzz_targets/name.rs"
-# test = false
-# doc = false
-
-# [[bin]]
-# name = "rdata"
-# path = "fuzz_targets/rdata.rs"
-# test = false
-# doc = false
+[[bin]]
+name = "preserve_rdata"
+path = "fuzz_targets/preserve_rdata.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/preserve_rdata.rs
+++ b/fuzz/fuzz_targets/preserve_rdata.rs
@@ -1,0 +1,285 @@
+#![no_main]
+
+//! This fuzzer checks that, if a DNS message can be decoded, it is re-encoded in a way that
+//! preserves RDATA sections of records as appropriate. Names embedded in the RDATA section of some
+//! well-known record types may be compressed or decompressed, but otherwise the RDATA should be
+//! preserved byte-for-byte. See RFC 3597, section 3:
+//!
+//! "... servers MUST also exactly preserve the RDATA of RRs of known type, except for changes due
+//! to compression or decompression where allowed by section 4 of this memo. In particular, the
+//! character case of domain names that are not subject to compression MUST be preserved."
+
+use std::fmt::Debug;
+
+use libfuzzer_sys::fuzz_target;
+
+use hickory_proto::{
+    op::Message,
+    serialize::binary::{BinDecodable, BinEncodable},
+};
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(message) = Message::from_bytes(data) {
+        let reencoded = message.to_bytes().unwrap();
+        compare(data, &message, &reencoded);
+    }
+});
+
+fn compare(original: &[u8], message: &Message, reencoded: &[u8]) {
+    assert_eq!(original[4..6], reencoded[4..6]);
+    let query_count = u16::from_be_bytes(reencoded[4..6].try_into().unwrap());
+    assert_eq!(original[6..8], reencoded[6..8]);
+    let answer_count = u16::from_be_bytes(reencoded[6..8].try_into().unwrap());
+    assert_eq!(original[8..10], reencoded[8..10]);
+    let name_server_count = u16::from_be_bytes(reencoded[8..10].try_into().unwrap());
+    assert_eq!(original[10..12], reencoded[10..12]);
+    let additional_records_count = u16::from_be_bytes(reencoded[10..12].try_into().unwrap());
+
+    let rr_count = answer_count + name_server_count + additional_records_count;
+    let original_rrs = split_rrs(original, query_count, rr_count);
+    let reencoded_rrs = split_rrs(reencoded, query_count, rr_count);
+
+    for (original_rr, reencoded_rr) in original_rrs.into_iter().zip(reencoded_rrs.into_iter()) {
+        assert_eq!(original_rr.r#type, reencoded_rr.r#type);
+        if let Err(()) = compare_rr(original, original_rr, reencoded, reencoded_rr) {
+            println!("Parsed message: {message:?}");
+            println!("Record type: {}", original_rr.r#type);
+            println!("Original: {:02x?}", &original_rr.rdata);
+            println!("Re-encoded: {:02x?}", &reencoded_rr.rdata);
+            panic!("record RDATA was not preserved when decoding and re-encoding");
+        }
+    }
+}
+
+fn compare_rr(
+    original: &[u8],
+    original_rr: Record<'_>,
+    reencoded: &[u8],
+    reencoded_rr: Record<'_>,
+) -> Result<(), ()> {
+    if original_rr.rdata == reencoded_rr.rdata {
+        return Ok(());
+    }
+    match original_rr.r#type {
+        record_types::NS
+        | record_types::MD
+        | record_types::MF
+        | record_types::CNAME
+        | record_types::MB
+        | record_types::MG
+        | record_types::MR
+        | record_types::PTR => {
+            // RDATA consists of a single `<domain-name>`.
+            let original_decompressed = Name::decompress(original_rr.rdata, original);
+            let reencoded_decompressed = Name::decompress(reencoded_rr.rdata, reencoded);
+            if original_decompressed == reencoded_decompressed {
+                return Ok(());
+            } else {
+                return Err(());
+            }
+        }
+        record_types::SOA => {
+            // RDATA consists of seven different fields.
+            let original_decompressed = Soa::decompress(original_rr.rdata, original);
+            let reencoded_decompressed = Soa::decompress(reencoded_rr.rdata, reencoded);
+            if original_decompressed == reencoded_decompressed {
+                return Ok(());
+            } else {
+                return Err(());
+            }
+        }
+        record_types::MINFO => {
+            // RDATA consists of two `<domain-name>`s.
+            let original_decompressed = Minfo::decompress(original_rr.rdata, original);
+            let reencoded_decompressed = Minfo::decompress(reencoded_rr.rdata, reencoded);
+            if original_decompressed == reencoded_decompressed {
+                return Ok(());
+            } else {
+                return Err(());
+            }
+        }
+        record_types::MX => {
+            // RDATA consists of a 16-bit integer and a `<domain-name>`.
+            let original_decompressed = Mx::decompress(original_rr.rdata, original);
+            let reencoded_decompressed = Mx::decompress(reencoded_rr.rdata, reencoded);
+            if original_decompressed == reencoded_decompressed {
+                return Ok(());
+            } else {
+                return Err(());
+            }
+        }
+        record_types::OPT => {
+            // Ignore OPT records because they are reconstructed hop-by-hop, not passed through
+            // transparently.
+            return Ok(());
+        }
+        _ => return Err(()),
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Record<'a> {
+    r#type: u16,
+    rdata: &'a [u8],
+}
+
+/// Walks through a DNS message and returns slices spanning each resource record in the main three
+/// sections.
+fn split_rrs(buffer: &[u8], query_count: u16, rr_count: u16) -> Vec<Record<'_>> {
+    let mut offset = 12;
+
+    // Skip over the question section.
+    for _ in 0..query_count {
+        offset += name_length(&buffer[offset..]); // QNAME
+        offset += 2; // QTYPE
+        offset += 2; // QCLASS
+    }
+
+    let mut output = Vec::new();
+    for _ in 0..rr_count {
+        offset += name_length(&buffer[offset..]); // NAME
+
+        // TYPE
+        let r#type = u16::from_be_bytes(buffer[offset..offset + 2].try_into().unwrap());
+        offset += 2;
+
+        offset += 2; // CLASS
+
+        offset += 4; // TTL
+
+        // RDLENGTH
+        let rdlength = u16::from_be_bytes(buffer[offset..offset + 2].try_into().unwrap());
+        offset += 2;
+
+        // RDATA
+        let rdata = &buffer[offset..offset + rdlength as usize];
+        offset += rdlength as usize;
+
+        output.push(Record { r#type, rdata });
+    }
+
+    output
+}
+
+const LABEL_TYPE_MASK: u8 = 0b1100_0000;
+const COMPRESSED_LABEL_TYPE: u8 = 0b1100_0000;
+
+/// Determines the encoded length of a name inside a DNS message.
+fn name_length(input: &[u8]) -> usize {
+    let mut offset = 0;
+
+    while input[offset] != 0 && input[offset] & LABEL_TYPE_MASK != COMPRESSED_LABEL_TYPE {
+        let length = input[offset];
+        offset += 1 + length as usize;
+    }
+
+    offset + 1
+}
+
+/// A decompressed domain name.
+#[derive(Debug, PartialEq, Eq)]
+struct Name(Vec<u8>);
+
+impl Decompressible for Name {
+    /// Decompress a name in a DNS message.
+    fn decompress(compressed_name: &[u8], message: &[u8]) -> Self {
+        let mut output = Vec::with_capacity(compressed_name.len());
+        let mut buffer = compressed_name;
+        loop {
+            if buffer[0] & LABEL_TYPE_MASK == COMPRESSED_LABEL_TYPE {
+                let offset = (buffer[0] & !LABEL_TYPE_MASK) as usize;
+                buffer = &message[offset..];
+            } else {
+                let length = (buffer[0] & !LABEL_TYPE_MASK) as usize;
+                output.extend_from_slice(&buffer[0..length + 1]);
+                if length == 0 {
+                    return Self(output);
+                }
+                buffer = &buffer[length + 1..];
+            }
+        }
+    }
+}
+
+/// `RDATA` for a `MINFO` record, with decompressed names.
+#[derive(Debug, PartialEq, Eq)]
+struct Minfo {
+    rmailbx: Name,
+    emailbx: Name,
+}
+
+impl Decompressible for Minfo {
+    /// Decompress a MINFO RDATA.
+    fn decompress(compressed_rdata: &[u8], message: &[u8]) -> Self {
+        let emailbx_offset = name_length(compressed_rdata);
+        let rmailbx = Name::decompress(compressed_rdata, message);
+        let emailbx = Name::decompress(&compressed_rdata[emailbx_offset..], message);
+
+        Minfo { rmailbx, emailbx }
+    }
+}
+
+/// `RDATA` for a `MX` record, with a decompressed name.
+#[derive(Debug, PartialEq, Eq)]
+struct Mx {
+    preference: [u8; 2],
+    exchange: Name,
+}
+
+impl Decompressible for Mx {
+    fn decompress(input: &[u8], message: &[u8]) -> Self {
+        let preference = input[0..2].try_into().unwrap();
+        let exchange = Name::decompress(&input[2..], message);
+        Self {
+            preference,
+            exchange,
+        }
+    }
+}
+
+/// `RDATA` for a `SOA` record, with decompressed names.
+#[derive(Debug, PartialEq, Eq)]
+struct Soa {
+    mname: Name,
+    rname: Name,
+    rest: Vec<u8>,
+}
+
+impl Decompressible for Soa {
+    /// Decompress a SOA RDATA.
+    fn decompress(compressed_rdata: &[u8], message: &[u8]) -> Self {
+        let rname_offset = name_length(compressed_rdata);
+        let serial_offset = rname_offset + name_length(&compressed_rdata[rname_offset..]);
+
+        let mname = Name::decompress(compressed_rdata, message);
+        let rname = Name::decompress(&compressed_rdata[rname_offset..], message);
+
+        let rest = compressed_rdata[serial_offset..].to_vec();
+
+        Soa { mname, rname, rest }
+    }
+}
+
+/// Any part of a message containing names that can be decompressed, and then compared.
+trait Decompressible: Debug + PartialEq + Eq {
+    /// Decompress one portion of a message, and return some representation of it.
+    ///
+    /// The second argument is the entire DNS message. Compressed names will refer to byte offsets
+    /// within this message.
+    fn decompress(input: &[u8], message: &[u8]) -> Self;
+}
+
+mod record_types {
+    pub(super) const NS: u16 = 2;
+    pub(super) const MD: u16 = 3;
+    pub(super) const MF: u16 = 4;
+    pub(super) const CNAME: u16 = 5;
+    pub(super) const SOA: u16 = 6;
+    pub(super) const MB: u16 = 7;
+    pub(super) const MG: u16 = 8;
+    pub(super) const MR: u16 = 9;
+    pub(super) const PTR: u16 = 12;
+    pub(super) const MINFO: u16 = 14;
+    pub(super) const MX: u16 = 15;
+    pub(super) const OPT: u16 = 41;
+}


### PR DESCRIPTION
This adds a new fuzzer, and one test for a bug discovered by it, focused on the following requirement from [RFC 3597](https://datatracker.ietf.org/doc/html/rfc3597#section-3).

>    To ensure the correct operation of equality comparison ([section 6](https://datatracker.ietf.org/doc/html/rfc3597#section-6))
>    and of the DNSSEC canonical form ([section 7](https://datatracker.ietf.org/doc/html/rfc3597#section-7)) when an RR type is known
>    to some but not all of the servers involved, servers MUST also
>    exactly preserve the RDATA of RRs of known type, except for changes
>    due to compression or decompression where allowed by [section 4](https://datatracker.ietf.org/doc/html/rfc3597#section-4) of
>    this memo.  In particular, the character case of domain names that
>    are not subject to compression MUST be preserved.

The fuzzer parses its input as a `Message`, then re-encodes the message again. It does its own parsing of both byte strings to split them up into resource records. For well-known record types that are allowed to use compression in the RDATA, names are decompressed, and equivalent records are reassembled. In either case, the original and re-encoded record byte arrays are compared to check for equality. As noted above, if the data changes while round-tripping through Hickory DNS's internal representation, this can invalidate DNSSEC signatures over the data.

The new conformance test illustrates this impact, on `CAA 0 issue ""` being transformed into `CAA 0 issue ";"`. I implemented basic CAA record support in `dns-test` to enable this.