### PR TITLE
Make SOA record optional in AuthorityData

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dns/scenarios/no_soa.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dns/scenarios/no_soa.rs
@@ -8,7 +8,6 @@ use dns_test::{
 };
 
 #[test]
-#[ignore = "hickory returns SERVFAIL due to the absence of an NS or SOA record"]
 fn no_soa() -> Result<()> {
     let target_fqdn = FQDN::TEST_DOMAIN;
     let network = Network::new()?;

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -383,7 +383,7 @@ impl From<AuthorityData> for NoRecords {
 
         Self {
             query: value.query,
-            soa: Some(value.soa),
+            soa: value.soa,
             ns: None,
             negative_ttl: None,
             response_code,
@@ -399,7 +399,7 @@ pub struct AuthorityData {
     /// Query
     pub query: Box<Query>,
     /// SOA
-    pub soa: Box<Record<SOA>>,
+    pub soa: Option<Box<Record<SOA>>>,
     /// No records found?
     no_records_found: bool,
     /// IS nx domain?
@@ -412,7 +412,7 @@ impl AuthorityData {
     /// Construct a new AuthorityData
     pub fn new(
         query: Box<Query>,
-        soa: Box<Record<SOA>>,
+        soa: Option<Box<Record<SOA>>>,
         no_records_found: bool,
         nx_domain: bool,
         authorities: Option<Arc<[Record]>>,

--- a/crates/recursor/src/error.rs
+++ b/crates/recursor/src/error.rs
@@ -118,7 +118,7 @@ impl Error {
     pub fn into_soa(self) -> Option<Box<Record<SOA>>> {
         match *self.kind {
             ErrorKind::Proto(proto) => proto.into_soa(),
-            ErrorKind::Negative(fwd) => Some(fwd.soa),
+            ErrorKind::Negative(fwd) => fwd.soa,
             _ => None,
         }
     }
@@ -214,16 +214,14 @@ impl From<ProtoError> for Error {
 
         if let Some(ns) = &no_records.ns {
             ErrorKind::ForwardNS(ns.clone())
-        } else if let Some(soa) = &no_records.soa {
+        } else {
             ErrorKind::Negative(AuthorityData::new(
                 no_records.query.clone(),
-                soa.clone(),
+                no_records.soa.clone(),
                 true,
                 matches!(no_records.response_code, ResponseCode::NXDomain),
                 no_records.authorities.clone(),
             ))
-        } else {
-            ErrorKind::Message("proto error missing ns and soa")
         }
         .into()
     }


### PR DESCRIPTION
This makes the `soa` field in `AuthorityData` optional, which removes an error edge case that was too strict. Closes #2814.