### PR TITLE
Clean up some `large_enum_variants` warnings

### DIFF
--- a/crates/server/src/authority/auth_lookup.rs
+++ b/crates/server/src/authority/auth_lookup.rs
@@ -22,7 +22,6 @@ use crate::proto::rr::{LowerName, Record, RecordSet, RecordType, RrsetRecords};
 /// * `'r` - the recordset lifetime, subset of 'c
 /// * `'q` - the queries lifetime
 #[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
 pub enum AuthLookup {
     /// No records
     Empty,
@@ -135,7 +134,6 @@ impl<'a> IntoIterator for &'a AuthLookup {
 }
 
 /// An iterator over an Authority Lookup
-#[allow(clippy::large_enum_variant)]
 #[derive(Default)]
 pub enum AuthLookupIter<'r> {
     /// The empty set


### PR DESCRIPTION
See #2994. I haven't audited all of them yet, but this cleans some of them up.

I think most of these suppressions are pretty much fine, either because (a) there's only one instance of the enum anyway, or (b) they're shortlived (the `Connect` enums in -proto).