### PR TITLE
proto & server: update message signature repr

### DIFF
--- a/crates/proto/src/dnssec/rdata/tsig.rs
+++ b/crates/proto/src/dnssec/rdata/tsig.rs
@@ -742,6 +742,7 @@ mod tests {
     use std::println;
 
     use super::*;
+    use crate::op::MessageSignature;
     use crate::rr::Record;
 
     fn test_encode_decode(rdata: TSIG) {
@@ -810,9 +811,7 @@ mod tests {
 
         let pre_tsig = pre_tsig.set_mac(b"some signature".to_vec());
 
-        let tsig = make_tsig_record(key_name, pre_tsig);
-
-        message.add_tsig(tsig);
+        message.set_signature(MessageSignature::Tsig(make_tsig_record(key_name, pre_tsig)));
 
         let message_byte = message.to_bytes().unwrap();
 
@@ -844,9 +843,7 @@ mod tests {
 
         let pre_tsig = pre_tsig.set_mac(b"some signature".to_vec());
 
-        let tsig = make_tsig_record(key_name, pre_tsig);
-
-        message.add_tsig(tsig);
+        message.set_signature(MessageSignature::Tsig(make_tsig_record(key_name, pre_tsig)));
 
         let message_byte = message.to_bytes().unwrap();
         let mut message = Message::from_bytes(&message_byte).unwrap();

--- a/crates/proto/src/op/header.rs
+++ b/crates/proto/src/op/header.rs
@@ -458,7 +458,7 @@ impl Header {
     /// # Return value
     ///
     /// If this is a query, this will return the number of queries in the query section of the
-    //   message, for updates this represents the zone count (must be no more than 1).
+    /// message, for updates this represents the zone count (must be no more than 1).
     pub fn query_count(&self) -> u16 {
         self.query_count
     }

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -779,7 +779,7 @@ impl From<MessageParts> for Message {
             answers,
             name_servers,
             additionals,
-            sig0,
+            signature,
             edns,
         } = msg;
         Self {
@@ -788,7 +788,7 @@ impl From<MessageParts> for Message {
             answers,
             name_servers,
             additionals,
-            signature: sig0,
+            signature,
             edns,
         }
     }
@@ -823,9 +823,7 @@ pub struct MessageParts {
     /// message additional records
     pub additionals: Vec<Record>,
     /// sig0 or tsig
-    // this can now contains TSIG too. It should probably be renamed to reflect that, but it's a
-    // breaking change
-    pub sig0: Vec<Record>,
+    pub signature: Vec<Record>,
     /// optional edns records
     pub edns: Option<Edns>,
 }
@@ -847,7 +845,7 @@ impl From<Message> for MessageParts {
             answers,
             name_servers,
             additionals,
-            sig0: signature,
+            signature,
             edns,
         }
     }

--- a/crates/proto/src/op/mod.rs
+++ b/crates/proto/src/op/mod.rs
@@ -29,7 +29,9 @@ pub mod update_message;
 pub use self::edns::{Edns, EdnsFlags};
 pub use self::header::Header;
 pub use self::header::MessageType;
-pub use self::message::{Message, MessageFinalizer, MessageParts, MessageVerifier};
+pub use self::message::{
+    Message, MessageFinalizer, MessageParts, MessageSignature, MessageVerifier,
+};
 pub use self::op_code::OpCode;
 pub use self::query::Query;
 pub use self::response_code::ResponseCode;

--- a/crates/proto/src/op/update_message.rs
+++ b/crates/proto/src/op/update_message.rs
@@ -69,7 +69,7 @@ pub trait UpdateMessage: Debug {
     /// This is used to authenticate update messages.
     ///
     /// see `Message::sig0()` for more information.
-    fn sig0(&self) -> &[Record];
+    fn signature(&self) -> &[Record];
 }
 
 /// to reduce errors in using the Message struct as an Update, this will do the call throughs
@@ -127,7 +127,7 @@ impl UpdateMessage for Message {
         self.additionals()
     }
 
-    fn sig0(&self) -> &[Record] {
+    fn signature(&self) -> &[Record] {
         self.sig0()
     }
 }

--- a/crates/proto/src/op/update_message.rs
+++ b/crates/proto/src/op/update_message.rs
@@ -16,7 +16,7 @@ use crate::{
     rr::{DNSClass, Name, RData, RecordSet, RecordType, rdata::SOA},
 };
 use crate::{
-    op::{Message, Query},
+    op::{Message, MessageSignature, Query},
     rr::Record,
 };
 
@@ -66,10 +66,10 @@ pub trait UpdateMessage: Debug {
     /// Returns the additional records
     fn additionals(&self) -> &[Record];
 
-    /// This is used to authenticate update messages.
+    /// Return the message's signature (if any)
     ///
-    /// see `Message::sig0()` for more information.
-    fn signature(&self) -> &[Record];
+    /// This is used to authenticate update messages.
+    fn signature(&self) -> &MessageSignature;
 }
 
 /// to reduce errors in using the Message struct as an Update, this will do the call throughs
@@ -127,8 +127,8 @@ impl UpdateMessage for Message {
         self.additionals()
     }
 
-    fn signature(&self) -> &[Record] {
-        self.sig0()
+    fn signature(&self) -> &MessageSignature {
+        self.signature()
     }
 }
 

--- a/crates/server/src/authority/message_request.rs
+++ b/crates/server/src/authority/message_request.rs
@@ -8,7 +8,7 @@
 use crate::proto::{
     ProtoError, ProtoErrorKind,
     op::{
-        Edns, Header, LowerQuery, Message, MessageType, OpCode, ResponseCode,
+        Edns, Header, LowerQuery, Message, MessageSignature, MessageType, OpCode, ResponseCode,
         message::{self, EmitAndCount},
     },
     rr::Record,
@@ -23,7 +23,7 @@ pub struct MessageRequest {
     answers: Vec<Record>,
     name_servers: Vec<Record>,
     additionals: Vec<Record>,
-    signature: Vec<Record>,
+    signature: MessageSignature,
     edns: Option<Edns>,
 }
 
@@ -150,8 +150,8 @@ impl MessageRequest {
         self.edns.as_ref()
     }
 
-    /// Any SIG0 or TSIG records for signed messages
-    pub fn signature(&self) -> &[Record] {
+    /// The message signature for signed messages
+    pub fn signature(&self) -> &MessageSignature {
         &self.signature
     }
 
@@ -362,8 +362,8 @@ pub trait UpdateRequest {
     /// Additional records
     fn additionals(&self) -> &[Record];
 
-    /// SIG0 or TSIG records for verifying the Message
-    fn signature(&self) -> &[Record];
+    /// Signature for verifying the Message
+    fn signature(&self) -> &MessageSignature;
 }
 
 impl UpdateRequest for MessageRequest {
@@ -388,7 +388,7 @@ impl UpdateRequest for MessageRequest {
         self.additionals()
     }
 
-    fn signature(&self) -> &[Record] {
+    fn signature(&self) -> &MessageSignature {
         self.signature()
     }
 }

--- a/crates/server/src/authority/message_response.rs
+++ b/crates/server/src/authority/message_response.rs
@@ -31,7 +31,7 @@ where
     name_servers: NameServers,
     soa: Soa,
     additionals: Additionals,
-    sig0: Vec<Record>,
+    signature: Vec<Record>,
     edns: Option<Edns>,
 }
 
@@ -78,7 +78,7 @@ where
             &mut name_servers,
             &mut self.additionals,
             self.edns.as_ref(),
-            &self.sig0,
+            &self.signature,
             encoder,
         )
         .map(Into::into)
@@ -88,7 +88,7 @@ where
 /// A builder for MessageResponses
 pub struct MessageResponseBuilder<'q> {
     queries: &'q Queries,
-    sig0: Option<Vec<Record>>,
+    signature: Option<Vec<Record>>,
     edns: Option<Edns>,
 }
 
@@ -101,7 +101,7 @@ impl<'q> MessageResponseBuilder<'q> {
     pub(crate) fn new(queries: &'q Queries) -> Self {
         MessageResponseBuilder {
             queries,
-            sig0: None,
+            signature: None,
             edns: None,
         }
     }
@@ -151,7 +151,7 @@ impl<'q> MessageResponseBuilder<'q> {
             name_servers: name_servers.into_iter(),
             soa: soa.into_iter(),
             additionals: additionals.into_iter(),
-            sig0: self.sig0.unwrap_or_default(),
+            signature: self.signature.unwrap_or_default(),
             edns: self.edns,
         }
     }
@@ -175,7 +175,7 @@ impl<'q> MessageResponseBuilder<'q> {
             name_servers: Box::new(None.into_iter()),
             soa: Box::new(None.into_iter()),
             additionals: Box::new(None.into_iter()),
-            sig0: self.sig0.unwrap_or_default(),
+            signature: self.signature.unwrap_or_default(),
             edns: self.edns,
         }
     }
@@ -209,7 +209,7 @@ impl<'q> MessageResponseBuilder<'q> {
             name_servers: Box::new(None.into_iter()),
             soa: Box::new(None.into_iter()),
             additionals: Box::new(None.into_iter()),
-            sig0: self.sig0.unwrap_or_default(),
+            signature: self.signature.unwrap_or_default(),
             edns: self.edns,
         }
     }
@@ -249,7 +249,7 @@ mod tests {
                 name_servers: iter::once(&answer),
                 soa: iter::once(&answer),
                 additionals: iter::once(&answer),
-                sig0: vec![],
+                signature: vec![],
                 edns: None,
             };
 
@@ -287,7 +287,7 @@ mod tests {
                 name_servers: iter::repeat(&answer),
                 soa: iter::repeat(&answer),
                 additionals: iter::repeat(&answer),
-                sig0: vec![],
+                signature: vec![],
                 edns: None,
             };
 

--- a/crates/server/src/authority/message_response.rs
+++ b/crates/server/src/authority/message_response.rs
@@ -9,7 +9,7 @@ use crate::{
     authority::{Queries, message_request::MessageRequest},
     proto::{
         ProtoError,
-        op::{Edns, Header, ResponseCode, message},
+        op::{Edns, Header, MessageSignature, ResponseCode, message},
         rr::Record,
         serialize::binary::BinEncoder,
     },
@@ -31,7 +31,7 @@ where
     name_servers: NameServers,
     soa: Soa,
     additionals: Additionals,
-    signature: Vec<Record>,
+    signature: MessageSignature,
     edns: Option<Edns>,
 }
 
@@ -88,7 +88,7 @@ where
 /// A builder for MessageResponses
 pub struct MessageResponseBuilder<'q> {
     queries: &'q Queries,
-    signature: Option<Vec<Record>>,
+    signature: MessageSignature,
     edns: Option<Edns>,
 }
 
@@ -101,7 +101,7 @@ impl<'q> MessageResponseBuilder<'q> {
     pub(crate) fn new(queries: &'q Queries) -> Self {
         MessageResponseBuilder {
             queries,
-            signature: None,
+            signature: MessageSignature::default(),
             edns: None,
         }
     }
@@ -151,7 +151,7 @@ impl<'q> MessageResponseBuilder<'q> {
             name_servers: name_servers.into_iter(),
             soa: soa.into_iter(),
             additionals: additionals.into_iter(),
-            signature: self.signature.unwrap_or_default(),
+            signature: self.signature,
             edns: self.edns,
         }
     }
@@ -175,7 +175,7 @@ impl<'q> MessageResponseBuilder<'q> {
             name_servers: Box::new(None.into_iter()),
             soa: Box::new(None.into_iter()),
             additionals: Box::new(None.into_iter()),
-            signature: self.signature.unwrap_or_default(),
+            signature: self.signature,
             edns: self.edns,
         }
     }
