### PR TITLE
Send error responses in two more cases

### DIFF
--- a/bin/tests/integration/server_harness/mod.rs
+++ b/bin/tests/integration/server_harness/mod.rs
@@ -18,8 +18,11 @@ use hickory_client::client::Client;
 use hickory_client::{ClientError, client::ClientHandle, proto::xfer::DnsResponse};
 #[cfg(feature = "__dnssec")]
 use hickory_proto::dnssec::Algorithm;
-use hickory_proto::rr::{DNSClass, Name, RData, RecordType, rdata::A};
 use hickory_proto::xfer::Protocol;
+use hickory_proto::{
+    op::ResponseCode,
+    rr::{DNSClass, Name, RData, RecordType, rdata::A},
+};
 use regex::Regex;
 use tokio::runtime::Runtime;
 use tracing::{info, warn};
@@ -287,14 +290,9 @@ pub fn query_a<C: ClientHandle>(io_loop: &mut Runtime, client: &mut C) {
 #[allow(dead_code)]
 pub fn query_a_refused<C: ClientHandle>(io_loop: &mut Runtime, client: &mut C) {
     let name = Name::from_str("www.example.com.").unwrap();
-    let error =
-        query_message(io_loop, client, name, RecordType::A).expect_err("Expected an Error here");
+    let response = query_message(io_loop, client, name, RecordType::A).unwrap();
 
-    println!("got error: {error:?}");
-    // assert!(
-    //     matches!(*error.kind(), ClientErrorKind::Timeout),
-    //     "Expected Timeout, got error: {error:?}"
-    // );
+    assert_eq!(response.response_code(), ResponseCode::Refused);
 }
 
 // This only validates that a query to the server works, it shouldn't be used for more than this.

--- a/crates/server/src/authority/message_request.rs
+++ b/crates/server/src/authority/message_request.rs
@@ -263,6 +263,11 @@ impl Queries {
         self.queries.is_empty()
     }
 
+    /// Returns the queries from the request
+    pub fn queries(&self) -> &[LowerQuery] {
+        &self.queries
+    }
+
     /// returns the bytes as they were seen from the Client
     pub fn as_bytes(&self) -> &[u8] {
         self.original.as_ref()

--- a/crates/server/src/server/mod.rs
+++ b/crates/server/src/server/mod.rs
@@ -1026,7 +1026,6 @@ pub(crate) async fn handle_request<R: ResponseHandler, T: RequestHandler>(
             metrics: ResponseHandlerMetrics::default(),
         };
 
-        let queries = Queries::empty();
         let response = MessageResponseBuilder::new(&queries);
         let result = reporter
             .send_response(response.error_msg(&header, response_code))

--- a/crates/server/src/server/response_handler.rs
+++ b/crates/server/src/server/response_handler.rs
@@ -111,8 +111,9 @@ impl ResponseHandler for ResponseHandle {
     ) -> io::Result<ResponseInfo> {
         let id = response.header().id();
         debug!(
-            "response: {id} response_code: {}",
-            response.header().response_code(),
+            id,
+            response_code = %response.header().response_code(),
+            "sending response",
         );
         let mut buffer = Vec::with_capacity(512);
         let encode_result = {


### PR DESCRIPTION
This sends a REFUSED response to clients that are not allowed to make requests, and sends a SERVFAIL response if response encoding otherwise fails for any reason. With these changes, the server will send some reply to requests in almost all cases (except for extreme edge cases like requests that don't even contain a full header). The relevant code path runs through `handle_request()`, `<MessageRequest as BinDecodable>::read()`, `<Catalog as RequestHandler>::handle_request()`, various implementations of `ResponseHandler`, etc. This closes #2572.