### PR TITLE
MSRV related follow-ups from NSID support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,13 +1049,13 @@ dependencies = [
 
 [[package]]
 name = "hostname"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
 dependencies = [
+ "cfg-if",
  "libc",
- "match_cfg",
- "winapi",
+ "windows-link",
 ]
 
 [[package]]
@@ -1545,12 +1545,6 @@ checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ console = "0.15.0"
 data-encoding = { version = "2.2.0", default-features = false }
 enum-as-inner = "0.6"
 hex = "0.4"
-hostname = "0.3" # 0.4 requires MSRV 1.74+
+hostname = "0.4"
 idna = { version = "1.0.3", default-features = false, features = ["alloc", "compiled_data"] }
 ipconfig = "0.3.0"
 ipnet = { version = "2.3.0", default-features = false }

--- a/bin/src/hickory-dns.rs
+++ b/bin/src/hickory-dns.rs
@@ -317,10 +317,7 @@ async fn async_run(args: Cli) -> Result<(), String> {
     if args.nsid_hostname {
         let hostname =
             hostname::get().map_err(|e| format!("failed to get system hostname: {e}"))?;
-        // TODO: After MSRV 1.74 we could use OsString::into_encoded_bytes() here to
-        //   allow using a non-UTF-8 hostname in the NSID payload.
-        let hostname = hostname.to_str().ok_or("hostname was not valid UTF-8")?;
-        let payload = NSIDPayload::new(hostname.as_bytes())
+        let payload = NSIDPayload::new(hostname.into_encoded_bytes())
             .map_err(|e| format!("invalid NSID payload: {e}"))?;
         catalog.set_nsid(Some(payload));
     }


### PR DESCRIPTION
This branch follows https://github.com/hickory-dns/hickory-dns/pull/3072 and https://github.com/hickory-dns/hickory-dns/pull/3070 and implements two changes that weren't possible before the MSRV increase.