### PR TITLE
Fix Clippy lints

### DIFF
--- a/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
@@ -678,6 +678,7 @@ where
 }
 
 /// This verifies a DNSKEY record against DS records from a secure delegation.
+#[allow(clippy::result_large_err)]
 fn verify_dnskey(
     rr: &RecordRef<'_, DNSKEY>,
     ds_records: &[Record<DS>],
@@ -1063,6 +1064,7 @@ where
 }
 
 /// Verifies the given SIG of the RRSET with the DNSKEY.
+#[allow(clippy::result_large_err)]
 fn verify_rrset_with_dnskey(
     dnskey: RecordRef<'_, DNSKEY>,
     dnskey_proof: Proof,

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -282,6 +282,7 @@ where
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 enum DnsExchangeConnectInner<F, S, TE>
 where
     F: Future<Output = Result<S, ProtoError>> + 'static + Send,

--- a/crates/server/src/store/in_memory/inner.rs
+++ b/crates/server/src/store/in_memory/inner.rs
@@ -73,11 +73,10 @@ impl InnerInMemory {
             return Ok(cover.map_or_else(Vec::new, |rr_set| vec![rr_set]));
         }
 
-        match qname_match {
-            // - No data response if the QTYPE is not DS.
-            // - No data response if the QTYPE is DS and there is an NSEC3 record matching QNAME.
-            Some(rr_set) => return Ok(vec![rr_set.clone()]),
-            None => {}
+        // - No data response if the QTYPE is not DS.
+        // - No data response if the QTYPE is DS and there is an NSEC3 record matching QNAME.
+        if let Some(rr_set) = qname_match {
+            return Ok(vec![rr_set.clone()]);
         }
 
         // - Name error response.


### PR DESCRIPTION
This fixes and ignores Clippy lints that show up with a 1.87 toolchain. This adds more ignores of `clippy::large_enum_variant` and `clippy::result_large_err`, which we have a few of already. 