### PR TITLE
Improve preserve_rdata fuzzer, store reserved CSYNC flags

### DIFF
--- a/crates/proto/src/rr/rdata/csync.rs
+++ b/crates/proto/src/rr/rdata/csync.rs
@@ -43,6 +43,7 @@ pub struct CSYNC {
     soa_serial: u32,
     immediate: bool,
     soa_minimum: bool,
+    reserved_flags: u16,
     type_bit_maps: RecordTypeSet,
 }
 
@@ -69,6 +70,7 @@ impl CSYNC {
             soa_serial,
             immediate,
             soa_minimum,
+            reserved_flags: 0,
             type_bit_maps: RecordTypeSet::new(type_bit_maps),
         }
     }
@@ -114,7 +116,7 @@ impl CSYNC {
     ///    flag that is unknown to or unsupported by the parental agent.
     /// ```
     pub fn flags(&self) -> u16 {
-        let mut flags: u16 = 0;
+        let mut flags = self.reserved_flags & 0b1111_1111_1111_1100;
         if self.immediate {
             flags |= 0b0000_0001
         };
@@ -148,6 +150,7 @@ impl<'r> RecordDataDecodable<'r> for CSYNC {
 
         let immediate: bool = flags & 0b0000_0001 == 0b0000_0001;
         let soa_minimum: bool = flags & 0b0000_0010 == 0b0000_0010;
+        let reserved_flags = flags & 0b1111_1111_1111_1100;
 
         let offset = u16::try_from(decoder.index() - start_idx)
             .map_err(|_| ProtoError::from("decoding offset too large in CSYNC"))?;
@@ -160,6 +163,7 @@ impl<'r> RecordDataDecodable<'r> for CSYNC {
             soa_serial,
             immediate,
             soa_minimum,
+            reserved_flags,
             type_bit_maps,
         })
     }

--- a/fuzz/fuzz_targets/preserve_rdata.rs
+++ b/fuzz/fuzz_targets/preserve_rdata.rs
@@ -26,13 +26,9 @@ fuzz_target!(|data: &[u8]| {
 });
 
 fn compare(original: &[u8], message: &Message, reencoded: &[u8]) {
-    assert_eq!(original[4..6], reencoded[4..6]);
     let query_count = u16::from_be_bytes(reencoded[4..6].try_into().unwrap());
-    assert_eq!(original[6..8], reencoded[6..8]);
     let answer_count = u16::from_be_bytes(reencoded[6..8].try_into().unwrap());
-    assert_eq!(original[8..10], reencoded[8..10]);
     let name_server_count = u16::from_be_bytes(reencoded[8..10].try_into().unwrap());
-    assert_eq!(original[10..12], reencoded[10..12]);
     let additional_records_count = u16::from_be_bytes(reencoded[10..12].try_into().unwrap());
 
     let rr_count = answer_count + name_server_count + additional_records_count;

--- a/fuzz/fuzz_targets/preserve_rdata.rs
+++ b/fuzz/fuzz_targets/preserve_rdata.rs
@@ -32,26 +32,32 @@ fn compare(original: &[u8], message: &Message, reencoded: &[u8]) {
     let additional_records_count = u16::from_be_bytes(reencoded[10..12].try_into().unwrap());
 
     let rr_count = answer_count + name_server_count + additional_records_count;
-    let Ok(original_rrs) = split_rrs(original, query_count, rr_count) else {
-        println!("Parsed message: {message:?}");
-        println!("Original: {:02x?}", original);
-        panic!("failed to split original message into resource records");
+    let original_rrs = match split_rrs(original, query_count, rr_count) {
+        Ok(original_rrs) => original_rrs,
+        Err(error_message) => {
+            println!("Parsed message: {message:?}");
+            println!("Original: {:02x?}", original);
+            panic!("failed to split original message into resource records: {error_message}");
+        }
     };
-    let Ok(reencoded_rrs) = split_rrs(reencoded, query_count, rr_count) else {
-        println!("Parsed message: {message:?}");
-        println!("Original:   {:02x?}", original);
-        println!("Re-encoded: {:02x?}", reencoded);
-        panic!("failed to split re-encoded message into resource records");
+    let reencoded_rrs = match split_rrs(reencoded, query_count, rr_count) {
+        Ok(reencoded_rrs) => reencoded_rrs,
+        Err(error_message) => {
+            println!("Parsed message: {message:?}");
+            println!("Original:   {:02x?}", original);
+            println!("Re-encoded: {:02x?}", reencoded);
+            panic!("failed to split re-encoded message into resource records: {error_message}");
+        }
     };
 
     for (original_rr, reencoded_rr) in original_rrs.into_iter().zip(reencoded_rrs.into_iter()) {
         assert_eq!(original_rr.r#type, reencoded_rr.r#type);
-        if let Err(()) = compare_rr(original, original_rr, reencoded, reencoded_rr) {
+        if let Err(error_message) = compare_rr(original, original_rr, reencoded, reencoded_rr) {
             println!("Parsed message: {message:?}");
             println!("Record type: {}", original_rr.r#type);
             println!("Original:   {:02x?}", &original_rr.rdata);
             println!("Re-encoded: {:02x?}", &reencoded_rr.rdata);
-            panic!("record RDATA was not preserved when decoding and re-encoding");
+            panic!("record RDATA was not preserved when decoding and re-encoding: {error_message}");
         }
     }
 }
@@ -61,7 +67,7 @@ fn compare_rr(
     original_rr: Record<'_>,
     reencoded: &[u8],
     reencoded_rr: Record<'_>,
-) -> Result<(), ()> {
+) -> Result<(), &'static str> {
     if original_rr.rdata == reencoded_rr.rdata {
         return Ok(());
     }
@@ -80,7 +86,7 @@ fn compare_rr(
             if original_decompressed == reencoded_decompressed {
                 Ok(())
             } else {
-                Err(())
+                Err("PTR RDATA was not preserved")
             }
         }
         record_types::SOA => {
@@ -90,7 +96,7 @@ fn compare_rr(
             if original_decompressed == reencoded_decompressed {
                 Ok(())
             } else {
-                Err(())
+                Err("SOA RDATA was not preserved")
             }
         }
         record_types::MINFO => {
@@ -100,7 +106,7 @@ fn compare_rr(
             if original_decompressed == reencoded_decompressed {
                 Ok(())
             } else {
-                Err(())
+                Err("MINFO RDATA was not preserved")
             }
         }
         record_types::MX => {
@@ -110,7 +116,7 @@ fn compare_rr(
             if original_decompressed == reencoded_decompressed {
                 Ok(())
             } else {
-                Err(())
+                Err("MX RDATA was not preserved")
             }
         }
         record_types::OPT => {
@@ -118,7 +124,7 @@ fn compare_rr(
             // transparently.
             Ok(())
         }
-        _ => Err(()),
+        _ => Err("RDATA was not preserved"),
     }
 }
 
@@ -130,7 +136,11 @@ struct Record<'a> {
 
 /// Walks through a DNS message and returns slices spanning each resource record in the main three
 /// sections.
-fn split_rrs(buffer: &[u8], query_count: u16, rr_count: u16) -> Result<Vec<Record<'_>>, ()> {
+fn split_rrs(
+    buffer: &[u8],
+    query_count: u16,
+    rr_count: u16,
+) -> Result<Vec<Record<'_>>, &'static str> {
     let mut offset = 12;
 
     // Skip over the question section.
@@ -170,14 +180,14 @@ const LABEL_TYPE_MASK: u8 = 0b1100_0000;
 const COMPRESSED_LABEL_TYPE: u8 = 0b1100_0000;
 
 /// Determines the encoded length of a name inside a DNS message.
-fn name_length(input: &[u8]) -> Result<usize, ()> {
+fn name_length(input: &[u8]) -> Result<usize, &'static str> {
     let mut offset = 0;
 
     while input[offset] != 0 && input[offset] & LABEL_TYPE_MASK != COMPRESSED_LABEL_TYPE {
         let length = input[offset];
         offset += 1 + length as usize;
         if offset >= input.len() {
-            return Err(());
+            return Err("name label length is longer than the remainder of the message");
         }
     }
 
@@ -190,7 +200,7 @@ struct Name(Vec<u8>);
 
 impl Decompressible for Name {
     /// Decompress a name in a DNS message.
-    fn decompress(compressed_name: &[u8], message: &[u8]) -> Result<Self, ()> {
+    fn decompress(compressed_name: &[u8], message: &[u8]) -> Result<Self, &'static str> {
         let mut output = Vec::with_capacity(compressed_name.len());
         let mut buffer = compressed_name;
         loop {
@@ -218,7 +228,7 @@ struct Minfo {
 
 impl Decompressible for Minfo {
     /// Decompress a MINFO RDATA.
-    fn decompress(compressed_rdata: &[u8], message: &[u8]) -> Result<Self, ()> {
+    fn decompress(compressed_rdata: &[u8], message: &[u8]) -> Result<Self, &'static str> {
         let emailbx_offset = name_length(compressed_rdata)?;
         let rmailbx = Name::decompress(compressed_rdata, message)?;
         let emailbx = Name::decompress(&compressed_rdata[emailbx_offset..], message)?;
@@ -235,7 +245,7 @@ struct Mx {
 }
 
 impl Decompressible for Mx {
-    fn decompress(input: &[u8], message: &[u8]) -> Result<Self, ()> {
+    fn decompress(input: &[u8], message: &[u8]) -> Result<Self, &'static str> {
         let preference = input[0..2].try_into().unwrap();
         let exchange = Name::decompress(&input[2..], message)?;
         Ok(Self {
@@ -255,7 +265,7 @@ struct Soa {
 
 impl Decompressible for Soa {
     /// Decompress a SOA RDATA.
-    fn decompress(compressed_rdata: &[u8], message: &[u8]) -> Result<Self, ()> {
+    fn decompress(compressed_rdata: &[u8], message: &[u8]) -> Result<Self, &'static str> {
         let rname_offset = name_length(compressed_rdata)?;
         let serial_offset = rname_offset + name_length(&compressed_rdata[rname_offset..])?;
 
@@ -274,7 +284,7 @@ trait Decompressible: Debug + PartialEq + Eq + Sized {
     ///
     /// The second argument is the entire DNS message. Compressed names will refer to byte offsets
     /// within this message.
-    fn decompress(input: &[u8], message: &[u8]) -> Result<Self, ()>;
+    fn decompress(input: &[u8], message: &[u8]) -> Result<Self, &'static str>;
 }
 
 mod record_types {

--- a/fuzz/fuzz_targets/preserve_rdata.rs
+++ b/fuzz/fuzz_targets/preserve_rdata.rs
@@ -145,6 +145,9 @@ fn split_rrs(
 
     // Skip over the question section.
     for _ in 0..query_count {
+        if offset >= buffer.len() {
+            return Err("question section queries extend past end of message");
+        }
         offset += name_length(&buffer[offset..])?; // QNAME
         offset += 2; // QTYPE
         offset += 2; // QCLASS

--- a/fuzz/fuzz_targets/preserve_rdata.rs
+++ b/fuzz/fuzz_targets/preserve_rdata.rs
@@ -60,13 +60,14 @@ fn compare(original: &[u8], message: &Message, reencoded: &[u8]) {
                 original_rr.r#type, reencoded_rr.r#type
             );
         }
-        if let Err(error_message) = compare_rr(original, original_rr, reencoded, reencoded_rr) {
-            println!("Parsed message: {message:?}");
-            println!("Record type: {}", original_rr.r#type);
-            println!("Original:   {:02x?}", &original_rr.rdata);
-            println!("Re-encoded: {:02x?}", &reencoded_rr.rdata);
-            panic!("record RDATA was not preserved when decoding and re-encoding: {error_message}");
-        }
+        let Err(error_message) = compare_rr(original, original_rr, reencoded, reencoded_rr) else {
+            continue;
+        };
+        println!("Parsed message: {message:?}");
+        println!("Record type: {}", original_rr.r#type);
+        println!("Original:   {:02x?}", &original_rr.rdata);
+        println!("Re-encoded: {:02x?}", &reencoded_rr.rdata);
+        panic!("record RDATA was not preserved when decoding and re-encoding: {error_message}");
     }
 }
 

--- a/fuzz/fuzz_targets/preserve_rdata.rs
+++ b/fuzz/fuzz_targets/preserve_rdata.rs
@@ -51,7 +51,15 @@ fn compare(original: &[u8], message: &Message, reencoded: &[u8]) {
     };
 
     for (original_rr, reencoded_rr) in original_rrs.into_iter().zip(reencoded_rrs.into_iter()) {
-        assert_eq!(original_rr.r#type, reencoded_rr.r#type);
+        if original_rr.r#type != reencoded_rr.r#type {
+            println!("Parsed message: {message:?}");
+            println!("Original:   {:02x?}", original);
+            println!("Re-encoded: {:02x?}", reencoded);
+            panic!(
+                "record type changed when decoding and re-encoding: {} vs. {}",
+                original_rr.r#type, reencoded_rr.r#type
+            );
+        }
         if let Err(error_message) = compare_rr(original, original_rr, reencoded, reencoded_rr) {
             println!("Parsed message: {message:?}");
             println!("Record type: {}", original_rr.r#type);


### PR DESCRIPTION
This makes various improvements to the preserve_rdata fuzzer. More information is printed on failure, and I fixed handling of compressed names -- compressed labels are two bytes, not one. I also changed the `CSYNC` struct to store all reserved flags, rather than dropping them on decoding and clearing them on encoding.