### PR TITLE
Fix QNAME minimization behavior

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dns.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns.rs
@@ -3,4 +3,5 @@
 mod rfc1035;
 mod rfc3597;
 mod rfc8906;
+mod rfc9156;
 mod scenarios;

--- a/conformance/packages/conformance-tests/src/resolver/dns/rfc9156.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/rfc9156.rs
@@ -1,0 +1,55 @@
+use std::net::Ipv4Addr;
+
+use dns_test::{
+    FQDN, Network, PEER, Resolver, Result,
+    client::{Client, DigSettings, DigStatus},
+    name_server::NameServer,
+    record::{CNAME, Record, RecordType},
+};
+
+#[test]
+#[ignore = "hickory stops looking for the nearest enclosing NS RRset when it encounters a CNAME record in a response"]
+fn cname_between_zone_cuts() -> Result<()> {
+    let network = Network::new()?;
+    let leaf_zone = FQDN::TEST_TLD.push_label("a").push_label("b");
+    let needle_fqdn = leaf_zone.push_label("www");
+
+    let mut root_ns = NameServer::new(&PEER, FQDN::ROOT, &network)?;
+    let mut tld_ns = NameServer::new(&PEER, FQDN::TEST_TLD, &network)?;
+    let mut leaf_ns = NameServer::new(&PEER, leaf_zone, &network)?;
+
+    leaf_ns.add(Record::a(needle_fqdn.clone(), Ipv4Addr::new(1, 2, 3, 4)));
+
+    tld_ns.referral_nameserver(&leaf_ns);
+    // Add an extra CNAME record which the first minimized query will match.
+    tld_ns.add(CNAME {
+        fqdn: FQDN::TEST_TLD.push_label("a"),
+        ttl: 86400,
+        target: FQDN::TEST_TLD.push_label("other"),
+    });
+
+    root_ns.referral_nameserver(&tld_ns);
+
+    let root_hint = root_ns.root_hint();
+
+    let _root_ns = root_ns.start()?;
+    let _tld_ns = tld_ns.start()?;
+    let _leaf_ns = leaf_ns.start()?;
+
+    let resolver = Resolver::new(&network, root_hint).start()?;
+
+    let client = Client::new(&network)?;
+    let settings = *DigSettings::default().recurse();
+    let output = client.dig(settings, resolver.ipv4_addr(), RecordType::A, &needle_fqdn)?;
+
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert_eq!(
+        output.answer.len(),
+        1,
+        "wrong number of answer records: {output:?}"
+    );
+    let record = output.answer[0].clone().try_into_a().unwrap();
+    assert_eq!(record.ipv4_addr, Ipv4Addr::new(1, 2, 3, 4));
+
+    Ok(())
+}

--- a/conformance/packages/conformance-tests/src/resolver/dns/rfc9156.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/rfc9156.rs
@@ -8,7 +8,6 @@ use dns_test::{
 };
 
 #[test]
-#[ignore = "hickory stops looking for the nearest enclosing NS RRset when it encounters a CNAME record in a response"]
 fn cname_between_zone_cuts() -> Result<()> {
     let network = Network::new()?;
     let leaf_zone = FQDN::TEST_TLD.push_label("a").push_label("b");

--- a/crates/recursor/src/error.rs
+++ b/crates/recursor/src/error.rs
@@ -112,6 +112,19 @@ impl Error {
         }
     }
 
+    /// Returns true if a query timed out
+    pub fn is_timeout(&self) -> bool {
+        let proto_error = match &*self.kind {
+            ErrorKind::Proto(proto) => proto,
+            ErrorKind::Resolve(err) => match err.kind() {
+                hickory_resolver::ResolveErrorKind::Proto(proto) => proto,
+                _ => return false,
+            },
+            _ => return false,
+        };
+        matches!(proto_error.kind(), ProtoErrorKind::Timeout)
+    }
+
     /// Returns the SOA record, if the error contains one
     pub fn into_soa(self) -> Option<Box<Record<SOA>>> {
         match *self.kind {

--- a/crates/recursor/src/recursor_dns_handle.rs
+++ b/crates/recursor/src/recursor_dns_handle.rs
@@ -462,6 +462,9 @@ impl RecursorDnsHandle {
             Ok((lookup, response_opt)) => (lookup, response_opt),
             // Short-circuit on NXDOMAIN, per RFC 8020.
             Err(e) if e.is_nx_domain() => return Err(e),
+            // Short-circuit on timeouts. Requesting a longer name from the same pool would likely
+            // encounter them again.
+            Err(e) if e.is_timeout() => return Err(e),
             // The name `zone` is not a zone cut. Return the same pool of name servers again, but do
             // not cache it. If this was recursively called by `ns_pool_for_zone()`, the outer call
             // will try again with one more label added to the iterative query name.

--- a/tests/e2e-tests/src/recursor/security/scenarios.rs
+++ b/tests/e2e-tests/src/recursor/security/scenarios.rs
@@ -40,7 +40,7 @@ fn tx_id_validation_test() -> Result<()> {
     let _leaf_ns = leaf_ns.start()?;
 
     thread::sleep(Duration::from_secs(2));
-    let a_settings = *DigSettings::default().recurse().timeout(20);
+    let a_settings = *DigSettings::default().recurse().timeout(7);
     let res = client.dig(
         a_settings,
         resolver.ipv4_addr(),

--- a/tests/e2e-tests/src/recursor/security/scenarios.rs
+++ b/tests/e2e-tests/src/recursor/security/scenarios.rs
@@ -40,7 +40,7 @@ fn tx_id_validation_test() -> Result<()> {
     let _leaf_ns = leaf_ns.start()?;
 
     thread::sleep(Duration::from_secs(2));
-    let a_settings = *DigSettings::default().recurse().timeout(7);
+    let a_settings = *DigSettings::default().recurse().timeout(20);
     let res = client.dig(
         a_settings,
         resolver.ipv4_addr(),


### PR DESCRIPTION
This simplifies the recursor's logic, and fixes #2788. A conformance test is included that reproduces the original issue.

Currently `ns_pool_for_zone()` includes a loop that follows "SOA referrals", but this seems to be a non-standard concept. What it was doing, in effect, was taking negative responses for NS queries and using the SOA owner name to get a different name server pool. However, in a well-constructed zone, this should produce an ancestor of the name we just queried for, and the tower of recursive `ns_pool_for_zone()` calls has already constructed a name server pool for that ancestor. Therefore, we can keep passing the parent zone's pool to the caller until we either get another referral or return to `resolve()` and run the original query against the pool. We do this when the NS query either returns any error or returns zero NS records (fixing the CNAME-related bug). This now better aligns with the algorithm from [RFC 9156](https://www.rfc-editor.org/rfc/rfc9156.html#section-3), because we effectively try again with a longer name in these cases, via the recursive calls already on the stack.

In the last commit, I implemented a short-circuit for when we get an NXDOMAIN response to one of the minimized NS queries. The algorithm in RFC 9156 mentions this in the context of interactions with RFC 8020.