### PR TITLE
Use ECDSA keys in most conformance tests

### DIFF
--- a/conformance/packages/conformance-tests/src/name_server/rfc8906.rs
+++ b/conformance/packages/conformance-tests/src/name_server/rfc8906.rs
@@ -9,9 +9,15 @@ mod basic;
 mod extended;
 
 fn setup() -> Result<(Network, NameServer<Running>, Client)> {
+    setup_with_sign_settings(SignSettings::default())
+}
+
+fn setup_with_sign_settings(
+    settings: SignSettings,
+) -> Result<(Network, NameServer<Running>, Client)> {
     let network = Network::new()?;
     let ns = NameServer::new(&dns_test::SUBJECT, FQDN::TEST_DOMAIN, &network)?;
-    let ns = ns.sign(SignSettings::default())?;
+    let ns = ns.sign(settings)?;
     let ns = ns.start()?;
     let client = Client::new(&network)?;
     Ok((network, ns, client))

--- a/conformance/packages/conformance-tests/src/name_server/rfc8906/extended.rs
+++ b/conformance/packages/conformance-tests/src/name_server/rfc8906/extended.rs
@@ -2,9 +2,10 @@ use dns_test::{
     FQDN, Result,
     client::{DigSettings, DigStatus},
     record::RecordType,
+    zone_file::SignSettings,
 };
 
-use crate::name_server::rfc8906::setup;
+use crate::name_server::rfc8906::{setup, setup_with_sign_settings};
 
 #[test]
 fn test_8_2_1_minimal_edns() -> Result<()> {
@@ -156,7 +157,8 @@ fn test_8_2_6_edns_version_negotiation_with_unknown_edns_options() -> Result<()>
 
 #[test]
 fn test_8_2_7_truncated_responses() -> Result<()> {
-    let (_network, ns, client) = setup()?;
+    // We need to use RSA keys in order to make the response big enough to trigger truncation.
+    let (_network, ns, client) = setup_with_sign_settings(SignSettings::rsasha256())?;
 
     let settings = *DigSettings::default()
         .nocookie()

--- a/conformance/packages/conformance-tests/src/resolver/dns/rfc8906.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/rfc8906.rs
@@ -9,14 +9,13 @@ mod basic;
 mod extended;
 
 fn setup() -> Result<(Network, Graph, Resolver, Client)> {
+    setup_with_sign_settings(SignSettings::default())
+}
+
+fn setup_with_sign_settings(settings: SignSettings) -> Result<(Network, Graph, Resolver, Client)> {
     let network = Network::new()?;
     let leaf_ns = NameServer::new(&dns_test::PEER, FQDN::TEST_DOMAIN, &network)?;
-    let graph = Graph::build(
-        leaf_ns,
-        dns_test::name_server::Sign::Yes {
-            settings: SignSettings::default(),
-        },
-    )?;
+    let graph = Graph::build(leaf_ns, dns_test::name_server::Sign::Yes { settings })?;
     let resolver = Resolver::new(&network, graph.root.clone()).start()?;
     let client = Client::new(&network)?;
     Ok((network, graph, resolver, client))

--- a/conformance/packages/conformance-tests/src/resolver/dns/rfc8906/extended.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/rfc8906/extended.rs
@@ -2,7 +2,10 @@ use dns_test::{
     FQDN, Result,
     client::{DigSettings, DigStatus},
     record::RecordType,
+    zone_file::SignSettings,
 };
+
+use crate::resolver::dns::rfc8906::setup_with_sign_settings;
 
 use super::setup;
 
@@ -173,7 +176,8 @@ fn test_8_2_6_edns_version_negotiation_with_unknown_edns_options() -> Result<()>
 
 #[test]
 fn test_8_2_7_truncated_responses() -> Result<()> {
-    let (_network, _graph, resolver, client) = setup()?;
+    // We need to use RSA keys in order to make the response big enough to trigger truncation.
+    let (_network, _graph, resolver, client) = setup_with_sign_settings(SignSettings::rsasha256())?;
 
     let settings = *DigSettings::default()
         .recurse()

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
@@ -67,7 +67,7 @@ fn ds_bad_tag() -> Result<()> {
 #[test]
 fn ds_bad_key_algo() -> Result<()> {
     let output = malformed_ds_fixture(&FQDN::TEST_TLD.push_label("ds-bad-key-algo"), |ds| {
-        assert_eq!(8, ds.algorithm, "number below may need to change");
+        assert_eq!(13, ds.algorithm, "number below may need to change");
         ds.algorithm = 7;
     })?;
 

--- a/conformance/packages/dns-test/src/zone_file/signer.rs
+++ b/conformance/packages/dns-test/src/zone_file/signer.rs
@@ -84,7 +84,7 @@ impl SignSettings {
         }
     }
 
-    fn rsasha256() -> Self {
+    pub fn rsasha256() -> Self {
         Self {
             algorithm: Algorithm::RSASHA256,
             // 2048-bit SHA256 matches `$ dig DNSKEY .` in length
@@ -136,7 +136,7 @@ impl SignSettings {
 
 impl Default for SignSettings {
     fn default() -> Self {
-        Self::rsasha256()
+        Self::ecdsap256sha256()
     }
 }
 


### PR DESCRIPTION
As suggested in https://github.com/hickory-dns/hickory-dns/issues/2875#issuecomment-2738010951, this changes the default signing algorithm from RSASHA256 to ECDSAP256SHA256. This speeds up key generation by about 10x. On my machine, this brought the conformance test suite runtime from 160s to 130s. Multiply that by 3 test suite runs, and add on some more to account for CI workers' low resources, and this should give us a nice speedup in CI.