### PR TITLE
CAA: Store tag field as-is

### DIFF
--- a/crates/proto/src/serialize/txt/rdata_parsers/caa.rs
+++ b/crates/proto/src/serialize/txt/rdata_parsers/caa.rs
@@ -73,6 +73,7 @@ pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResu
         }
         tag
     };
+    let raw_tag = tag_str.as_bytes().to_vec();
 
     // parse the value
     let raw_value = value_str.as_bytes().to_vec();
@@ -88,6 +89,7 @@ pub(crate) fn parse<'i, I: Iterator<Item = &'i str>>(mut tokens: I) -> ParseResu
         issuer_critical,
         reserved_flags,
         tag,
+        raw_tag,
         value,
         raw_value,
     })


### PR DESCRIPTION
This changes CAA handling to store the raw tag field when decoding, and use that value when encoding. This keeps us from changing the capitalization of the tag when it matches one of the defined tags, "issue", "issuewild", or "iodef". We should preserve this field in this manner to avoid invalidating RRSIGs in case some zone has an unusual tag value.

I tried adding a conformance test for this, but Unbound is strict about the tag's contents, and failed to load the zone with this message: "invalid tag ISSUE: contains invalid char I". RFC 8659 says the tag MAY contain any ASCII lowercase letter, upppercase letter, or number, and says that "Matching of tags is case insensitive".

Note that this could be cleaned up in the future when making breaking changes. Currently, any unknown tags will be stored twice, in both the `tag` and `raw_tag` fields.