### PR TITLE
server: remove deprecated ZoneType enum variants

### DIFF
--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -269,13 +269,12 @@ impl Catalog {
         if let Some(authorities) = self.find(verify_request.query.name()) {
             #[allow(clippy::never_loop)]
             for authority in authorities {
-                #[allow(deprecated)]
                 let response_code = match authority.zone_type() {
-                    ZoneType::Secondary | ZoneType::Slave => {
+                    ZoneType::Secondary => {
                         error!("secondary forwarding for update not yet implemented");
                         ResponseCode::NotImp
                     }
-                    ZoneType::Primary | ZoneType::Master => {
+                    ZoneType::Primary => {
                         let update_result = authority.update(update).await;
                         match update_result {
                             // successful update
@@ -526,9 +525,8 @@ async fn build_response(
     let mut response_header = Header::response_from_request(request_header);
     response_header.set_authoritative(authority.zone_type().is_authoritative());
 
-    #[allow(deprecated)]
     let sections = match authority.zone_type() {
-        ZoneType::Primary | ZoneType::Secondary | ZoneType::Master | ZoneType::Slave => {
+        ZoneType::Primary | ZoneType::Secondary => {
             build_authoritative_response(
                 result,
                 authority,

--- a/crates/server/src/authority/mod.rs
+++ b/crates/server/src/authority/mod.rs
@@ -158,26 +158,16 @@ mod zone_type {
     pub enum ZoneType {
         /// This authority for a zone
         Primary,
-        /// This authority for a zone, i.e. the Primary
-        #[deprecated = "please read about Juneteenth"]
-        Master,
         /// A secondary, i.e. replicated from the Primary
         Secondary,
-        /// A secondary, i.e. replicated from the Primary
-        #[deprecated = "please read about Juneteenth"]
-        Slave,
         /// A cached zone that queries other nameservers
         External,
     }
 
     impl ZoneType {
         /// Is this an authoritative Authority, i.e. it owns the records of the zone.
-        #[allow(deprecated)]
         pub fn is_authoritative(self) -> bool {
-            matches!(
-                self,
-                Self::Primary | Self::Secondary | Self::Master | Self::Slave
-            )
+            matches!(self, Self::Primary | Self::Secondary)
         }
     }
 }

--- a/crates/server/src/store/in_memory/mod.rs
+++ b/crates/server/src/store/in_memory/mod.rs
@@ -587,9 +587,8 @@ impl Authority for InMemoryAuthority {
                 return LookupControlFlow::Continue(Err(LookupError::from(ResponseCode::Refused)));
             }
 
-            #[allow(deprecated)]
             match self.zone_type() {
-                ZoneType::Primary | ZoneType::Secondary | ZoneType::Master | ZoneType::Slave => (),
+                ZoneType::Primary | ZoneType::Secondary => (),
                 // TODO: Forward?
                 _ => {
                     return LookupControlFlow::Continue(Err(LookupError::from(


### PR DESCRIPTION
These variants have been deprecated for some time (c.f. https://github.com/hickory-dns/hickory-dns/pull/1141). Since breaking changes are being accepted into `main` let's ax them for good, just in time for this year's Juneteenth.