### PR TITLE
Remove extra query depth increments in verifier

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dnssec/regression.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/regression.rs
@@ -231,7 +231,6 @@ fn single_node_dns_graph_with_bind_as_peer() -> Result<()> {
 }
 
 #[test]
-#[ignore = "hickory-proto DNSSEC validation fails when traversing too many zones"]
 fn five_secure_zones() -> Result<()> {
     let network = Network::new()?;
 

--- a/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
@@ -403,7 +403,7 @@ where
         );
 
         // verify this rrset
-        let proof = verify_rrset(handle.clone_with_context(), &rrset, rrsigs, options).await;
+        let proof = verify_rrset(handle.clone(), &rrset, rrsigs, options).await;
 
         let proof = match proof {
             Ok(proof) => {
@@ -489,26 +489,12 @@ where
 
     // DNSKEYS have different logic for their verification
     if matches!(rrset.record_type(), RecordType::DNSKEY) {
-        let proof = verify_dnskey_rrset(
-            handle.clone_with_context(),
-            rrset,
-            &rrsigs,
-            current_time,
-            options,
-        )
-        .await?;
+        let proof = verify_dnskey_rrset(handle, rrset, &rrsigs, current_time, options).await?;
 
         return Ok(proof);
     }
 
-    verify_default_rrset(
-        &handle.clone_with_context(),
-        rrset,
-        &rrsigs,
-        current_time,
-        options,
-    )
-    .await
+    verify_default_rrset(&handle, rrset, &rrsigs, current_time, options).await
 }
 
 /// DNSKEY-specific verification
@@ -943,7 +929,6 @@ where
         .iter()
         .enumerate()
         .filter_map(|(i, rrsig)| {
-            let handle = handle.clone_with_context();
             let query = Query::query(rrsig.data().signer_name().clone(), RecordType::DNSKEY);
 
             if i > MAX_RRSIGS_PER_RRSET {

--- a/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
@@ -19,7 +19,7 @@ use futures_util::{
     future::{self, TryFutureExt},
     stream::{self, Stream, TryStreamExt},
 };
-use tracing::{debug, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 use crate::{
     dnssec::{
@@ -119,6 +119,7 @@ where
 
         // backstop
         if self.request_depth > request.options().max_request_depth {
+            error!("exceeded max validation depth");
             return Box::pin(stream::once(future::err(ProtoError::from(
                 "exceeded max validation depth",
             ))));


### PR DESCRIPTION
This fixes #2889 by removing some extra increments to `DnssecDnsHandle`'s request depth. We now only increment it in the `send()` method, i.e. once per request, or twice per zone.