### PR TITLE
Add negative tests for NSEC validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,6 +876,7 @@ dependencies = [
  "hickory-resolver",
  "hickory-server",
  "once_cell",
+ "pretty_assertions",
  "rand",
  "rusqlite",
  "rustls",
@@ -1834,6 +1841,16 @@ checksum = "85cf4c7c25f1dd66c76b451e9041a8cfce26e4ca754934fa7aed8d5a59a01d20"
 dependencies = [
  "ipnet",
  "num-traits",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -3602,6 +3619,12 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/crates/proto/src/dnssec/rdata/nsec.rs
+++ b/crates/proto/src/dnssec/rdata/nsec.rs
@@ -71,8 +71,8 @@ impl NSEC {
         }
     }
 
-    /// Constructs a new NSEC RData, this will add the NSEC itself as covered, generally
-    ///   correct for NSEC records generated at their own name
+    /// Constructs a new NSEC RData, this will add the NSEC itself and its RRSIG as covered,
+    ///   generally correct for NSEC records generated at their own name
     ///
     /// # Arguments
     ///
@@ -88,7 +88,9 @@ impl NSEC {
     ) -> Self {
         Self::new(
             next_domain_name,
-            type_bit_maps.into_iter().chain([RecordType::NSEC]),
+            type_bit_maps
+                .into_iter()
+                .chain([RecordType::NSEC, RecordType::RRSIG]),
         )
     }
 

--- a/crates/server/src/store/in_memory/inner.rs
+++ b/crates/server/src/store/in_memory/inner.rs
@@ -530,12 +530,12 @@ impl InnerInMemory {
             for key in self.records.keys() {
                 match &mut nsec_info {
                     None => nsec_info = Some((&key.name, BTreeSet::from([key.record_type]))),
-                    Some((name, vec)) if LowerName::new(name) == key.name => {
-                        vec.insert(key.record_type);
+                    Some((name, set)) if LowerName::new(name) == key.name => {
+                        set.insert(key.record_type);
                     }
-                    Some((name, vec)) => {
+                    Some((name, set)) => {
                         // names aren't equal, create the NSEC record
-                        let rdata = NSEC::new_cover_self(key.name.clone().into(), mem::take(vec));
+                        let rdata = NSEC::new_cover_self(key.name.clone().into(), mem::take(set));
                         let record = Record::from_rdata(name.clone(), ttl, rdata);
                         records.push(record.into_record_of_rdata());
 
@@ -546,9 +546,9 @@ impl InnerInMemory {
             }
 
             // the last record
-            if let Some((name, vec)) = nsec_info {
+            if let Some((name, set)) = nsec_info {
                 // names aren't equal, create the NSEC record
-                let rdata = NSEC::new_cover_self(origin.clone().into(), vec);
+                let rdata = NSEC::new_cover_self(origin.clone().into(), set);
                 let record = Record::from_rdata(name.clone(), ttl, rdata);
                 records.push(record.into_record_of_rdata());
             }

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -125,6 +125,7 @@ webpki-roots = { workspace = true, optional = true }
 [dev-dependencies]
 data-encoding.workspace = true
 futures = { workspace = true, features = ["thread-pool"] }
+pretty_assertions = "1"
 tokio = { workspace = true, features = ["macros", "rt"] }
 test-support.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "std"] }

--- a/tests/integration-tests/src/mock_request_handler.rs
+++ b/tests/integration-tests/src/mock_request_handler.rs
@@ -1,0 +1,132 @@
+use async_trait::async_trait;
+#[cfg(feature = "__dnssec")]
+use hickory_client::client::{ClientHandle, DnssecClient};
+#[cfg(feature = "__dnssec")]
+use hickory_proto::rr::DNSClass;
+use hickory_proto::{
+    op::{Header, MessageType, ResponseCode},
+    rr::{LowerName, RecordType},
+    xfer::DnsResponse,
+};
+use hickory_resolver::Name;
+use hickory_server::{
+    authority::MessageResponseBuilder,
+    server::{Request, RequestHandler, ResponseHandler, ResponseInfo},
+};
+use tracing::error;
+
+/// Replacement for `Catalog` that returns one of two canned responses.
+pub struct MockHandler {
+    query_name: LowerName,
+    query_type: RecordType,
+    response: DnsResponse,
+    dnskey_name: LowerName,
+    dnskey_response: DnsResponse,
+}
+
+impl MockHandler {
+    pub fn new(
+        query_name: LowerName,
+        query_type: RecordType,
+        response: DnsResponse,
+        dnskey_response: DnsResponse,
+    ) -> Self {
+        let dnskey_name = Name::parse("example.", None).unwrap().into();
+        Self {
+            query_name,
+            query_type,
+            response,
+            dnskey_name,
+            dnskey_response,
+        }
+    }
+}
+
+#[async_trait]
+impl RequestHandler for MockHandler {
+    async fn handle_request<R: ResponseHandler>(
+        &self,
+        request: &Request,
+        mut response_handle: R,
+    ) -> ResponseInfo {
+        let request_info = request.request_info().unwrap();
+        if request_info.query.name() == &self.query_name
+            && request_info.query.query_type() == self.query_type
+        {
+            send_response(response_handle, request, &self.response).await
+        } else if request_info.query.name() == &self.dnskey_name
+            && request_info.query.query_type() == RecordType::DNSKEY
+        {
+            send_response(response_handle, request, &self.dnskey_response).await
+        } else {
+            error!(query = ?request_info.query, "unexpected request");
+            let response_builder = MessageResponseBuilder::from_message_request(request);
+            let mut response_header = Header::response_from_request(request.header());
+            response_header.set_response_code(ResponseCode::ServFail);
+            let result = response_handle
+                .send_response(response_builder.build_no_records(response_header))
+                .await;
+            if let Err(e) = result {
+                error!(error = %e, "error responding to request");
+            }
+            response_header.into()
+        }
+    }
+}
+
+/// Helper for implementation of `RequestHandler`.
+///
+/// Turns a `DnsResponse` into a `MessageResponse`, performs error handling, and produces a
+/// `ResponseInfo`.
+async fn send_response(
+    mut response_handle: impl ResponseHandler,
+    request: &Request,
+    response: &DnsResponse,
+) -> ResponseInfo {
+    let mut response_header = *response.header();
+    response_header.set_id(request.id());
+
+    let mut message_response_builder = MessageResponseBuilder::from_message_request(request);
+    if let Some(edns) = response.extensions() {
+        message_response_builder.edns(edns.clone());
+    }
+    let message_response = message_response_builder.build(
+        response_header,
+        response.answers(),
+        response.name_servers(),
+        [],
+        response.additionals(),
+    );
+
+    let result = response_handle.send_response(message_response).await;
+    match result {
+        Ok(info) => info,
+        Err(e) => {
+            error!(error = %e, "error responding to request");
+            let mut header = Header::new(
+                request.id(),
+                MessageType::Response,
+                request.header().op_code(),
+            );
+            header.set_response_code(ResponseCode::ServFail);
+            ResponseInfo::from(header)
+        }
+    }
+}
+
+/// Helper to query `example. IN DNSKEY` and return the response.
+///
+/// This response is needed by [`MockHandler::new`].
+#[cfg(feature = "__dnssec")]
+pub async fn fetch_dnskey(client: &mut DnssecClient) -> DnsResponse {
+    let dnskey_response = client
+        .query(
+            Name::parse("example.", None).unwrap(),
+            DNSClass::IN,
+            RecordType::DNSKEY,
+        )
+        .await
+        .unwrap();
+    assert_eq!(dnskey_response.response_code(), ResponseCode::NoError);
+    dnskey_response
+}

--- a/tests/integration-tests/tests/integration/invalid_nsec_tests.rs
+++ b/tests/integration-tests/tests/integration/invalid_nsec_tests.rs
@@ -1,0 +1,671 @@
+#![cfg(feature = "__dnssec")]
+
+//! These tests confirm that NSEC validation fails when omitting any required NSEC record from
+//! responses.
+
+use std::{sync::Arc, time::Duration};
+
+use hickory_client::client::ClientHandle;
+use hickory_integration::{
+    generate_key,
+    mock_request_handler::{MockHandler, fetch_dnskey},
+    print_response, setup_dnssec_client_server,
+};
+use hickory_proto::{
+    ProtoErrorKind,
+    dnssec::{
+        Algorithm, DigestType, Proof, SigSigner, SigningKey,
+        crypto::Ed25519SigningKey,
+        rdata::{DNSKEY, DNSSECRData, DS, NSEC},
+    },
+    op::ResponseCode,
+    rr::{
+        DNSClass, RData, Record, RecordType,
+        rdata::{A, AAAA, HINFO, MX, NS, SOA},
+    },
+    xfer::DnsResponse,
+};
+use hickory_resolver::Name;
+use hickory_server::{
+    authority::{AxfrPolicy, Catalog, ZoneType},
+    dnssec::NxProofKind,
+    store::in_memory::InMemoryAuthority,
+};
+use test_support::subscribe;
+
+/// Based on RFC 4035 section B.2.
+#[tokio::test]
+async fn name_error() {
+    subscribe();
+
+    let (key, public_key) = generate_key();
+    let catalog = example_zone_catalog(key);
+    let (mut client, _honest_server) = setup_dnssec_client_server(catalog, &public_key).await;
+
+    let query_name = Name::parse("ml.example.", None).unwrap();
+    let query_type = RecordType::A;
+    let response = client
+        .query(query_name.clone(), DNSClass::IN, query_type)
+        .await
+        .unwrap();
+    print_response(&response);
+    assert_eq!(response.response_code(), ResponseCode::NXDomain);
+
+    let nsec_count = response
+        .all_sections()
+        .filter(|record| record.record_type() == RecordType::NSEC)
+        .count();
+    assert_eq!(nsec_count, 2);
+
+    let dnskey_response = fetch_dnskey(&mut client).await;
+
+    // Proves name does not exist.
+    test_exclude_nsec(
+        &query_name,
+        query_type,
+        &response,
+        &dnskey_response,
+        Name::parse("b.example.", None).unwrap(),
+    )
+    .await;
+
+    // Proves covering wildcard name does not exist.
+    test_exclude_nsec(
+        &query_name,
+        query_type,
+        &response,
+        &dnskey_response,
+        Name::parse("example.", None).unwrap(),
+    )
+    .await;
+}
+
+/// Based on RFC 4035 section B.3.
+#[tokio::test]
+async fn no_data_error() {
+    subscribe();
+
+    let (key, public_key) = generate_key();
+    let catalog = example_zone_catalog(key);
+    let (mut client, _honest_server) = setup_dnssec_client_server(catalog, &public_key).await;
+
+    let query_name = Name::parse("ns1.example.", None).unwrap();
+    let query_type = RecordType::MX;
+    let response = client
+        .query(query_name.clone(), DNSClass::IN, query_type)
+        .await
+        .unwrap();
+    print_response(&response);
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+
+    let nsec_count = response
+        .all_sections()
+        .filter(|record| record.record_type() == RecordType::NSEC)
+        .count();
+    assert_eq!(nsec_count, 1);
+
+    let dnskey_response = fetch_dnskey(&mut client).await;
+
+    // Proves the requested RR type does not exist.
+    test_exclude_nsec(
+        &query_name,
+        query_type,
+        &response,
+        &dnskey_response,
+        Name::parse("ns1.example.", None).unwrap(),
+    )
+    .await;
+}
+
+/// Based on RFC 4035 section B.6.
+#[ignore = "Authoritative response is missing the NSEC record"]
+#[tokio::test]
+async fn wildcard_expansion() {
+    subscribe();
+
+    let (key, public_key) = generate_key();
+    let catalog = example_zone_catalog(key);
+    let (mut client, _honest_server) = setup_dnssec_client_server(catalog, &public_key).await;
+
+    let query_name = Name::parse("a.z.w.example.", None).unwrap();
+    let query_type = RecordType::MX;
+    let response = client
+        .query(query_name.clone(), DNSClass::IN, query_type)
+        .await
+        .unwrap();
+    print_response(&response);
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+
+    let nsec_count = response
+        .all_sections()
+        .filter(|record| record.record_type() == RecordType::NSEC)
+        .count();
+    assert_eq!(nsec_count, 1);
+
+    let dnskey_response = fetch_dnskey(&mut client).await;
+
+    // Proves that no closer match exists.
+    test_exclude_nsec(
+        &query_name,
+        query_type,
+        &response,
+        &dnskey_response,
+        Name::parse("x.y.w.example.", None).unwrap(),
+    )
+    .await;
+}
+
+/// Based on RFC 4035 section B.7.
+#[ignore = "Authoritative response uses wrong response code"]
+#[tokio::test]
+async fn wildcard_no_data_error() {
+    subscribe();
+
+    let (key, public_key) = generate_key();
+    let catalog = example_zone_catalog(key);
+    let (mut client, _honest_server) = setup_dnssec_client_server(catalog, &public_key).await;
+
+    let query_name = Name::parse("a.z.w.example.", None).unwrap();
+    let query_type = RecordType::AAAA;
+    let response = client
+        .query(query_name.clone(), DNSClass::IN, query_type)
+        .await
+        .unwrap();
+    print_response(&response);
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+
+    let nsec_count = response
+        .all_sections()
+        .filter(|record| record.record_type() == RecordType::NSEC)
+        .count();
+    assert_eq!(nsec_count, 2);
+
+    let dnskey_response = fetch_dnskey(&mut client).await;
+
+    // Proves that the matching wildcard name does not have the requested RR type.
+    test_exclude_nsec(
+        &query_name,
+        query_type,
+        &response,
+        &dnskey_response,
+        Name::parse("x.y.w.example.", None).unwrap(),
+    )
+    .await;
+
+    // Proves that no closer match exists.
+    test_exclude_nsec(
+        &query_name,
+        query_type,
+        &response,
+        &dnskey_response,
+        Name::parse("*.w.example.", None).unwrap(),
+    )
+    .await;
+}
+
+/// Based on RFC 4035 section B.8.
+#[tokio::test]
+async fn ds_child_zone_no_data_error() {
+    subscribe();
+
+    let (key, public_key) = generate_key();
+    let catalog = example_zone_catalog(key);
+    let (mut client, _honest_server) = setup_dnssec_client_server(catalog, &public_key).await;
+
+    let query_name = Name::parse("example.", None).unwrap();
+    let query_type = RecordType::DS;
+    let response = client
+        .query(query_name.clone(), DNSClass::IN, query_type)
+        .await
+        .unwrap();
+    print_response(&response);
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+
+    let nsec_count = response
+        .all_sections()
+        .filter(|record| record.record_type() == RecordType::NSEC)
+        .count();
+    assert_eq!(nsec_count, 1);
+
+    let dnskey_response = fetch_dnskey(&mut client).await;
+
+    // Proves the requested RR type does not exist.
+    test_exclude_nsec(
+        &query_name,
+        query_type,
+        &response,
+        &dnskey_response,
+        Name::parse("example.", None).unwrap(),
+    )
+    .await;
+}
+
+/// Modifies a response to remove a specific NSEC record, and confirms that the validating client
+/// treats the response as bogus.
+async fn test_exclude_nsec(
+    query_name: &Name,
+    query_type: RecordType,
+    original_response: &DnsResponse,
+    dnskey_response: &DnsResponse,
+    nsec_owner_name: Name,
+) {
+    let mut modified_response = original_response.clone();
+    modified_response.name_servers_mut().retain(|record| {
+        record.name() != &nsec_owner_name || record.record_type() != RecordType::NSEC
+    });
+    let new_count = modified_response.name_servers().len().try_into().unwrap();
+    modified_response.set_name_server_count(new_count);
+    assert!(
+        modified_response.name_servers().len() < original_response.name_servers().len(),
+        "failed to remove expected NSEC record at {nsec_owner_name}: {modified_response:?}"
+    );
+
+    let public_key = dnskey_response.answers()[0]
+        .data()
+        .as_dnssec()
+        .unwrap()
+        .as_dnskey()
+        .unwrap()
+        .public_key();
+
+    let mock = MockHandler::new(
+        query_name.into(),
+        query_type,
+        modified_response,
+        dnskey_response.clone(),
+    );
+    let (mut client, _mock_server) = setup_dnssec_client_server(mock, public_key).await;
+
+    let error = client
+        .query(query_name.clone(), DNSClass::IN, query_type)
+        .await
+        .unwrap_err();
+    let ProtoErrorKind::Nsec { proof, .. } = error.kind() else {
+        panic!("wrong proto error kind {error}");
+    };
+    assert_eq!(proof, &Proof::Bogus);
+}
+
+/// Constructs a catalog based on the zone file described in RFC 4035 Appendix A.
+fn example_zone_catalog(key: Box<dyn SigningKey>) -> Catalog {
+    let origin = Name::parse("example.", None).unwrap();
+
+    let authority = example_zone_authority(origin.clone(), key);
+
+    let mut catalog = Catalog::new();
+    catalog.upsert(origin.into(), vec![Arc::new(authority)]);
+    catalog
+}
+
+/// Constructs an authority based on the zone file described in RFC 4035 Appendix A.
+fn example_zone_authority(origin: Name, key: Box<dyn SigningKey>) -> InMemoryAuthority {
+    let mut authority = InMemoryAuthority::empty(
+        origin.clone(),
+        ZoneType::Primary,
+        AxfrPolicy::Deny,
+        Some(NxProofKind::Nsec),
+    );
+
+    // Note that the serial will be incremented to 1081539377 by `secure_zone_mut()`.
+    const SERIAL: u32 = 1081539376;
+    const TTL: u32 = 3600;
+
+    authority.upsert_mut(
+        Record::from_rdata(
+            origin.clone(),
+            TTL,
+            RData::SOA(SOA::new(
+                Name::parse("ns1", Some(&origin)).unwrap(),
+                Name::parse("bugs.x.w", Some(&origin)).unwrap(),
+                SERIAL,
+                3600,
+                300,
+                3600000,
+                TTL,
+            )),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            origin.clone(),
+            TTL,
+            RData::NS(NS(Name::parse("ns1", Some(&origin)).unwrap())),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            origin.clone(),
+            3600,
+            RData::NS(NS(Name::parse("ns2", Some(&origin)).unwrap())),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            origin.clone(),
+            TTL,
+            RData::MX(MX::new(1, Name::parse("xx", Some(&origin)).unwrap())),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("a", Some(&origin)).unwrap(),
+            TTL,
+            RData::NS(NS(Name::parse("ns1.a", Some(&origin)).unwrap())),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("a", Some(&origin)).unwrap(),
+            TTL,
+            RData::NS(NS(Name::parse("ns2.a", Some(&origin)).unwrap())),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("a", Some(&origin)).unwrap(),
+            TTL,
+            RData::DNSSEC(DNSSECRData::DS(DS::new(
+                57855,
+                #[allow(deprecated)]
+                Algorithm::RSASHA1,
+                DigestType::SHA1,
+                data_encoding::HEXUPPER_PERMISSIVE
+                    .decode(b"B6DCD485719ADCA18E5F3D48A2331627FDD3636B")
+                    .unwrap(),
+            ))),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("ns1.a", Some(&origin)).unwrap(),
+            TTL,
+            RData::A(A::new(192, 0, 2, 5)),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("ns2.a", Some(&origin)).unwrap(),
+            TTL,
+            RData::A(A::new(192, 0, 2, 6)),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("ai", Some(&origin)).unwrap(),
+            TTL,
+            RData::A(A::new(192, 0, 2, 9)),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("ai", Some(&origin)).unwrap(),
+            TTL,
+            RData::HINFO(HINFO::new("KLH-10".to_string(), "ITS".to_string())),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("ai", Some(&origin)).unwrap(),
+            TTL,
+            RData::AAAA(AAAA::new(0x2001, 0xdb8, 0, 0, 0, 0, 0xf00, 0xbaa9)),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("b", Some(&origin)).unwrap(),
+            TTL,
+            RData::NS(NS(Name::parse("ns1.b", Some(&origin)).unwrap())),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("b", Some(&origin)).unwrap(),
+            TTL,
+            RData::NS(NS(Name::parse("ns2.b", Some(&origin)).unwrap())),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("ns1.b", Some(&origin)).unwrap(),
+            TTL,
+            RData::A(A::new(192, 0, 2, 7)),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("ns2.b", Some(&origin)).unwrap(),
+            TTL,
+            RData::A(A::new(192, 0, 2, 8)),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("ns1", Some(&origin)).unwrap(),
+            TTL,
+            RData::A(A::new(192, 0, 2, 1)),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("ns2", Some(&origin)).unwrap(),
+            TTL,
+            RData::A(A::new(192, 0, 2, 2)),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("*.w", Some(&origin)).unwrap(),
+            TTL,
+            RData::MX(MX::new(1, Name::parse("ai", Some(&origin)).unwrap())),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("x.w", Some(&origin)).unwrap(),
+            TTL,
+            RData::MX(MX::new(1, Name::parse("xx", Some(&origin)).unwrap())),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("x.y.w", Some(&origin)).unwrap(),
+            TTL,
+            RData::MX(MX::new(1, Name::parse("xx", Some(&origin)).unwrap())),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("xx", Some(&origin)).unwrap(),
+            TTL,
+            RData::A(A::new(192, 0, 2, 10)),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("xx", Some(&origin)).unwrap(),
+            TTL,
+            RData::HINFO(HINFO::new("KLH-10".to_string(), "TOPS-20".to_string())),
+        ),
+        SERIAL,
+    );
+    authority.upsert_mut(
+        Record::from_rdata(
+            Name::parse("xx", Some(&origin)).unwrap(),
+            TTL,
+            RData::AAAA(AAAA::new(0x2001, 0xdb8, 0, 0, 0, 0, 0xf00, 0xbaaa)),
+        ),
+        SERIAL,
+    );
+
+    // Add DNSKEY and sign zone
+    authority
+        .add_zone_signing_key_mut(SigSigner::dnssec(
+            DNSKEY::from_key(&key.to_public_key().unwrap()),
+            key,
+            origin.clone(),
+            Duration::from_secs(86400),
+        ))
+        .unwrap();
+    authority.secure_zone_mut().unwrap();
+
+    authority
+}
+
+/// Confirm that the generated NSEC chain matches the zone file from RFC 4035 Appendix A.
+#[test]
+fn example_zone_nsec_chain() {
+    let key = Ed25519SigningKey::from_pkcs8(&Ed25519SigningKey::generate_pkcs8().unwrap()).unwrap();
+    let origin = Name::parse("example.", None).unwrap();
+    let mut authority = example_zone_authority(origin.clone(), Box::new(key));
+
+    let mut nsecs = authority
+        .records_get_mut()
+        .iter()
+        .filter_map(|(key, records)| {
+            if key.record_type != RecordType::NSEC {
+                return None;
+            }
+            let mut iterator = records.records(false);
+            let record = iterator.next().unwrap();
+            assert_eq!(iterator.next(), None);
+            Some((
+                record.name().clone(),
+                record
+                    .data()
+                    .as_dnssec()
+                    .unwrap()
+                    .as_nsec()
+                    .unwrap()
+                    .clone(),
+            ))
+        })
+        .collect::<Vec<_>>();
+    nsecs.sort_by(|(left_name, _), (right_name, _)| left_name.cmp(right_name));
+
+    let mut expected_name = nsecs.last().unwrap().1.next_domain_name();
+    for (name, nsec) in nsecs.iter() {
+        assert_eq!(name, expected_name, "NSEC chain is not complete {nsecs:#?}");
+        expected_name = nsec.next_domain_name();
+    }
+
+    let expected_nsecs = vec![
+        (
+            Name::parse("example.", None).unwrap(),
+            NSEC::new(
+                Name::parse("a.example.", None).unwrap(),
+                vec![
+                    RecordType::NS,
+                    RecordType::SOA,
+                    RecordType::MX,
+                    RecordType::RRSIG,
+                    RecordType::NSEC,
+                    RecordType::DNSKEY,
+                ],
+            ),
+        ),
+        (
+            Name::parse("a.example.", None).unwrap(),
+            NSEC::new(
+                Name::parse("ai.example.", None).unwrap(),
+                vec![
+                    RecordType::NS,
+                    RecordType::DS,
+                    RecordType::RRSIG,
+                    RecordType::NSEC,
+                ],
+            ),
+        ),
+        (
+            Name::parse("ai.example.", None).unwrap(),
+            NSEC::new(
+                Name::parse("b.example.", None).unwrap(),
+                vec![
+                    RecordType::A,
+                    RecordType::HINFO,
+                    RecordType::AAAA,
+                    RecordType::RRSIG,
+                    RecordType::NSEC,
+                ],
+            ),
+        ),
+        (
+            Name::parse("b.example.", None).unwrap(),
+            NSEC::new(
+                Name::parse("ns1.example.", None).unwrap(),
+                vec![RecordType::NS, RecordType::RRSIG, RecordType::NSEC],
+            ),
+        ),
+        (
+            Name::parse("ns1.example.", None).unwrap(),
+            NSEC::new(
+                Name::parse("ns2.example.", None).unwrap(),
+                vec![RecordType::A, RecordType::RRSIG, RecordType::NSEC],
+            ),
+        ),
+        (
+            Name::parse("ns2.example.", None).unwrap(),
+            NSEC::new(
+                Name::parse("*.w.example.", None).unwrap(),
+                vec![RecordType::A, RecordType::RRSIG, RecordType::NSEC],
+            ),
+        ),
+        (
+            Name::parse("*.w.example.", None).unwrap(),
+            NSEC::new(
+                Name::parse("x.w.example.", None).unwrap(),
+                vec![RecordType::MX, RecordType::RRSIG, RecordType::NSEC],
+            ),
+        ),
+        (
+            Name::parse("x.w.example.", None).unwrap(),
+            NSEC::new(
+                Name::parse("x.y.w.example.", None).unwrap(),
+                vec![RecordType::MX, RecordType::RRSIG, RecordType::NSEC],
+            ),
+        ),
+        (
+            Name::parse("x.y.w.example.", None).unwrap(),
+            NSEC::new(
+                Name::parse("xx.example.", None).unwrap(),
+                vec![RecordType::MX, RecordType::RRSIG, RecordType::NSEC],
+            ),
+        ),
+        (
+            Name::parse("xx.example.", None).unwrap(),
+            NSEC::new(
+                Name::parse("example.", None).unwrap(),
+                vec![
+                    RecordType::A,
+                    RecordType::HINFO,
+                    RecordType::AAAA,
+                    RecordType::RRSIG,
+                    RecordType::NSEC,
+                ],
+            ),
+        ),
+    ];
+
+    pretty_assertions::assert_eq!(nsecs, expected_nsecs);
+}

--- a/tests/integration-tests/tests/integration/main.rs
+++ b/tests/integration-tests/tests/integration/main.rs
@@ -4,6 +4,7 @@ mod client_future_tests;
 mod client_tests;
 mod dnssec_client_handle_tests;
 mod invalid_nsec3_tests;
+mod invalid_nsec_tests;
 mod lookup_tests;
 mod name_server_pool_tests;
 mod retry_dns_handle_tests;


### PR DESCRIPTION
This adds negative tests for NSEC validation, parallel to the existing `invalid_nsec3_tests` module. As before, we have known issues both on the authoritative side and validation side when dealing with wildcard records. This PR also includes some easy fixes to make NSEC chains match examples from RFC 4035: including RRSIG in the type bit map, and excluding names with no authoritative records.