### PR TITLE
Fix AdGuard IP address in test

### DIFF
--- a/crates/resolver/src/quic.rs
+++ b/crates/resolver/src/quic.rs
@@ -72,7 +72,7 @@ mod tests {
         let name_servers = NameServerConfigGroup::from_ips_quic(
             &[
                 IpAddr::from([94, 140, 14, 140]),
-                IpAddr::from([94, 140, 15, 141]),
+                IpAddr::from([94, 140, 14, 141]),
                 IpAddr::from([0x2a10, 0x50c0, 0, 0, 0, 0, 0x1, 0xff]),
                 IpAddr::from([0x2a10, 0x50c0, 0, 0, 0, 0, 0x2, 0xff]),
             ],


### PR DESCRIPTION
This fixes an incorrect IP address in a unit test.

```
$ dig A unfiltered.adguard-dns.com.

; <<>> DiG 9.18.30-0ubuntu0.24.04.2-Ubuntu <<>> A unfiltered.adguard-dns.com.
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 58759
;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 65494
;; QUESTION SECTION:
;unfiltered.adguard-dns.com.	IN	A

;; ANSWER SECTION:
unfiltered.adguard-dns.com. 3159 IN	A	94.140.14.140
unfiltered.adguard-dns.com. 3159 IN	A	94.140.14.141
```