### PR TITLE
Run Clippy on fuzz workspace

### DIFF
--- a/justfile
+++ b/justfile
@@ -99,6 +99,7 @@ clippy:
     just clippy-inner --no-default-features
     just clippy-inner
     just clippy-inner --all-features
+    cargo clippy --manifest-path fuzz/Cargo.toml --locked --all-targets -- -D warnings
 
 # Check the format of all the Rust code with rustfmt
 fmt:


### PR DESCRIPTION
This is a follow-up to #2907 to check for Clippy suggestions in the fuzz subdirectory in CI.