### PR TITLE
 Add metrics infrastructure and prometheus endpoint for hickory-dns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy 0.7.35",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +160,12 @@ dependencies = [
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
@@ -723,7 +741,7 @@ dependencies = [
  "hickory-proto",
  "once_cell",
  "radix_trie",
- "rand",
+ "rand 0.9.0",
  "serde",
  "test-support",
  "thiserror 2.0.12",
@@ -740,7 +758,7 @@ dependencies = [
  "data-encoding",
  "futures",
  "hickory-client",
- "rand",
+ "rand 0.9.0",
  "rustls-pki-types",
  "test-support",
  "time",
@@ -761,6 +779,7 @@ dependencies = [
  "hickory-server",
  "ipnet",
  "libc",
+ "metrics-exporter-prometheus",
  "regex",
  "rusqlite",
  "rustls",
@@ -788,7 +807,7 @@ dependencies = [
  "hickory-resolver",
  "hickory-server",
  "once_cell",
- "rand",
+ "rand 0.9.0",
  "rusqlite",
  "rustls",
  "rustls-pki-types",
@@ -828,7 +847,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "quinn",
- "rand",
+ "rand 0.9.0",
  "ring",
  "rustls",
  "rustls-pki-types",
@@ -887,7 +906,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "quinn",
- "rand",
+ "rand 0.9.0",
  "resolv-conf",
  "rustls",
  "serde",
@@ -921,6 +940,7 @@ dependencies = [
  "hickory-resolver",
  "http",
  "ipnet",
+ "metrics",
  "prefix-trie",
  "rusqlite",
  "rustls",
@@ -983,6 +1003,81 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1328,6 +1423,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "metrics"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a7deb012b3b2767169ff203fadb4c6b0b82b947512e5eb9e0b78c2e186ad9e3"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+dependencies = [
+ "base64",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "indexmap",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbd4884b1dd24f7d6628274a2f5ae22465c337c5ba065ec9b6edccddf8acc673"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown",
+ "metrics",
+ "quanta",
+ "rand 0.8.5",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,7 +1663,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -1555,6 +1696,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bd1fe6824cea6538803de3ff1bc0cf3949024db3d43c9643024bfb33a807c0e"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,7 +1740,7 @@ dependencies = [
  "aws-lc-rs",
  "bytes",
  "getrandom 0.3.1",
- "rand",
+ "rand 0.9.0",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -1631,13 +1787,34 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
- "rand_chacha",
- "rand_core",
- "zerocopy",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.23",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1647,7 +1824,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1657,6 +1843,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.1",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1985,6 +2189,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2255,6 +2465,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2303,6 +2519,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
@@ -2380,6 +2602,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,6 +2615,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -2460,6 +2697,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2902,11 +3149,31 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.23",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ tracing = { version = "0.1.30", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }
 thiserror = { version = "2", default-features = false }
 
+# metrics
+metrics = { version = "0.24.1" }
+metrics-exporter-prometheus = { version = "0.16.2", default-features = false, features = ["http-listener"] }
+
 # async/await
 async-recursion = "1.0.0"
 async-trait = "0.1.43"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -37,6 +37,7 @@ recursor = ["hickory-server/recursor"]
 # Recursive Resolution is Experimental!
 resolver = ["hickory-server/resolver"]
 sqlite = ["hickory-server/sqlite", "dep:rusqlite"]
+prometheus-metrics = ["hickory-server/metrics", "dep:metrics-exporter-prometheus"]
 
 tls-aws-lc-rs = ["hickory-server/tls-aws-lc-rs", "__tls"]
 https-aws-lc-rs = ["hickory-server/https-aws-lc-rs", "tls-aws-lc-rs", "__https"]
@@ -88,6 +89,7 @@ toml.workspace = true
 hickory-client.workspace = true
 hickory-proto.workspace = true
 hickory-server = { workspace = true, features = ["toml"] }
+metrics-exporter-prometheus = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -10,6 +10,8 @@
 #[cfg(feature = "__dnssec")]
 pub mod dnssec;
 
+#[cfg(feature = "prometheus-metrics")]
+use std::net::SocketAddr;
 #[cfg(feature = "__tls")]
 use std::{ffi::OsStr, fs};
 use std::{
@@ -91,6 +93,9 @@ pub struct Config {
     quic_listen_port: Option<u16>,
     /// HTTP/3 port to listen on
     h3_listen_port: Option<u16>,
+    /// Prometheus listen address
+    #[cfg(feature = "prometheus-metrics")]
+    prometheus_listen_addr: Option<SocketAddr>,
     /// Disable TCP protocol
     disable_tcp: Option<bool>,
     /// Disable UDP protocol
@@ -101,6 +106,9 @@ pub struct Config {
     disable_https: Option<bool>,
     /// Disable QUIC protocol
     disable_quic: Option<bool>,
+    /// Disable Prometheus metrics
+    #[cfg(feature = "prometheus-metrics")]
+    disable_prometheus: Option<bool>,
     /// Timeout associated to a request before it is closed.
     tcp_request_timeout: Option<u64>,
     /// Level at which to log, default is INFO
@@ -185,6 +193,13 @@ impl Config {
         self.h3_listen_port.unwrap_or(DEFAULT_H3_PORT)
     }
 
+    /// prometheus metric endpoint listen address
+    #[cfg(feature = "prometheus-metrics")]
+    pub fn prometheus_listen_addr(&self) -> SocketAddr {
+        self.prometheus_listen_addr
+            .unwrap_or(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 9000))
+    }
+
     /// get if TCP protocol should be disabled
     pub fn disable_tcp(&self) -> bool {
         self.disable_tcp.unwrap_or_default()
@@ -208,6 +223,12 @@ impl Config {
     /// get if QUIC protocol should be disabled
     pub fn disable_quic(&self) -> bool {
         self.disable_quic.unwrap_or_default()
+    }
+
+    /// get if Prometheus metrics endpoint should be disabled
+    #[cfg(feature = "prometheus-metrics")]
+    pub fn disable_prometheus(&self) -> bool {
+        self.disable_prometheus.unwrap_or_default()
     }
 
     /// default timeout for all TCP connections before forcibly shutdown

--- a/bin/tests/integration/server_harness/mod.rs
+++ b/bin/tests/integration/server_harness/mod.rs
@@ -106,6 +106,8 @@ where
     command.arg(format!("--https-port={}", 0));
     #[cfg(feature = "__quic")]
     command.arg(format!("--quic-port={}", 0));
+    #[cfg(feature = "prometheus-metrics")]
+    command.arg(format!("--prometheus-listen-address=127.0.0.1:{}", 0));
 
     println!("named cli options: {command:#?}");
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -38,6 +38,7 @@ resolver = ["dep:hickory-resolver"]
 sqlite = ["rusqlite"]
 blocklist = ["resolver"]
 toml = ["dep:toml"]
+metrics = ["dep:metrics"]
 
 tls-aws-lc-rs = [
     "hickory-proto/tls-aws-lc-rs",
@@ -131,6 +132,7 @@ tokio-util.workspace = true
 hickory-proto = { workspace = true, features = ["serde", "text-parsing", "tokio"] }
 hickory-recursor = { workspace = true, features = ["serde"], optional = true }
 hickory-resolver = { workspace = true, features = ["serde", "system-config", "tokio"], optional = true }
+metrics = { workspace = true, optional = true }
 
 [dev-dependencies]
 futures-executor = { workspace = true, default-features = false, features = ["std"] }

--- a/crates/server/src/store/metrics.rs
+++ b/crates/server/src/store/metrics.rs
@@ -1,0 +1,69 @@
+use metrics::{Counter, Gauge, Unit, counter, describe_counter, describe_gauge, gauge};
+
+pub(super) struct StoreMetrics {
+    pub(crate) query: QueryStoreMetrics,
+    pub(crate) persistent: PersistentStoreMetrics,
+}
+
+impl StoreMetrics {
+    pub(super) fn new(store: &'static str) -> Self {
+        Self {
+            query: QueryStoreMetrics::new(store),
+            persistent: PersistentStoreMetrics::new(store),
+        }
+    }
+}
+
+pub(super) struct PersistentStoreMetrics {
+    pub(super) zone_records_total: Gauge,
+    #[cfg(feature = "__dnssec")]
+    pub(super) zone_records_dynamically_updated: Counter,
+}
+
+impl PersistentStoreMetrics {
+    pub(crate) fn new(store: &'static str) -> Self {
+        let zone_records_total = gauge!("hickory_zone_records_total", "store" => store);
+        describe_gauge!(
+            "hickory_zone_records_total",
+            Unit::Count,
+            "number of dns zone records in persisted storages"
+        );
+
+        #[cfg(feature = "__dnssec")]
+        let zone_records_dynamically_updated = {
+            let zone_records_dynamically_updated =
+                counter!("hickory_zone_records_dynamically_updated_total", "store" => store);
+            describe_counter!(
+                "hickory_zone_records_dynamically_updated_total",
+                Unit::Count,
+                "number of dns zone records that had been dynamically updated"
+            );
+            zone_records_dynamically_updated
+        };
+
+        Self {
+            zone_records_total,
+            #[cfg(feature = "__dnssec")]
+            zone_records_dynamically_updated,
+        }
+    }
+}
+
+pub(super) struct QueryStoreMetrics {
+    pub(super) zone_record_lookups: Counter,
+}
+
+impl QueryStoreMetrics {
+    pub(crate) fn new(store: &'static str) -> Self {
+        let zone_record_lookups = counter!("hickory_zone_record_lookups_total", "store" => store);
+        describe_counter!(
+            "hickory_zone_record_lookups_total",
+            Unit::Count,
+            "number of occurred dns zone record lookups"
+        );
+
+        Self {
+            zone_record_lookups,
+        }
+    }
+}

--- a/crates/server/src/store/mod.rs
+++ b/crates/server/src/store/mod.rs
@@ -11,6 +11,8 @@ pub mod blocklist;
 pub mod file;
 pub mod forwarder;
 pub mod in_memory;
+#[cfg(feature = "metrics")]
+mod metrics;
 pub mod recursor;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;


### PR DESCRIPTION
Introduces a prometheus endpoint within hickory-dns and adds initial metrics for server persisted zones.

The approach is based on the details described within:
https://github.com/hickory-dns/hickory-dns/issues/2032

Currently the implementation can be activated using the feature `hickory-dns/prometheus-metrics`.

Before adding more metrics I'd like to clarify:
- is the compile time feature for the metrics required or is it sufficient to keep it on `hickory-dns` for the prometheus endpoint and tracing/recorder setup
- is the approach taken corresponding to the current requirements (especially the used dependencies)