### PR TITLE
DNSSEC validation: find zone cut with NS queries

### DIFF
--- a/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
@@ -453,10 +453,10 @@ impl<H: DnsHandle> DnssecDnsHandle<H> {
     /// Checks whether a DS RRset exists for the given name or an ancestor of it.
     async fn find_ds_records(
         &self,
-        zone: Name,
+        name: Name,
         options: DnsRequestOptions,
     ) -> Result<(), ProofError> {
-        match self.fetch_ds_records(zone.clone(), options).await {
+        match self.fetch_ds_records(name.clone(), options).await {
             Ok(_) => return Ok(()),
             Err(err) if matches!(err.kind(), ProofErrorKind::DsRecordShouldExist { .. }) => {}
             Err(err) => return Err(err),
@@ -464,13 +464,13 @@ impl<H: DnsHandle> DnssecDnsHandle<H> {
 
         // Otherwise, we need to discover the status of DS RRsets up the chain. If we find a valid DS
         // RRset, then we're in a Bogus state. If we get a ProofError, our result is the same.
-        let mut parent = zone.base_name();
+        let mut parent = name.base_name();
         loop {
             if parent.is_root() {
-                return Err(ProofError::ds_should_exist(zone));
+                return Err(ProofError::ds_should_exist(name));
             }
             match self.fetch_ds_records(parent.clone(), options).await {
-                Ok(_) => return Err(ProofError::ds_should_exist(zone)),
+                Ok(_) => return Err(ProofError::ds_should_exist(name)),
                 Err(err) if matches!(err.kind(), ProofErrorKind::DsRecordShouldExist { .. }) => {}
                 Err(err) => return Err(err),
             }

--- a/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
@@ -450,32 +450,50 @@ impl<H: DnsHandle> DnssecDnsHandle<H> {
         ))
     }
 
-    /// Checks whether a DS RRset exists for the given name or an ancestor of it.
+    /// Checks whether a DS RRset exists for the zone containing a name.
+    ///
+    /// Returns an error with an `Insecure` proof if the zone is proven to be
+    /// insecure. Returns `Ok(())` if the zone is secure.
     async fn find_ds_records(
         &self,
         name: Name,
         options: DnsRequestOptions,
     ) -> Result<(), ProofError> {
-        match self.fetch_ds_records(name.clone(), options).await {
-            Ok(_) => return Ok(()),
-            Err(err) if matches!(err.kind(), ProofErrorKind::DsRecordShouldExist { .. }) => {}
-            Err(err) => return Err(err),
-        }
-
-        // Otherwise, we need to discover the status of DS RRsets up the chain. If we find a valid DS
-        // RRset, then we're in a Bogus state. If we get a ProofError, our result is the same.
-        let mut parent = name.base_name();
-        loop {
-            if parent.is_root() {
+        let mut ancestor = name.clone();
+        let zone = loop {
+            if ancestor.is_root() {
                 return Err(ProofError::ds_should_exist(name));
             }
-            match self.fetch_ds_records(parent.clone(), options).await {
-                Ok(_) => return Err(ProofError::ds_should_exist(name)),
-                Err(err) if matches!(err.kind(), ProofErrorKind::DsRecordShouldExist { .. }) => {}
-                Err(err) => return Err(err),
+
+            // Make an un-verified request for the NS RRset at this ancestor name.
+            let query = Query::query(ancestor.clone(), RecordType::NS);
+            let result = self
+                .handle
+                .lookup(query.clone(), options)
+                .first_answer()
+                .await;
+            match result {
+                Ok(response) => {
+                    if response.all_sections().any(|record| {
+                        record.record_type() == RecordType::NS && record.name() == &ancestor
+                    }) {
+                        break ancestor;
+                    }
+                }
+                Err(e) if e.is_no_records_found() || e.is_nx_domain() => {}
+                Err(e) => {
+                    return Err(ProofError::new(
+                        Proof::Bogus,
+                        ProofErrorKind::Proto { query, proto: e },
+                    ));
+                }
             }
-            parent = parent.base_name();
-        }
+
+            ancestor = ancestor.base_name();
+        };
+
+        self.fetch_ds_records(zone.clone(), options).await?;
+        Ok(())
     }
 
     /// Retrieves DS records for the given zone.


### PR DESCRIPTION
This implements the idea from #3042, rewriting `find_ds_records()` to first find the zone cut with NS queries, without trying to verify the answers, and then requesting the DS RRset at the zone cut, performing DNSSEC validation on that response.

I tried running tests again with a change hacked in to include records from other sections in recursive responses, and the infinite recursion was not a problem. I did see some test failures because of responses wtih glue A records, but no accompanying RRSIG records, failing to validate. This is related to #3041.