### PR TITLE
Change RecursorBuilder to take a list of IPs

### DIFF
--- a/crates/recursor/src/recursor_dns_handle.rs
+++ b/crates/recursor/src/recursor_dns_handle.rs
@@ -59,7 +59,7 @@ pub(crate) struct RecursorDnsHandle {
 impl RecursorDnsHandle {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        roots: impl Into<NameServerConfigGroup>,
+        roots: &[IpAddr],
         ns_cache_size: usize,
         record_cache_size: usize,
         recursion_limit: Option<u8>,
@@ -72,7 +72,7 @@ impl RecursorDnsHandle {
         case_randomization: bool,
     ) -> Self {
         // configure the hickory-resolver
-        let roots: NameServerConfigGroup = roots.into();
+        let roots = NameServerConfigGroup::from_ips_clear(roots, 53, true);
 
         assert!(!roots.is_empty(), "roots must not be empty");
 
@@ -837,7 +837,7 @@ fn test_nameserver_filter() {
     ];
 
     let recursor = RecursorDnsHandle::new(
-        NameServerConfigGroup::from_ips_clear(&[IpAddr::from([192, 0, 2, 1])], 53, true),
+        &[IpAddr::from([192, 0, 2, 1])],
         1,
         1,
         Some(1),

--- a/util/src/bin/recurse.rs
+++ b/util/src/bin/recurse.rs
@@ -20,23 +20,16 @@
     unreachable_pub
 )]
 
-use std::{
-    net::{IpAddr, SocketAddr},
-    path::PathBuf,
-    time::Instant,
-};
+use std::{net::IpAddr, time::Instant};
 
 use clap::Parser;
 use console::style;
 
-use hickory_proto::op::Query;
-use hickory_proto::rr::RecordType;
-use hickory_proto::xfer::Protocol;
-use hickory_recursor::Recursor;
-use hickory_resolver::{
-    Name,
-    config::{NameServerConfig, NameServerConfigGroup},
+use hickory_proto::{
+    op::Query,
+    rr::{Name, RecordType},
 };
+use hickory_recursor::Recursor;
 
 /// A CLI interface for the hickory-dns-recursor.
 ///
@@ -52,30 +45,11 @@ struct Opts {
     #[clap(short = 't', long = "type", default_value = "A")]
     ty: RecordType,
 
-    /// Specify a nameserver to use, ip and port e.g. 8.8.8.8:53 or \[2001:4860:4860::8888\]:53 (port required)
-    /// ip:port are delimited by a comma like 8.8.8.8:53,1.1.1.1:53
+    /// Specify the IP addresses of the root zone nameservers to use.
+    ///
+    /// Multiple IP addresses may be delimited with commas.
     #[clap(short = 'n', long, use_value_delimiter = true, value_delimiter(','))]
-    nameserver: Vec<SocketAddr>,
-
-    /// Specify the IP address to connect from.
-    #[clap(long)]
-    bind: Option<IpAddr>,
-
-    /// Use ipv4 addresses only, default is both ipv4 and ipv6
-    #[clap(long)]
-    ipv4: bool,
-
-    /// Use ipv6 addresses only, default is both ipv4 and ipv6
-    #[clap(long)]
-    ipv6: bool,
-
-    /// Use only UDP, default to UDP and TCP
-    #[clap(long)]
-    udp: bool,
-
-    /// Use only TCP, default to UDP and TCP
-    #[clap(long)]
-    tcp: bool,
+    nameservers: Vec<IpAddr>,
 
     /// Enable debug and all logging
     #[clap(long)]
@@ -92,13 +66,9 @@ struct Opts {
     /// Enable error logging
     #[clap(long)]
     error: bool,
-
-    /// Path to a roots file
-    #[clap(short = 'r', long)]
-    roots: Option<PathBuf>,
 }
 
-/// Run the resolve programf
+/// Run the resolve program
 #[tokio::main]
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let opts: Opts = Opts::parse();
@@ -118,45 +88,11 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     hickory_util::logger(env!("CARGO_BIN_NAME"), log_level);
 
-    // Configure all the name servers
-    let mut roots = NameServerConfigGroup::new();
-
-    for socket_addr in &opts.nameserver {
-        roots.push(NameServerConfig {
-            socket_addr: *socket_addr,
-            protocol: Protocol::Tcp,
-            tls_dns_name: None,
-            http_endpoint: None,
-            trust_negative_responses: false,
-            bind_addr: opts.bind.map(|ip| SocketAddr::new(ip, 0)),
-        });
-
-        roots.push(NameServerConfig {
-            socket_addr: *socket_addr,
-            protocol: Protocol::Udp,
-            tls_dns_name: None,
-            http_endpoint: None,
-            trust_negative_responses: false,
-            bind_addr: opts.bind.map(|ip| SocketAddr::new(ip, 0)),
-        });
-    }
-
-    let ipv4 = opts.ipv4 || !opts.ipv6;
-    let ipv6 = opts.ipv6 || !opts.ipv4;
-
-    let udp = opts.udp || !opts.tcp;
-    let tcp = opts.tcp || !opts.udp;
-
-    roots.retain(|ns| (ipv4 && ns.socket_addr.is_ipv4()) || (ipv6 && ns.socket_addr.is_ipv6()));
-    roots.retain(|ns| {
-        (udp && ns.protocol == Protocol::Udp) || (tcp && ns.protocol == Protocol::Tcp)
-    });
-
     // query parameters
     let name = opts.domainname;
     let ty = opts.ty;
 
-    let recursor = Recursor::builder().build(roots)?;
+    let recursor = Recursor::builder().build(&opts.nameservers)?;
 
     // execute query
     println!(


### PR DESCRIPTION
This changes recursor constructors to take a slice of IP addresses instead of a `NameServerConfigGroup`. This reduces boilerplate and eliminates a source of misconfigurations. While this removes the ability to choose a different set of protocols or set a bind address in each `NameServerConfig`, these settings are not very useful when applied solely to the root zone. If there is need for such features in the future, they could be added as separate configuration, and applied to all name server connections made by the recursor.

Closes #2853.