### PR TITLE
Rewrite Dockerfile with cargo-chef

### DIFF
--- a/conformance/packages/dns-test/src/docker/hickory.Dockerfile
+++ b/conformance/packages/dns-test/src/docker/hickory.Dockerfile
@@ -1,23 +1,39 @@
-FROM rust:1-slim-bookworm
-
+FROM rust:1-slim-bookworm AS chef
+ENV CARGO_INCREMENTAL=0
+ENV CARGO_PROFILE_DEV_DEBUG=0
+ENV CARGO_PROFILE_DEV_STRIP=true
+RUN cargo install cargo-chef --version 0.1.71 --profile dev
 ARG DNSSEC_FEATURE=dnssec-ring
-
-# ldns-utils = ldns-{key2ds,keygen,signzone}
-RUN apt-get update && \
-    apt-get install -y \
-        ldnsutils \
-        bind9-utils \
-        tshark \
-        libssl-dev \
-        pkg-config
 
 # `dns-test` will invoke `docker build` from a temporary directory that contains
 # a clone of the hickory repository. `./src` here refers to that clone; not to
 # any directory inside the `hickory-dns` repository
+
+FROM chef AS planner
 COPY ./src /usr/src/hickory
-RUN --mount=type=cache,target=/usr/src/hickory/target \
-    cargo build --manifest-path /usr/src/hickory/Cargo.toml -p hickory-dns --features recursor,$DNSSEC_FEATURE && \
-    cargo build --manifest-path /usr/src/hickory/Cargo.toml --bin dns --features h3-aws-lc-rs,https-aws-lc-rs && \
-    cp /usr/src/hickory/target/debug/hickory-dns /usr/bin/ && \
-    cp /usr/src/hickory/target/debug/dns /usr/bin/
+WORKDIR /usr/src/hickory
+RUN cargo chef prepare
+
+FROM chef AS builder
+COPY --from=planner /usr/src/hickory/recipe.json /usr/src/hickory/recipe.json
+WORKDIR /usr/src/hickory
+RUN cargo chef cook -p hickory-dns --bin hickory-dns --features recursor,$DNSSEC_FEATURE && \
+    cargo chef cook -p hickory-util --bin dns --features h3-aws-lc-rs,https-aws-lc-rs
+COPY ./src /usr/src/hickory
+RUN cargo build -p hickory-dns --bin hickory-dns --features recursor,$DNSSEC_FEATURE && \
+    cargo build -p hickory-util --bin dns --features h3-aws-lc-rs,https-aws-lc-rs
+
+FROM debian:bookworm-slim AS final
+# ldns-utils = ldns-{key2ds,keygen,signzone}
+RUN apt-get update && \
+    apt-get install -y \
+    ldnsutils \
+    bind9-utils \
+    tshark \
+    openssl \
+    libssl-dev \
+    pkg-config
+
+COPY --from=builder /usr/src/hickory/target/debug/hickory-dns /usr/bin/
+COPY --from=builder /usr/src/hickory/target/debug/dns /usr/bin/
 ENV RUST_LOG=debug

--- a/conformance/packages/dns-test/src/docker/hickory.Dockerfile
+++ b/conformance/packages/dns-test/src/docker/hickory.Dockerfile
@@ -30,9 +30,7 @@ RUN apt-get update && \
     ldnsutils \
     bind9-utils \
     tshark \
-    openssl \
-    libssl-dev \
-    pkg-config
+    openssl
 
 COPY --from=builder /usr/src/hickory/target/debug/hickory-dns /usr/bin/
 COPY --from=builder /usr/src/hickory/target/debug/dns /usr/bin/

--- a/conformance/packages/dns-test/src/docker/hickory.Dockerfile
+++ b/conformance/packages/dns-test/src/docker/hickory.Dockerfile
@@ -3,7 +3,7 @@ ENV CARGO_INCREMENTAL=0
 ENV CARGO_PROFILE_DEV_DEBUG=0
 ENV CARGO_PROFILE_DEV_STRIP=true
 RUN cargo install cargo-chef --version 0.1.71 --profile dev
-ARG DNSSEC_FEATURE=dnssec-ring
+ARG DNSSEC_FEATURE=dnssec-aws-lc-rs
 
 # `dns-test` will invoke `docker build` from a temporary directory that contains
 # a clone of the hickory repository. `./src` here refers to that clone; not to

--- a/conformance/packages/dns-test/src/docker/hickory.Dockerfile
+++ b/conformance/packages/dns-test/src/docker/hickory.Dockerfile
@@ -24,7 +24,14 @@ RUN cargo build -p hickory-dns --bin hickory-dns --features recursor,$DNSSEC_FEA
     cargo build -p hickory-util --bin dns --features h3-aws-lc-rs,https-aws-lc-rs
 
 FROM debian:bookworm-slim AS final
-# ldns-utils = ldns-{key2ds,keygen,signzone}
+# - ldnsutils is needed for ldns-keygen, ldns-signzone, and ldns-key2dns. These
+#   are used to sign zones in name server tests, though the signed zone is later
+#   discarded, because Hickory DNS does not yet support serving signed zones.
+# - bind9-utils is needed for dnssec-signzone, which is used to sign zones using
+#   NSEC3 Opt-Out.
+# - tshark is needed for packet captures.
+# - openssl is needed to generate a keypair to be used in Hickory DNS's name
+#   server configuration.
 RUN apt-get update && \
     apt-get install -y \
     ldnsutils \


### PR DESCRIPTION
This rewrites the Dockerfile used for Hickory DNS in conformance tests. It splits it into a multi-stage build, and uses `cargo-chef` to split building dependencies and building the final binary into separate image layers. This will allow the layer for building the dependencies to be reused in most situation, and it will also allow running `apt-get install` from the final stage in parallel with compilation in the earlier stages.

I also removed a cache mount for the target directory. This was not effective previously. I think this was likely because only the target directory was cached, and not the Cargo registry. ~~I stopped building the `dns` binary, since it was not used.~~ Note that `rust:1-slim-bookworm` includes the `openssl` CLI, but `debian:bookworm-slim` does not, so I had to additionally install that in the final stage. This is used for key generation when setting up configuration at runtime. I set some Cargo environment variables as well, to reduce binary size, and thus conserve cache space.

Edit: Nevermind, the `dns` binary is used in `e2e-tests`.