### PR TITLE
Update specification excerpts

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Zones will be automatically resigned on any record updates via dynamic DNS. To e
 - [RFC 6761](https://tools.ietf.org/html/rfc6761): Special-Use Domain Names (resolver)
 - [RFC 6762](https://tools.ietf.org/html/rfc6762): mDNS Multicast DNS (experimental feature: `mdns`)
 - [RFC 6763](https://tools.ietf.org/html/rfc6763): DNS-SD Service Discovery (experimental feature: `mdns`)
-- [RFC ANAME](https://tools.ietf.org/html/draft-ietf-dnsop-aname-02): Address-specific DNS aliases (`ANAME`)
+- [draft-ietf-dnsop-aname](https://tools.ietf.org/html/draft-ietf-dnsop-aname-04): Address-specific DNS aliases (`ANAME`)
 
 ### Update operations
 
@@ -86,7 +86,7 @@ Zones will be automatically resigned on any record updates via dynamic DNS. To e
 - [RFC 6944](https://tools.ietf.org/html/rfc6944): DNSKEY Algorithm Implementation Status
 - [RFC 6975](https://tools.ietf.org/html/rfc6975): Signaling Cryptographic Algorithm Understanding
 - [RFC 7858](https://tools.ietf.org/html/rfc7858): DNS over TLS (feature: `dns-over-rustls`, `dns-over-native-tls`, or `dns-over-openssl`)
-- [RFC DoH](https://tools.ietf.org/html/draft-ietf-doh-dns-over-https-14): DNS over HTTPS, DoH (feature: `dns-over-https-rustls`)
+- [RFC 8484](https://tools.ietf.org/html/rfc8484): DNS over HTTPS, DoH (feature: `dns-over-https-rustls`)
 
 ## RFCs in progress or not yet implemented
 
@@ -99,12 +99,12 @@ Zones will be automatically resigned on any record updates via dynamic DNS. To e
 - [RFC 1995](https://tools.ietf.org/html/rfc1995): Incremental Zone Transfer
 - [RFC 1996](https://tools.ietf.org/html/rfc1996): Notify secondaries of update
 - [Update Leases](https://tools.ietf.org/html/draft-sekar-dns-ul-01): Dynamic DNS Update Leases
-- [Long-Lived Queries](https://tools.ietf.org/html/draft-sekar-dns-llq-01): Notify with bells
+- [RFC 8764](https://tools.ietf.org/html/rfc8764): Notify with bells
 
 ### Secure DNS operations
 
 - [DNSCrypt](https://dnscrypt.org): Trusted DNS queries
-- [S/MIME](https://tools.ietf.org/html/draft-ietf-dane-smime-09): Domain Names For S/MIME
+- [RFC 8162](https://tools.ietf.org/html/rfc8162): Domain Names For S/MIME
 
 ## Minimum Rust Version
 

--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -69,7 +69,7 @@ static DEFAULT_PATH: &str = "/var/named"; // TODO what about windows (do I care?
 static DEFAULT_PORT: u16 = 53;
 static DEFAULT_TLS_PORT: u16 = 853;
 static DEFAULT_HTTPS_PORT: u16 = 443;
-static DEFAULT_QUIC_PORT: u16 = 853; // https://www.ietf.org/archive/id/draft-ietf-dprive-dnsoquic-11.html#name-reservation-of-dedicated-po
+static DEFAULT_QUIC_PORT: u16 = 853; // https://www.rfc-editor.org/rfc/rfc9250.html#name-reservation-of-a-dedicated-
 static DEFAULT_H3_PORT: u16 = 443;
 static DEFAULT_TCP_REQUEST_TIMEOUT: u64 = 5;
 

--- a/crates/proto/src/dnssec/algorithm.rs
+++ b/crates/proto/src/dnssec/algorithm.rs
@@ -132,7 +132,7 @@ pub enum Algorithm {
     ECDSAP256SHA256,
     /// [rfc6605](https://tools.ietf.org/html/rfc6605)
     ECDSAP384SHA384,
-    /// [draft-ietf-curdle-dnskey-eddsa-03](https://tools.ietf.org/html/draft-ietf-curdle-dnskey-eddsa-03)
+    /// [RFC 8080](https://datatracker.ietf.org/doc/html/rfc8080)
     ED25519,
     /// An unknown algorithm identifier
     Unknown(u8),

--- a/crates/proto/src/dnssec/crypto.rs
+++ b/crates/proto/src/dnssec/crypto.rs
@@ -261,13 +261,12 @@ pub struct Ed25519<'k> {
 
 impl<'k> Ed25519<'k> {
     /// ```text
-    ///  Internet-Draft              EdDSA for DNSSEC               December 2016
+    /// RFC 8080                    EdDSA for DNSSEC               February 2017
     ///
     ///  An Ed25519 public key consists of a 32-octet value, which is encoded
     ///  into the Public Key field of a DNSKEY resource record as a simple bit
     ///  string.  The generation of a public key is defined in Section 5.1.5
-    ///  in [RFC 8032]. Breaking tradition, the keys are encoded in little-
-    ///  endian byte order.
+    ///  of [RFC8032].
     /// ```
     pub fn from_public_bytes(public_key: Cow<'k, [u8]>) -> ProtoResult<Self> {
         if public_key.len() != ED25519_PUBLIC_KEY_LEN {

--- a/crates/proto/src/dnssec/rdata/ds.rs
+++ b/crates/proto/src/dnssec/rdata/ds.rs
@@ -322,8 +322,6 @@ impl Display for DS {
 
 /// The key tag is calculated as a hash to more quickly lookup a DNSKEY.
 ///
-/// [RFC 1035](https://tools.ietf.org/html/rfc1035), DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987
-///
 /// ```text
 /// RFC 2535                DNS Security Extensions               March 1999
 ///

--- a/crates/proto/src/dnssec/signer.rs
+++ b/crates/proto/src/dnssec/signer.rs
@@ -342,8 +342,6 @@ impl SigSigner {
     // TODO: move this to DNSKEY/KEY?
     /// The key tag is calculated as a hash to more quickly lookup a DNSKEY.
     ///
-    /// [RFC 1035](https://tools.ietf.org/html/rfc1035), DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987
-    ///
     /// ```text
     /// RFC 2535                DNS Security Extensions               March 1999
     ///

--- a/crates/proto/src/h2/h2_client_stream.rs
+++ b/crates/proto/src/h2/h2_client_stream.rs
@@ -194,46 +194,50 @@ impl DnsRequestSender for HttpsClientStream {
     ///   this will have no date.
     ///
     /// ```text
-    /// 5.2.  The HTTP Response
+    /// RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
     ///
-    ///    An HTTP response with a 2xx status code ([RFC7231] Section 6.3)
-    ///    indicates a valid DNS response to the query made in the HTTP request.
-    ///    A valid DNS response includes both success and failure responses.
-    ///    For example, a DNS failure response such as SERVFAIL or NXDOMAIN will
-    ///    be the message in a successful 2xx HTTP response even though there
-    ///    was a failure at the DNS layer.  Responses with non-successful HTTP
-    ///    status codes do not contain DNS answers to the question in the
-    ///    corresponding request.  Some of these non-successful HTTP responses
-    ///    (e.g., redirects or authentication failures) could mean that clients
-    ///    need to make new requests to satisfy the original question.
     ///
-    ///    Different response media types will provide more or less information
-    ///    from a DNS response.  For example, one response type might include
-    ///    the information from the DNS header bytes while another might omit
-    ///    it.  The amount and type of information that a media type gives is
-    ///    solely up to the format, and not defined in this protocol.
+    /// 4.2.  The HTTP Response
     ///
     ///    The only response type defined in this document is "application/dns-
     ///    message", but it is possible that other response formats will be
-    ///    defined in the future.
+    ///    defined in the future.  A DoH server MUST be able to process
+    ///    "application/dns-message" request messages.
     ///
-    ///    The DNS response for "application/dns-message" in Section 7 MAY have
-    ///    one or more EDNS options [RFC6891], depending on the extension
-    ///    definition of the extensions given in the DNS request.
+    ///    Different response media types will provide more or less information
+    ///    from a DNS response.  For example, one response type might include
+    ///    information from the DNS header bytes while another might omit it.
+    ///    The amount and type of information that a media type gives are solely
+    ///    up to the format, which is not defined in this protocol.
     ///
-    ///    Each DNS request-response pair is matched to one HTTP exchange.  The
+    ///    Each DNS request-response pair is mapped to one HTTP exchange.  The
     ///    responses may be processed and transported in any order using HTTP's
-    ///    multi-streaming functionality ([RFC7540] Section 5).
+    ///    multi-streaming functionality (see Section 5 of [RFC7540]).
     ///
-    ///    Section 6.1 discusses the relationship between DNS and HTTP response
+    ///    Section 5.1 discusses the relationship between DNS and HTTP response
     ///    caching.
     ///
-    ///    A DNS API server MUST be able to process application/dns-message
-    ///    request messages.
+    /// 4.2.1.  Handling DNS and HTTP Errors
     ///
-    ///    A DNS API server SHOULD respond with HTTP status code 415
-    ///    (Unsupported Media Type) upon receiving a media type it is unable to
-    ///    process.
+    ///    DNS response codes indicate either success or failure for the DNS
+    ///    query.  A successful HTTP response with a 2xx status code (see
+    ///    Section 6.3 of [RFC7231]) is used for any valid DNS response,
+    ///    regardless of the DNS response code.  For example, a successful 2xx
+    ///    HTTP status code is used even with a DNS message whose DNS response
+    ///    code indicates failure, such as SERVFAIL or NXDOMAIN.
+    ///
+    ///    HTTP responses with non-successful HTTP status codes do not contain
+    ///    replies to the original DNS question in the HTTP request.  DoH
+    ///    clients need to use the same semantic processing of non-successful
+    ///    HTTP status codes as other HTTP clients.  This might mean that the
+    ///    DoH client retries the query with the same DoH server, such as if
+    ///    there are authorization failures (HTTP status code 401; see
+    ///    Section 3.1 of [RFC7235]).  It could also mean that the DoH client
+    ///    retries with a different DoH server, such as for unsupported media
+    ///    types (HTTP status code 415; see Section 6.5.13 of [RFC7231]), or
+    ///    where the server cannot generate a representation suitable for the
+    ///    client (HTTP status code 406; see Section 6.5.6 of [RFC7231]), and so
+    ///    on.
     /// ```
     fn send_message(&mut self, mut request: DnsRequest) -> DnsResponseStream {
         if self.is_shutdown {

--- a/crates/proto/src/h3/h3_client_stream.rs
+++ b/crates/proto/src/h3/h3_client_stream.rs
@@ -197,46 +197,50 @@ impl DnsRequestSender for H3ClientStream {
     ///   this will have no date.
     ///
     /// ```text
-    /// 5.2.  The HTTP Response
+    /// RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
     ///
-    ///    An HTTP response with a 2xx status code ([RFC7231] Section 6.3)
-    ///    indicates a valid DNS response to the query made in the HTTP request.
-    ///    A valid DNS response includes both success and failure responses.
-    ///    For example, a DNS failure response such as SERVFAIL or NXDOMAIN will
-    ///    be the message in a successful 2xx HTTP response even though there
-    ///    was a failure at the DNS layer.  Responses with non-successful HTTP
-    ///    status codes do not contain DNS answers to the question in the
-    ///    corresponding request.  Some of these non-successful HTTP responses
-    ///    (e.g., redirects or authentication failures) could mean that clients
-    ///    need to make new requests to satisfy the original question.
     ///
-    ///    Different response media types will provide more or less information
-    ///    from a DNS response.  For example, one response type might include
-    ///    the information from the DNS header bytes while another might omit
-    ///    it.  The amount and type of information that a media type gives is
-    ///    solely up to the format, and not defined in this protocol.
+    /// 4.2.  The HTTP Response
     ///
     ///    The only response type defined in this document is "application/dns-
     ///    message", but it is possible that other response formats will be
-    ///    defined in the future.
+    ///    defined in the future.  A DoH server MUST be able to process
+    ///    "application/dns-message" request messages.
     ///
-    ///    The DNS response for "application/dns-message" in Section 7 MAY have
-    ///    one or more EDNS options [RFC6891], depending on the extension
-    ///    definition of the extensions given in the DNS request.
+    ///    Different response media types will provide more or less information
+    ///    from a DNS response.  For example, one response type might include
+    ///    information from the DNS header bytes while another might omit it.
+    ///    The amount and type of information that a media type gives are solely
+    ///    up to the format, which is not defined in this protocol.
     ///
-    ///    Each DNS request-response pair is matched to one HTTP exchange.  The
+    ///    Each DNS request-response pair is mapped to one HTTP exchange.  The
     ///    responses may be processed and transported in any order using HTTP's
-    ///    multi-streaming functionality ([RFC7540] Section 5).
+    ///    multi-streaming functionality (see Section 5 of [RFC7540]).
     ///
-    ///    Section 6.1 discusses the relationship between DNS and HTTP response
+    ///    Section 5.1 discusses the relationship between DNS and HTTP response
     ///    caching.
     ///
-    ///    A DNS API server MUST be able to process application/dns-message
-    ///    request messages.
+    /// 4.2.1.  Handling DNS and HTTP Errors
     ///
-    ///    A DNS API server SHOULD respond with HTTP status code 415
-    ///    (Unsupported Media Type) upon receiving a media type it is unable to
-    ///    process.
+    ///    DNS response codes indicate either success or failure for the DNS
+    ///    query.  A successful HTTP response with a 2xx status code (see
+    ///    Section 6.3 of [RFC7231]) is used for any valid DNS response,
+    ///    regardless of the DNS response code.  For example, a successful 2xx
+    ///    HTTP status code is used even with a DNS message whose DNS response
+    ///    code indicates failure, such as SERVFAIL or NXDOMAIN.
+    ///
+    ///    HTTP responses with non-successful HTTP status codes do not contain
+    ///    replies to the original DNS question in the HTTP request.  DoH
+    ///    clients need to use the same semantic processing of non-successful
+    ///    HTTP status codes as other HTTP clients.  This might mean that the
+    ///    DoH client retries the query with the same DoH server, such as if
+    ///    there are authorization failures (HTTP status code 401; see
+    ///    Section 3.1 of [RFC7235]).  It could also mean that the DoH client
+    ///    retries with a different DoH server, such as for unsupported media
+    ///    types (HTTP status code 415; see Section 6.5.13 of [RFC7231]), or
+    ///    where the server cannot generate a representation suitable for the
+    ///    client (HTTP status code 406; see Section 6.5.6 of [RFC7231]), and so
+    ///    on.
     /// ```
     fn send_message(&mut self, mut request: DnsRequest) -> DnsResponseStream {
         if self.is_shutdown {

--- a/crates/proto/src/http/request.rs
+++ b/crates/proto/src/http/request.rs
@@ -20,11 +20,12 @@ use crate::http::error::Result;
 /// Create a new Request for an http dns-message request
 ///
 /// ```text
-/// https://tools.ietf.org/html/draft-ietf-doh-dns-over-https-10#section-5.1
+/// RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+///
 /// The URI Template defined in this document is processed without any
-/// variables when the HTTP method is POST.  When the HTTP method is GET
+/// variables when the HTTP method is POST.  When the HTTP method is GET,
 /// the single variable "dns" is defined as the content of the DNS
-/// request (as described in Section 7), encoded with base64url
+/// request (as described in Section 6), encoded with base64url
 /// [RFC4648].
 /// ```
 #[allow(clippy::field_reassign_with_default)] // https://github.com/rust-lang/rust-clippy/issues/6527

--- a/crates/proto/src/http/response.rs
+++ b/crates/proto/src/http/response.rs
@@ -17,27 +17,29 @@ use crate::http::error::Result;
 /// Create a new Response for an http dns-message request
 ///
 /// ```text
+/// RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+///
 ///  4.2.1.  Handling DNS and HTTP Errors
 ///
 /// DNS response codes indicate either success or failure for the DNS
-/// query.  A successful HTTP response with a 2xx status code ([RFC7231]
-/// Section 6.3) is used for any valid DNS response, regardless of the
-/// DNS response code.  For example, a successful 2xx HTTP status code is
-/// used even with a DNS message whose DNS response code indicates
-/// failure, such as SERVFAIL or NXDOMAIN.
+/// query.  A successful HTTP response with a 2xx status code (see
+/// Section 6.3 of [RFC7231]) is used for any valid DNS response,
+/// regardless of the DNS response code.  For example, a successful 2xx
+/// HTTP status code is used even with a DNS message whose DNS response
+/// code indicates failure, such as SERVFAIL or NXDOMAIN.
 ///
 /// HTTP responses with non-successful HTTP status codes do not contain
 /// replies to the original DNS question in the HTTP request.  DoH
-///
 /// clients need to use the same semantic processing of non-successful
 /// HTTP status codes as other HTTP clients.  This might mean that the
 /// DoH client retries the query with the same DoH server, such as if
-/// there are authorization failures (HTTP status code 401 [RFC7235]
-/// Section 3.1).  It could also mean that the DoH client retries with a
-/// different DoH server, such as for unsupported media types (HTTP
-/// status code 415, [RFC7231] Section 6.5.13), or where the server
-/// cannot generate a representation suitable for the client (HTTP status
-/// code 406, [RFC7231] Section 6.5.6), and so on.
+/// there are authorization failures (HTTP status code 401; see
+/// Section 3.1 of [RFC7235]).  It could also mean that the DoH client
+/// retries with a different DoH server, such as for unsupported media
+/// types (HTTP status code 415; see Section 6.5.13 of [RFC7231]), or
+/// where the server cannot generate a representation suitable for the
+/// client (HTTP status code 406; see Section 6.5.6 of [RFC7231]), and so
+/// on.
 /// ```
 pub fn new(version: Version, message_len: usize) -> Result<Response<()>> {
     Response::builder()

--- a/crates/proto/src/op/response_code.rs
+++ b/crates/proto/src/op/response_code.rs
@@ -123,7 +123,7 @@ pub enum ResponseCode {
     /// Bad Truncation [RFC 4635](https://tools.ietf.org/html/rfc4635#section-4)
     BADTRUNC,
 
-    /// Bad/missing server cookie [draft-ietf-dnsop-cookies](https://tools.ietf.org/html/draft-ietf-dnsop-cookies-10)
+    /// Bad/missing Server Cookie [RFC 7873](https://datatracker.ietf.org/doc/html/rfc7873)
     BADCOOKIE,
     // 24-3840      Unassigned
     // 3841-4095    Reserved for Private Use                        [RFC6895]
@@ -179,7 +179,7 @@ impl ResponseCode {
             Self::BADNAME => "Duplicate key name", // 20    BADNAME       Duplicate key name                  [RFC2930]
             Self::BADALG => "Algorithm not supported", // 21    BADALG        Algorithm not supported             [RFC2930]
             Self::BADTRUNC => "Bad truncation", // 22    BADTRUNC      Bad Truncation                      [RFC4635]
-            Self::BADCOOKIE => "Bad server cookie", // 23    BADCOOKIE (TEMPORARY - registered 2015-07-26, expires 2016-07-26)    Bad/missing server cookie    [draft-ietf-dnsop-cookies]
+            Self::BADCOOKIE => "Bad server cookie", // 23    BADCOOKIE     Bad/missing Server Cookie           [RFC7873]
             Self::Unknown(_) => "Unknown response code",
         }
     }
@@ -234,8 +234,7 @@ impl From<ResponseCode> for u16 {
             ResponseCode::BADNAME => 20, // 20  BADNAME   Duplicate key name                     [RFC2930]
             ResponseCode::BADALG => 21, // 21  BADALG    Algorithm not supported                [RFC2930]
             ResponseCode::BADTRUNC => 22, // 22  BADTRUNC  Bad Truncation                         [RFC4635]
-            // 23  BADCOOKIE (TEMPORARY - registered 2015-07-26, expires 2016-07-26)    Bad/missing server cookie    [draft-ietf-dnsop-cookies]
-            ResponseCode::BADCOOKIE => 23,
+            ResponseCode::BADCOOKIE => 23, // 23  BADCOOKIE Bad/missing Server Cookie              [RFC7873]
             ResponseCode::Unknown(code) => code,
         }
     }
@@ -277,7 +276,7 @@ impl From<u16> for ResponseCode {
             20 => Self::BADNAME, // 20    BADNAME   Duplicate key name                   [RFC2930]
             21 => Self::BADALG, // 21    BADALG    Algorithm not supported              [RFC2930]
             22 => Self::BADTRUNC, // 22    BADTRUNC  Bad Truncation                       [RFC4635]
-            23 => Self::BADCOOKIE, // 23    BADCOOKIE (TEMPORARY - registered 2015-07-26, expires 2016-07-26)    Bad/missing server cookie    [draft-ietf-dnsop-cookies]
+            23 => Self::BADCOOKIE, // 23    BADCOOKIE Bad/missing Server Cookie            [RFC7873]
             code => Self::Unknown(code),
         }
     }

--- a/crates/proto/src/rr/lower_name.rs
+++ b/crates/proto/src/rr/lower_name.rs
@@ -209,7 +209,7 @@ impl Ord for LowerName {
     /// ```text
     /// RFC 4034                DNSSEC Resource Records               March 2005
     ///
-    /// 6.1.  Canonical DNS LowerName Order
+    /// 6.1.  Canonical DNS Name Order
     ///
     ///  For the purposes of DNS security, owner names are ordered by treating
     ///  individual labels as unsigned left-justified octet strings.  The

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -374,7 +374,7 @@ pub enum EdnsCode {
     /// [RFC 6891, Reserved](https://tools.ietf.org/html/rfc6891)
     Zero,
 
-    /// [RFC 8764l, Apple's Long-Lived Queries, Optional](https://tools.ietf.org/html/rfc8764)
+    /// [RFC 8764, Apple's Long-Lived Queries, Optional](https://tools.ietf.org/html/rfc8764)
     LLQ,
 
     /// [UL On-hold](https://files.dns-sd.org/draft-sekar-dns-ul.txt)

--- a/crates/proto/src/rr/rdata/svcb.rs
+++ b/crates/proto/src/rr/rdata/svcb.rs
@@ -162,41 +162,51 @@ impl SVCB {
 ///  [RFC 9460 SVCB and HTTPS Resource Records, Nov 2023](https://datatracker.ietf.org/doc/html/rfc9460#section-14.3.2)
 ///
 /// ```text
-/// 14.3.2.  Initial contents
+/// 14.3.2.  Initial Contents
 ///
-///   The "Service Binding (SVCB) Parameter Registry" shall initially be
-///   populated with the registrations below:
+///    The "Service Parameter Keys (SvcParamKeys)" registry has been
+///    populated with the following initial registrations:
 ///
-///   +=============+=================+======================+===========+
-///   | Number      | Name            | Meaning              | Reference |
-///   +=============+=================+======================+===========+
-///   | 0           | mandatory       | Mandatory keys in    | (This     |
-///   |             |                 | this RR              | document) |
-///   +-------------+-----------------+----------------------+-----------+
-///   | 1           | alpn            | Additional supported | (This     |
-///   |             |                 | protocols            | document) |
-///   +-------------+-----------------+----------------------+-----------+
-///   | 2           | no-default-alpn | No support for       | (This     |
-///   |             |                 | default protocol     | document) |
-///   +-------------+-----------------+----------------------+-----------+
-///   | 3           | port            | Port for alternative | (This     |
-///   |             |                 | endpoint             | document) |
-///   +-------------+-----------------+----------------------+-----------+
-///   | 4           | ipv4hint        | IPv4 address hints   | (This     |
-///   |             |                 |                      | document) |
-///   +-------------+-----------------+----------------------+-----------+
-///   | 5           | ech             | RESERVED (held for   | N/A       |
-///   |             |                 | ECH)                 |           |
-///   +-------------+-----------------+----------------------+-----------+
-///   | 6           | ipv6hint        | IPv6 address hints   | (This     |
-///   |             |                 |                      | document) |
-///   +-------------+-----------------+----------------------+-----------+
-///   | 65280-65534 | N/A             | Private Use          | (This     |
-///   |             |                 |                      | document) |
-///   +-------------+-----------------+----------------------+-----------+
-///   | 65535       | N/A             | Reserved ("Invalid   | (This     |
-///   |             |                 | key")                | document) |
-///   +-------------+-----------------+----------------------+-----------+
+///    +===========+=================+================+=========+==========+
+///    |   Number  | Name            | Meaning        |Reference|Change    |
+///    |           |                 |                |         |Controller|
+///    +===========+=================+================+=========+==========+
+///    |     0     | mandatory       | Mandatory      |RFC 9460,|IETF      |
+///    |           |                 | keys in this   |Section 8|          |
+///    |           |                 | RR             |         |          |
+///    +-----------+-----------------+----------------+---------+----------+
+///    |     1     | alpn            | Additional     |RFC 9460,|IETF      |
+///    |           |                 | supported      |Section  |          |
+///    |           |                 | protocols      |7.1      |          |
+///    +-----------+-----------------+----------------+---------+----------+
+///    |     2     | no-default-alpn | No support     |RFC 9460,|IETF      |
+///    |           |                 | for default    |Section  |          |
+///    |           |                 | protocol       |7.1      |          |
+///    +-----------+-----------------+----------------+---------+----------+
+///    |     3     | port            | Port for       |RFC 9460,|IETF      |
+///    |           |                 | alternative    |Section  |          |
+///    |           |                 | endpoint       |7.2      |          |
+///    +-----------+-----------------+----------------+---------+----------+
+///    |     4     | ipv4hint        | IPv4 address   |RFC 9460,|IETF      |
+///    |           |                 | hints          |Section  |          |
+///    |           |                 |                |7.3      |          |
+///    +-----------+-----------------+----------------+---------+----------+
+///    |     5     | ech             | RESERVED       |N/A      |IETF      |
+///    |           |                 | (held for      |         |          |
+///    |           |                 | Encrypted      |         |          |
+///    |           |                 | ClientHello)   |         |          |
+///    +-----------+-----------------+----------------+---------+----------+
+///    |     6     | ipv6hint        | IPv6 address   |RFC 9460,|IETF      |
+///    |           |                 | hints          |Section  |          |
+///    |           |                 |                |7.3      |          |
+///    +-----------+-----------------+----------------+---------+----------+
+///    |65280-65534| N/A             | Reserved for   |RFC 9460 |IETF      |
+///    |           |                 | Private Use    |         |          |
+///    +-----------+-----------------+----------------+---------+----------+
+///    |   65535   | N/A             | Reserved       |RFC 9460 |IETF      |
+///    |           |                 | ("Invalid      |         |          |
+///    |           |                 | key")          |         |          |
+///    +-----------+-----------------+----------------+---------+----------+
 ///
 /// parsing done via:
 ///   *  a 2 octet field containing the SvcParamKey as an integer in
@@ -659,62 +669,68 @@ impl fmt::Display for Mandatory {
 ///  [RFC 9460 SVCB and HTTPS Resource Records, Nov 2023](https://datatracker.ietf.org/doc/html/rfc9460#section-7.1)
 ///
 /// ```text
-/// 6.1.  "alpn" and "no-default-alpn"
+/// 7.1.  "alpn" and "no-default-alpn"
 ///
 ///   The "alpn" and "no-default-alpn" SvcParamKeys together indicate the
-///   set of Application Layer Protocol Negotiation (ALPN) protocol
+///   set of Application-Layer Protocol Negotiation (ALPN) protocol
 ///   identifiers [ALPN] and associated transport protocols supported by
-///   this service endpoint.
+///   this service endpoint (the "SVCB ALPN set").
 ///
-///   As with Alt-Svc [AltSvc], the ALPN protocol identifier is used to
+///   As with Alt-Svc [AltSvc], each ALPN protocol identifier is used to
 ///   identify the application protocol and associated suite of protocols
-///   supported by the endpoint (the "protocol suite"). The presence of an
+///   supported by the endpoint (the "protocol suite").  The presence of an
 ///   ALPN protocol identifier in the SVCB ALPN set indicates that this
 ///   service endpoint, described by TargetName and the other parameters
 ///   (e.g., "port"), offers service with the protocol suite associated
 ///   with this ALPN identifier.
 ///
-///   Clients filter the set of ALPN identifiers to match the protocol suites
-///   they support, and this informs the underlying transport protocol used
-///   (such as QUIC over UDP or TLS over TCP). ALPN protocol identifiers that do
-///   not uniquely identify a protocol suite (e.g., an Identification Sequence
-///   that can be used with both TLS and DTLS) are not compatible with this
-///   SvcParamKey and MUST NOT be included in the SVCB ALPN set.
+///   Clients filter the set of ALPN identifiers to match the protocol
+///   suites they support, and this informs the underlying transport
+///   protocol used (such as QUIC over UDP or TLS over TCP).  ALPN protocol
+///   identifiers that do not uniquely identify a protocol suite (e.g., an
+///   Identification Sequence that can be used with both TLS and DTLS) are
+///   not compatible with this SvcParamKey and MUST NOT be included in the
+///   SVCB ALPN set.
+///
+/// 7.1.1.  Representation
 ///
 ///   ALPNs are identified by their registered "Identification Sequence"
-///   ("alpn-id"), which is a sequence of 1-255 octets.
+///   (alpn-id), which is a sequence of 1-255 octets.
 ///
 ///   alpn-id = 1*255OCTET
 ///
 ///   For "alpn", the presentation value SHALL be a comma-separated list
-///   (Appendix A.1) of one or more alpn-ids. Zone-file implementations MAY
-///   disallow the "," and "\" characters in ALPN IDs instead of implementing
-///   the value-list escaping procedure, relying on the opaque key format
-///   (e.g., key1=\002h2) in the event that these characters are needed.
+///   (Appendix A.1) of one or more alpn-ids.  Zone-file implementations
+///   MAY disallow the "," and "\" characters in ALPN IDs instead of
+///   implementing the value-list escaping procedure, relying on the opaque
+///   key format (e.g., key1=\002h2) in the event that these characters are
+///   needed.
 ///
-///   The wire format value for "alpn" consists of at least one "alpn-id"
+///   The wire-format value for "alpn" consists of at least one alpn-id
 ///   prefixed by its length as a single octet, and these length-value
 ///   pairs are concatenated to form the SvcParamValue.  These pairs MUST
 ///   exactly fill the SvcParamValue; otherwise, the SvcParamValue is
 ///   malformed.
 ///
-///   For "no-default-alpn", the presentation and wire format values MUST
+///   For "no-default-alpn", the presentation and wire-format values MUST
 ///   be empty.  When "no-default-alpn" is specified in an RR, "alpn" must
 ///   also be specified in order for the RR to be "self-consistent"
 ///   (Section 2.4.3).
 ///
-///   Each scheme that uses this SvcParamKey defines a "default set" of ALPN
-///   IDs that are supported by nearly all clients and servers; this set MAY
-///   be empty. To determine the SVCB ALPN set, the client starts with the
-///   list of alpn-ids from the "alpn" SvcParamKey, and it adds the default
-///   set unless the "no-default-alpn" SvcParamKey is present.
+///   Each scheme that uses this SvcParamKey defines a "default set" of
+///   ALPN IDs that are supported by nearly all clients and servers; this
+///   set MAY be empty.  To determine the SVCB ALPN set, the client starts
+///   with the list of alpn-ids from the "alpn" SvcParamKey, and it adds
+///   the default set unless the "no-default-alpn" SvcParamKey is present.
+///
+/// 7.1.2.  Use
 ///
 ///   To establish a connection to the endpoint, clients MUST
 ///
 ///   1.  Let SVCB-ALPN-Intersection be the set of protocols in the SVCB
 ///       ALPN set that the client supports.
 ///
-///   2.  Let Intersection-Transports be the set of transports (e.g.  TLS,
+///   2.  Let Intersection-Transports be the set of transports (e.g., TLS,
 ///       DTLS, QUIC) implied by the protocols in SVCB-ALPN-Intersection.
 ///
 ///   3.  For each transport in Intersection-Transports, construct a
@@ -722,10 +738,10 @@ impl fmt::Display for Mandatory {
 ///       the client's supported ALPN protocols for that transport, without
 ///       regard to the SVCB ALPN set.
 ///
-///   For example, if the SVCB ALPN set is ["http/1.1", "h3"], and the
+///   For example, if the SVCB ALPN set is ["http/1.1", "h3"] and the
 ///   client supports HTTP/1.1, HTTP/2, and HTTP/3, the client could
 ///   attempt to connect using TLS over TCP with a ProtocolNameList of
-///   ["http/1.1", "h2"], and could also attempt a connection using QUIC,
+///   ["http/1.1", "h2"] and could also attempt a connection using QUIC
 ///   with a ProtocolNameList of ["h3"].
 ///
 ///   Once the client has constructed a ClientHello, protocol negotiation
@@ -733,13 +749,13 @@ impl fmt::Display for Mandatory {
 ///   the SVCB ALPN set.
 ///
 ///   Clients MAY implement a fallback procedure, using a less-preferred
-///   transport if more-preferred transports fail to connect. This fallback
-///   behavior is vulnerable to manipulation by a network attacker who blocks
-///   the more-preferred transports, but it may be necessary for compatibility
-///   with existing networks.
+///   transport if more-preferred transports fail to connect.  This
+///   fallback behavior is vulnerable to manipulation by a network attacker
+///   who blocks the more-preferred transports, but it may be necessary for
+///   compatibility with existing networks.
 ///
 ///   With this procedure in place, an attacker who can modify DNS and
-///   network traffic can prevent a successful transport connection, but
+///   network traffic can prevent a successful transport connection but
 ///   cannot otherwise interfere with ALPN protocol selection.  This
 ///   procedure also ensures that each ProtocolNameList includes at least
 ///   one protocol from the SVCB ALPN set.
@@ -747,14 +763,14 @@ impl fmt::Display for Mandatory {
 ///   Clients SHOULD NOT attempt connection to a service endpoint whose
 ///   SVCB ALPN set does not contain any supported protocols.
 ///
-///   To ensure consistency of behavior, clients MAY reject the entire SVCB RRSet
-///   and fall back to basic connection establishment if all of the RRs
-///   indicate "no-default-alpn", even if connection could have succeeded
-///   using a non-default alpn.
+///   To ensure consistency of behavior, clients MAY reject the entire SVCB
+///   RRset and fall back to basic connection establishment if all of the
+///   compatible RRs indicate "no-default-alpn", even if connection could
+///   have succeeded using a non-default ALPN protocol.
 ///
-///   Zone operators SHOULD ensure that at least one RR in each RRset supports
-///   the default transports. This enables compatibility with the greatest
-///   number of clients.
+///   Zone operators SHOULD ensure that at least one RR in each RRset
+///   supports the default transports.  This enables compatibility with the
+///   greatest number of clients.
 /// ```
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -766,7 +782,7 @@ impl<'r> BinDecodable<'r> for Alpn {
     ///   is the end of input for the fields
     ///
     /// ```text
-    ///   The wire format value for "alpn" consists of at least one "alpn-id"
+    ///   The wire format value for "alpn" consists of at least one alpn-id
     ///   prefixed by its length as a single octet, and these length-value
     ///   pairs are concatenated to form the SvcParamValue.  These pairs MUST
     ///   exactly fill the SvcParamValue; otherwise, the SvcParamValue is
@@ -790,7 +806,7 @@ impl<'r> BinDecodable<'r> for Alpn {
 }
 
 impl BinEncodable for Alpn {
-    ///   The wire format value for "alpn" consists of at least one "alpn-id"
+    ///   The wire format value for "alpn" consists of at least one alpn-id
     ///   prefixed by its length as a single octet, and these length-value
     ///   pairs are concatenated to form the SvcParamValue.  These pairs MUST
     ///   exactly fill the SvcParamValue; otherwise, the SvcParamValue is
@@ -905,39 +921,39 @@ impl fmt::Debug for EchConfigList {
 ///   MAY use to reach the service.  If A and AAAA records for TargetName
 ///   are locally available, the client SHOULD ignore these hints.
 ///   Otherwise, clients SHOULD perform A and/or AAAA queries for
-///   TargetName as in Section 3, and clients SHOULD use the IP address in
+///   TargetName per Section 3, and clients SHOULD use the IP address in
 ///   those responses for future connections.  Clients MAY opt to terminate
 ///   any connections using the addresses in hints and instead switch to
 ///   the addresses in response to the TargetName query.  Failure to use A
 ///   and/or AAAA response addresses could negatively impact load balancing
 ///   or other geo-aware features and thereby degrade client performance.
 ///
-///   The presentation value SHALL be a comma-separated list
-///   (Appendix A.1) of one or more IP addresses of the appropriate family
-///   in standard textual format [RFC5952].  To enable simpler parsing,
-///   this SvcParamValue MUST NOT contain escape sequences.
+///   The presentation value SHALL be a comma-separated list (Appendix A.1)
+///   of one or more IP addresses of the appropriate family in standard
+///   textual format [RFC5952] [RFC4001].  To enable simpler parsing, this
+///   SvcParamValue MUST NOT contain escape sequences.
 ///
 ///   The wire format for each parameter is a sequence of IP addresses in
-///   network byte order (for the respective address family). Like an A or
-///   AAAA RRSet, the list of addresses represents an unordered collection,
+///   network byte order (for the respective address family).  Like an A or
+///   AAAA RRset, the list of addresses represents an unordered collection,
 ///   and clients SHOULD pick addresses to use in a random order.  An empty
 ///   list of addresses is invalid.
 ///
 ///   When selecting between IPv4 and IPv6 addresses to use, clients may
 ///   use an approach such as Happy Eyeballs [HappyEyeballsV2].  When only
-///   "ipv4hint" is present, NAT64 clients may synthesize IPv6 addresses
-///   as specified in [RFC7050] or ignore the "ipv4hint" key and
-///   wait for AAAA resolution (Section 3). For best performance, server
-///   operators SHOULD include an "ipv6hint" parameter whenever they
-///   include an "ipv4hint" parameter.
+///   "ipv4hint" is present, NAT64 clients may synthesize IPv6 addresses as
+///   specified in [RFC7050] or ignore the "ipv4hint" key and wait for AAAA
+///   resolution (Section 3).  For best performance, server operators
+///   SHOULD include an "ipv6hint" parameter whenever they include an
+///   "ipv4hint" parameter.
 ///
 ///   These parameters are intended to minimize additional connection
 ///   latency when a recursive resolver is not compliant with the
-///   requirements in Section 4, and SHOULD NOT be included if most clients
+///   requirements in Section 4 and SHOULD NOT be included if most clients
 ///   are using compliant recursive resolvers.  When TargetName is the
-///   origin hostname or the owner name (which can be written as "."),
-///   server operators SHOULD NOT include these hints, because they are
-///   unlikely to convey any performance benefit.
+///   service name or the owner name (which can be written as "."), server
+///   operators SHOULD NOT include these hints, because they are unlikely
+///   to convey any performance benefit.
 /// ```
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]

--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -238,24 +238,21 @@ pub enum RData {
     /// `HINFO` is also used by [RFC 8482](https://tools.ietf.org/html/rfc8482)
     HINFO(HINFO),
 
-    /// [RFC draft-ietf-dnsop-svcb-https-03, DNS SVCB and HTTPS RRs](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-03#section-8)
+    /// [RFC 9460, SVCB and HTTPS RRs](https://datatracker.ietf.org/doc/html/rfc9460#section-9)
     ///
     /// ```text
-    ///    8.  Using SVCB with HTTPS and HTTP
+    /// 9.  Using Service Bindings with HTTP
     ///
-    ///    Use of any protocol with SVCB requires a protocol-specific mapping
-    ///    specification.  This section specifies the mapping for HTTPS and
-    ///    HTTP.
+    ///    The use of any protocol with SVCB requires a protocol-specific
+    ///    mapping specification.  This section specifies the mapping for the
+    ///    "http" and "https" URI schemes [HTTP].
     ///
-    ///    To enable special handling for the HTTPS and HTTP use-cases, the
-    ///    HTTPS RR type is defined as a SVCB-compatible RR type, specific to
-    ///    the https and http schemes.  Clients MUST NOT perform SVCB queries or
-    ///    accept SVCB responses for "https" or "http" schemes.
+    ///    To enable special handling for HTTP use cases, the HTTPS RR type is
+    ///    defined as a SVCB-compatible RR type, specific to the "https" and
+    ///    "http" schemes.  Clients MUST NOT perform SVCB queries or accept SVCB
+    ///    responses for "https" or "http" schemes.
     ///
-    ///    The HTTPS RR wire format and presentation format are identical to
-    ///    SVCB, and both share the SvcParamKey registry.  SVCB semantics apply
-    ///    equally to HTTPS RRs unless specified otherwise.  The presentation
-    ///    format of the record is:
+    ///    The presentation format of the record is:
     ///
     ///    Name TTL IN HTTPS SvcPriority TargetName SvcParams
     /// ```
@@ -465,8 +462,8 @@ pub enum RData {
     ///        +------------+--------------+------------------------------+
     ///
     /// The variable part of an OPT RR may contain zero or more options in
-    ///    the RDATA.  Each option MUST be treated as a bit field.  Each option
-    ///    is encoded as:
+    /// the RDATA.  Each option MUST be treated as a bit field.  Each option
+    /// is encoded as:
     ///
     ///                   +0 (MSB)                            +1 (LSB)
     ///        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
@@ -640,28 +637,29 @@ pub enum RData {
     /// [RFC 7479](https://tools.ietf.org/html/rfc7479).
     SSHFP(SSHFP),
 
-    /// [RFC draft-ietf-dnsop-svcb-https-03, DNS SVCB and HTTPS RRs](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-03#section-2)
+    /// [RFC 9460, SVCB and HTTPS RRs](https://datatracker.ietf.org/doc/html/rfc9460#section-2)
     ///
     /// ```text
-    ///    2.  The SVCB record type
+    /// 2.  The SVCB Record Type
     ///
-    ///   The SVCB DNS resource record (RR) type (RR type 64) is used to locate
-    ///   alternative endpoints for a service.
+    ///    The SVCB DNS RR type (RR type 64) is used to locate alternative
+    ///    endpoints for a service.
     ///
-    ///   The algorithm for resolving SVCB records and associated address
-    ///   records is specified in Section 3.
+    ///    The algorithm for resolving SVCB records and associated address
+    ///    records is specified in Section 3.
     ///
-    ///   Other SVCB-compatible resource record types can also be defined as-
-    ///   needed.  In particular, the HTTPS RR (RR type 65) provides special
-    ///   handling for the case of "https" origins as described in Section 8.
+    ///    Other SVCB-compatible RR types can also be defined as needed (see
+    ///    Section 6).  In particular, the HTTPS RR (RR type 65) provides
+    ///    special handling for the case of "https" origins as described in
+    ///    Section 9.
     ///
-    ///   SVCB RRs are extensible by a list of SvcParams, which are pairs
-    ///   consisting of a SvcParamKey and a SvcParamValue.  Each SvcParamKey
-    ///   has a presentation name and a registered number.  Values are in a
-    ///   format specific to the SvcParamKey.  Their definition should specify
-    ///   both their presentation format and wire encoding (e.g., domain names,
-    ///   binary data, or numeric values).  The initial SvcParamKeys and
-    ///   formats are defined in Section 6.
+    ///    SVCB RRs are extensible by a list of SvcParams, which are pairs
+    ///    consisting of a SvcParamKey and a SvcParamValue.  Each SvcParamKey
+    ///    has a presentation name and a registered number.  Values are in a
+    ///    format specific to the SvcParamKey.  Each SvcParam has a specified
+    ///    presentation format (used in zone files) and wire encoding (e.g.,
+    ///    domain names, binary data, or numeric values).  The initial
+    ///    SvcParamKeys and their formats are defined in Section 7.
     /// ```
     SVCB(SVCB),
 
@@ -926,7 +924,7 @@ impl BinEncodable for RData {
     /// ```
     ///
     /// Canonical name form for all non-1035 records:
-    ///   [RFC 3579](https://tools.ietf.org/html/rfc3597)
+    ///   [RFC 3597](https://tools.ietf.org/html/rfc3597)
     /// ```text
     ///  4.  Domain Name Compression
     ///

--- a/crates/proto/src/rr/record_type.rs
+++ b/crates/proto/src/rr/record_type.rs
@@ -65,7 +65,7 @@ pub enum RecordType {
     /// [RFC 1035](https://tools.ietf.org/html/rfc1035) host information
     HINFO,
     //  HIP,        // 55 RFC 5205 Host Identity Protocol
-    /// [RFC draft-ietf-dnsop-svcb-https-03](https://tools.ietf.org/html/draft-ietf-dnsop-svcb-httpssvc-03) DNS SVCB and HTTPS RRs
+    /// [RFC 9460](https://tools.ietf.org/html/rfc9460) DNS SVCB and HTTPS RRs
     HTTPS,
     //  IPSECKEY,   // 45 RFC 4025 IPsec Key
     /// [RFC 1996](https://tools.ietf.org/html/rfc1996) Incremental Zone Transfer
@@ -105,7 +105,7 @@ pub enum RecordType {
     SRV,
     /// [RFC 4255](https://tools.ietf.org/html/rfc4255) SSH Public Key Fingerprint
     SSHFP,
-    /// [RFC draft-ietf-dnsop-svcb-https-03](https://tools.ietf.org/html/draft-ietf-dnsop-svcb-httpssvc-03) DNS SVCB and HTTPS RRs
+    /// [RFC 9460](https://tools.ietf.org/html/rfc9460) DNS SVCB and HTTPS RRs
     SVCB,
     //  TA,         // 32768 N/A DNSSEC Trust Authorities
     //  TKEY,       // 249 RFC 2930 Secret key record

--- a/crates/proto/src/rr/resource.rs
+++ b/crates/proto/src/rr/resource.rs
@@ -577,7 +577,7 @@ impl<R: RecordData> fmt::Display for Record<R> {
 }
 
 impl<R: RecordData> PartialEq for Record<R> {
-    /// Equality or records, as defined by
+    /// Equality of records, as defined by
     ///  [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
     ///
     /// ```text

--- a/crates/proto/src/rr/rr_set.rs
+++ b/crates/proto/src/rr/rr_set.rs
@@ -303,23 +303,27 @@ impl RecordSet {
             //         to have more than one CNAME RR, even if their data fields
             //         differ.
             //
-            // ANAME https://tools.ietf.org/html/draft-ietf-dnsop-aname-02
+            // ANAME https://tools.ietf.org/html/draft-ietf-dnsop-aname-04
             //    2.2.  Coexistence with other types
             //
             //   Only one ANAME <target> can be defined per <owner>.  An ANAME RRset
             //   MUST NOT contain more than one resource record.
             //
             //   An ANAME's sibling address records are under the control of ANAME
-            //   processing (see Section 5) and are not first-class records in their
+            //   processing (see Section 4) and are not first-class records in their
             //   own right.  They MAY exist in zone files, but they can subsequently
             //   be altered by ANAME processing.
             //
-            //   ANAME records MAY freely coexist at the same owner name with other RR
-            //   types, except they MUST NOT coexist with CNAME or any other RR type
-            //   that restricts the types with which it can itself coexist.
+            //   An ANAME record MAY freely coexist at the same owner name with other
+            //   RR types, except they MUST NOT coexist with CNAME or any other RR
+            //   type that restricts the types with which it can itself coexist. That
+            //   means An ANAME record can coexist at the same owner name with A and
+            //   AAAA records.  These are the sibling address records that are updated
+            //   with the target addresses that are retrieved through the ANAME
+            //   substitution process Section 3.
             //
-            //   Like other types, ANAME records can coexist with DNAME records at the
-            //   same owner name; in fact, the two can be used cooperatively to
+            //   Like other types, An ANAME record can coexist with DNAME records at
+            //   the same owner name; in fact, the two can be used cooperatively to
             //   redirect both the owner name address records (via ANAME) and
             //   everything under it (via DNAME).
             RecordType::CNAME | RecordType::ANAME => {

--- a/crates/proto/src/serialize/txt/rdata_parsers/svcb.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/svcb.rs
@@ -188,7 +188,7 @@ fn parse_mandatory(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
 ///
 /// ```text
 ///   ALPNs are identified by their registered "Identification Sequence"
-///   ("alpn-id"), which is a sequence of 1-255 octets.
+///   (alpn-id), which is a sequence of 1-255 octets.
 ///
 ///   alpn-id = 1*255OCTET
 ///


### PR DESCRIPTION
This updates various specification excerpts in comments, and updates some Internet-Draft references to the corresponding RFCs. I also fixed a few typos near RFC references. I was primarily looking for more instances of old draft text with a newer RFC reference, and fixed that up in `svcb.rs`.