### PR TITLE
NSEC3 Max Iterations Limits

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/insecure.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/insecure.rs
@@ -16,6 +16,7 @@ mod deprecated_algorithm;
 #[test]
 fn unsigned_zone_nsec3() -> Result<()> {
     unsigned_zone_fixture(Nsec::_3 {
+        iterations: 0,
         opt_out: false,
         salt: None,
     })
@@ -109,6 +110,7 @@ fn no_ds_record_nsec1() -> Result<()> {
 fn no_ds_record_nsec3() -> Result<()> {
     let (output, _logs) = no_ds_record_fixture(
         SignSettings::default().nsec(Nsec::_3 {
+            iterations: 0,
             salt: None,
             opt_out: false,
         }),
@@ -128,6 +130,7 @@ fn no_ds_record_nsec3() -> Result<()> {
 fn no_ds_record_nsec3_case_randomization() -> Result<()> {
     let (output, _logs) = no_ds_record_fixture(
         SignSettings::default().nsec(Nsec::_3 {
+            iterations: 0,
             salt: None,
             opt_out: false,
         }),

--- a/conformance/packages/conformance-tests/src/resolver/nsec.rs
+++ b/conformance/packages/conformance-tests/src/resolver/nsec.rs
@@ -13,6 +13,7 @@ use dns_test::{
 #[test]
 fn zone_exist_domain_does_not_nsec3() -> Result<()> {
     zone_exist_domain_does_not(Nsec::_3 {
+        iterations: 0,
         opt_out: false,
         salt: None,
     })
@@ -26,6 +27,7 @@ fn zone_exist_domain_does_not_nsec() -> Result<()> {
 #[test]
 fn zone_does_not_exist_nsec3() -> Result<()> {
     zone_does_not_exist(Nsec::_3 {
+        iterations: 0,
         opt_out: false,
         salt: None,
     })
@@ -39,6 +41,7 @@ fn zone_does_not_exist_nsec() -> Result<()> {
 #[test]
 fn domain_exists_record_type_does_not_nsec3() -> Result<()> {
     domain_exists_record_type_does_not(Nsec::_3 {
+        iterations: 0,
         opt_out: false,
         salt: None,
     })

--- a/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
@@ -300,6 +300,7 @@ fn check_nsec(verified_message: DnsResponse, query: &Query) -> Result<DnsRespons
         // TODO change this to remove the NSECs, like we do for the others?
         return Err(ProtoError::from(ProtoErrorKind::Nsec {
             query: Box::new(query.clone()),
+            response: Box::new(verified_message),
             proof: nsec_proof,
         }));
     }
@@ -858,10 +859,10 @@ where
     };
 
     // If the response was an empty DS RRset that was itself insecure, then we have another insecure zone.
-    if let Some((query, _proof)) = error
+    if let Some((query, _res, _proof)) = error
         .kind()
         .as_nsec()
-        .filter(|(_query, proof)| proof.is_insecure())
+        .filter(|(_query, _res, proof)| proof.is_insecure())
     {
         debug!(
             "marking {} as insecure based on insecure NSEC/NSEC3 proof",

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -108,6 +108,8 @@ pub enum ProtoErrorKind {
     Nsec {
         /// Query for which the NSEC was returned
         query: Box<Query>,
+        /// Response for which the NSEC was returned
+        response: Box<DnsResponse>,
         /// DNSSEC proof of the record
         proof: Proof,
     },
@@ -790,8 +792,13 @@ impl Clone for ProtoErrorKind {
             NoRecordsFound(ref inner) => NoRecordsFound(inner.clone()),
             RequestRefused => RequestRefused,
             #[cfg(feature = "__dnssec")]
-            Nsec { ref query, proof } => Nsec {
+            Nsec {
+                ref query,
+                ref response,
+                proof,
+            } => Nsec {
                 query: query.clone(),
+                response: response.clone(),
                 proof,
             },
             UnknownAlgorithmTypeValue(value) => UnknownAlgorithmTypeValue(value),

--- a/crates/recursor/src/lib.rs
+++ b/crates/recursor/src/lib.rs
@@ -64,6 +64,12 @@ pub enum DnssecPolicy {
     ValidateWithStaticKey {
         /// set to `None` to use built-in trust anchor
         trust_anchor: Option<Arc<TrustAnchors>>,
+        /// NSEC3 soft iteration limit.  Responses with NSEC3 records having an iteration count
+        /// exceeding this value, but less than the hard limit, will return Proof::Insecure
+        nsec3_soft_iteration_limit: Option<u16>,
+        /// NSEC3 hard iteration limit.  Responses with NSEC3 responses having an iteration count
+        /// exceeding this value will return Proof::Bogus
+        nsec3_hard_iteration_limit: Option<u16>,
     },
     // TODO RFC5011
     // ValidateWithInitialKey { ..  },}

--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -186,7 +186,11 @@ impl Recursor {
             DnssecPolicy::ValidationDisabled => RecursorMode::NonValidating { handle },
 
             #[cfg(feature = "__dnssec")]
-            DnssecPolicy::ValidateWithStaticKey { trust_anchor } => {
+            DnssecPolicy::ValidateWithStaticKey {
+                trust_anchor,
+                nsec3_soft_iteration_limit,
+                nsec3_hard_iteration_limit,
+            } => {
                 let record_cache = handle.record_cache().clone();
                 let trust_anchor = match trust_anchor {
                     Some(anchor) if anchor.is_empty() => {
@@ -198,7 +202,11 @@ impl Recursor {
 
                 RecursorMode::Validating {
                     record_cache,
-                    handle: DnssecDnsHandle::with_trust_anchor(handle, trust_anchor),
+                    handle: DnssecDnsHandle::with_trust_anchor(handle, trust_anchor)
+                        .nsec3_iteration_limits(
+                            nsec3_soft_iteration_limit,
+                            nsec3_hard_iteration_limit,
+                        ),
                 }
             }
         };

--- a/tests/e2e-tests/src/recursor.rs
+++ b/tests/e2e-tests/src/recursor.rs
@@ -1,4 +1,5 @@
 pub mod basic;
 pub mod cname;
 pub mod delegation;
+pub mod dnssec;
 pub mod security;

--- a/tests/e2e-tests/src/recursor/dnssec.rs
+++ b/tests/e2e-tests/src/recursor/dnssec.rs
@@ -1,0 +1,1 @@
+mod scenarios;

--- a/tests/e2e-tests/src/recursor/dnssec/custom_nsec3_iterations.toml.jinja
+++ b/tests/e2e-tests/src/recursor/dnssec/custom_nsec3_iterations.toml.jinja
@@ -1,0 +1,15 @@
+user = "nobody"
+group = "nogroup"
+
+[[zones]]
+zone = "."
+zone_type = "External"
+
+[zones.stores]
+type = "recursor"
+roots = "/etc/root.hints"
+dnssec_policy.ValidateWithStaticKey.path = "/etc/trusted-key.key"
+dnssec_policy.ValidateWithStaticKey.nsec3_soft_iteration_limit = 10
+dnssec_policy.ValidateWithStaticKey.nsec3_hard_iteration_limit = 20
+
+allow_server = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]

--- a/tests/e2e-tests/src/recursor/dnssec/scenarios.rs
+++ b/tests/e2e-tests/src/recursor/dnssec/scenarios.rs
@@ -11,7 +11,6 @@ use dns_test::{
 /// This tests that the server will return an insecure answer when receiving NSEC3 records with
 /// an iteration count exceeding the default soft limit, but below the hard limit.
 #[test]
-#[ignore = "hickory does not limit NSEC3 hash iterations"]
 fn soft_nsec3_iteration_failure() -> Result<()> {
     let (output, logs) = insecure_record_fixture(
         FQDN("noexist.insecure.testing.")?,
@@ -35,7 +34,6 @@ fn soft_nsec3_iteration_failure() -> Result<()> {
 /// This tests that the server will return SERVFAIL when receiving NSEC3 records with
 /// an iteration count exceeding the default hard limit.
 #[test]
-#[ignore = "hickory does not limit NSEC3 hash iterations"]
 fn hard_nsec3_iteration_failure() -> Result<()> {
     let (output, logs) = insecure_record_fixture(
         FQDN("noexist.insecure.testing.")?,
@@ -98,7 +96,6 @@ fn nsec3_custom_iteration_count() -> Result<()> {
 
 /// This test verifies the server will verify NSEC3 RRSIGs before rejecting high iteration counts.
 #[test]
-#[ignore = "hickory does not limit NSEC3 hash iterations or uncovered NSEC3 records"]
 fn hard_nsec3_iteration_invalid_rrsig() -> Result<()> {
     let network = Network::new()?;
     let leaf_zone = FQDN::TEST_DOMAIN;

--- a/tests/e2e-tests/src/recursor/dnssec/scenarios.rs
+++ b/tests/e2e-tests/src/recursor/dnssec/scenarios.rs
@@ -1,0 +1,238 @@
+use std::net::Ipv4Addr;
+
+use dns_test::{
+    FQDN, Implementation, Network, Resolver, Result, TrustAnchor,
+    client::{Client, DigOutput, DigSettings},
+    name_server::{Graph, NameServer, Sign},
+    record::{Record, RecordType},
+    zone_file::{Nsec, SignSettings},
+};
+
+/// This tests that the server will return an insecure answer when receiving NSEC3 records with
+/// an iteration count exceeding the default soft limit, but below the hard limit.
+#[test]
+#[ignore = "hickory does not limit NSEC3 hash iterations"]
+fn soft_nsec3_iteration_failure() -> Result<()> {
+    let (output, logs) = insecure_record_fixture(
+        FQDN("noexist.insecure.testing.")?,
+        SignSettings::default().nsec(Nsec::_3 {
+            iterations: 101,
+            salt: None,
+            opt_out: false,
+        }),
+        None,
+    )?;
+
+    dbg!(&output);
+
+    assert!(output.status.is_nxdomain());
+    assert!(!output.flags.authenticated_data);
+    assert!(logs.contains("iteration count 101 is over 100"));
+
+    Ok(())
+}
+
+/// This tests that the server will return SERVFAIL when receiving NSEC3 records with
+/// an iteration count exceeding the default hard limit.
+#[test]
+#[ignore = "hickory does not limit NSEC3 hash iterations"]
+fn hard_nsec3_iteration_failure() -> Result<()> {
+    let (output, logs) = insecure_record_fixture(
+        FQDN("noexist.insecure.testing.")?,
+        SignSettings::default().nsec(Nsec::_3 {
+            iterations: 501,
+            salt: None,
+            opt_out: false,
+        }),
+        None,
+    )?;
+
+    dbg!(&output);
+
+    assert!(output.status.is_servfail());
+    assert!(logs.contains("iteration count 501 is over 500"));
+
+    Ok(())
+}
+
+/// This tests the nsec3_soft_iteration_limit and nsec3_hard_iteration_limit configuration settings
+#[test]
+fn nsec3_custom_iteration_count() -> Result<()> {
+    let (output, logs) = insecure_record_fixture(
+        FQDN("noexist.insecure.testing.")?,
+        SignSettings::default().nsec(Nsec::_3 {
+            iterations: 11,
+            salt: None,
+            opt_out: false,
+        }),
+        Some(minijinja::render!(include_str!(
+            "custom_nsec3_iterations.toml.jinja"
+        ))),
+    )?;
+
+    dbg!(&output);
+
+    assert!(output.status.is_nxdomain());
+    assert!(!output.flags.authenticated_data);
+    assert!(logs.contains("iteration count 11 is over 10"));
+
+    let (output, logs) = insecure_record_fixture(
+        FQDN("noexist.insecure.testing.")?,
+        SignSettings::default().nsec(Nsec::_3 {
+            iterations: 21,
+            salt: None,
+            opt_out: false,
+        }),
+        Some(minijinja::render!(include_str!(
+            "custom_nsec3_iterations.toml.jinja"
+        ))),
+    )?;
+
+    dbg!(&output);
+
+    assert!(output.status.is_servfail());
+    assert!(logs.contains("iteration count 21 is over 20"));
+
+    Ok(())
+}
+
+/// This test verifies the server will verify NSEC3 RRSIGs before rejecting high iteration counts.
+#[test]
+#[ignore = "hickory does not limit NSEC3 hash iterations or uncovered NSEC3 records"]
+fn hard_nsec3_iteration_invalid_rrsig() -> Result<()> {
+    let network = Network::new()?;
+    let leaf_zone = FQDN::TEST_DOMAIN;
+    let mut leaf_ns = NameServer::new(&Implementation::test_peer(), leaf_zone.clone(), &network)?;
+
+    leaf_ns.add(Record::a(
+        leaf_zone.push_label("host"),
+        Ipv4Addr::new(1, 2, 3, 4),
+    ));
+
+    let Graph {
+        nameservers: _nameservers,
+        root,
+        trust_anchor,
+    } = Graph::build(
+        leaf_ns,
+        Sign::AndAmend {
+            settings: SignSettings::default().nsec(Nsec::_3 {
+                iterations: 501,
+                salt: None,
+                opt_out: false,
+            }),
+            mutate: &|zone, records| {
+                if zone == &leaf_zone {
+                    let mut did_remove = false;
+                    for record in records.iter_mut() {
+                        if let Record::RRSIG(rrsig) = record {
+                            if rrsig.type_covered == RecordType::NSEC3 {
+                                let mut rrsig = rrsig.clone();
+                                rrsig.signature = "bm90YXJlYWxycnNpZ3JlY29yZA==".to_string();
+                                *record = Record::RRSIG(rrsig);
+                                did_remove = true;
+                            }
+                        }
+                    }
+                    assert!(did_remove, "did not find an RRSIG covering an NSEC3 record");
+                }
+            },
+        },
+    )?;
+
+    let mut resolver = Resolver::new(&network, root);
+
+    let resolver = resolver
+        .trust_anchor(&trust_anchor.unwrap())
+        .start_with_subject(&Implementation::hickory())?;
+
+    let client = Client::new(resolver.network())?;
+    let settings = *DigSettings::default().recurse().authentic_data();
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::A,
+        &leaf_zone.push_label("noexist"),
+    )?;
+
+    let logs = resolver.logs()?;
+
+    dbg!(&output);
+
+    assert!(output.status.is_servfail());
+    assert!(!logs.contains("iteration count 501 is over 500"));
+    assert!(logs.contains("response does not contain NSEC or NSEC3 records."));
+
+    Ok(())
+}
+
+pub fn insecure_record_fixture(
+    query_fqdn: FQDN,
+    sign_settings: SignSettings,
+    custom_config: Option<String>,
+) -> Result<(DigOutput, String)> {
+    let network = Network::new()?;
+
+    let insecure_zone = FQDN::TEST_TLD.push_label("insecure");
+    let needle_fqdn = FQDN("example.insecure.testing.")?;
+    let needle_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
+
+    let mut leaf_ns = NameServer::new(
+        &Implementation::test_peer(),
+        insecure_zone.clone(),
+        &network,
+    )?;
+    leaf_ns.add(Record::a(needle_fqdn.clone(), needle_ipv4_addr));
+
+    let mut sibling_ns =
+        NameServer::new(&Implementation::test_peer(), FQDN::TEST_DOMAIN, &network)?;
+    let mut tld_ns = NameServer::new(&Implementation::test_peer(), FQDN::TEST_TLD, &network)?;
+    let mut root_ns = NameServer::new(&Implementation::test_peer(), FQDN::ROOT, &network)?;
+
+    sibling_ns.add(root_ns.a());
+    sibling_ns.add(tld_ns.a());
+    sibling_ns.add(leaf_ns.a());
+    sibling_ns.add(sibling_ns.a());
+
+    root_ns.referral_nameserver(&tld_ns);
+    tld_ns.referral_nameserver(&sibling_ns);
+    tld_ns.referral_nameserver(&leaf_ns);
+
+    let leaf_ns = leaf_ns.sign(sign_settings.clone())?;
+    let sibling_ns = sibling_ns.sign(sign_settings.clone())?;
+
+    tld_ns.add(sibling_ns.ds().ksk.clone());
+    tld_ns.add(leaf_ns.ds().ksk.clone());
+
+    let tld_ns = tld_ns.sign(sign_settings.clone())?;
+
+    root_ns.add(tld_ns.ds().ksk.clone());
+
+    let mut trust_anchor = TrustAnchor::empty();
+    let root_ns = root_ns.sign(sign_settings)?;
+
+    trust_anchor.add(root_ns.key_signing_key().clone());
+    trust_anchor.add(root_ns.zone_signing_key().clone());
+
+    let root_hint = root_ns.root_hint();
+    let _root_ns = root_ns.start()?;
+    let _com_ns = tld_ns.start()?;
+    let _sibling_ns = sibling_ns.start()?;
+    let _leaf_ns = leaf_ns.start()?;
+
+    let mut resolver_settings = Resolver::new(&network, root_hint);
+    resolver_settings.trust_anchor(&trust_anchor);
+    let resolver = if let Some(config) = custom_config {
+        resolver_settings
+            .custom_config(config)
+            .start_with_subject(&Implementation::hickory())?
+    } else {
+        resolver_settings.start_with_subject(&Implementation::hickory())?
+    };
+
+    let client = Client::new(&network)?;
+    let settings = *DigSettings::default().recurse().authentic_data();
+    let output = client.dig(settings, resolver.ipv4_addr(), RecordType::A, &query_fqdn)?;
+
+    Ok((output, resolver.logs()?))
+}


### PR DESCRIPTION
Addresses #2626.  This introduces configurable NSEC3 soft and hard iteration limits, as suggested in RFC 9276.  The default values are 100 for the soft limit, and 500 for the hard limit. Both values are configurable.