### PR TITLE
hickory-dns: implement RFC 5001 NSID for auth. server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -826,10 +826,12 @@ dependencies = [
  "clap",
  "futures-executor",
  "futures-util",
+ "hex",
  "hickory-client",
  "hickory-proto",
  "hickory-resolver",
  "hickory-server",
+ "hostname",
  "http",
  "hyper",
  "hyper-util",
@@ -1043,6 +1045,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
 ]
 
 [[package]]
@@ -1534,6 +1547,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,7 +1965,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2187,7 +2206,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2246,7 +2265,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3079,7 +3098,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,8 @@ clap = { version = "4.0", default-features = false }
 console = "0.15.0"
 data-encoding = { version = "2.2.0", default-features = false }
 enum-as-inner = "0.6"
+hex = "0.4"
+hostname = "0.3" # 0.4 requires MSRV 1.74+
 idna = { version = "1.0.3", default-features = false, features = ["alloc", "compiled_data"] }
 ipconfig = "0.3.0"
 ipnet = { version = "2.3.0", default-features = false }

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -91,9 +91,11 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "std"]
 tokio = { workspace = true, features = ["time", "rt", "signal"] }
 tokio-util = { workspace = true, optional = true }
 toml.workspace = true
+hex.workspace = true
 hickory-client.workspace = true
 hickory-proto.workspace = true
 hickory-server = { workspace = true, features = ["toml"] }
+hostname.workspace = true
 metrics = { workspace = true, optional = true }
 metrics-exporter-prometheus = { workspace = true, optional = true }
 metrics-process = { workspace = true, optional = true }