@@ -209,7 +209,7 @@ impl<'q> MessageResponseBuilder<'q> {
             name_servers: Box::new(None.into_iter()),
             soa: Box::new(None.into_iter()),
             additionals: Box::new(None.into_iter()),
-            signature: self.signature.unwrap_or_default(),
+            signature: self.signature,
             edns: self.edns,
         }
     }
@@ -249,7 +249,7 @@ mod tests {
                 name_servers: iter::once(&answer),
                 soa: iter::once(&answer),
                 additionals: iter::once(&answer),
-                signature: vec![],
+                signature: MessageSignature::default(),
                 edns: None,
             };
 
@@ -287,7 +287,7 @@ mod tests {
                 name_servers: iter::repeat(&answer),
                 soa: iter::repeat(&answer),
                 additionals: iter::repeat(&answer),
-                signature: vec![],
+                signature: MessageSignature::default(),
                 edns: None,
             };
 

--- a/crates/server/src/store/in_memory/mod.rs
+++ b/crates/server/src/store/in_memory/mod.rs
@@ -196,7 +196,7 @@ impl InMemoryAuthority {
             .increment_soa_serial(self.origin(), self.class)
     }
 
-    /// Inserts or updates a `Record` depending on it's existence in the authority.
+    /// Inserts or updates a `Record` depending on its existence in the authority.
     ///
     /// Guarantees that SOA, CNAME only has one record, will implicitly update if they already exist.
     ///

