### PR TITLE
Add metrics for zone lookups, DNS classes and record types

### DIFF
--- a/bin/tests/integration/named_metrics_tests.rs
+++ b/bin/tests/integration/named_metrics_tests.rs
@@ -275,6 +275,73 @@ fn test_request_response() {
             verify_metric(metrics, "hickory_response_flags_total", &flag, Some(value))
         });
 
+        let record_types = [
+            "a",
+            "aaaa",
+            "aname",
+            "any",
+            "axfr",
+            "caa",
+            "cdnskey",
+            "cds",
+            "cert",
+            "cname",
+            "csync",
+            "dnskey",
+            "ds",
+            "hinfo",
+            "https",
+            "ixfr",
+            "key",
+            "mx",
+            "naptr",
+            "ns",
+            "nsec",
+            "nsec3",
+            "nsec3param",
+            "null",
+            "openpgpkey",
+            "opt",
+            "ptr",
+            "rrsig",
+            "sig",
+            "soa",
+            "srv",
+            "sshfp",
+            "svcb",
+            "tlsa",
+            "tsig",
+            "txt",
+            "unknown",
+            "zero",
+        ];
+        record_types.iter().for_each(|r#type| {
+            let value = if *r#type == "a" { 1f64 } else { 0f64 };
+            let r#type = [("type", *r#type)];
+            for direction in ["request", "response"] {
+                verify_metric(
+                    metrics,
+                    format!("hickory_{direction}_record_types_total").as_str(),
+                    &r#type,
+                    Some(value),
+                )
+            }
+        });
+
+        let dns_classes = ["in", "ch", "hs", "none", "any", "unknown"];
+        dns_classes.iter().for_each(|class| {
+            let value = if *class == "in" { 1f64 } else { 0f64 };
+            let class = [("class", *class)];
+            for direction in ["request", "response"] {
+                verify_metric(
+                    metrics,
+                    format!("hickory_{direction}_dns_classes_total").as_str(),
+                    &class,
+                    Some(value),
+                )
+            }
+        });
+
         // check store lookups
         verify_metric(
             metrics,

--- a/crates/server/src/authority/authority.rs
+++ b/crates/server/src/authority/authority.rs
@@ -227,6 +227,10 @@ pub trait Authority: Send + Sync {
     /// Returns the kind of non-existence proof used for this zone.
     #[cfg(feature = "__dnssec")]
     fn nx_proof_kind(&self) -> Option<&NxProofKind>;
+
+    /// Returns the authority metrics label.
+    #[cfg(feature = "metrics")]
+    fn metrics_label(&self) -> &'static str;
 }
 
 /// Extension to Authority to allow for DNSSEC features

--- a/crates/server/src/authority/metrics.rs
+++ b/crates/server/src/authority/metrics.rs
@@ -1,0 +1,243 @@
+// Copyright 2015-2021 Benjamin Fry <benjaminfry@me.com>
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// https://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// https://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use hickory_proto::op::LowerQuery;
+use hickory_proto::rr::{DNSClass, Record, RecordType};
+use metrics::{Counter, Unit, counter, describe_counter};
+
+pub(super) struct CatalogMetrics {
+    request_metrics: DnsClassesRecordTypesMetrics,
+    response_metrics: DnsClassesRecordTypesMetrics,
+}
+
+impl CatalogMetrics {
+    pub(super) fn update_request_response<'a>(
+        &self,
+        query: &LowerQuery,
+        answers: impl Iterator<Item = &'a Record> + Send + 'a,
+    ) {
+        self.request_metrics
+            .record_type
+            .increment(query.query_type());
+        self.request_metrics
+            .dns_classes
+            .increment(query.query_class());
+
+        answers.for_each(|a| {
+            self.response_metrics.record_type.increment(a.record_type());
+            self.response_metrics.dns_classes.increment(a.dns_class());
+        });
+    }
+}
+
+impl Default for CatalogMetrics {
+    fn default() -> Self {
+        Self {
+            request_metrics: DnsClassesRecordTypesMetrics::new("request"),
+            response_metrics: DnsClassesRecordTypesMetrics::new("response"),
+        }
+    }
+}
+
+struct DnsClassesRecordTypesMetrics {
+    dns_classes: DNSClassMetrics,
+    record_type: RecordTypeMetrics,
+}
+
+impl DnsClassesRecordTypesMetrics {
+    fn new(direction: &'static str) -> Self {
+        Self {
+            dns_classes: DNSClassMetrics::new(direction),
+            record_type: RecordTypeMetrics::new(direction),
+        }
+    }
+}
+
+struct DNSClassMetrics {
+    r#in: Counter,
+    ch: Counter,
+    hs: Counter,
+    none: Counter,
+    any: Counter,
+    unknown: Counter,
+}
+
+impl DNSClassMetrics {
+    fn new(direction: &'static str) -> Self {
+        let dns_class_name = format!("hickory_{direction}_dns_classes_total");
+        let key = "class";
+        Self {
+            r#in: {
+                let new = counter!(dns_class_name.clone(), key => "in");
+                describe_counter!(
+                    dns_class_name.clone(),
+                    Unit::Count,
+                    format!("number of {} dns classes", direction)
+                );
+                new
+            },
+            ch: counter!(dns_class_name.clone(), key => "ch"),
+            hs: counter!(dns_class_name.clone(), key => "hs"),
+            none: counter!(dns_class_name.clone(), key => "none"),
+            any: counter!(dns_class_name.clone(), key => "any"),
+            unknown: counter!(dns_class_name, key => "unknown"),
+        }
+    }
+
+    fn increment(&self, dns_class: DNSClass) {
+        match dns_class {
+            DNSClass::IN => self.r#in.increment(1),
+            DNSClass::CH => self.ch.increment(1),
+            DNSClass::HS => self.hs.increment(1),
+            DNSClass::NONE => self.none.increment(1),
+            DNSClass::ANY => self.any.increment(1),
+            DNSClass::Unknown(_) => self.unknown.increment(1),
+            DNSClass::OPT(_) => { /* skip OPT class type */ }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct RecordTypeMetrics {
+    a: Counter,
+    aname: Counter,
+    any: Counter,
+    aaaa: Counter,
+    axfr: Counter,
+    caa: Counter,
+    cds: Counter,
+    cdnskey: Counter,
+    cert: Counter,
+    mx: Counter,
+    csync: Counter,
+    dnskey: Counter,
+    cname: Counter,
+    ds: Counter,
+    hinfo: Counter,
+    https: Counter,
+    ixfr: Counter,
+    key: Counter,
+    srv: Counter,
+    sshfp: Counter,
+    tlsa: Counter,
+    tsig: Counter,
+    txt: Counter,
+    unknown: Counter,
+    zero: Counter,
+    svcb: Counter,
+    soa: Counter,
+    sig: Counter,
+    rrsig: Counter,
+    ptr: Counter,
+    opt: Counter,
+    openpgpkey: Counter,
+    null: Counter,
+    nsec3param: Counter,
+    nsec3: Counter,
+    nsec: Counter,
+    ns: Counter,
+    naptr: Counter,
+}
+
+impl RecordTypeMetrics {
+    fn new(direction: &'static str) -> Self {
+        let record_type_name = format!("hickory_{direction}_record_types_total");
+        let key = "type";
+
+        Self {
+            a: {
+                let new = counter!(record_type_name.clone(), key => "a");
+                describe_counter!(
+                    record_type_name.clone(),
+                    Unit::Count,
+                    format!("number of {direction} record types")
+                );
+                new
+            },
+            aaaa: counter!(record_type_name.clone(), key => "aaaa"),
+            aname: counter!(record_type_name.clone(), key => "aname"),
+            any: counter!(record_type_name.clone(), key => "any"),
+            axfr: counter!(record_type_name.clone(), key => "axfr"),
+            caa: counter!(record_type_name.clone(), key => "caa"),
+            cds: counter!(record_type_name.clone(), key => "cds"),
+            cdnskey: counter!(record_type_name.clone(), key => "cdnskey"),
+            cert: counter!(record_type_name.clone(), key => "cert"),
+            cname: counter!(record_type_name.clone(), key => "cname"),
+            csync: counter!(record_type_name.clone(), key => "csync"),
+            dnskey: counter!(record_type_name.clone(), key => "dnskey"),
+            ds: counter!(record_type_name.clone(), key => "ds"),
+            hinfo: counter!(record_type_name.clone(), key => "hinfo"),
+            https: counter!(record_type_name.clone(), key => "https"),
+            ixfr: counter!(record_type_name.clone(), key => "ixfr"),
+            key: counter!(record_type_name.clone(), key => "key"),
+            mx: counter!(record_type_name.clone(), key => "mx"),
+            naptr: counter!(record_type_name.clone(), key => "naptr"),
+            ns: counter!(record_type_name.clone(), key => "ns"),
+            nsec: counter!(record_type_name.clone(), key => "nsec"),
+            nsec3: counter!(record_type_name.clone(), key => "nsec3"),
+            nsec3param: counter!(record_type_name.clone(), key => "nsec3param"),
+            null: counter!(record_type_name.clone(), key => "null"),
+            openpgpkey: counter!(record_type_name.clone(), key => "openpgpkey"),
+            opt: counter!(record_type_name.clone(), key => "opt"),
+            ptr: counter!(record_type_name.clone(), key => "ptr"),
+            rrsig: counter!(record_type_name.clone(), key => "rrsig"),
+            sig: counter!(record_type_name.clone(), key => "sig"),
+            soa: counter!(record_type_name.clone(), key => "soa"),
+            srv: counter!(record_type_name.clone(), key => "srv"),
+            sshfp: counter!(record_type_name.clone(), key => "sshfp"),
+            svcb: counter!(record_type_name.clone(), key => "svcb"),
+            tlsa: counter!(record_type_name.clone(), key => "tlsa"),
+            tsig: counter!(record_type_name.clone(), key => "tsig"),
+            txt: counter!(record_type_name.clone(), key => "txt"),
+            unknown: counter!(record_type_name.clone(), key => "unknown"),
+            zero: counter!(record_type_name, key => "zero"),
+        }
+    }
+
+    fn increment(&self, record_type: RecordType) {
+        match record_type {
+            RecordType::A => self.a.increment(1),
+            RecordType::AAAA => self.aaaa.increment(1),
+            RecordType::ANAME => self.aname.increment(1),
+            RecordType::ANY => self.any.increment(1),
+            RecordType::AXFR => self.axfr.increment(1),
+            RecordType::CAA => self.caa.increment(1),
+            RecordType::CDS => self.cds.increment(1),
+            RecordType::CDNSKEY => self.cdnskey.increment(1),
+            RecordType::CERT => self.cert.increment(1),
+            RecordType::CNAME => self.cname.increment(1),
+            RecordType::CSYNC => self.csync.increment(1),
+            RecordType::DNSKEY => self.dnskey.increment(1),
+            RecordType::DS => self.ds.increment(1),
+            RecordType::HINFO => self.hinfo.increment(1),
+            RecordType::HTTPS => self.https.increment(1),
+            RecordType::IXFR => self.ixfr.increment(1),
+            RecordType::KEY => self.key.increment(1),
+            RecordType::MX => self.mx.increment(1),
+            RecordType::NAPTR => self.naptr.increment(1),
+            RecordType::NS => self.ns.increment(1),
+            RecordType::NSEC => self.nsec.increment(1),
+            RecordType::NSEC3 => self.nsec3.increment(1),
+            RecordType::NSEC3PARAM => self.nsec3param.increment(1),
+            RecordType::NULL => self.null.increment(1),
+            RecordType::OPENPGPKEY => self.openpgpkey.increment(1),
+            RecordType::OPT => self.opt.increment(1),
+            RecordType::PTR => self.ptr.increment(1),
+            RecordType::RRSIG => self.rrsig.increment(1),
+            RecordType::SIG => self.sig.increment(1),
+            RecordType::SOA => self.soa.increment(1),
+            RecordType::SRV => self.srv.increment(1),
+            RecordType::SSHFP => self.sshfp.increment(1),
+            RecordType::SVCB => self.svcb.increment(1),
+            RecordType::TLSA => self.tlsa.increment(1),
+            RecordType::TSIG => self.tsig.increment(1),
+            RecordType::TXT => self.txt.increment(1),
+            RecordType::ZERO => self.zero.increment(1),
+            RecordType::Unknown(_) | _ => self.unknown.increment(1),
+        }
+    }
+}

--- a/crates/server/src/authority/mod.rs
+++ b/crates/server/src/authority/mod.rs
@@ -26,6 +26,8 @@ mod authority;
 mod catalog;
 pub(crate) mod message_request;
 mod message_response;
+#[cfg(feature = "metrics")]
+mod metrics;
 
 pub use self::auth_lookup::{
     AnyRecords, AuthLookup, AuthLookupIter, LookupRecords, LookupRecordsIter,

--- a/crates/server/src/authority/mod.rs
+++ b/crates/server/src/authority/mod.rs
@@ -191,7 +191,7 @@ mod zone_type {
     use serde::{Deserialize, Serialize};
 
     /// The type of zone stored in a Catalog
-    #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy)]
+    #[derive(Serialize, Deserialize, Hash, PartialEq, Eq, Debug, Clone, Copy)]
     pub enum ZoneType {
         /// This authority for a zone
         Primary,

--- a/crates/server/src/store/blocklist.rs
+++ b/crates/server/src/store/blocklist.rs
@@ -430,6 +430,11 @@ impl Authority for BlocklistAuthority {
     fn nx_proof_kind(&self) -> Option<&NxProofKind> {
         None
     }
+
+    #[cfg(feature = "metrics")]
+    fn metrics_label(&self) -> &'static str {
+        "blocklist"
+    }
 }
 
 /// Consult action enum.  Controls how consult lookups are handled.

--- a/crates/server/src/store/file.rs
+++ b/crates/server/src/store/file.rs
@@ -248,6 +248,11 @@ impl Authority for FileAuthority {
     fn nx_proof_kind(&self) -> Option<&NxProofKind> {
         self.in_memory.nx_proof_kind()
     }
+
+    #[cfg(feature = "metrics")]
+    fn metrics_label(&self) -> &'static str {
+        "file"
+    }
 }
 
 #[cfg(feature = "__dnssec")]

--- a/crates/server/src/store/forwarder.rs
+++ b/crates/server/src/store/forwarder.rs
@@ -325,6 +325,11 @@ impl<P: ConnectionProvider> Authority for ForwardAuthority<P> {
     fn nx_proof_kind(&self) -> Option<&NxProofKind> {
         None
     }
+
+    #[cfg(feature = "metrics")]
+    fn metrics_label(&self) -> &'static str {
+        "forwarder"
+    }
 }
 
 /// Configuration for file based zones

--- a/crates/server/src/store/in_memory/mod.rs
+++ b/crates/server/src/store/in_memory/mod.rs
@@ -712,6 +712,11 @@ impl Authority for InMemoryAuthority {
     fn nx_proof_kind(&self) -> Option<&NxProofKind> {
         self.nx_proof_kind.as_ref()
     }
+
+    #[cfg(feature = "metrics")]
+    fn metrics_label(&self) -> &'static str {
+        "in-memory"
+    }
 }
 
 #[cfg(feature = "__dnssec")]

--- a/crates/server/src/store/recursor.rs
+++ b/crates/server/src/store/recursor.rs
@@ -219,6 +219,11 @@ impl<P: RuntimeProvider> Authority for RecursiveAuthority<P> {
     fn nx_proof_kind(&self) -> Option<&NxProofKind> {
         None
     }
+
+    #[cfg(feature = "metrics")]
+    fn metrics_label(&self) -> &'static str {
+        "recursive"
+    }
 }
 
 /// Configuration for file based zones

