### PR TITLE
Use GitHub Actions cache backend for Docker

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -13,6 +13,8 @@ jobs:
   everything:
     # host is irrelevant because everything will run in Docker containers
     runs-on: ubuntu-latest
+    env:
+      DNS_TEST_DOCKER_CACHE_GHA: 1
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -20,6 +22,15 @@ jobs:
           toolchain: stable
           components: clippy, rustfmt
       - uses: extractions/setup-just@v3
+      # Install the `docker-container` build driver. The GitHub Actions cache
+      # backend is supported with this driver, but not the default `docker`
+      # driver. Additionally, make `docker build` an alias to
+      # `docker buildx build`.
+      - uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+          use: true
+          install: true
 
       - name: run test-framework tests
         run: just conformance-framework

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -31,6 +31,11 @@ jobs:
           driver: docker-container
           use: true
           install: true
+      # Expose the GitHub runtime via environment variables
+      # (`ACTIONS_RUNTIME_TOKEN` and `ACTIONS_RUNTIME_URL`). This is needed by
+      # the `gha` cache backend. These values are normally only available to
+      # reusable workflows, not shell commands.
+      - uses: crazy-max/ghaction-github-runtime@v3
 
       - name: run test-framework tests
         run: just conformance-framework

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -46,6 +46,10 @@ $ DNS_TEST_SUBJECT="hickory https://github.com/hickory-dns/hickory-dns" cargo ru
 
 - `DNS_TEST_SKIP_DOCKER_BUILD`. Setting this variable skips running `docker build`. This should only be used if containers have been built recently.
 
+- `DNS_TEST_DOCKER_CACHE_GHA`. Setting this variable enables passing
+  `--cache-from` and `--cache-to` arguments to `docker build`, using the GitHub
+  Actions cache backend.
+
 ### Automatic clean-up
 
 `dns-test` has been designed to clean up, that is remove, the Docker containers and Docker networks that it creates.

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -40,7 +40,8 @@ $ DNS_TEST_SUBJECT="hickory https://github.com/hickory-dns/hickory-dns" cargo ru
 
 - `DNS_TEST_SUBJECT`. This variable controls what the `dns_test::subject` function returns. The variable can contain one of these values:
   - `unbound`
-  - `hickory $REPOSITORY`. where `$REPOSITORY` is a placeholder for a git repository. Examples values for `$REPOSITORY`: `https://github.com/hickory-dns/hickory-dns`; `/home/user/git-repos/hickory-dns`. NOTE: when using a local repository, changes that have not been committed, regardless of whether they are staged or not, will **not** be included in the `hickory-dns` build.
+  - `bind`
+  - `hickory $REPOSITORY $DNSSEC_FEATURE`. where `$REPOSITORY` is a placeholder for a git repository, and `$DNSSEC_FEATURE` is `dnssec-ring` or `dnssec-aws-lc-rs`. Examples values for `$REPOSITORY`: `https://github.com/hickory-dns/hickory-dns`; `/home/user/git-repos/hickory-dns`. NOTE: when using a local repository, changes that have not been committed, regardless of whether they are staged or not, will **not** be included in the `hickory-dns` build.
   
 - `DNS_TEST_VERBOSE_DOCKER_BUILD`. Setting this variable prints the output of the `docker build` invocations that the framework does to the console. This is useful to verify that image caching is working; for example if you set `DNS_TEST_SUBJECT` to a local `hickory-dns` repository then consecutively running the `explore` example and/or `conformance-tests` test suite **must** not rebuild `hickory-dns` provided that you have not *committed* any new change to the local repository.
 

--- a/conformance/packages/dns-test/src/container.rs
+++ b/conformance/packages/dns-test/src/container.rs
@@ -139,9 +139,14 @@ impl Container {
 
         let mut command = Command::new("docker");
         command
-            .args(["build", "-t"])
+            .args(["build", "--load", "-t"])
             .arg(&image_tag)
             .arg(docker_build_dir);
+        // Use BuildKit instead of the legacy builder. We need to choose this in order to
+        // pass the `--load` flag above. Depending on which BuildKit build driver is in use,
+        // the `--load` flag may be necessary, in order to load the resulting image as a
+        // local Docker image.
+        command.env("DOCKER_BUILDKIT", "1");
 
         if let Image::Hickory {
             dnssec_feature: Some(dnssec_feature),

--- a/conformance/packages/dns-test/src/implementation.rs
+++ b/conformance/packages/dns-test/src/implementation.rs
@@ -53,7 +53,7 @@ pub enum Implementation {
     Dnslib,
     Hickory {
         repo: Repository<'static>,
-        dnssec_feature: Option<HickoryDnssecFeature>,
+        dnssec_feature: HickoryDnssecFeature,
     },
     Unbound,
     EdeDotCom,
@@ -74,7 +74,7 @@ impl Implementation {
     pub fn hickory() -> Self {
         Self::Hickory {
             repo: Repository(crate::repo_root()),
-            dnssec_feature: None,
+            dnssec_feature: HickoryDnssecFeature::AwsLcRs,
         }
     }
 
@@ -180,8 +180,7 @@ impl Implementation {
                 }
 
                 Self::Hickory { dnssec_feature, .. } => {
-                    let use_pkcs8 =
-                        matches!(dnssec_feature, None | Some(HickoryDnssecFeature::Ring));
+                    let use_pkcs8 = matches!(dnssec_feature, HickoryDnssecFeature::Ring);
                     minijinja::render!(
                         include_str!("templates/hickory.name-server.toml.jinja"),
                         fqdn => origin.as_str(),

--- a/conformance/packages/dns-test/src/lib.rs
+++ b/conformance/packages/dns-test/src/lib.rs
@@ -130,20 +130,18 @@ fn parse_implementation(env_var: &str) -> Implementation {
             return Implementation::Bind;
         }
 
-        if subject.starts_with("hickory") {
-            let Some(rest) = subject.strip_prefix("hickory ") else {
+        if subject.starts_with("hickory ") {
+            let tokens = subject.split_ascii_whitespace().collect::<Vec<_>>();
+            let Ok([_, url, dnssec_feature]) = <[&str; 3]>::try_from(tokens) else {
                 panic!(
-                    "the syntax of {env_var} is 'hickory $URL' or 'hickory $URL $DNSSEC_FEATURE', e.g. 'hickory /tmp/hickory' or 'hickory https://github.com/owner/repo'"
+                    "the syntax of {env_var} is 'hickory $URL $DNSSEC_FEATURE', e.g. \
+                    'hickory /tmp/hickory aws-lc-rs' or \
+                    'hickory https://github.com/owner/repo ring'"
                 )
-            };
-            let (url, dnssec_feature) = if let Some((url, dnssec_feature)) = rest.split_once(' ') {
-                (url, Some(dnssec_feature.parse().unwrap()))
-            } else {
-                (rest, None)
             };
             Implementation::Hickory {
                 repo: Repository(url.to_string()),
-                dnssec_feature,
+                dnssec_feature: dnssec_feature.parse().unwrap(),
             }
         } else {
             panic!("unknown implementation: {subject}")


### PR DESCRIPTION
This enables use of the GitHub Actions cache to cache Docker image layers for the conformance test. When the new environment variable `DNS_TEST_DOCKER_CACHE_GHA` is set, extra command line flags will be passed to `docker build`. This cache backend also requires using the `docker-container` build driver, so that is set up using the `docker/setup-buildx-action` workflow. I also made it required to explicitly choose a Hickory DNS DNSSEC feature when running conformance tests, to eliminate some untested edge cases and inconsistent behavior when no feature is selected.