### PR TITLE
docs: fix errors in line and document comments

### DIFF
--- a/crates/client/src/client/client.rs
+++ b/crates/client/src/client/client.rs
@@ -74,9 +74,9 @@ impl Client {
     ///
     /// * `stream` - A stream of bytes that can be used to send/receive DNS messages
     ///   (see TcpClientStream or UdpClientStream)
+    /// * `stream_handle` - The handle for the `stream` on which bytes can be sent/received.
     /// * `timeout_duration` - All requests may fail due to lack of response, this is the time to
     ///   wait for a response before canceling the request.
-    /// * `stream_handle` - The handle for the `stream` on which bytes can be sent/received.
     /// * `signer` - An optional signer for requests, needed for Updates with Sig0, otherwise not needed
     pub async fn with_timeout<F, S>(
         stream: F,

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -56,7 +56,7 @@
 //!
 //! # Usage
 //!
-//! This shows basic usage of the SyncClient. More examples will be associated directly with other types.
+//! This shows basic usage of the Client. More examples will be associated directly with other types.
 //!
 //! ## Dependency
 //!

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -137,9 +137,9 @@ where
     ///
     /// * `stream` - A stream of bytes that can be used to send/receive DNS messages
     ///   (see TcpClientStream or UdpClientStream)
+    /// * `stream_handle` - The handle for the `stream` on which bytes can be sent/received.
     /// * `timeout_duration` - All requests may fail due to lack of response, this is the time to
     ///   wait for a response before canceling the request.
-    /// * `stream_handle` - The handle for the `stream` on which bytes can be sent/received.
     /// * `signer` - An optional signer for requests, needed for Updates with Sig0, otherwise not needed
     pub fn with_timeout<F>(
         stream: F,


### PR DESCRIPTION
This patch fixes some errors in cargo docs and inline comments.
1. missing arg document `use_edns`
2. SyncClient not used anymore
3. `delete_by_rdata`: this method doesn't have any prerequisites. Also according to RFC 2136 and the implementation here. The document shouldn't include the prerequisites section, as it's not used. It could be misleading
4. fix some typos