### PR TITLE
Add test for no data response without SOA

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/scenarios.rs
@@ -7,6 +7,7 @@ use dns_test::tshark::{Capture, Direction};
 use dns_test::{FQDN, Network, Resolver, Result};
 
 mod bad_referral;
+mod no_soa;
 mod packet_loss;
 
 #[test]

--- a/conformance/packages/conformance-tests/src/resolver/dns/scenarios/empty_response.py
+++ b/conformance/packages/conformance-tests/src/resolver/dns/scenarios/empty_response.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# This server sends empty responses, not even including an SOA record.
+from dnslib import DNSRecord
+from dnslib.server import BaseResolver, DNSHandler, DNSServer
+
+
+class Resolver(BaseResolver):
+    def resolve(self, request: DNSRecord, _handler: DNSHandler) -> DNSRecord:
+        return request.reply()
+
+
+if __name__ == "__main__":
+    resolver = Resolver()
+    server = DNSServer(resolver, address="0.0.0.0", port=53)
+    server.start()

--- a/conformance/packages/conformance-tests/src/resolver/dns/scenarios/no_soa.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/scenarios/no_soa.rs
@@ -1,0 +1,42 @@
+use std::fs;
+
+use dns_test::{
+    FQDN, Implementation, Network, PEER, Resolver, Result,
+    client::{Client, DigSettings, DigStatus},
+    name_server::NameServer,
+    record::RecordType,
+};
+
+#[test]
+#[ignore = "hickory returns SERVFAIL due to the absence of an NS or SOA record"]
+fn no_soa() -> Result<()> {
+    let target_fqdn = FQDN::TEST_DOMAIN;
+    let network = Network::new()?;
+
+    let mut root_ns = NameServer::new(&PEER, FQDN::ROOT, &network)?;
+    let leaf_ns = NameServer::new(&Implementation::Dnslib, FQDN::TEST_TLD, &network)?;
+    let script = fs::read_to_string("src/resolver/dns/scenarios/empty_response.py")?;
+    leaf_ns.cp("/script.py", &script)?;
+
+    root_ns.referral_nameserver(&leaf_ns);
+
+    let root_hint = root_ns.root_hint();
+    let resolver = Resolver::new(&network, root_hint).start()?;
+    let client = Client::new(resolver.network())?;
+    let dig_settings = *DigSettings::default().recurse();
+
+    let _root_ns = root_ns.start()?;
+    let _leaf_ns = leaf_ns.start()?;
+
+    let response = client.dig(
+        dig_settings,
+        resolver.ipv4_addr(),
+        RecordType::A,
+        &target_fqdn,
+    )?;
+
+    assert_eq!(response.status, DigStatus::NOERROR);
+    assert!(response.answer.is_empty());
+
+    Ok(())
+}


### PR DESCRIPTION
This adds a conformance test for #2814. It uses a barebones dnslib server to send empty responses, as seen in the wild.