--- a/crates/server/src/authority/message_response.rs
+++ b/crates/server/src/authority/message_response.rs
@@ -101,11 +101,12 @@ impl<'q> MessageResponseBuilder<'q> {
     /// # Arguments
     ///
     /// * `queries` - queries (from the Request) to associate with the Response
-    pub(crate) fn new(queries: &'q Queries) -> Self {
+    /// * `edns` - Optional Edns data to associate with the Response
+    pub(crate) fn new(queries: &'q Queries, edns: Option<Edns>) -> Self {
         MessageResponseBuilder {
             queries,
             signature: MessageSignature::default(),
-            edns: None,
+            edns,
         }
     }
 
@@ -137,7 +138,7 @@ impl<'q> MessageResponseBuilder<'q> {
     /// }
     /// ```
     pub fn from_message_request(message: &'q MessageRequest) -> Self {
-        Self::new(message.raw_queries())
+        Self::new(message.raw_queries(), None)
     }
 
     /// Associate EDNS with the Response
@@ -366,7 +367,7 @@ mod tests {
 
         eprintln!("queries: {:?}", msg.queries());
 
-        MessageResponseBuilder::new(msg.raw_queries())
+        MessageResponseBuilder::new(msg.raw_queries(), None)
             .build_no_records(Header::response_from_request(msg.header()))
             .destructive_emit(&mut encoder)
             .unwrap();

--- a/crates/server/src/server/mod.rs
+++ b/crates/server/src/server/mod.rs
@@ -1098,7 +1098,7 @@ async fn error_response_handler(
         metrics: ResponseHandlerMetrics::default(),
     };
 
-    let response = MessageResponseBuilder::new(&queries);
+    let response = MessageResponseBuilder::new(&queries, None);
     let result = reporter
         .send_response(response.error_msg(&header, response_code))
         .await;

--- a/tests/integration-tests/tests/integration/catalog_tests.rs
+++ b/tests/integration-tests/tests/integration/catalog_tests.rs
@@ -132,7 +132,7 @@ async fn test_catalog_lookup() {
 
     let mut question = Message::query();
 
-    let mut query: Query = Query::new();
+    let mut query = Query::new();
     query.set_name(origin.into());
 
     question.add_query(query);
@@ -171,7 +171,7 @@ async fn test_catalog_lookup() {
 
     // other zone
     let mut question = Message::query();
-    let mut query: Query = Query::new();
+    let mut query = Query::new();
     query.set_name(test_origin.into());
 
     question.add_query(query);
@@ -221,7 +221,7 @@ async fn test_catalog_lookup_soa() {
 
     let mut question = Message::query();
 
-    let mut query: Query = Query::new();
+    let mut query = Query::new();
     query.set_name(origin.into());
     query.set_query_type(RecordType::SOA);
 
@@ -294,7 +294,7 @@ async fn test_catalog_nx_soa() {
 
     let mut question = Message::query();
 
-    let mut query: Query = Query::new();
+    let mut query = Query::new();
     query.set_name(Name::parse("nx.example.com.", None).unwrap());
 
     question.add_query(query);
@@ -349,7 +349,7 @@ async fn test_non_authoritive_nx_refused() {
 
     let mut question = Message::query();
 
-    let mut query: Query = Query::new();
+    let mut query = Query::new();
     query.set_name(Name::parse("com.", None).unwrap());
     query.set_query_type(RecordType::SOA);
 
@@ -408,7 +408,7 @@ async fn test_axfr() {
     let mut catalog = Catalog::new();
     catalog.upsert(origin.clone(), vec![Arc::new(test)]);
 
-    let mut query: Query = Query::new();
+    let mut query = Query::new();
     query.set_name(origin.clone().into());
     query.set_query_type(RecordType::AXFR);
 
@@ -531,7 +531,7 @@ async fn test_axfr_refused() {
     let mut catalog = Catalog::new();
     catalog.upsert(origin.clone(), vec![Arc::new(test)]);
 
-    let mut query: Query = Query::new();
+    let mut query = Query::new();
     query.set_name(origin.into());
     query.set_query_type(RecordType::AXFR);
 
@@ -579,7 +579,7 @@ async fn test_cname_additionals() {
 
     let mut question = Message::query();
 
-    let mut query: Query = Query::new();
+    let mut query = Query::new();
     query.set_name(Name::from_str("alias.example.com.").unwrap());
     query.set_query_type(RecordType::A);
 
@@ -633,7 +633,7 @@ async fn test_multiple_cname_additionals() {
 
     let mut question = Message::query();
 
-    let mut query: Query = Query::new();
+    let mut query = Query::new();
     query.set_name(Name::from_str("alias2.example.com.").unwrap());
     query.set_query_type(RecordType::A);
 


### PR DESCRIPTION
### Description

[RFC 5001](https://www.rfc-editor.org/rfc/rfc5001) _"DNS Name Server Identifier (NSID) Option"_ specifies a mechanism where clients can ask an authoritative or recursive server to include an identifier for the server that processed the request in the generated response. 

Clients opt-in via sending an NSID EDNS option (0x03) with an empty value in outbound requests, and if the processing server has an NSID it includes EDNS data in the response with the same NSID EDNS option, but using the unstructured binary identifier as the option value. This can be helpful information when using DNS anycast, load balancing, or some other configuration that means it's not trivial to know ahead of time which particular nameserver handled a request.

This branch implements NSID support for the `hickory-dns` authoritative server binary. The nameserver ID can be set in two ways:

* Using `--nsid-hostname` to use the system hostname as the identifier
* Using `--nsid <value>` to use a specific identifier value, e.g. `--nsid HickoryDNS`

Since the NSID payload is arbitrary binary data, the `--nsid <value>` argument can be prefixed with `0x` to treat it as hex encoded data (e.g. `--nsid 0xC0FFEE`).

By default, no NSID is configured, matching the status quo. Some nameservers (e.g. `knot`) default to `--nsid-hostname` unless NSID is specifically disabled, but to me this seems like a risky default and so I've made it opt-in. Happy to revisit if folks disagree.

### Examples

<details>
<summary>Using a string NSID:</summary>

Running with `hickory-dns --config config.toml --zonedir . --port 5454 --nsid "Hello World!"`:

```
$ dig -p5454 +nsid @localhost example.com | grep NSID
; NSID: 48 65 6c 6c 6f 20 57 6f 72 6c 64 21 ("Hello World!")
```
</details>

<details>
<summary>Using a hex NSID:</summary>

Running with `hickory-dns --config config.toml --zonedir . --port 5454 --nsid "0xC0FFEE"`:

```
$ dig -p5454 +nsid @localhost example.com | grep NSID
; NSID: c0 ff ee ("...")
```
</details>

<details>
<summary>Using the hostname as NSID:</summary>

Running with `hickory-dns --config config.toml --zonedir . --port 5454 --nsid-hostname

```
$ hostname
noire

$ dig -p5454 +nsid @localhost example.com | grep NSID
; NSID: 6e 6f 69 72 65 ("noire")
```
</details>


