### PR TITLE
Remove post-hoc recursion depth check

### DIFF
--- a/tests/e2e-tests/src/recursor/delegation/scenarios.rs
+++ b/tests/e2e-tests/src/recursor/delegation/scenarios.rs
@@ -119,8 +119,9 @@ fn recursive_delegation() -> Result<()> {
 ///  example19.testing IN NS example20.testing.
 ///  example20.testing IN NS example21.testing.
 ///  example21.testing IN NS example22.testing.
-///  example22.testing IN NS example22.testing.
-///  example22.testing IN A <NS IP>
+///  example22.testing IN NS example23.testing.
+///  example23.testing IN NS example23.testing.
+///  example23.testing IN A <NS IP>
 ///
 /// Querying for any host in example.testing should cause the recursor to return no answer and the
 /// recursor log should contain a NoConnections error.
@@ -153,11 +154,11 @@ fn multi_domain_delegation() -> Result<()> {
         FQDN("ns.example2.testing.")?,
     ));
 
-    for i in 1..=22 {
-        if i == 22 {
+    for i in 1..=23 {
+        if i == 23 {
             tld_ns.referral(
-                FQDN("example22.testing.")?,
-                FQDN("ns.example22.testing.")?,
+                FQDN("example23.testing.")?,
+                FQDN("ns.example23.testing.")?,
                 example_ns.ipv4_addr(),
             );
         } else {


### PR DESCRIPTION
This removes a recursion depth check that happens after the recursive calls are complete. This check alone does not protect us from DoS attacks, since it's in the wrong place, but the depth check at the top of `ns_pool_for_zone()` does take care of this. Since the `ns_depth` variable is not used anywhere else in this method, we can delete the increment of it, and ignore the depth returned from `ns_pool_for_zone()` here. This will simplify future analysis of and changes to recursion limits. One test needed to be tweaked as a result of removing this check.