### PR TITLE
Update recursion limit defaults in other places

### DIFF
--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -491,11 +491,8 @@ impl Default for RecursorBuilder {
         Self {
             ns_cache_size: 1_024,
             record_cache_size: 1_048_576,
-            // This default is based on CNAME recursion failures of long (> 8 records) CNAME chains
-            // that users of Unbound encountered (see https://github.com/NLnetLabs/unbound/issues/438)
-            // with a small safety margin added.
-            recursion_limit: Some(12),
-            ns_recursion_limit: Some(16),
+            recursion_limit: Some(24),
+            ns_recursion_limit: Some(24),
             dnssec_policy: DnssecPolicy::SecurityUnaware,
             allow_servers: vec![],
             deny_servers: vec![],

--- a/tests/test-data/test_configs/example_recursor.toml
+++ b/tests/test-data/test_configs/example_recursor.toml
@@ -40,8 +40,8 @@ type = "recursor"
 roots = "default/root.zone"
 ns_cache_size = 1024
 record_cache_size = 1048576
-recursion_limit = 12
-ns_recursion_limit = 16
+recursion_limit = 24
+ns_recursion_limit = 24
 
 ## allow_server: these networks will override entries in deny_server and allow you to make
 ## granular exceptions to networks you otherwise want to deny.  This allows queries to be


### PR DESCRIPTION
This is a follow-up to #2983 to update recursion limits in two more places for consistency. Previously, only the config parsing default was changed.