### PR TITLE
fix some clippy::uninlined_format_args findings

### DIFF
--- a/fuzz/fuzz_targets/message.rs
+++ b/fuzz/fuzz_targets/message.rs
@@ -18,8 +18,8 @@ fuzz_target!(|data: &[u8]| {
                 }
             }
             Err(e) => {
-                eprintln!("{:?}", original);
-                panic!("Message failed to deserialize: {:?}", e);
+                eprintln!("{original:?}");
+                panic!("Message failed to deserialize: {e:?}");
             }
         }
     }

--- a/fuzz/fuzz_targets/preserve_rdata.rs
+++ b/fuzz/fuzz_targets/preserve_rdata.rs
@@ -36,7 +36,7 @@ fn compare(original: &[u8], message: &Message, reencoded: &[u8]) {
         Ok(original_rrs) => original_rrs,
         Err(error_message) => {
             println!("Parsed message: {message:?}");
-            println!("Original: {:02x?}", original);
+            println!("Original: {original:02x?}");
             panic!("failed to split original message into resource records: {error_message}");
         }
     };
@@ -44,8 +44,8 @@ fn compare(original: &[u8], message: &Message, reencoded: &[u8]) {
         Ok(reencoded_rrs) => reencoded_rrs,
         Err(error_message) => {
             println!("Parsed message: {message:?}");
-            println!("Original:   {:02x?}", original);
-            println!("Re-encoded: {:02x?}", reencoded);
+            println!("Original:   {original:02x?}");
+            println!("Re-encoded: {reencoded:02x?}");
             panic!("failed to split re-encoded message into resource records: {error_message}");
         }
     };

--- a/tests/integration-tests/tests/integration/server_future_tests.rs
+++ b/tests/integration-tests/tests/integration/server_future_tests.rs
@@ -208,10 +208,10 @@ async fn test_server_www_tls() {
     subscribe();
 
     let server_path = env::var("TDNS_WORKSPACE_ROOT").unwrap_or_else(|_| "../..".to_owned());
-    println!("using server src path: {}", server_path);
+    println!("using server src path: {server_path}");
 
-    let ca = read_certs(format!("{}/tests/test-data/ca.pem", server_path)).unwrap();
-    let cert_chain = read_certs(format!("{}/tests/test-data/cert.pem", server_path)).unwrap();
+    let ca = read_certs(format!("{server_path}/tests/test-data/ca.pem")).unwrap();
+    let cert_chain = read_certs(format!("{server_path}/tests/test-data/cert.pem")).unwrap();
 
     let key =
         PrivateKeyDer::from_pem_file(format!("{server_path}/tests/test-data/cert.key")).unwrap();
@@ -242,7 +242,7 @@ async fn test_server_www_tls() {
 
     let client_result = client.await;
 
-    assert!(client_result.is_ok(), "client failed: {:?}", client_result);
+    assert!(client_result.is_ok(), "client failed: {client_result:?}");
     server_continue.store(false, Ordering::Relaxed);
     server.await.unwrap();
 }


### PR DESCRIPTION
Of the form:
```
error: variables can be used directly in the `format!` string
  --> fuzz_targets/message.rs:21:17
   |
21 |                 eprintln!("{:?}", original);
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
   = note: `-D clippy::uninlined-format-args` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::uninlined_format_args)]`
```