### PR TITLE
Clean up after removal of SOA referrals

### DIFF
--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -374,28 +374,28 @@ impl NoRecords {
     }
 }
 
-impl From<ForwardData> for NoRecords {
-    fn from(fwd: ForwardData) -> Self {
-        let response_code = match fwd.is_nx_domain() {
+impl From<AuthorityData> for NoRecords {
+    fn from(value: AuthorityData) -> Self {
+        let response_code = match value.is_nx_domain() {
             true => ResponseCode::NXDomain,
             false => ResponseCode::NoError,
         };
 
         Self {
-            query: fwd.query,
-            soa: Some(fwd.soa),
+            query: value.query,
+            soa: Some(value.soa),
             ns: None,
             negative_ttl: None,
             response_code,
             trusted: true,
-            authorities: fwd.authorities,
+            authorities: value.authorities,
         }
     }
 }
 
-/// Data needed to process a SOA-record-based referral.
+/// Data from the authority section of a response.
 #[derive(Clone, Debug)]
-pub struct ForwardData {
+pub struct AuthorityData {
     /// Query
     pub query: Box<Query>,
     /// SOA
@@ -408,8 +408,8 @@ pub struct ForwardData {
     pub authorities: Option<Arc<[Record]>>,
 }
 
-impl ForwardData {
-    /// Construct a new ForwardData
+impl AuthorityData {
+    /// Construct a new AuthorityData
     pub fn new(
         query: Box<Query>,
         soa: Box<Record<SOA>>,

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -32,7 +32,7 @@ use crate::dnssec::Proof;
 #[cfg(any(feature = "dnssec-aws-lc-rs", feature = "dnssec-ring"))]
 use crate::dnssec::ring_like::Unspecified;
 use crate::op::{Header, Query, ResponseCode};
-use crate::rr::{Record, RecordType, domain::Name, rdata::SOA, resource::RecordRef};
+use crate::rr::{Record, RecordType, rdata::SOA, resource::RecordRef};
 use crate::serialize::binary::DecodeError;
 use crate::xfer::DnsResponse;
 
@@ -398,8 +398,6 @@ impl From<ForwardData> for NoRecords {
 pub struct ForwardData {
     /// Query
     pub query: Box<Query>,
-    /// Name
-    pub name: Name,
     /// SOA
     pub soa: Box<Record<SOA>>,
     /// No records found?
@@ -414,7 +412,6 @@ impl ForwardData {
     /// Construct a new ForwardData
     pub fn new(
         query: Box<Query>,
-        name: Name,
         soa: Box<Record<SOA>>,
         no_records_found: bool,
         nx_domain: bool,
@@ -422,7 +419,6 @@ impl ForwardData {
     ) -> Self {
         Self {
             query,
-            name,
             soa,
             no_records_found,
             nx_domain,

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -90,9 +90,9 @@ pub use crate::xfer::dns_handle::{DnsHandle, DnsStreamHandle};
 pub use crate::xfer::dns_multiplexer::DnsMultiplexer;
 #[doc(hidden)]
 pub use crate::xfer::retry_dns_handle::RetryDnsHandle;
+pub use error::{AuthorityData, ForwardNSData, NoRecords, ProtoError, ProtoErrorKind};
 #[cfg(feature = "backtrace")]
 pub use error::{ENABLE_BACKTRACE, ExtBacktrace};
-pub use error::{ForwardData, ForwardNSData, NoRecords, ProtoError, ProtoErrorKind};
 
 #[cfg(feature = "std")]
 pub(crate) use rand::random;

--- a/crates/recursor/src/error.rs
+++ b/crates/recursor/src/error.rs
@@ -242,7 +242,6 @@ impl From<ResolveError> for Error {
         } else if let Some(soa) = soa {
             ErrorKind::Forward(ForwardData::new(
                 query,
-                soa.name().clone(),
                 soa,
                 no_records_found,
                 nx_domain,

--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -574,7 +574,7 @@ mod for_dnssec {
                     Err(e) => {
                         return Err(match e.kind() {
                             // Translate back into a ProtoError::NoRecordsFound
-                            ErrorKind::Forward(_fwd) => e.into(),
+                            ErrorKind::Negative(_fwd) => e.into(),
                             _ => ProtoError::from(e.to_string()),
                         });
                     }

--- a/crates/server/src/authority/mod.rs
+++ b/crates/server/src/authority/mod.rs
@@ -121,7 +121,7 @@ impl LookupError {
             },
             #[cfg(feature = "recursor")]
             Self::RecursiveError(e) => match e.kind() {
-                ErrorKind::Forward(fwd) => fwd.authorities.clone(),
+                ErrorKind::Negative(fwd) => fwd.authorities.clone(),
                 ErrorKind::Proto(proto) => match proto.kind() {
                     ProtoErrorKind::NoRecordsFound(NoRecords { authorities, .. }) => {
                         authorities.clone()


### PR DESCRIPTION
This removes the unused `name` field from the `ForwardData` struct, and then renames the struct (and related ErrorKind variant) to reflect that it is now only used for NXDOMAIN and no data responses. Closes #2921.