### PR TITLE
Add more server metrics and enhance existing metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +278,18 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "clang-sys"
@@ -806,7 +833,9 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-process",
+ "prometheus-parse",
  "regex",
+ "reqwest",
  "rusqlite",
  "rustls",
  "rustls-pki-types",
@@ -1105,6 +1134,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.58.0",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1533,6 +1586,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,6 +1841,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "811031bea65e5a401fb2e1f37d802cca6601e204ac463809a3189352d13b78a5"
+dependencies = [
+ "chrono",
+ "itertools",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
 name = "quanta"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2006,6 +2077,42 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "reqwest"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
+]
 
 [[package]]
 name = "resolv-conf"
@@ -2283,6 +2390,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,6 +2483,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -2583,6 +2711,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,6 +2935,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2941,8 +3103,8 @@ checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -2969,6 +3131,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+dependencies = [
+ "windows-result 0.3.2",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.0",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2978,13 +3157,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3062,11 +3259,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -3088,6 +3301,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3104,6 +3323,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3124,10 +3349,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3148,6 +3385,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3164,6 +3407,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3184,6 +3433,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3200,6 +3455,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f7720b74ed28ca77f90769a71fd8c637a0137f6fae4ae947e1050229cff57f"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.5",
  "cc",
  "cmake",
  "dunce",
@@ -188,6 +188,24 @@ dependencies = [
  "shlex",
  "syn",
  "which",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -730,6 +748,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hickory-client"
 version = "0.25.1"
 dependencies = [
@@ -779,7 +803,9 @@ dependencies = [
  "hickory-server",
  "ipnet",
  "libc",
+ "metrics",
  "metrics-exporter-prometheus",
+ "metrics-process",
  "regex",
  "rusqlite",
  "rustls",
@@ -1343,6 +1369,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libproc"
+version = "0.14.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78a09b56be5adbcad5aa1197371688dc6bb249a26da3bca2011ee2fb987ebfb"
+dependencies = [
+ "bindgen 0.70.1",
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,6 +1447,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,6 +1498,22 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "metrics-process"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a82c8add4382f29a122fa64fff1891453ed0f6b2867d971e7d60cb8dfa322ff"
+dependencies = [
+ "libc",
+ "libproc",
+ "mach2",
+ "metrics",
+ "once_cell",
+ "procfs",
+ "rlimit",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -1695,6 +1757,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "procfs"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+dependencies = [
+ "bitflags",
+ "hex",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags",
+ "hex",
 ]
 
 [[package]]
@@ -1944,6 +2028,15 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rlimit"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ thiserror = { version = "2", default-features = false }
 metrics = { version = "0.24.1" }
 metrics-exporter-prometheus = { version = "0.16.2", default-features = false, features = ["http-listener"] }
 metrics-process = "2.4.0"
+# metrics tests
+reqwest = { version = "0.12.12", default-features = false }
+prometheus-parse = "0.2.5"
 
 # async/await
 async-recursion = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ thiserror = { version = "2", default-features = false }
 # metrics
 metrics = { version = "0.24.1" }
 metrics-exporter-prometheus = { version = "0.16.2", default-features = false, features = ["http-listener"] }
+metrics-process = "2.4.0"
 
 # async/await
 async-recursion = "1.0.0"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -37,7 +37,8 @@ recursor = ["hickory-server/recursor"]
 # Recursive Resolution is Experimental!
 resolver = ["hickory-server/resolver"]
 sqlite = ["hickory-server/sqlite", "dep:rusqlite"]
-prometheus-metrics = ["hickory-server/metrics", "dep:metrics-exporter-prometheus"]
+prometheus-metrics = ["metrics", "dep:metrics-exporter-prometheus"]
+metrics = ["hickory-server/metrics", "dep:metrics", "dep:metrics-process"]
 
 tls-aws-lc-rs = ["hickory-server/tls-aws-lc-rs", "__tls"]
 https-aws-lc-rs = ["hickory-server/https-aws-lc-rs", "tls-aws-lc-rs", "__https"]
@@ -89,7 +90,9 @@ toml.workspace = true
 hickory-client.workspace = true
 hickory-proto.workspace = true
 hickory-server = { workspace = true, features = ["toml"] }
+metrics = { workspace = true, optional = true }
 metrics-exporter-prometheus = { workspace = true, optional = true }
+metrics-process = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -105,6 +105,9 @@ hickory-resolver.workspace = true
 test-support.workspace = true
 toml.workspace = true
 webpki-roots.workspace = true
+# metrics tests
+reqwest = { workspace = true, default-features = false }
+prometheus-parse = { workspace = true }
 
 [lints]
 workspace = true

--- a/bin/tests/integration/main.rs
+++ b/bin/tests/integration/main.rs
@@ -4,6 +4,8 @@ mod config_tests;
 mod forwarder;
 mod in_memory;
 mod named_https_tests;
+#[cfg(feature = "metrics")]
+mod named_metrics_tests;
 mod named_quic_tests;
 mod named_rustls_tests;
 mod named_test_rsa_dnssec;

--- a/bin/tests/integration/named_metrics_tests.rs
+++ b/bin/tests/integration/named_metrics_tests.rs
@@ -1,0 +1,510 @@
+// Copyright 2015-2025 Benjamin Fry <benjaminfry@me.com>
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// https://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// https://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use std::net::{Ipv4Addr, SocketAddr};
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+use test_support::subscribe;
+
+use hickory_client::client::{Client, ClientHandle};
+#[cfg(feature = "__dnssec")]
+use hickory_proto::dnssec::{
+    Algorithm, DnssecDnsHandle, SigSigner, SigningKey, TrustAnchors, crypto::RsaSigningKey,
+    rdata::DNSKEY,
+};
+use hickory_proto::op::MessageFinalizer;
+#[cfg(feature = "__dnssec")]
+use hickory_proto::rr::Record;
+use hickory_proto::rr::rdata::A;
+use hickory_proto::rr::{DNSClass, Name, RData, RecordType};
+use hickory_proto::runtime::TokioRuntimeProvider;
+use hickory_proto::tcp::TcpClientStream;
+use hickory_proto::xfer::Protocol;
+use prometheus_parse::{Scrape, Value};
+#[cfg(feature = "__dnssec")]
+use rustls_pki_types::PrivatePkcs8KeyDer;
+use tokio::runtime::Runtime;
+use tokio::time::sleep;
+
+use crate::server_harness::{ServerProtocol, SocketPorts, named_test_harness};
+
+#[test]
+fn test_prometheus_endpoint_startup() {
+    subscribe();
+
+    named_test_harness("example_forwarder.toml", |socket_ports| {
+        let io_loop = Runtime::new().unwrap();
+        let metrics = &io_loop.block_on(fetch_parse_check_metrics(&socket_ports));
+
+        // check process metrics
+        verify_metric(metrics, "process_cpu_seconds_total", &[], None);
+        verify_metric(metrics, "process_max_fds", &[], None);
+        verify_metric(metrics, "process_open_fds", &[], None);
+        verify_metric(metrics, "process_resident_memory_bytes", &[], None);
+        verify_metric(metrics, "process_start_time_seconds", &[], None);
+        verify_metric(metrics, "process_virtual_memory_bytes", &[], None);
+
+        #[cfg(not(windows))]
+        {
+            verify_metric(metrics, "process_virtual_memory_max_bytes", &[], None);
+            verify_metric(metrics, "process_threads", &[], None);
+        }
+
+        // check config metrics
+        let info = [("version", hickory_server::version())];
+        let config_info = [
+            ("directory", "/var/named"),
+            ("disable_https", "false"),
+            ("disable_quic", "false"),
+            ("disable_tcp", "false"),
+            ("disable_tls", "false"),
+            ("disable_udp", "false"),
+            ("allow_networks", "0"), // move to separate counter hickory_config_allow_networks_total ?
+            ("deny_networks", "0"), // move to separate counter hickory_config_deny_networks_total ?
+            ("zones", "6"),         // redundant ?
+        ];
+        verify_metric(metrics, "hickory_info", &info, Some(1f64));
+        verify_metric(metrics, "hickory_config_info", &config_info, Some(1f64));
+
+        let store_forwarder = [("store", "forwarder")];
+        verify_metric(metrics, "hickory_zones_total", &store_forwarder, Some(1f64));
+
+        let store_file_primary = [("store", "file"), ("role", "primary")];
+        let store_file_secondary = [("store", "file"), ("role", "secondary")];
+        verify_metric(
+            metrics,
+            "hickory_zones_total",
+            &store_file_primary,
+            Some(5f64),
+        );
+        verify_metric(
+            metrics,
+            "hickory_zones_total",
+            &store_file_secondary,
+            Some(0f64),
+        );
+
+        #[cfg(feature = "sqlite")]
+        {
+            let store_sqlite_primary = [("store", "sqlite"), ("role", "primary")];
+            let store_sqlite_secondary = [("store", "sqlite"), ("role", "secondary")];
+            verify_metric(
+                metrics,
+                "hickory_zones_total",
+                &store_sqlite_primary,
+                Some(0f64),
+            );
+            verify_metric(
+                metrics,
+                "hickory_zones_total",
+                &store_sqlite_secondary,
+                Some(0f64),
+            );
+        }
+
+        // check store metrics
+        // forwarder store only has QueryStoreMetrics
+        // sqlite store not initialized within example_forwarder.toml
+        let store_file = [("store", "file")];
+        verify_metric(
+            metrics,
+            "hickory_zone_records_total",
+            &store_file,
+            Some(14f64),
+        );
+
+        verify_metric(
+            metrics,
+            "hickory_zone_record_lookups_total",
+            &STORE_FILE_SUCCESS,
+            Some(0f64),
+        );
+        verify_metric(
+            metrics,
+            "hickory_zone_record_lookups_total",
+            &STORE_FILE_FAILED,
+            Some(0f64),
+        );
+        verify_metric(
+            metrics,
+            "hickory_zone_record_lookups_total",
+            &STORE_FORWARDER_SUCCESS,
+            Some(0f64),
+        );
+        verify_metric(
+            metrics,
+            "hickory_zone_record_lookups_total",
+            &STORE_FORWARDER_FAILED,
+            Some(0f64),
+        );
+
+        // sqlite store is not configured within example_forwarder.toml
+        // therefore StoreMetrics for sqlite are not initialized
+
+        // currently this feature returns is NotImpl, only functional with sqlite && dnssec feature
+        // empty metrics available for file store as they are part of PersistentStoreMetrics
+        // migrate to Option within PersistentStoreMetrics ?
+        #[cfg(feature = "__dnssec")]
+        {
+            let store_file_added = [("store", "file"), ("operation", "added")];
+            let store_file_deleted = [("store", "file"), ("operation", "deleted")];
+            let store_file_updated = [("store", "file"), ("operation", "updated")];
+
+            verify_metric(
+                metrics,
+                "hickory_zone_records_modified_total",
+                &store_file_added,
+                Some(0f64),
+            );
+            verify_metric(
+                metrics,
+                "hickory_zone_records_modified_total",
+                &store_file_deleted,
+                Some(0f64),
+            );
+            verify_metric(
+                metrics,
+                "hickory_zone_records_modified_total",
+                &store_file_updated,
+                Some(0f64),
+            );
+        }
+    })
+}
+
+#[test]
+fn test_request_response() {
+    subscribe();
+
+    named_test_harness("example_forwarder.toml", |socket_ports| {
+        let io_loop = Runtime::new().unwrap();
+        let metrics = &io_loop.block_on(async {
+            let mut client = create_local_client(&socket_ports, None).await;
+            let response = client
+                .query(
+                    Name::from_str("localhost.").unwrap(),
+                    DNSClass::IN,
+                    RecordType::A,
+                )
+                .await
+                .unwrap();
+
+            if let RData::A(addr) = response.answers()[0].data() {
+                assert_eq!(*addr, A::new(127, 0, 0, 1));
+            };
+
+            fetch_parse_check_metrics(&socket_ports).await
+        });
+
+        // check request
+        let request_operations = ["notify", "query", "status", "unknown", "update"];
+        request_operations.iter().for_each(|op| {
+            let value = if *op == "query" { 1f64 } else { 0f64 };
+            let op = [("operation", *op)];
+            verify_metric(
+                metrics,
+                "hickory_request_operations_total",
+                &op,
+                Some(value),
+            )
+        });
+
+        let flags = ["aa", "ad", "cd", "ra", "rd", "tc"];
+        flags.iter().for_each(|flag| {
+            let value = if *flag == "rd" { 1f64 } else { 0f64 };
+            let flag = [("flag", *flag)];
+            verify_metric(metrics, "hickory_request_flags_total", &flag, Some(value))
+        });
+
+        let protocols = ["tcp", "udp"];
+        protocols.iter().for_each(|proto| {
+            let value = if *proto == "tcp" { 1f64 } else { 0f64 };
+            let proto = [("protocol", *proto)];
+            verify_metric(
+                metrics,
+                "hickory_request_protocols_total",
+                &proto,
+                Some(value),
+            )
+        });
+
+        // check response
+        let response_codes = vec![
+            "bad_alg",
+            "bad_cookie",
+            "bad_key",
+            "bad_mode",
+            "bad_name",
+            "bad_sig",
+            "bad_time",
+            "bad_trunc",
+            "bad_vers",
+            "form_error",
+            "no_error",
+            "not_auth",
+            "not_imp",
+            "not_zone",
+            "nx_domain",
+            "nx_rrset",
+            "refused",
+            "serv_fail",
+            "unknown",
+            "yx_domain",
+            "yx_rrset",
+        ];
+        response_codes.iter().for_each(|code| {
+            let value = if *code == "no_error" { 1f64 } else { 0f64 };
+            let code = [("code", *code)];
+            verify_metric(metrics, "hickory_response_codes_total", &code, Some(value))
+        });
+
+        flags.iter().for_each(|flag| {
+            let value = if ["aa", "rd"].contains(flag) {
+                1f64
+            } else {
+                0f64
+            };
+            let flag = [("flag", *flag)];
+            verify_metric(metrics, "hickory_response_flags_total", &flag, Some(value))
+        });
+
+        // check store lookups
+        verify_metric(
+            metrics,
+            "hickory_zone_record_lookups_total",
+            &STORE_FILE_SUCCESS,
+            Some(1f64),
+        );
+        verify_metric(
+            metrics,
+            "hickory_zone_record_lookups_total",
+            &STORE_FILE_FAILED,
+            Some(0f64),
+        );
+        verify_metric(
+            metrics,
+            "hickory_zone_record_lookups_total",
+            &STORE_FORWARDER_SUCCESS,
+            Some(0f64),
+        );
+        verify_metric(
+            metrics,
+            "hickory_zone_record_lookups_total",
+            &STORE_FORWARDER_FAILED,
+            Some(0f64),
+        );
+    })
+}
+
+#[test]
+#[cfg(all(feature = "__dnssec", feature = "sqlite"))]
+fn test_updates() {
+    subscribe();
+
+    named_test_harness("dnssec_with_update.toml", |socket_ports| {
+        let io_loop = Runtime::new().unwrap();
+        let metrics = &io_loop.block_on(async {
+            let rsa_key =
+                include_bytes!("../../../tests/test-data/test_configs/dnssec/rsa_2048.pk8");
+            let verify_algo = Algorithm::RSASHA256;
+            let verify_key =
+                RsaSigningKey::from_pkcs8(&PrivatePkcs8KeyDer::from(rsa_key.to_vec()), verify_algo)
+                    .unwrap();
+            let mut trust_anchor = TrustAnchors::empty();
+            trust_anchor.insert(&verify_key.to_public_key().unwrap());
+
+            let origin: Name = Name::parse("example.com.", None).unwrap();
+
+            let update_algo = Algorithm::RSASHA512;
+            let update_key =
+                RsaSigningKey::from_pkcs8(&PrivatePkcs8KeyDer::from(rsa_key.to_vec()), update_algo)
+                    .unwrap();
+            let signer = SigSigner::dnssec(
+                DNSKEY::from_key(&update_key.to_public_key().unwrap()),
+                Box::new(update_key),
+                origin.clone(),
+                time::Duration::weeks(1).try_into().unwrap(),
+            );
+
+            let client = create_local_client(&socket_ports, Some(Arc::new(signer))).await;
+            let mut client = DnssecDnsHandle::with_trust_anchor(client, Arc::new(trust_anchor));
+
+            let rrset_create = Record::from_rdata(
+                Name::from_str("zzz.example.com").unwrap(),
+                3600,
+                RData::A(A::from(Ipv4Addr::LOCALHOST)),
+            );
+            client.create(rrset_create, origin.clone()).await.unwrap();
+
+            let record_update = Record::from_rdata(
+                Name::from_str("zzz.example.com").unwrap(),
+                1800,
+                RData::A(A::from(Ipv4Addr::LOCALHOST)),
+            );
+            client
+                .append(record_update, origin.clone(), true)
+                .await
+                .unwrap();
+
+            let rrset_delete = Record::from_rdata(
+                Name::from_str("zzz.example.com").unwrap(),
+                3600,
+                RData::A(A::from(Ipv4Addr::LOCALHOST)),
+            );
+            client
+                .delete_rrset(rrset_delete, origin.clone())
+                .await
+                .unwrap();
+
+            fetch_parse_check_metrics(&socket_ports).await
+        });
+
+        verify_metric(
+            metrics,
+            "hickory_request_operations_total",
+            &[("operation", "update")],
+            Some(3f64),
+        );
+        // check updates lookups
+        verify_metric(
+            metrics,
+            "hickory_zone_records_modified_total",
+            &[("store", "sqlite"), ("operation", "added")],
+            Some(1f64),
+        );
+        verify_metric(
+            metrics,
+            "hickory_zone_records_modified_total",
+            &[("store", "sqlite"), ("operation", "deleted")],
+            Some(1f64),
+        );
+        verify_metric(
+            metrics,
+            "hickory_zone_records_modified_total",
+            &[("store", "sqlite"), ("operation", "updated")],
+            Some(1f64),
+        );
+    });
+}
+
+async fn create_local_client(
+    socket_ports: &SocketPorts,
+    signer: Option<Arc<dyn MessageFinalizer>>,
+) -> Client {
+    let dns_port = socket_ports.get_v4(ServerProtocol::Dns(Protocol::Tcp));
+    let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, dns_port.expect("no dns tcp port")));
+
+    let (stream, sender) = TcpClientStream::new(addr, None, None, TokioRuntimeProvider::new());
+    let client = Client::new(stream, sender, signer);
+    let (client, bg) = client.await.expect("connection failed");
+    tokio::spawn(bg);
+    client
+}
+
+async fn fetch_parse_check_metrics(socket_ports: &SocketPorts) -> Scrape {
+    let prometheus_port = socket_ports.get_v4(ServerProtocol::PrometheusMetrics);
+    let addr = SocketAddr::from((
+        Ipv4Addr::LOCALHOST,
+        prometheus_port.expect("no prometheus_port"),
+    ));
+
+    // the collect interval for process metrics is set to 1s
+    // wait to avoid missing the process metrics
+    sleep(Duration::from_secs(1)).await;
+
+    // fetch from metrics from server
+    let body = reqwest::get(format!("http://{}:{}/", addr.ip(), addr.port()))
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    let lines = body.lines().map(|s| Ok(s.to_owned())).collect::<Vec<_>>();
+    let scrape = Scrape::parse(lines.into_iter()).unwrap();
+
+    test_metrics_description_present(scrape.clone());
+    scrape
+}
+
+fn test_metrics_description_present(scrape: Scrape) {
+    let missing = scrape
+        .samples
+        .into_iter()
+        .filter_map(|s| {
+            if !scrape.docs.contains_key(&s.metric) {
+                Some(s.metric)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<String>>();
+
+    assert_eq!(
+        Vec::<String>::new(),
+        missing,
+        "due to missing metric descriptions"
+    );
+}
+
+fn verify_metric(metrics: &Scrape, name: &str, labels: &[(&str, &str)], value: Option<f64>) {
+    let named = metrics
+        .samples
+        .iter()
+        .filter(|s| s.metric == name)
+        .collect::<Vec<_>>();
+
+    assert!(!named.is_empty(), "failed locating metric: {}", name);
+
+    let labeled = named
+        .iter()
+        .filter(|s| {
+            labels.len()
+                == labels
+                    .iter()
+                    .filter(|(k, v)| {
+                        let Some(val) = s.labels.get(k) else {
+                            return false;
+                        };
+                        val == *v
+                    })
+                    .count()
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        labeled.len(),
+        1,
+        "locating metric: {}, labels: {:?}",
+        name,
+        labels
+    );
+
+    let Some(value) = value else { return };
+
+    labeled.iter().for_each(|s| match s.value {
+        Value::Counter(v) | Value::Gauge(v) | Value::Untyped(v) => {
+            println!(
+                "checking metric: {}, labels: {}, value: {}",
+                s.metric, s.labels, v
+            );
+            assert_eq!(
+                v, value,
+                "checking metric: {}, labels: {}, value: {}",
+                s.metric, s.labels, v
+            )
+        }
+        Value::Histogram(_) | Value::Summary(_) => {
+            panic!("metric type check not supported")
+        }
+    })
+}
+
+const STORE_FILE_SUCCESS: [(&str, &str); 2] = [("store", "file"), ("success", "true")];
+const STORE_FILE_FAILED: [(&str, &str); 2] = [("store", "file"), ("success", "false")];
+const STORE_FORWARDER_SUCCESS: [(&str, &str); 2] = [("store", "forwarder"), ("success", "true")];
+const STORE_FORWARDER_FAILED: [(&str, &str); 2] = [("store", "forwarder"), ("success", "false")];

--- a/crates/recursor/Cargo.toml
+++ b/crates/recursor/Cargo.toml
@@ -91,7 +91,7 @@ path = "src/lib.rs"
 [dependencies]
 async-trait.workspace = true
 async-recursion.workspace = true
-backtrace = { version = "0.3.50", optional = true }
+backtrace = { workspace = true, optional = true }
 bytes.workspace = true
 cfg-if.workspace = true
 enum-as-inner.workspace = true

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -60,7 +60,7 @@ name = "hickory_resolver"
 path = "src/lib.rs"
 
 [dependencies]
-backtrace = { version = "0.3.50", optional = true }
+backtrace = { workspace = true, optional = true }
 cfg-if.workspace = true
 futures-util = { workspace = true, default-features = false, features = [
     "std",

--- a/crates/server/src/server/metrics.rs
+++ b/crates/server/src/server/metrics.rs
@@ -1,0 +1,273 @@
+use hickory_proto::op::{Header, OpCode, ResponseCode};
+use hickory_proto::xfer::Protocol;
+use metrics::{Counter, Unit, counter, describe_counter};
+
+#[derive(Clone)]
+pub(super) struct ResponseHandlerMetrics {
+    pub(super) proto: ProtocolMetrics,
+    pub(super) operation: OpCodeMetrics,
+    pub(super) request_flags: FlagMetrics,
+    pub(super) response_code: ResponseCodeMetrics,
+    pub(super) response_flags: FlagMetrics,
+}
+
+impl Default for ResponseHandlerMetrics {
+    fn default() -> Self {
+        Self {
+            proto: ProtocolMetrics::default(),
+            operation: OpCodeMetrics::default(),
+            request_flags: FlagMetrics::new("request"),
+            response_code: ResponseCodeMetrics::default(),
+            response_flags: FlagMetrics::new("response"),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct FlagMetrics {
+    authoritative: Counter,
+    authentic_data: Counter,
+    checking_disabled: Counter,
+    recursion_available: Counter,
+    recursion_desired: Counter,
+    truncation: Counter,
+}
+
+impl FlagMetrics {
+    fn new(direction: &'static str) -> Self {
+        let flags_name = format!("hickory_{}_flags_total", direction);
+        let key = "flag";
+        Self {
+            authoritative: {
+                let new = counter!(flags_name.clone(), key => "aa");
+                describe_counter!(
+                    flags_name.clone(),
+                    Unit::Count,
+                    "number of dns request flags"
+                );
+                new
+            },
+            authentic_data: counter!(flags_name.clone(), key => "ad"),
+            checking_disabled: counter!(flags_name.clone(), key => "cd"),
+            recursion_available: counter!(flags_name.clone(), key => "ra"),
+            recursion_desired: counter!(flags_name.clone(), key => "rd"),
+            truncation: counter!(flags_name, key => "tc"),
+        }
+    }
+}
+
+impl FlagMetrics {
+    pub(super) fn increment(&self, header: &Header) {
+        if header.authoritative() {
+            self.authoritative.increment(1);
+        }
+        if header.authentic_data() {
+            self.authentic_data.increment(1);
+        }
+        if header.checking_disabled() {
+            self.checking_disabled.increment(1);
+        }
+        if header.recursion_available() {
+            self.recursion_available.increment(1);
+        }
+        if header.recursion_desired() {
+            self.recursion_desired.increment(1);
+        }
+        if header.truncated() {
+            self.truncation.increment(1);
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct ProtocolMetrics {
+    udp: Counter,
+    tcp: Counter,
+    #[cfg(feature = "__tls")]
+    tls: Counter,
+    #[cfg(feature = "__https")]
+    https: Counter,
+    #[cfg(feature = "__quic")]
+    quic: Counter,
+    #[cfg(feature = "__h3")]
+    h3: Counter,
+}
+
+impl Default for ProtocolMetrics {
+    fn default() -> Self {
+        let request_protocols_name = "hickory_request_protocols_total";
+        let key = "protocol";
+        Self {
+            udp: {
+                let new = counter!(request_protocols_name, key => "udp");
+                describe_counter!(
+                    request_protocols_name,
+                    Unit::Count,
+                    "number of dns requests operations"
+                );
+                new
+            },
+            tcp: counter!(request_protocols_name, key => "tcp"),
+            #[cfg(feature = "__tls")]
+            tls: counter!(request_protocols_name, key => "tls"),
+            #[cfg(feature = "__https")]
+            https: counter!(request_protocols_name, key => "https"),
+            #[cfg(feature = "__quic")]
+            quic: counter!(request_protocols_name, key => "quic"),
+            #[cfg(feature = "__h3")]
+            h3: counter!(request_protocols_name, key => "http3"),
+        }
+    }
+}
+
+impl ProtocolMetrics {
+    pub(super) fn increment(&self, proto: &Protocol) {
+        match proto {
+            Protocol::Udp => self.udp.increment(1),
+            Protocol::Tcp => self.tcp.increment(1),
+            #[cfg(feature = "__tls")]
+            Protocol::Tls => self.tls.increment(1),
+            #[cfg(feature = "__https")]
+            Protocol::Https => self.https.increment(1),
+            #[cfg(feature = "__quic")]
+            Protocol::Quic => self.quic.increment(1),
+            #[cfg(feature = "__h3")]
+            Protocol::H3 => self.h3.increment(1),
+            _ => {}
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct OpCodeMetrics {
+    query: Counter,
+    status: Counter,
+    notify: Counter,
+    update: Counter,
+    unknown: Counter,
+}
+
+impl Default for OpCodeMetrics {
+    fn default() -> Self {
+        let request_operations_name = "hickory_request_operations_total";
+        let key = "operation";
+        Self {
+            query: {
+                let new = counter!(request_operations_name, key => "query");
+                describe_counter!(
+                    request_operations_name,
+                    Unit::Count,
+                    "number of dns request operations"
+                );
+                new
+            },
+            status: counter!(request_operations_name, key => "status"),
+            notify: counter!(request_operations_name, key => "notify"),
+            update: counter!(request_operations_name, key => "update"),
+            unknown: counter!(request_operations_name, key => "unknown"),
+        }
+    }
+}
+
+impl OpCodeMetrics {
+    pub(super) fn increment(&self, op_code: &OpCode) {
+        match op_code {
+            OpCode::Query => self.query.increment(1),
+            OpCode::Status => self.status.increment(1),
+            OpCode::Notify => self.notify.increment(1),
+            OpCode::Update => self.update.increment(1),
+            OpCode::Unknown(_) => self.unknown.increment(1),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct ResponseCodeMetrics {
+    no_error: Counter,
+    form_error: Counter,
+    serv_fail: Counter,
+    nx_domain: Counter,
+    not_imp: Counter,
+    refused: Counter,
+    yx_domain: Counter,
+    yx_rrset: Counter,
+    nx_rrset: Counter,
+    not_auth: Counter,
+    not_zone: Counter,
+    bad_vers: Counter,
+    bad_sig: Counter,
+    bad_key: Counter,
+    bad_time: Counter,
+    bad_mode: Counter,
+    bad_name: Counter,
+    bad_alg: Counter,
+    bad_trunc: Counter,
+    bad_cookie: Counter,
+    unknown: Counter,
+}
+
+impl Default for ResponseCodeMetrics {
+    fn default() -> Self {
+        let response_codes_name = "hickory_response_codes_total";
+        let key = "code";
+        Self {
+            no_error: {
+                let new = counter!(response_codes_name, "code" => "no_error");
+                describe_counter!(
+                    response_codes_name,
+                    Unit::Count,
+                    "number of dns response codes"
+                );
+                new
+            },
+            form_error: counter!(response_codes_name, key => "form_error"),
+            serv_fail: counter!(response_codes_name, key => "serv_fail"),
+            nx_domain: counter!(response_codes_name, key => "nx_domain"),
+            not_imp: counter!(response_codes_name, key => "not_imp"),
+            refused: counter!(response_codes_name, key => "refused"),
+            yx_domain: counter!(response_codes_name, key => "yx_domain"),
+            yx_rrset: counter!(response_codes_name, key => "yx_rrset"),
+            nx_rrset: counter!(response_codes_name, key => "nx_rrset"),
+            not_auth: counter!(response_codes_name, key => "not_auth"),
+            not_zone: counter!(response_codes_name, key => "not_zone"),
+            bad_vers: counter!(response_codes_name, key => "bad_vers"),
+            bad_sig: counter!(response_codes_name, key => "bad_sig"),
+            bad_key: counter!(response_codes_name, key => "bad_key"),
+            bad_time: counter!(response_codes_name, key => "bad_time"),
+            bad_mode: counter!(response_codes_name, key => "bad_mode"),
+            bad_name: counter!(response_codes_name, key => "bad_name"),
+            bad_alg: counter!(response_codes_name, key => "bad_alg"),
+            bad_trunc: counter!(response_codes_name, key => "bad_trunc"),
+            bad_cookie: counter!(response_codes_name, key => "bad_cookie"),
+            unknown: counter!(response_codes_name, key => "unknown"),
+        }
+    }
+}
+
+impl ResponseCodeMetrics {
+    pub(super) fn increment(&self, response_code: &ResponseCode) {
+        match response_code {
+            ResponseCode::NoError => self.no_error.increment(1),
+            ResponseCode::FormErr => self.form_error.increment(1),
+            ResponseCode::ServFail => self.serv_fail.increment(1),
+            ResponseCode::NXDomain => self.nx_domain.increment(1),
+            ResponseCode::NotImp => self.not_imp.increment(1),
+            ResponseCode::Refused => self.refused.increment(1),
+            ResponseCode::YXDomain => self.yx_domain.increment(1),
+            ResponseCode::YXRRSet => self.yx_rrset.increment(1),
+            ResponseCode::NXRRSet => self.nx_rrset.increment(1),
+            ResponseCode::NotAuth => self.not_auth.increment(1),
+            ResponseCode::NotZone => self.not_zone.increment(1),
+            ResponseCode::BADVERS => self.bad_vers.increment(1),
+            ResponseCode::BADSIG => self.bad_sig.increment(1),
+            ResponseCode::BADKEY => self.bad_key.increment(1),
+            ResponseCode::BADTIME => self.bad_time.increment(1),
+            ResponseCode::BADMODE => self.bad_mode.increment(1),
+            ResponseCode::BADNAME => self.bad_name.increment(1),
+            ResponseCode::BADALG => self.bad_alg.increment(1),
+            ResponseCode::BADTRUNC => self.bad_trunc.increment(1),
+            ResponseCode::BADCOOKIE => self.bad_cookie.increment(1),
+            ResponseCode::Unknown(_) => self.unknown.increment(1),
+        }
+    }
+}

--- a/crates/server/src/server/response_handler.rs
+++ b/crates/server/src/server/response_handler.rs
@@ -26,7 +26,7 @@ pub trait ResponseHandler: Clone + Send + Sync + Unpin + 'static {
     // TODO: add associated error type
     //type Error;
 
-    /// Serializes and sends a message to to the wrapped handle
+    /// Serializes and sends a message to the wrapped handle
     ///
     /// self is consumed as only one message should ever be sent in response to a Request
     async fn send_response<'a>(

--- a/crates/server/src/store/forwarder.rs
+++ b/crates/server/src/store/forwarder.rs
@@ -268,7 +268,7 @@ impl<P: ConnectionProvider> Authority for ForwardAuthority<P> {
         };
 
         #[cfg(feature = "metrics")]
-        self.metrics.zone_record_lookups.increment(1);
+        self.metrics.increment_lookup(&lookup);
 
         lookup
     }

--- a/crates/server/src/store/metrics.rs
+++ b/crates/server/src/store/metrics.rs
@@ -1,3 +1,4 @@
+use crate::authority::{LookupControlFlow, LookupObject};
 use metrics::{Counter, Gauge, Unit, counter, describe_counter, describe_gauge, gauge};
 
 pub(super) struct StoreMetrics {
@@ -15,16 +16,19 @@ impl StoreMetrics {
 }
 
 pub(super) struct PersistentStoreMetrics {
-    pub(super) zone_records_total: Gauge,
+    pub(super) zone_records: Gauge,
     #[cfg(feature = "__dnssec")]
     pub(super) zone_records_dynamically_updated: Counter,
 }
 
 impl PersistentStoreMetrics {
     pub(crate) fn new(store: &'static str) -> Self {
-        let zone_records_total = gauge!("hickory_zone_records_total", "store" => store);
+        let store_key = "store";
+
+        let zone_records_name = "hickory_zone_records_total";
+        let zone_records = gauge!(zone_records_name, store_key => store);
         describe_gauge!(
-            "hickory_zone_records_total",
+            zone_records_name,
             Unit::Count,
             "number of dns zone records in persisted storages"
         );
@@ -42,7 +46,7 @@ impl PersistentStoreMetrics {
         };
 
         Self {
-            zone_records_total,
+            zone_records,
             #[cfg(feature = "__dnssec")]
             zone_records_dynamically_updated,
         }
@@ -50,20 +54,47 @@ impl PersistentStoreMetrics {
 }
 
 pub(super) struct QueryStoreMetrics {
-    pub(super) zone_record_lookups: Counter,
+    pub(super) zone_record_lookups_success: Counter,
+    pub(super) zone_record_lookups_error: Counter,
 }
 
 impl QueryStoreMetrics {
     pub(crate) fn new(store: &'static str) -> Self {
-        let zone_record_lookups = counter!("hickory_zone_record_lookups_total", "store" => store);
+        let zone_record_lookups_name = "hickory_zone_record_lookups_total";
+        let store_key = "store";
+        let success_key = "success";
+
+        let zone_record_lookups_success =
+            counter!(zone_record_lookups_name, store_key => store, success_key => "true");
+        let zone_record_lookups_error =
+            counter!(zone_record_lookups_name, store_key => store, success_key => "false");
+
         describe_counter!(
-            "hickory_zone_record_lookups_total",
+            zone_record_lookups_name,
             Unit::Count,
             "number of occurred dns zone record lookups"
         );
 
         Self {
-            zone_record_lookups,
+            zone_record_lookups_success,
+            zone_record_lookups_error,
+        }
+    }
+
+    pub(super) fn increment_lookup<T: LookupObject>(
+        &self,
+        lookup_control_flow: &LookupControlFlow<T>,
+    ) {
+        let is_success = match lookup_control_flow {
+            LookupControlFlow::Continue(res) => res.is_ok(),
+            LookupControlFlow::Break(res) => res.is_ok(),
+            LookupControlFlow::Skip => false,
+        };
+
+        if is_success {
+            self.zone_record_lookups_success.increment(1)
+        } else {
+            self.zone_record_lookups_error.increment(1)
         }
     }
 }

--- a/crates/server/src/store/metrics.rs
+++ b/crates/server/src/store/metrics.rs
@@ -17,10 +17,16 @@ impl StoreMetrics {
 
 pub(super) struct PersistentStoreMetrics {
     pub(super) zone_records: Gauge,
+    #[cfg(feature = "__dnssec")]
+    pub(super) zone_records_added: Counter,
+    #[cfg(feature = "__dnssec")]
+    pub(super) zone_records_deleted: Counter,
+    #[cfg(feature = "__dnssec")]
+    pub(super) zone_records_updated: Counter,
 }
 
 impl PersistentStoreMetrics {
-    pub(crate) fn new(store: &'static str) -> Self {
+    pub(super) fn new(store: &'static str) -> Self {
         let store_key = "store";
 
         let zone_records_name = "hickory_zone_records_total";
@@ -31,7 +37,51 @@ impl PersistentStoreMetrics {
             "number of dns zone records in persisted storages"
         );
 
-        Self { zone_records }
+        #[cfg(feature = "__dnssec")]
+        let (zone_records_added, zone_records_deleted, zone_records_updated) = {
+            let zone_records_modified_name = "hickory_zone_records_modified_total";
+
+            let operation_key = "operation";
+
+            let records_added =
+                counter!(zone_records_modified_name, store_key => store, operation_key => "added");
+            let records_deleted = counter!(zone_records_modified_name, store_key => store, operation_key => "deleted");
+            let records_updated = counter!(zone_records_modified_name, store_key => store, operation_key => "updated");
+
+            describe_counter!(
+                zone_records_modified_name,
+                Unit::Count,
+                "number of dns zone records that had been modified"
+            );
+
+            (records_added, records_deleted, records_updated)
+        };
+
+        Self {
+            zone_records,
+            #[cfg(feature = "__dnssec")]
+            zone_records_added,
+            #[cfg(feature = "__dnssec")]
+            zone_records_deleted,
+            #[cfg(feature = "__dnssec")]
+            zone_records_updated,
+        }
+    }
+
+    #[cfg(feature = "__dnssec")]
+    pub(super) fn added(&self) {
+        self.zone_records_added.increment(1);
+        self.zone_records.increment(1);
+    }
+
+    #[cfg(feature = "__dnssec")]
+    pub(super) fn deleted(&self) {
+        self.zone_records_deleted.increment(1);
+        self.zone_records.decrement(1)
+    }
+    #[cfg(feature = "__dnssec")]
+    pub(super) fn updated(&self) {
+        self.zone_records_updated.increment(1);
     }
 }
 

--- a/crates/server/src/store/metrics.rs
+++ b/crates/server/src/store/metrics.rs
@@ -17,8 +17,6 @@ impl StoreMetrics {
 
 pub(super) struct PersistentStoreMetrics {
     pub(super) zone_records: Gauge,
-    #[cfg(feature = "__dnssec")]
-    pub(super) zone_records_dynamically_updated: Counter,
 }
 
 impl PersistentStoreMetrics {
@@ -33,23 +31,7 @@ impl PersistentStoreMetrics {
             "number of dns zone records in persisted storages"
         );
 
-        #[cfg(feature = "__dnssec")]
-        let zone_records_dynamically_updated = {
-            let zone_records_dynamically_updated =
-                counter!("hickory_zone_records_dynamically_updated_total", "store" => store);
-            describe_counter!(
-                "hickory_zone_records_dynamically_updated_total",
-                Unit::Count,
-                "number of dns zone records that had been dynamically updated"
-            );
-            zone_records_dynamically_updated
-        };
-
-        Self {
-            zone_records,
-            #[cfg(feature = "__dnssec")]
-            zone_records_dynamically_updated,
-        }
+        Self { zone_records }
     }
 }
 

--- a/crates/server/src/store/sqlite/mod.rs
+++ b/crates/server/src/store/sqlite/mod.rs
@@ -136,7 +136,7 @@ impl SqliteAuthority {
                 zone_file_path: config.zone_file_path.clone(),
             };
 
-            let in_memory = FileAuthority::try_from_config(
+            let in_memory = FileAuthority::try_from_config_internal(
                 zone_name.clone(),
                 zone_type,
                 allow_axfr,
@@ -144,6 +144,8 @@ impl SqliteAuthority {
                 &file_config,
                 #[cfg(feature = "__dnssec")]
                 nx_proof_kind,
+                #[cfg(feature = "metrics")]
+                true,
             )?
             .unwrap();
 

--- a/crates/server/src/store/sqlite/mod.rs
+++ b/crates/server/src/store/sqlite/mod.rs
@@ -951,17 +951,7 @@ impl Authority for SqliteAuthority {
         self.verify_prerequisites(update.prerequisites()).await?;
         self.pre_scan(update.updates()).await?;
 
-        let updated = self.update_records(update.updates(), true).await;
-
-        #[cfg(feature = "metrics")]
-        if updated == Ok(true) {
-            self.metrics
-                .persistent
-                .zone_records_dynamically_updated
-                .increment(update.updates().len() as u64);
-        }
-
-        updated
+        self.update_records(update.updates(), true).await
     }
 
     /// Always fail when DNSSEC is disabled.


### PR DESCRIPTION
This PR adds more https://github.com/hickory-dns/hickory-dns/issues/2032 and enhances existing metrics (https://github.com/hickory-dns/hickory-dns/pull/2886).

The following areas are covered:
- process metrics
- hickory & config metadata
- request / response metrics
- refined dynamic record update metrics
- refined store lookup metrics

Kind regards,
Harald