### PR TITLE
tests: tidy legacy config field comments

### DIFF
--- a/tests/test-data/test_configs/all_supported_dnssec.toml
+++ b/tests/test-data/test_configs/all_supported_dnssec.toml
@@ -43,10 +43,6 @@ key_path = "../tests/test-data/test_configs/dnssec/rsa_2048.pk8"
 algorithm = "RSASHA256"
 ## this key should be used to sign the zone
 purpose = "ZoneSigning"
-## this key is authorized for dynamic update access to the zone via SIG0
-# is_zone_update_auth = true
-## create the key if it is not found
-# create_if_absent = false
 
 [[zones.keys]]
 key_path = "../tests/test-data/test_configs/dnssec/rsa_2048.pk8"

--- a/tests/test-data/test_configs/dnssec_with_update.toml
+++ b/tests/test-data/test_configs/dnssec_with_update.toml
@@ -54,12 +54,9 @@ key_path = "../tests/test-data/test_configs/dnssec/rsa_2048.pk8"
 algorithm = "RSASHA256"
 ## this key should be used to sign the zone
 purpose = "ZoneSigning"
-## this key is authorized for dynamic update access to the zone via SIG0
-# is_zone_update_auth = true
-## create the key if it is not found
-# create_if_absent = false
 
 [[zones.keys]]
 key_path = "../tests/test-data/test_configs/dnssec/rsa_2048.pk8"
 algorithm = "RSASHA512"
+## this key is authorized for dynamic update access to the zone via SIG0
 purpose = "ZoneUpdateAuth"

--- a/tests/test-data/test_configs/dnssec_with_update_2.toml
+++ b/tests/test-data/test_configs/dnssec_with_update_2.toml
@@ -54,12 +54,9 @@ key_path = "../tests/test-data/test_configs/dnssec/rsa_2048.pk8"
 algorithm = "RSASHA256"
 ## this key should be used to sign the zone
 purpose = "ZoneSigning"
-## this key is authorized for dynamic update access to the zone via SIG0
-# is_zone_update_auth = true
-## create the key if it is not found
-# create_if_absent = false
 
 [[zones.keys]]
 key_path = "../tests/test-data/test_configs/dnssec/rsa_2048.pk8"
 algorithm = "RSASHA512"
+## this key is authorized for dynamic update access to the zone via SIG0
 purpose = "ZoneUpdateAuth"

--- a/tests/test-data/test_configs/example.toml
+++ b/tests/test-data/test_configs/example.toml
@@ -123,14 +123,12 @@ file = "example.com.zone"
 # password = ""
 ## specify the algorithm
 # algorithm = "RSASHA256"
-## this key should be used to sign the zone
-# is_zone_signing_key = true
-## this key is authorized for dynamic update access to the zone via SIG0
-# is_zone_update_auth = true
+## This key is used to sign a zone
+# purpose = ZoneSigning
 #
 # [[zones.keys]]
 # key_path = "/path/to/my_ed25519.pk8"
 # algorithm = "ED25519"
+## This key is used to authorize zone updates
 ## for keys that are not zone signing, the pem need only include the pubic_key
-# is_zone_signing_key = false
-# is_zone_update_auth = true
+# purpose = ZoneUpdateAuth


### PR DESCRIPTION
This branch removes commented out instances of some legacy config fields from test/example config files since they will error if uncommented.

The `create_if_absent` config field was [removed back in 2017](https://github.com/hickory-dns/hickory-dns/commit/f12fd8d23fc6fc5e52ff687221b8d966f1035bb3) to discourage this kind of adhoc key management.

The `is_zone_signing_key` and `is_zone_update_auth` config field were [merged into a single `purpose` enum](https://github.com/hickory-dns/hickory-dns/commit/07e0183ffef0274d59ffb61f2da4619f2a63ef14) in 2024.