### PR TITLE
feat(resolver): add a `ResolverBuilder::with_options()` method

### DIFF
--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -49,6 +49,12 @@ impl<P> ResolverBuilder<P>
 where
     P: ConnectionProvider,
 {
+    /// Sets the [`ResolverOpts`] to be used by the resolver.
+    pub fn with_options(mut self, options: ResolverOpts) -> Self {
+        self.options = options;
+        self
+    }
+
     /// Returns a mutable reference to the [`ResolverOpts`].
     pub fn options_mut(&mut self) -> &mut ResolverOpts {
         &mut self.options

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -50,6 +50,13 @@ where
     P: ConnectionProvider,
 {
     /// Sets the [`ResolverOpts`] to be used by the resolver.
+    ///
+    /// NB: A [`ResolverBuilder<P>`] will use the system configuration e.g., `resolv.conf`, by
+    /// default. Usage of this method will overwrite any options set by the system configuration.
+    ///
+    /// See [`system_conf`][crate::system_conf] for functions that can parse a [`ResolverOpts`]
+    /// from the system configuration, or use [`options_mut()`][ResolverBuilder::with_options] to
+    /// acquire a muitable reference to the existing [`ResolverOpts`].
     pub fn with_options(mut self, options: ResolverOpts) -> Self {
         self.options = options;
         self


### PR DESCRIPTION
this commit introduces a new method to `hickory-resolver`'s `Builder` structure.

in the v0.24 release, users of the DNS lookup `Resolver` could provide configuration (`ResolverConfig`) and and options (`ResolverOpts`) to the `Resolver::new(..)` constructor.

as of the v0.25 release, builders are now acquired by calling `Resolver::builder()`, `Resolver::builder_tokio()`, or `Resolver::builder_with_config()`

these can be used to provide a `P`-typed connection provider, and the resolver configuration. there is not however, a way for callers to set the resolver options without assigning options via `Resolver::options_mut()`.

this requires binding the builder to a temporary variable however, resulting in code shaped approximately like so:

```rust
let mut builder = hickory_resolver::Resolver::builder_tokio();
*builder.options_mut() = opts;
let dns = builder.build();
```

this commit adds a `with_options()` method, so that a dns resolver can be constructed using builder-style api calls.

```rust
let dns = hickory_resolver::Resolver::builder_tokio()
    .with_options(opts)
    .build();
```

* https://github.com/hickory-dns/hickory-dns/pull/2830
* https://docs.rs/hickory-resolver/0.24.4/hickory_resolver/struct.Resolver.html#method.new
* https://docs.rs/hickory-resolver/latest/hickory_resolver/struct.ResolverBuilder.html#method.options_mut
* https://docs.rs/hickory-resolver/latest/hickory_resolver/struct.Resolver.html#method.builder_with_config