### PR TITLE
Allow disabling H3 grease, as needed for cloudflare

### DIFF
--- a/crates/proto/src/h3/h3_client_stream.rs
+++ b/crates/proto/src/h3/h3_client_stream.rs
@@ -632,6 +632,11 @@ mod tests {
         let mut request = Message::query();
         let query = Query::query(Name::from_str("www.example.com.").unwrap(), RecordType::A);
         request.add_query(query);
+        request.set_recursion_desired(true);
+        let mut edns = Edns::new();
+        edns.set_version(0);
+        edns.set_max_payload(1232);
+        *request.extensions_mut() = Some(edns);
 
         let request = DnsRequest::new(request, DnsRequestOptions::default());
 
@@ -669,6 +674,12 @@ mod tests {
             RecordType::AAAA,
         );
         request.add_query(query);
+        request.set_recursion_desired(true);
+        let mut edns = Edns::new();
+        edns.set_version(0);
+        edns.set_max_payload(1232);
+        *request.extensions_mut() = Some(edns);
+
         let request = DnsRequest::new(request, DnsRequestOptions::default());
 
         let response = runtime

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -409,6 +409,7 @@ impl NameServerConfigGroup {
             ProtocolConfig::H3 {
                 server_name,
                 path: Arc::from(DEFAULT_DNS_QUERY_PATH),
+                disable_grease: false,
             },
             trust_negative_responses,
         )
@@ -674,6 +675,9 @@ pub enum ProtocolConfig {
         server_name: Arc<str>,
         /// The path (or endpoint) to use for the DNS query.
         path: Arc<str>,
+        /// Whether to disable sending "grease"
+        #[cfg_attr(feature = "serde", serde(default))]
+        disable_grease: bool,
     },
 }
 

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -197,7 +197,14 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
                 ))
             }
             #[cfg(feature = "__h3")]
-            (ProtocolConfig::H3 { server_name, path }, Some(binder)) => {
+            (
+                ProtocolConfig::H3 {
+                    server_name,
+                    path,
+                    disable_grease,
+                },
+                Some(binder),
+            ) => {
                 let bind_addr = config.bind_addr.unwrap_or(match config.socket_addr {
                     SocketAddr::V4(_) => SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
                     SocketAddr::V6(_) => SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
@@ -206,6 +213,7 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
                 Connecting::H3(DnsExchange::connect(
                     H3ClientStream::builder()
                         .crypto_config(options.tls_config.clone())
+                        .disable_grease(*disable_grease)
                         .build_with_future(
                             binder.bind_quic(bind_addr, config.socket_addr)?,
                             config.socket_addr,


### PR DESCRIPTION
Allow disabling H3 grease through the config, so non-compliant implementations such as cloudflare's work.
As described in #2085.

I'm using this as follows:
```
[[zones.stores.name_servers]]
socket_addr = "1.1.1.1:443"
protocol = { type = "h3", server_name = "1dot1dot1dot1.cloudflare-dns.com", path="/dns-query", disable_grease=true }

[[zones.stores.name_servers]]
socket_addr = "8.8.8.8:443"
protocol = { type = "h3", server_name = "dns.google", path = "/dns-query" }

```