### PR TITLE
Handle byte-order mark when reading hosts file

### DIFF
--- a/crates/resolver/src/hosts.rs
+++ b/crates/resolver/src/hosts.rs
@@ -163,9 +163,10 @@ impl Hosts {
 
             // Remove byte-order mark if present
             let line = if line_index == 0 && line.starts_with('\u{feff}') {
-                line[3..].to_string()
+                // BOM is 3 bytes
+                &line[3..]
             } else {
-                line
+                &line
             };
 
             // Remove comments from the line

--- a/crates/resolver/src/hosts.rs
+++ b/crates/resolver/src/hosts.rs
@@ -172,7 +172,7 @@ impl Hosts {
             // Remove comments from the line
             let line = match line.split_once('#') {
                 Some((line, _)) => line,
-                None => &line,
+                None => line,
             }
             .trim();
 

--- a/crates/resolver/src/hosts.rs
+++ b/crates/resolver/src/hosts.rs
@@ -158,9 +158,17 @@ impl Hosts {
         // if line only include `addr` without `host` will be ignored,
         // the src will be parsed to map in the form `Name -> LookUp`.
 
-        for line in BufReader::new(src).lines() {
-            // Remove comments from the line
+        for (line_index, line) in BufReader::new(src).lines().enumerate() {
             let line = line?;
+
+            // Remove byte-order mark if present
+            let line = if line_index == 0 && line.starts_with('\u{feff}') {
+                line[3..].to_string()
+            } else {
+                line
+            };
+
+            // Remove comments from the line
             let line = match line.split_once('#') {
                 Some((line, _)) => line,
                 None => &line,


### PR DESCRIPTION
A user for one of my crates was getting this warning from hickory-resolver:
```rs
WARN hickory_resolver::hosts: could not parse an IP from hosts file ("\u{feff}")
```

Upon investigation, we found that their hosts file at `C:\Windows\System32\Drivers\etc\hosts` began with that codepoint (a byte order mark). We don't know exactly how it showed up, but apparently some text editors insert it when writing files. Additionally, it never caused issues for this user before because most programs strip it when reading files, but Rust doesn't.

You should be able to reproduce their issue on Windows by running the following code:
```rs
use std::{fs::read_to_string, path::Path};
use hickory_resolver::Resolver;

#[tokio::main]
async fn main() {
    let system_root =
        std::env::var_os("SystemRoot").expect("Environment variable SystemRoot not found");
    let system_root = Path::new(&system_root);
    let hosts_path = system_root.join("System32\\drivers\\etc\\hosts");
    let hosts = read_to_string(&hosts_path).unwrap();
    println!("{hosts:?}");
    let hosts = format!("\u{FEFF}{hosts}");
    std::fs::write(hosts_path, hosts).unwrap();

    let resolver = Resolver::builder_tokio().unwrap().build();
    let response = resolver.lookup_ip("www.example.com.").await.unwrap();
    println!("{response:?}");
}
```

This PR solves the problem by updating the logic for reading the hosts file to correctly strip the byte-order mark codepoint. The user has confirmed with me that my fix does resolve the issue.
