### PR TITLE
Further TSIG related cleanups

### DIFF
--- a/bin/tests/integration/named_metrics_tests.rs
+++ b/bin/tests/integration/named_metrics_tests.rs
@@ -19,7 +19,7 @@ use hickory_proto::dnssec::{
     Algorithm, DnssecDnsHandle, SigSigner, SigningKey, TrustAnchors, crypto::RsaSigningKey,
     rdata::DNSKEY,
 };
-use hickory_proto::op::MessageFinalizer;
+use hickory_proto::op::MessageSigner;
 #[cfg(feature = "__dnssec")]
 use hickory_proto::rr::Record;
 use hickory_proto::rr::rdata::A;
@@ -403,7 +403,7 @@ fn test_updates() {
 
 async fn create_local_client(
     socket_ports: &SocketPorts,
-    signer: Option<Arc<dyn MessageFinalizer>>,
+    signer: Option<Arc<dyn MessageSigner>>,
 ) -> Client {
     let dns_port = socket_ports.get_v4(ServerProtocol::Dns(Protocol::Tcp));
     let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, dns_port.expect("no dns tcp port")));

--- a/crates/client/src/client/client.rs
+++ b/crates/client/src/client/client.rs
@@ -22,7 +22,7 @@ use tracing::debug;
 
 use hickory_proto::{
     ProtoError, ProtoErrorKind,
-    op::{Edns, Message, MessageFinalizer, MessageType, OpCode, Query, update_message},
+    op::{Edns, Message, MessageSigner, MessageType, OpCode, Query, update_message},
     rr::{DNSClass, Name, Record, RecordSet, RecordType, rdata::SOA},
     runtime::TokioTime,
     xfer::{
@@ -58,7 +58,7 @@ impl Client {
     pub async fn new<F, S>(
         stream: F,
         stream_handle: BufDnsStreamHandle,
-        signer: Option<Arc<dyn MessageFinalizer>>,
+        signer: Option<Arc<dyn MessageSigner>>,
     ) -> Result<(Self, DnsExchangeBackground<DnsMultiplexer<S>, TokioTime>), ProtoError>
     where
         F: Future<Output = Result<S, ProtoError>> + Send + Unpin + 'static,
@@ -81,7 +81,7 @@ impl Client {
         stream: F,
         stream_handle: BufDnsStreamHandle,
         timeout_duration: Duration,
-        signer: Option<Arc<dyn MessageFinalizer>>,
+        signer: Option<Arc<dyn MessageSigner>>,
     ) -> Result<(Self, DnsExchangeBackground<DnsMultiplexer<S>, TokioTime>), ProtoError>
     where
         F: Future<Output = Result<S, ProtoError>> + 'static + Send + Unpin,

--- a/crates/proto/src/dnssec/rdata/tsig.rs
+++ b/crates/proto/src/dnssec/rdata/tsig.rs
@@ -645,6 +645,7 @@ pub fn message_tbs<M: BinEncodable>(
 /// * `previous_hash` - hash of previous message in case of message chaining, or of query in case
 ///   of response. Should be None for query
 /// * `message` - the byte-message to authenticate, with included TSIG
+/// * `first_message` - whether to emit the tsig pseudo-record for a first message
 pub fn signed_bitmessage_to_buf(
     previous_hash: Option<&[u8]>,
     message: &[u8],

--- a/crates/proto/src/dnssec/rdata/tsig.rs
+++ b/crates/proto/src/dnssec/rdata/tsig.rs
@@ -609,18 +609,18 @@ impl fmt::Display for TsigAlgorithm {
     }
 }
 
-/// Return the byte-message to be authenticated with a TSIG
+/// Return the to-be-signed data for authenticating the message with TSIG.
 ///
 /// # Arguments
 ///
-/// * `previous_hash` - hash of previous message in case of message chaining, or of query in case
-///   of response. Should be None for query
-/// * `message` - the message to authenticate. Should not be modified after calling message_tbs
-///   except for adding the TSIG record
-/// * `pre_tsig` - TSIG rrdata, possibly with missing mac. Should not be modified in any other way
-///   after calling message_tbs
-/// * `key_name` - name of they key, should be the same as the name known by the remove
-///   server/client
+/// * `previous_hash` - hash of a previous message in case of message chaining, or of a query in
+///   case of a response message. Should be None for query messages.
+/// * `message` - the message to authenticate. Should not be modified after calling this function
+///   except to add the final TSIG record
+/// * `pre_tsig` - TSIG rrdata, possibly with missing MAC. Should not be modified in any other way
+///   after calling this function.
+/// * `key_name` - the name of the TSIG key, should be the same as the name known by the remote
+///   peer.
 pub fn message_tbs<M: BinEncodable>(
     previous_hash: Option<&[u8]>,
     message: &M,

--- a/crates/proto/src/dnssec/rdata/tsig.rs
+++ b/crates/proto/src/dnssec/rdata/tsig.rs
@@ -627,8 +627,8 @@ pub fn message_tbs<M: BinEncodable>(
     pre_tsig: &TSIG,
     key_name: &Name,
 ) -> ProtoResult<Vec<u8>> {
-    let mut buf: Vec<u8> = Vec::with_capacity(512);
-    let mut encoder: BinEncoder<'_> = BinEncoder::with_mode(&mut buf, EncodeMode::Normal);
+    let mut buf = Vec::with_capacity(512);
+    let mut encoder = BinEncoder::with_mode(&mut buf, EncodeMode::Normal);
 
     if let Some(previous_hash) = previous_hash {
         encoder.emit_u16(previous_hash.len() as u16)?;

--- a/crates/proto/src/dnssec/rdata/tsig.rs
+++ b/crates/proto/src/dnssec/rdata/tsig.rs
@@ -640,8 +640,8 @@ pub fn message_tbs<M: BinEncodable>(
 /// * `message` - the byte-message to authenticate, with included TSIG
 /// * `first_message` - whether to emit the tsig pseudo-record for a first message
 pub fn signed_bitmessage_to_buf(
-    previous_hash: Option<&[u8]>,
     message: &[u8],
+    previous_hash: Option<&[u8]>,
     first_message: bool,
 ) -> ProtoResult<(Vec<u8>, Record)> {
     let mut decoder = BinDecoder::new(message);
@@ -819,7 +819,7 @@ mod tests {
 
         let message_byte = message.to_bytes().unwrap();
 
-        let tbv = signed_bitmessage_to_buf(None, &message_byte, true)
+        let tbv = signed_bitmessage_to_buf(&message_byte, None, true)
             .unwrap()
             .0;
 
@@ -856,7 +856,7 @@ mod tests {
 
         let message_byte = message.to_bytes().unwrap();
 
-        let tbv = signed_bitmessage_to_buf(None, &message_byte, true)
+        let tbv = signed_bitmessage_to_buf(&message_byte, None, true)
             .unwrap()
             .0;
 

--- a/crates/proto/src/dnssec/signer.rs
+++ b/crates/proto/src/dnssec/signer.rs
@@ -19,7 +19,7 @@ use crate::{
         tbs,
     },
     error::{ProtoErrorKind, ProtoResult},
-    op::{Message, MessageFinalizer, MessageVerifier},
+    op::{Message, MessageFinalizer, MessageSignature, MessageVerifier},
     rr::{
         Record, {DNSClass, Name, RData, RecordType},
     },
@@ -486,7 +486,7 @@ impl MessageFinalizer for SigSigner {
         &self,
         message: &Message,
         current_time: u32,
-    ) -> ProtoResult<(Vec<Record>, Option<MessageVerifier>)> {
+    ) -> ProtoResult<(MessageSignature, Option<MessageVerifier>)> {
         debug!("signing message: {message:?}");
         let key_tag: u16 = self.calculate_key_tag()?;
 
@@ -528,7 +528,7 @@ impl MessageFinalizer for SigSigner {
         // The CLASS field SHOULD be ANY
         sig0.set_dns_class(DNSClass::ANY);
 
-        Ok((vec![sig0], None))
+        Ok((MessageSignature::Sig0(sig0), None))
     }
 }
 

--- a/crates/proto/src/dnssec/signer.rs
+++ b/crates/proto/src/dnssec/signer.rs
@@ -19,7 +19,7 @@ use crate::{
         tbs,
     },
     error::{ProtoErrorKind, ProtoResult},
-    op::{Message, MessageFinalizer, MessageSignature, MessageVerifier},
+    op::{Message, MessageSignature, MessageSigner, MessageVerifier},
     rr::{
         Record, {DNSClass, Name, RData, RecordType},
     },
@@ -481,8 +481,8 @@ impl SigSigner {
     }
 }
 
-impl MessageFinalizer for SigSigner {
-    fn finalize_message(
+impl MessageSigner for SigSigner {
+    fn sign_message(
         &self,
         message: &Message,
         current_time: u32,

--- a/crates/proto/src/dnssec/tsig.rs
+++ b/crates/proto/src/dnssec/tsig.rs
@@ -100,7 +100,7 @@ impl TSigner {
 
     /// Compute authentication tag for a message
     pub fn sign_message(&self, message: &Message, pre_tsig: &TSIG) -> Result<Vec<u8>, DnsSecError> {
-        self.sign(&message_tbs(None, message, pre_tsig, &self.0.signer_name)?)
+        self.sign(&message_tbs(message, pre_tsig, &self.0.signer_name)?)
     }
 
     /// Verify hmac in constant time to prevent timing attacks

--- a/crates/proto/src/dnssec/tsig.rs
+++ b/crates/proto/src/dnssec/tsig.rs
@@ -28,7 +28,7 @@ use super::rdata::tsig::{
 use super::{DnsSecError, DnsSecErrorKind};
 use crate::error::{ProtoError, ProtoResult};
 use crate::op::{Message, MessageFinalizer, MessageSignature, MessageVerifier};
-use crate::rr::{Name, RData, Record};
+use crate::rr::{Name, RData};
 use crate::xfer::DnsResponse;
 
 /// Struct to pass to a client for it to authenticate requests using TSIG.

--- a/crates/proto/src/dnssec/tsig.rs
+++ b/crates/proto/src/dnssec/tsig.rs
@@ -27,7 +27,7 @@ use super::rdata::tsig::{
 };
 use super::{DnsSecError, DnsSecErrorKind};
 use crate::error::{ProtoError, ProtoResult};
-use crate::op::{Message, MessageFinalizer, MessageSignature, MessageVerifier};
+use crate::op::{Message, MessageSignature, MessageSigner, MessageVerifier};
 use crate::rr::{Name, RData};
 use crate::xfer::DnsResponse;
 
@@ -180,8 +180,8 @@ impl TSigner {
     }
 }
 
-impl MessageFinalizer for TSigner {
-    fn finalize_message(
+impl MessageSigner for TSigner {
+    fn sign_message(
         &self,
         message: &Message,
         current_time: u32,

--- a/crates/proto/src/dnssec/tsig.rs
+++ b/crates/proto/src/dnssec/tsig.rs
@@ -109,22 +109,27 @@ impl TSigner {
     }
 
     /// Verify the message is correctly signed
-    /// This does not perform time verification on its own, instead one should verify current time
-    /// lie in returned Range
+    ///
+    /// This does not perform signature time verification. The caller should verify the
+    /// current time lies in the returned `Range`. See [RFC 8945 Section 5.2.3] for more information.
     ///
     /// # Arguments
-    /// * `previous_hash` - Hash of the last message received before this one, or of the query for
-    ///   the first message
-    /// * `message` - byte buffer containing current message
-    /// * `first_message` - is this the first response message
+    /// * `message` - byte buffer containing the to-be-verified `Message`
+    /// * `previous_hash` - Hash of the last message received before this one when processing chained
+    ///    messages, or of a query for a first response message.
+    /// * `first_message` - whether `message` is the first response message
     ///
     /// # Returns
-    /// Return Ok(_) on valid signature. Inner tuple contain the following values, in order:
-    /// * a byte buffer containing the hash of this message. Need to be passed back when
-    ///   authenticating next message
-    /// * a Range of time that is acceptable
+    ///
+    /// Return `Ok(_)` for valid signatures. Inner tuple contain the following values, in order:
+    /// * a byte buffer containing the hash of `message`. This can be passed back when
+    ///   authenticating a later chained message.
+    /// * a `Range` of time that the signature is considered acceptable within based on the signer
+    ///   fudge value.
     /// * the time the signature was emitted. It must be greater or equal to the time of previous
-    ///   messages, if any
+    ///   messages, if any.
+    ///
+    /// [RFC 8945 Section 5.2.3]: https://www.rfc-editor.org/rfc/rfc8945.html#section-5.2.3
     pub fn verify_message_byte(
         &self,
         message: &[u8],

--- a/crates/proto/src/dnssec/tsig.rs
+++ b/crates/proto/src/dnssec/tsig.rs
@@ -27,7 +27,7 @@ use super::rdata::tsig::{
 };
 use super::{DnsSecError, DnsSecErrorKind};
 use crate::error::{ProtoError, ProtoResult};
-use crate::op::{Message, MessageFinalizer, MessageVerifier};
+use crate::op::{Message, MessageFinalizer, MessageSignature, MessageVerifier};
 use crate::rr::{Name, RData, Record};
 use crate::xfer::DnsResponse;
 
@@ -185,7 +185,7 @@ impl MessageFinalizer for TSigner {
         &self,
         message: &Message,
         current_time: u32,
-    ) -> ProtoResult<(Vec<Record>, Option<MessageVerifier>)> {
+    ) -> ProtoResult<(MessageSignature, Option<MessageVerifier>)> {
         debug!("signing message: {:?}", message);
         let current_time = current_time as u64;
 
@@ -221,7 +221,7 @@ impl MessageFinalizer for TSigner {
                 Err(ProtoError::from("tsig validation error: outdated response"))
             }
         };
-        Ok((vec![tsig], Some(Box::new(verifier))))
+        Ok((MessageSignature::Tsig(tsig), Some(Box::new(verifier))))
     }
 }
 

--- a/crates/proto/src/op/mod.rs
+++ b/crates/proto/src/op/mod.rs
@@ -29,9 +29,7 @@ pub mod update_message;
 pub use self::edns::{Edns, EdnsFlags};
 pub use self::header::Header;
 pub use self::header::MessageType;
-pub use self::message::{
-    Message, MessageFinalizer, MessageParts, MessageSignature, MessageVerifier,
-};
+pub use self::message::{Message, MessageParts, MessageSignature, MessageSigner, MessageVerifier};
 pub use self::op_code::OpCode;
 pub use self::query::Query;
 pub use self::response_code::ResponseCode;

--- a/tests/compatibility-tests/tests/integration/tsig_tests.rs
+++ b/tests/compatibility-tests/tests/integration/tsig_tests.rs
@@ -20,7 +20,7 @@ use time::Duration;
 use hickory_client::client::{Client, ClientHandle};
 use hickory_client::proto::dnssec::rdata::tsig::TsigAlgorithm;
 use hickory_client::proto::dnssec::tsig::TSigner;
-use hickory_client::proto::op::{MessageFinalizer, ResponseCode};
+use hickory_client::proto::op::{MessageSigner, ResponseCode};
 use hickory_client::proto::rr::{Name, RData, Record, rdata::A};
 use hickory_client::proto::runtime::TokioRuntimeProvider;
 use hickory_client::proto::tcp::TcpClientStream;
@@ -29,7 +29,7 @@ use hickory_client::proto::xfer::DnsMultiplexer;
 use hickory_compatibility::named_process;
 use test_support::subscribe;
 
-fn signer() -> Arc<dyn MessageFinalizer> {
+fn signer() -> Arc<dyn MessageSigner> {
     let server_path = env::var("TDNS_WORKSPACE_ROOT").unwrap_or_else(|_| "../..".to_owned());
     let pem_path = format!("{server_path}/tests/compatibility-tests/tests/conf/tsig.raw");
     println!("loading key from: {pem_path}");

--- a/tests/integration-tests/tests/integration/client_tests.rs
+++ b/tests/integration-tests/tests/integration/client_tests.rs
@@ -28,7 +28,7 @@ use hickory_proto::dnssec::rdata::{DNSSECRData, KEY};
 #[cfg(all(feature = "__dnssec", feature = "sqlite"))]
 use hickory_proto::dnssec::{Algorithm, PublicKey, SigSigner, SigningKey, crypto::RsaSigningKey};
 #[cfg(all(feature = "__dnssec", feature = "sqlite"))]
-use hickory_proto::op::MessageFinalizer;
+use hickory_proto::op::MessageSigner;
 #[cfg(feature = "__dnssec")]
 use hickory_proto::op::ResponseCode;
 use hickory_proto::op::{Edns, Message, MessageType, OpCode, Query};
@@ -62,7 +62,7 @@ impl TestClientConnection {
     #[allow(clippy::type_complexity)]
     fn to_multiplexer(
         &self,
-        signer: Option<Arc<dyn MessageFinalizer>>,
+        signer: Option<Arc<dyn MessageSigner>>,
     ) -> DnsMultiplexerConnect<
         Pin<Box<dyn Future<Output = Result<TestClientStream, ProtoError>> + Send>>,
         TestClientStream,


### PR DESCRIPTION
This is a follow-up to https://github.com/hickory-dns/hickory-dns/pull/2964

Outside of documentation cleanups, there were a couple more meaningful changes;

1. The TSIG `signed_bitmessage_to_buf()` fn was reworked to lean more heavily on `Message::read_records()`, and to correctly specify `is_additional`. This in turn allows making `Message::read_records()` enforce that `OPT` records are only found in the additional section (See [this comment thread](https://github.com/hickory-dns/hickory-dns/pull/2964#discussion_r2072663936) for more information).
2. The TSIG `message_tbs()` fn loses its `previous_hash` argument; it was dead code as there's no use-case where we need to consider a previous message digest when signing a message.
3. I changed the order of some functions arguments and return values for clarity.
4. The `MessageFinalizer` trait was overly generic, supporting adding any number of `Record`s to the end of a to-be-finalized `Message`. In practice there are only two meaningful implementations: TSIG and SIG(0). In these cases the only thing we want to do is append a single `MessageSignature`, so let's make the trait support that specifically. This is less general/flexible, but I don't think other use-cases exist to justify the flexibility.