### PR TITLE
Delete print statements dumping logs in tests

### DIFF
--- a/conformance/packages/conformance-tests/src/forwarder/dnssec/scenarios/bogus.rs
+++ b/conformance/packages/conformance-tests/src/forwarder/dnssec/scenarios/bogus.rs
@@ -99,7 +99,7 @@ fn nsec3_does_not_cover() -> Result<()> {
     let root_hint = root_ns.root_hint();
     let trust_anchor = root_ns.trust_anchor();
 
-    let leaf_ns = leaf_ns.start()?;
+    let _leaf_ns = leaf_ns.start()?;
     let _tld_ns = tld_ns.start()?;
     let _root_ns = root_ns.start()?;
 
@@ -121,11 +121,6 @@ fn nsec3_does_not_cover() -> Result<()> {
             RecordType::A,
             &FQDN::TEST_DOMAIN.push_label(&subdomain.to_string()),
         )?;
-
-        if subdomain == 'a' {
-            println!("{}", forwarder.logs()?);
-            println!("{}", leaf_ns.logs()?);
-        }
 
         assert_eq!(response.status, DigStatus::SERVFAIL);
     }

--- a/conformance/packages/conformance-tests/src/name_server/rfc5155.rs
+++ b/conformance/packages/conformance-tests/src/name_server/rfc5155.rs
@@ -353,9 +353,6 @@ fn query_nameserver(
         qtype,
         qname,
     );
-    if output_res.is_err() {
-        println!("{}", ns.logs().unwrap());
-    }
     let output = output_res?;
 
     let nsec3_rrs_response = output

--- a/conformance/packages/conformance-tests/src/resolver/dns/rfc1035/truncation.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/rfc1035/truncation.rs
@@ -50,8 +50,6 @@ fn truncated_response_caching_with_tcp_fallback() -> Result<()> {
     println!("second response: {response_2:?}");
     let (protocol_2, counter_2) = parse_txt_records(&response_2.answer)?;
 
-    println!("{}", resolver.logs()?);
-
     assert_eq!(response_2.status, DigStatus::NOERROR);
 
     // Check that we got a cached response.
@@ -99,8 +97,6 @@ fn truncated_response_caching_udp_only() -> Result<()> {
         .unwrap_or_else(|e| panic!("error {e:?} resolver logs: {}", resolver.logs().unwrap()));
     println!("second response: {response_2:?}");
     let (_protocol_2, counter_2) = parse_txt_records(&response_2.answer)?;
-
-    println!("{}", resolver.logs()?);
 
     assert_eq!(response_2.status, DigStatus::NOERROR);
 

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/regression.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/regression.rs
@@ -287,8 +287,6 @@ fn five_secure_zones() -> Result<()> {
         &leaf_zone,
     )?;
 
-    println!("{}", resolver.logs()?);
-
     assert!(output.status.is_noerror());
     assert!(!output.answer.is_empty());
 

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
@@ -225,10 +225,7 @@ fn malformed_ds_fixture(leaf_zone: &FQDN, mutate: impl FnOnce(&mut DS)) -> Resul
     let client = Client::new(&network)?;
     let settings = *DigSettings::default().recurse().authentic_data();
 
-    let ret = client.dig(settings, resolver.ipv4_addr(), RecordType::SOA, leaf_zone);
-    println!("{}", resolver.logs()?);
-
-    ret
+    client.dig(settings, resolver.ipv4_addr(), RecordType::SOA, leaf_zone)
 }
 
 #[test]
@@ -307,9 +304,6 @@ fn bogus_zone_plus_trust_anchor_dnskey() -> Result<()> {
     let settings = *DigSettings::default().recurse().authentic_data();
 
     let output = client.dig(settings, resolver.ipv4_addr(), RecordType::SOA, &leaf_zone)?;
-
-    println!("{}", _leaf_ns.logs()?);
-    println!("{}", resolver.logs()?);
 
     dbg!(&output);
 
@@ -390,9 +384,6 @@ fn bogus_zone_plus_ds_covered_dnskey() -> Result<()> {
     let settings = *DigSettings::default().recurse().authentic_data();
 
     let output = client.dig(settings, resolver.ipv4_addr(), RecordType::SOA, &leaf_zone)?;
-
-    println!("{}", _leaf_ns.logs()?);
-    println!("{}", resolver.logs()?);
 
     dbg!(&output);
 
@@ -511,9 +502,6 @@ AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
     let settings = *DigSettings::default().recurse().authentic_data();
 
     let output = client.dig(settings, resolver.ipv4_addr(), RecordType::SOA, &leaf_zone)?;
-
-    println!("{}", _leaf_ns.logs()?);
-    println!("{}", resolver.logs()?);
 
     dbg!(&output);
 

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/insecure/deprecated_algorithm.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/insecure/deprecated_algorithm.rs
@@ -124,9 +124,5 @@ fn fixture(label: &str, deprecated_settings: SignSettings) -> Result<DigOutput> 
     }
 
     let settings = *DigSettings::default().recurse().authentic_data();
-    let ret = client.dig(settings, resolver.ipv4_addr(), RecordType::A, &needle_fqdn);
-
-    println!("{}", resolver.logs().unwrap());
-
-    ret
+    client.dig(settings, resolver.ipv4_addr(), RecordType::A, &needle_fqdn)
 }

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/nsec3/does_not_cover/mod.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/nsec3/does_not_cover/mod.rs
@@ -42,7 +42,7 @@ fn does_not_cover() -> Result<()> {
     let root_hint = root_ns.root_hint();
     let trust_anchor = root_ns.trust_anchor();
 
-    let leaf_ns = leaf_ns.start()?;
+    let _leaf_ns = leaf_ns.start()?;
     let _tld_ns = tld_ns.start()?;
     let _root_ns = root_ns.start()?;
 
@@ -63,11 +63,6 @@ fn does_not_cover() -> Result<()> {
             RecordType::A,
             &FQDN::TEST_DOMAIN.push_label(&subdomain.to_string()),
         )?;
-
-        if subdomain == 'a' {
-            println!("{}", resolver.logs()?);
-            println!("{}", leaf_ns.logs()?);
-        }
 
         assert_eq!(response.status, DigStatus::SERVFAIL);
     }

--- a/tests/e2e-tests/src/resolver/do_not_query.rs
+++ b/tests/e2e-tests/src/resolver/do_not_query.rs
@@ -105,8 +105,6 @@ fn run_test(
 
     let res = client.dig(dig_settings, resolver_addr, RecordType::A, &needle_fqdn);
     dbg!(&res);
-    let logs = resolver.logs()?;
-    eprintln!("resolver logs:\n{logs}");
     let ans = res?;
 
     tshark.wait_for_capture()?;


### PR DESCRIPTION
This deletes several `println!()` calls throughout the conformance test suite that dump logs from servers. These are only really needed when debugging, and very easy to add back. This is primarily annoying when running `just conformance-ignored`, since the server logs make the output of that recipe far longer.