### PR TITLE
style: remove needless return to make clippy happy

### DIFF
--- a/fuzz/fuzz_targets/preserve_rdata.rs
+++ b/fuzz/fuzz_targets/preserve_rdata.rs
@@ -73,9 +73,9 @@ fn compare_rr(
             let original_decompressed = Name::decompress(original_rr.rdata, original);
             let reencoded_decompressed = Name::decompress(reencoded_rr.rdata, reencoded);
             if original_decompressed == reencoded_decompressed {
-                return Ok(());
+                Ok(())
             } else {
-                return Err(());
+                Err(())
             }
         }
         record_types::SOA => {
@@ -83,9 +83,9 @@ fn compare_rr(
             let original_decompressed = Soa::decompress(original_rr.rdata, original);
             let reencoded_decompressed = Soa::decompress(reencoded_rr.rdata, reencoded);
             if original_decompressed == reencoded_decompressed {
-                return Ok(());
+                Ok(())
             } else {
-                return Err(());
+                Err(())
             }
         }
         record_types::MINFO => {
@@ -93,9 +93,9 @@ fn compare_rr(
             let original_decompressed = Minfo::decompress(original_rr.rdata, original);
             let reencoded_decompressed = Minfo::decompress(reencoded_rr.rdata, reencoded);
             if original_decompressed == reencoded_decompressed {
-                return Ok(());
+                Ok(())
             } else {
-                return Err(());
+                Err(())
             }
         }
         record_types::MX => {
@@ -103,17 +103,17 @@ fn compare_rr(
             let original_decompressed = Mx::decompress(original_rr.rdata, original);
             let reencoded_decompressed = Mx::decompress(reencoded_rr.rdata, reencoded);
             if original_decompressed == reencoded_decompressed {
-                return Ok(());
+                Ok(())
             } else {
-                return Err(());
+                Err(())
             }
         }
         record_types::OPT => {
             // Ignore OPT records because they are reconstructed hop-by-hop, not passed through
             // transparently.
-            return Ok(());
+            Ok(())
         }
-        _ => return Err(()),
+        _ => Err(()),
     }
 }
 


### PR DESCRIPTION
style change. remove needless return to make clippy happy

![image](https://github.com/user-attachments/assets/b935f44f-6cdd-4c57-8375-05d173ba650c)
