### PR TITLE
ci: change log level to TRACE

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
-      RUST_LOG: info
+      RUST_LOG: trace
     steps:
       - uses: actions/checkout@v4
 
@@ -127,7 +127,7 @@ jobs:
             doc,
           ]
     env:
-      RUST_LOG: info
+      RUST_LOG: trace
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
I can't reproduce the `test_sec_lookup` failures in CI locally (despite testing on macOS).