### PR TITLE
Only fetch signer's DS RRset when validating keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,7 +823,6 @@ dependencies = [
 name = "hickory-proto"
 version = "0.25.1"
 dependencies = [
- "async-recursion",
  "async-trait",
  "aws-lc-rs",
  "backtrace",

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -85,7 +85,6 @@ name = "hickory_proto"
 path = "src/lib.rs"
 
 [dependencies]
-async-recursion.workspace = true
 async-trait.workspace = true
 aws-lc-rs = { workspace = true, optional = true }
 backtrace = { workspace = true, optional = true }

--- a/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
@@ -849,17 +849,11 @@ where
     if zone == parent {
         // zone is `.`. do not call `find_ds_records(.., parent, ..)` or that will lead to infinite
         // recursion
-        return Err(ProofError::new(
-            Proof::Bogus,
-            ProofErrorKind::DsRecordShouldExist { name: zone },
-        ));
+        return Err(ProofError::ds_should_exist(zone));
     }
 
     match find_ds_records(handle, parent, options).await {
-        Ok(ds_records) if !ds_records.is_empty() => Err(ProofError::new(
-            Proof::Bogus,
-            ProofErrorKind::DsRecordShouldExist { name: zone },
-        )),
+        Ok(ds_records) if !ds_records.is_empty() => Err(ProofError::ds_should_exist(zone)),
         result => result,
     }
 }

--- a/crates/proto/src/dnssec/proof.rs
+++ b/crates/proto/src/dnssec/proof.rs
@@ -338,6 +338,14 @@ impl ProofError {
     pub fn kind(&self) -> &ProofErrorKind {
         &self.kind
     }
+
+    /// Returns an error related to the absence of a DS record
+    pub fn ds_should_exist(name: Name) -> Self {
+        Self {
+            proof: Proof::Bogus,
+            kind: ProofErrorKind::DsRecordShouldExist { name },
+        }
+    }
 }
 
 impl fmt::Display for ProofError {

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -33,17 +33,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 
 [[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,7 +341,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 name = "hickory-proto"
 version = "0.25.1"
 dependencies = [
- "async-recursion",
  "async-trait",
  "aws-lc-rs",
  "bitflags",


### PR DESCRIPTION
This splits `find_ds_records()` into two separate functions, one that just fetches a specific DS RRset, and one that walks up ancestor names if a DS RRset is not found. `verify_dnskey_rrset()` now uses the new function that just fetches one RRset, and `verify_default_rrset()` still uses the original function that walks up parent names, and calls it when no RRSIGs are present for an RRset. See also https://github.com/hickory-dns/hickory-dns/issues/2889#issuecomment-2806667970. I rewrote `find_ds_records()` to use the newly extracted function, changed it from recursive to iterative, and changed the return type to `Result<(), ProofError>`.