### PR TITLE
Use wait_until() in a second conformance test

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
@@ -49,6 +49,10 @@ fn on_clients_ds_query_it_queries_the_parent_zone() -> Result<()> {
 
     // check that DS query was forwarded to the `testing.` (parent zone) nameserver
     let client_addr = client.ipv4_addr();
+    // in tshark's output, the domain name in the query omits the last `.`, so strip it from
+    // FQDN::TEST_DOMAIN
+    let test_domain = FQDN::TEST_DOMAIN.as_str();
+    let test_domain = test_domain.strip_suffix('.').unwrap();
     tshark.wait_until(
         |captures| {
             captures.iter().any(|capture| {
@@ -68,10 +72,6 @@ fn on_clients_ds_query_it_queries_the_parent_zone() -> Result<()> {
                 println!("outgoing query: {queries:?}");
                 for query in queries.keys() {
                     if query.contains("type DS") {
-                        // the domain name in the query omits the last `.` so strip it from
-                        // FQDN::TEST_DOMAIN
-                        let test_domain = FQDN::TEST_DOMAIN.as_str();
-                        let test_domain = test_domain.strip_suffix('.').unwrap_or(test_domain);
                         assert!(query.contains(test_domain));
                         assert_eq!(tld_ns_addr, *destination);
                         return true;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
@@ -52,27 +52,27 @@ fn on_clients_ds_query_it_queries_the_parent_zone() -> Result<()> {
     tshark.wait_until(
         |captures| {
             captures.iter().any(|capture| {
-                if let Capture {
+                let Capture {
                     direction: Direction::Outgoing { destination },
                     message,
                 } = capture
-                {
-                    if *destination != client_addr {
-                        let queries = message.as_value()["Queries"]
-                            .as_object()
-                            .expect("expected Object");
-                        println!("outgoing query: {queries:?}");
-                        for query in queries.keys() {
-                            if query.contains("type DS") {
-                                // the domain name in the query omits the last `.` so strip it from
-                                // FQDN::TEST_DOMAIN
-                                let test_domain = FQDN::TEST_DOMAIN.as_str();
-                                let test_domain =
-                                    test_domain.strip_suffix('.').unwrap_or(test_domain);
-                                assert!(query.contains(test_domain));
-                                assert_eq!(tld_ns_addr, *destination);
-                                return true;
-                            }
+                else {
+                    return false;
+                };
+                if *destination != client_addr {
+                    let queries = message.as_value()["Queries"]
+                        .as_object()
+                        .expect("expected Object");
+                    println!("outgoing query: {queries:?}");
+                    for query in queries.keys() {
+                        if query.contains("type DS") {
+                            // the domain name in the query omits the last `.` so strip it from
+                            // FQDN::TEST_DOMAIN
+                            let test_domain = FQDN::TEST_DOMAIN.as_str();
+                            let test_domain = test_domain.strip_suffix('.').unwrap_or(test_domain);
+                            assert!(query.contains(test_domain));
+                            assert_eq!(tld_ns_addr, *destination);
+                            return true;
                         }
                     }
                 }

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use dns_test::{
     FQDN, Network, Resolver, Result,
     client::{Client, DigSettings},
@@ -45,44 +47,47 @@ fn on_clients_ds_query_it_queries_the_parent_zone() -> Result<()> {
     let settings = *DigSettings::default().recurse();
     let output = client.dig(settings, resolver_addr, RecordType::DS, &FQDN::TEST_DOMAIN)?;
 
-    tshark.wait_for_capture()?;
-
-    let captures = tshark.terminate()?;
-    println!("captured {} packets", captures.len());
+    // check that DS query was forwarded to the `testing.` (parent zone) nameserver
+    let client_addr = client.ipv4_addr();
+    tshark.wait_until(
+        |captures| {
+            captures.iter().any(|capture| {
+                if let Capture {
+                    direction: Direction::Outgoing { destination },
+                    message,
+                } = capture
+                {
+                    if *destination != client_addr {
+                        let queries = message.as_value()["Queries"]
+                            .as_object()
+                            .expect("expected Object");
+                        println!("outgoing query: {queries:?}");
+                        for query in queries.keys() {
+                            if query.contains("type DS") {
+                                // the domain name in the query omits the last `.` so strip it from
+                                // FQDN::TEST_DOMAIN
+                                let test_domain = FQDN::TEST_DOMAIN.as_str();
+                                let test_domain =
+                                    test_domain.strip_suffix('.').unwrap_or(test_domain);
+                                assert!(query.contains(test_domain));
+                                assert_eq!(tld_ns_addr, *destination);
+                                return true;
+                            }
+                        }
+                    }
+                }
+                false
+            })
+        },
+        Duration::from_secs(10),
+    )?;
+    tshark.terminate()?;
 
     // check that we were able to retrieve the DS record
     assert!(output.status.is_noerror());
     let [record] = output.answer.try_into().unwrap();
     let ds = record.try_into_ds().unwrap();
     assert_eq!(ds.zone, FQDN::TEST_DOMAIN);
-
-    // check that DS query was forwarded to the `testing.` (parent zone) nameserver
-    let client_addr = client.ipv4_addr();
-    let mut outgoing_ds_query_count = 0;
-    for Capture { message, direction } in captures {
-        if let Direction::Outgoing { destination } = direction {
-            if destination != client_addr {
-                let queries = message.as_value()["Queries"]
-                    .as_object()
-                    .expect("expected Object");
-                println!("outgoing query: {queries:?}");
-                for query in queries.keys() {
-                    if query.contains("type DS") {
-                        // the domain name in the query omits the last `.` so strip it from
-                        // FQDN::TEST_DOMAIN
-                        let test_domain = FQDN::TEST_DOMAIN.as_str();
-                        let test_domain = test_domain.strip_suffix('.').unwrap_or(test_domain);
-                        assert!(query.contains(test_domain));
-                        assert_eq!(tld_ns_addr, destination);
-
-                        outgoing_ds_query_count += 1;
-                    }
-                }
-            }
-        }
-    }
-
-    assert_eq!(1, outgoing_ds_query_count);
 
     Ok(())
 }

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
@@ -71,11 +71,12 @@ fn on_clients_ds_query_it_queries_the_parent_zone() -> Result<()> {
                     .expect("expected Object");
                 println!("outgoing query: {queries:?}");
                 for query in queries.keys() {
-                    if query.contains("type DS") {
-                        assert!(query.contains(test_domain));
-                        assert_eq!(tld_ns_addr, *destination);
-                        return true;
+                    if !query.contains("type DS") {
+                        continue;
                     }
+                    assert!(query.contains(test_domain));
+                    assert_eq!(tld_ns_addr, *destination);
+                    return true;
                 }
                 false
             })

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/rfc4035/section_3/section_3_1/section_3_1_4.rs
@@ -59,21 +59,22 @@ fn on_clients_ds_query_it_queries_the_parent_zone() -> Result<()> {
                 else {
                     return false;
                 };
-                if *destination != client_addr {
-                    let queries = message.as_value()["Queries"]
-                        .as_object()
-                        .expect("expected Object");
-                    println!("outgoing query: {queries:?}");
-                    for query in queries.keys() {
-                        if query.contains("type DS") {
-                            // the domain name in the query omits the last `.` so strip it from
-                            // FQDN::TEST_DOMAIN
-                            let test_domain = FQDN::TEST_DOMAIN.as_str();
-                            let test_domain = test_domain.strip_suffix('.').unwrap_or(test_domain);
-                            assert!(query.contains(test_domain));
-                            assert_eq!(tld_ns_addr, *destination);
-                            return true;
-                        }
+                if *destination == client_addr {
+                    return false;
+                }
+                let queries = message.as_value()["Queries"]
+                    .as_object()
+                    .expect("expected Object");
+                println!("outgoing query: {queries:?}");
+                for query in queries.keys() {
+                    if query.contains("type DS") {
+                        // the domain name in the query omits the last `.` so strip it from
+                        // FQDN::TEST_DOMAIN
+                        let test_domain = FQDN::TEST_DOMAIN.as_str();
+                        let test_domain = test_domain.strip_suffix('.').unwrap_or(test_domain);
+                        assert!(query.contains(test_domain));
+                        assert_eq!(tld_ns_addr, *destination);
+                        return true;
                     }
                 }
                 false


### PR DESCRIPTION
I noticed this test flaking in CI a couple times recently. Perhaps #2868 made the race condition tighter? This PR rewrites the tshark-related assertion to use the new `wait_until()` method, so we won't proceed until we see the expected packet, and not just any packet.