### PR TITLE
Remove redundant `just std` from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,8 +190,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: just std
-        run: just std
+      - name: just no-default-features
+        run: just no-default-features
 
       - name: just build-bench
         if: contains( matrix.version, 'nightly' )

--- a/justfile
+++ b/justfile
@@ -27,10 +27,6 @@ all-features: (default "--all-features")
 # Check, build, and test all crates with no-default-features
 no-default-features: (default "--no-default-features" "--ignore=\\{hickory-compatibility\\}")
 
-# Check, build, and test all crates with no-default-features, but with std features enabled
-std: (default "--no-default-features" "--ignore=\\{hickory-compatibility,hickory-proto\\}")
-    cargo {{MSRV}} test --locked --package hickory-proto --no-default-features --features="std"
-
 # Check, build, and test all crates with tls-aws-lc-rs enabled
 tls-aws-lc-rs: (default "--features=tls-aws-lc-rs" "--ignore=\\{hickory-compatibility,test-support\\}")
 


### PR DESCRIPTION
With the latest no_std changes, building proto with `no-default-features` is possible again.
This resets the justfile and the test.yml accordingly.