### PR TITLE
Use retain() instead of calling remove() in a loop

### DIFF
--- a/crates/proto/src/rr/rr_set.rs
+++ b/crates/proto/src/rr/rr_set.rs
@@ -402,19 +402,12 @@ impl RecordSet {
             _ => (), // move on to the delete
         }
 
-        // remove the records, first collect all the indexes, then remove the records
-        let to_remove: Vec<usize> = self
-            .records
-            .iter()
-            .enumerate()
-            .filter(|&(_, rr)| rr.data() == record.data())
-            .map(|(i, _)| i)
-            .collect::<Vec<usize>>();
+        // remove the records
+        let old_size = self.records.len();
+        self.records.retain(|rr| rr.data() != record.data());
+        let removed = self.records.len() < old_size;
 
-        let mut removed = false;
-        for i in to_remove {
-            self.records.remove(i);
-            removed = true;
+        if removed {
             self.updated(serial);
         }
 

--- a/crates/server/src/store/in_memory/inner.rs
+++ b/crates/server/src/store/in_memory/inner.rs
@@ -509,16 +509,8 @@ impl InnerInMemory {
         debug!("generating nsec records: {}", origin);
 
         // first remove all existing nsec records
-        let delete_keys: Vec<RrKey> = self
-            .records
-            .keys()
-            .filter(|k| k.record_type == RecordType::NSEC)
-            .cloned()
-            .collect();
-
-        for key in delete_keys {
-            self.records.remove(&key);
-        }
+        self.records
+            .retain(|k, _| k.record_type != RecordType::NSEC);
 
         // now go through and generate the nsec records
         let ttl = self.minimum_ttl(origin);
@@ -578,16 +570,8 @@ impl InnerInMemory {
         debug!("generating nsec3 records: {origin}");
 
         // first remove all existing nsec records
-        let delete_keys = self
-            .records
-            .keys()
-            .filter(|k| k.record_type == RecordType::NSEC3)
-            .cloned()
-            .collect::<Vec<_>>();
-
-        for key in delete_keys {
-            self.records.remove(&key);
-        }
+        self.records
+            .retain(|k, _| k.record_type != RecordType::NSEC3);
 
         // now go through and generate the nsec3 records
         let ttl = self.minimum_ttl(origin);


### PR DESCRIPTION
I noticed a pattern in a few places of iterating over a collection, filtering the iterator, collecting the indexes or keys into a vector, and then calling `remove()` for each index or key in the vector. This PR replaces this pattern with a call to `retain()` instead, using the logical inverse of the filter predicate. This should be both more idiomatic and more efficient.

Furthermore, note that `RecordSet::remove()` removes vector elements by index, in increasing index order. This would not be safe if it ever removed more than one element, because the first `Vec::remove()` call shifts the tail of the vector left, invalidating the semantics of the rest of the stored indices. In this case I think it was fine, because of the invariant that an RRset cannot contain any duplicate records, but just using `retain()` is less fragile.