### PR TITLE
Don't request root DS RRset in find_ds_records()

### DIFF
--- a/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
@@ -881,6 +881,9 @@ where
     // RRset, then we're in a Bogus state. If we get a ProofError, our result is the same.
     let mut parent = zone.base_name();
     loop {
+        if parent.is_root() {
+            return Err(ProofError::ds_should_exist(zone));
+        }
         match fetch_ds_records(handle, parent.clone(), options).await {
             Ok(_) => {
                 return Err(ProofError::ds_should_exist(zone));
@@ -891,10 +894,7 @@ where
             }) => {}
             Err(err) => return Err(err),
         }
-        parent = match parent.is_root() {
-            true => return Err(ProofError::ds_should_exist(zone)),
-            false => parent.base_name(),
-        };
+        parent = parent.base_name();
     }
 }
 


### PR DESCRIPTION
This is a follow-up to the refactoring of `find_ds_records()`. The query `. IN DS` is not well-formed, since such DS records would need to live at the parent of the root zone, so we can stop this loop one iteration earlier.