--- a/crates/server/src/store/sqlite/mod.rs
+++ b/crates/server/src/store/sqlite/mod.rs
@@ -1174,6 +1174,11 @@ impl Authority for SqliteAuthority {
     fn nx_proof_kind(&self) -> Option<&NxProofKind> {
         self.in_memory.nx_proof_kind()
     }
+
+    #[cfg(feature = "metrics")]
+    fn metrics_label(&self) -> &'static str {
+        "sqlite"
+    }
 }
 
 #[cfg(feature = "__dnssec")]

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -103,6 +103,7 @@ __tls = ["dep:rustls"]
 __https = ["dep:rustls", "dep:webpki-roots"]
 
 sqlite = ["rusqlite", "hickory-server/sqlite"]
+metrics = ["hickory-server/metrics"]
 
 [dependencies]
 async-trait.workspace = true

--- a/tests/integration-tests/tests/integration/chained_authority_tests.rs
+++ b/tests/integration-tests/tests/integration/chained_authority_tests.rs
@@ -264,6 +264,11 @@ impl Authority for TestAuthority {
         };
         (res, None)
     }
+
+    #[cfg(feature = "metrics")]
+    fn metrics_label(&self) -> &'static str {
+        "test"
+    }
 }
 
 #[derive(Debug)]

--- a/tests/test-data/test_configs/example_forwarder.toml
+++ b/tests/test-data/test_configs/example_forwarder.toml
@@ -7,7 +7,7 @@ file = "default/localhost.zone"
 
 [[zones]]
 zone = "0.0.127.in-addr.arpa"
-zone_type = "Primary"
+zone_type = "Secondary"
 file = "default/127.0.0.1.zone"
 
 [[zones]]


### PR DESCRIPTION
The PR adds metrics covering the following areas:
- zone (authority) lookups
- request/response DNS classes
- request/response DNS record types (#3007)

Kind regdards,
Harald