--- a/crates/server/src/store/sqlite/mod.rs
+++ b/crates/server/src/store/sqlite/mod.rs
@@ -507,12 +507,12 @@ impl SqliteAuthority {
             return Err(ResponseCode::Refused);
         }
 
-        // verify sig0, currently the only authorization that is accepted.
-        let sig0s: &[Record] = update_message.sig0();
-        debug!("authorizing with: {:?}", sig0s);
-        if !sig0s.is_empty() {
+        let signature = update_message.signature();
+        debug!("authorizing with: {:?}", signature);
+        if !signature.is_empty() {
             let mut found_key = false;
-            for sig in sig0s
+            // verify sig0, currently the only authorization that is accepted.
+            for sig in signature
                 .iter()
                 .filter_map(|sig0| sig0.data().as_dnssec().and_then(DNSSECRData::as_sig))
             {

--- a/crates/server/src/store/sqlite/mod.rs
+++ b/crates/server/src/store/sqlite/mod.rs
@@ -973,7 +973,6 @@ impl Authority for SqliteAuthority {
     ///  returned in the case of bad data, etc.
     #[cfg(feature = "__dnssec")]
     async fn update(&self, update: &MessageRequest) -> UpdateResult<bool> {
-        //let this = &mut self.in_memory.lock().await;
         // the spec says to authorize after prereqs, seems better to auth first.
         self.authorize(update).await?;
         self.verify_prerequisites(update.prerequisites()).await?;


### PR DESCRIPTION
This branch refactors `Message` signature representation with an `enum`.

Previously message signatures were represented by a `Vec<Record>` that (based on the parsing logic) could hold:

* Nothing, for unsigned messages or builds w/o dnssec
* One TSIG record
* One SIG(0) record

The existing API for accessing the fields referred to SIG(0) RRs even when it could return TSIG RRs (_based on [this comment](https://github.com/hickory-dns/hickory-dns/blob/8f63f58fccfe2e643d6ff17c800ce9e27e770b62/crates/proto/src/op/message.rs#L826-L828) I believe this was an intentional choice to maintain semver_). It also used a `Vec` even when only one sig record of a given type would be present.

This branch refactors to add a new `MessageSignature` enum that better encapsulates the valid states at the cost of a breaking API change. As a result, the `Message::read_records()` parsing logic , and the Sqlite authority SIG(0) verifying logic can also be simplified. Some small & insignificant tidying commits come along for the ride and are separated up front.