### PR TITLE
Change field and method names for Authority section of messages

### DIFF
--- a/crates/proto/src/dnssec/rdata/tsig.rs
+++ b/crates/proto/src/dnssec/rdata/tsig.rs
@@ -745,9 +745,9 @@ pub fn signed_bitmessage_to_buf(
         Query::read(&mut decoder)?;
     }
 
-    // Advance past answer and name server records together.
-    let answer_ns_count = header.answer_count() as usize + header.name_server_count() as usize;
-    let (_, _, sig) = Message::read_records(&mut decoder, answer_ns_count, false)?;
+    // Advance past answer and authority records together.
+    let answer_authority_count = header.answer_count() as usize + header.authority_count() as usize;
+    let (_, _, sig) = Message::read_records(&mut decoder, answer_authority_count, false)?;
     debug_assert_eq!(sig, MessageSignature::Unsigned);
 
     // Advance past additional records, up to the final TSIG record.

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -567,7 +567,7 @@ impl ProtoError {
 
                     // Collect any referral nameservers and associated glue records
                     let mut referral_name_servers = vec![];
-                    for ns in response.name_servers().iter().filter(|ns| ns.record_type() == RecordType::NS) {
+                    for ns in response.authorities().iter().filter(|ns| ns.record_type() == RecordType::NS) {
                         let glue = response
                             .additionals()
                             .iter()
@@ -591,8 +591,8 @@ impl ProtoError {
                         None
                     };
 
-                    let authorities = if ! response.name_servers().is_empty() {
-                        Some(response.name_servers().to_owned().into())
+                    let authorities = if !response.authorities().is_empty() {
+                        Some(response.authorities().to_owned().into())
                     } else {
                         None
                     };

--- a/crates/proto/src/op/header.rs
+++ b/crates/proto/src/op/header.rs
@@ -67,7 +67,7 @@ pub struct Header {
     response_code: ResponseCode,
     query_count: u16,
     answer_count: u16,
-    name_server_count: u16,
+    authority_count: u16,
     additional_count: u16,
 }
 
@@ -87,7 +87,7 @@ impl Header {
             response_code: ResponseCode::NoError,
             query_count: 0,
             answer_count: 0,
-            name_server_count: 0,
+            authority_count: 0,
             additional_count: 0,
         }
     }
@@ -124,7 +124,7 @@ impl Header {
             response_code: ResponseCode::default(),
             query_count: 0,
             answer_count: 0,
-            name_server_count: 0,
+            authority_count: 0,
             additional_count: 0,
         }
     }
@@ -225,9 +225,9 @@ impl Header {
         self
     }
 
-    /// Number of name server records in the message
-    pub fn set_name_server_count(&mut self, name_server_count: u16) -> &mut Self {
-        self.name_server_count = name_server_count;
+    /// Number of authority records in the message
+    pub fn set_authority_count(&mut self, authority_count: u16) -> &mut Self {
+        self.authority_count = authority_count;
         self
     }
 
@@ -390,10 +390,10 @@ impl Header {
     ///
     /// # Return value
     ///
-    /// For query responses this is the number of authorities, or nameservers, in the name server
+    /// For query responses this is the number of authorities, or nameservers, in the authority
     ///  section, for updates this is the number of update records being sent.
-    pub fn name_server_count(&self) -> u16 {
-        self.name_server_count
+    pub fn authority_count(&self) -> u16 {
+        self.authority_count
     }
 
     /// ```text
@@ -447,7 +447,7 @@ impl BinEncodable for Header {
 
         encoder.emit_u16(self.query_count)?;
         encoder.emit_u16(self.answer_count)?;
-        encoder.emit_u16(self.name_server_count)?;
+        encoder.emit_u16(self.authority_count)?;
         encoder.emit_u16(self.additional_count)?;
 
         Ok(())
@@ -485,7 +485,7 @@ impl<'r> BinDecodable<'r> for Header {
             decoder.read_u16()?.unverified(/*this must be verified when reading queries*/);
         let answer_count =
             decoder.read_u16()?.unverified(/*this must be evaluated when reading records*/);
-        let name_server_count =
+        let authority_count =
             decoder.read_u16()?.unverified(/*this must be evaluated when reading records*/);
         let additional_count =
             decoder.read_u16()?.unverified(/*this must be evaluated when reading records*/);
@@ -505,7 +505,7 @@ impl<'r> BinDecodable<'r> for Header {
             response_code,
             query_count,
             answer_count,
-            name_server_count,
+            authority_count,
             additional_count,
         })
     }
@@ -522,7 +522,7 @@ impl fmt::Display for Header {
             code = self.response_code,
             op_code = self.op_code,
             answers = self.answer_count,
-            authorities = self.name_server_count,
+            authorities = self.authority_count,
             additionals = self.additional_count,
         )
     }
@@ -620,7 +620,7 @@ mod tests {
             response_code: ResponseCode::NXDomain,
             query_count: 0x8877,
             answer_count: 0x6655,
-            name_server_count: 0x4433,
+            authority_count: 0x4433,
             additional_count: 0x2211,
         };
 
@@ -644,7 +644,7 @@ mod tests {
             response_code: ResponseCode::NXDomain,
             query_count: 0x8877,
             answer_count: 0x6655,
-            name_server_count: 0x4433,
+            authority_count: 0x4433,
             additional_count: 0x2211,
         };
 

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -140,68 +140,68 @@ impl Message {
         msg
     }
 
-    /// Sets the `Header` with provided
+    /// Sets the [`Header`]
     pub fn set_header(&mut self, header: Header) -> &mut Self {
         self.header = header;
         self
     }
 
-    /// see `Header::set_id`
+    /// See [`Header::set_id`]
     #[allow(dead_code)] // Complicated feature combination
     pub(crate) fn set_id(&mut self, id: u16) -> &mut Self {
         self.header.set_id(id);
         self
     }
 
-    /// see `Header::set_op_code`
+    /// See [`Header::set_op_code`]
     pub fn set_op_code(&mut self, op_code: OpCode) -> &mut Self {
         self.header.set_op_code(op_code);
         self
     }
 
-    /// see `Header::set_authoritative`
+    /// See [`Header::set_authoritative`]
     pub fn set_authoritative(&mut self, authoritative: bool) -> &mut Self {
         self.header.set_authoritative(authoritative);
         self
     }
 
-    /// see `Header::set_truncated`
+    /// See [`Header::set_truncated`]
     pub fn set_truncated(&mut self, truncated: bool) -> &mut Self {
         self.header.set_truncated(truncated);
         self
     }
 
-    /// see `Header::set_recursion_desired`
+    /// See [`Header::set_recursion_desired`]
     pub fn set_recursion_desired(&mut self, recursion_desired: bool) -> &mut Self {
         self.header.set_recursion_desired(recursion_desired);
         self
     }
 
-    /// see `Header::set_recursion_available`
+    /// See [`Header::set_recursion_available`]
     pub fn set_recursion_available(&mut self, recursion_available: bool) -> &mut Self {
         self.header.set_recursion_available(recursion_available);
         self
     }
 
-    /// see `Header::set_authentic_data`
+    /// See [`Header::set_authentic_data`]
     pub fn set_authentic_data(&mut self, authentic_data: bool) -> &mut Self {
         self.header.set_authentic_data(authentic_data);
         self
     }
 
-    /// see `Header::set_checking_disabled`
+    /// See [`Header::set_checking_disabled`]
     pub fn set_checking_disabled(&mut self, checking_disabled: bool) -> &mut Self {
         self.header.set_checking_disabled(checking_disabled);
         self
     }
 
-    /// see `Header::set_response_code`
+    /// See [`Header::set_response_code`]
     pub fn set_response_code(&mut self, response_code: ResponseCode) -> &mut Self {
         self.header.set_response_code(response_code);
         self
     }
 
-    /// see `Header::set_query_count`
+    /// See [`Header::set_query_count`]
     ///
     /// this count will be ignored during serialization,
     /// where the length of the associated records will be used instead.
@@ -210,7 +210,7 @@ impl Message {
         self
     }
 
-    /// see `Header::set_answer_count`
+    /// See [`Header::set_answer_count`]
     ///
     /// this count will be ignored during serialization,
     /// where the length of the associated records will be used instead.
@@ -228,7 +228,7 @@ impl Message {
         self
     }
 
-    /// see `Header::set_additional_count`
+    /// See [`Header::set_additional_count`]
     ///
     /// this count will be ignored during serialization,
     /// where the length of the associated records will be used instead.
@@ -256,13 +256,13 @@ impl Message {
         self
     }
 
-    /// Add an answer to the Message
+    /// Add a record to the Answer section.
     pub fn add_answer(&mut self, record: Record) -> &mut Self {
         self.answers.push(record);
         self
     }
 
-    /// Add all the records from the iterator to the answers section of the Message
+    /// Add all the records from the iterator to the Answer section of the message.
     pub fn add_answers<R, I>(&mut self, records: R) -> &mut Self
     where
         R: IntoIterator<Item = Record, IntoIter = I>,
@@ -275,11 +275,11 @@ impl Message {
         self
     }
 
-    /// Sets the answers to the specified set of Records.
+    /// Sets the Answer section to the specified set of records.
     ///
     /// # Panics
     ///
-    /// Will panic if answer records are already associated to the message.
+    /// Will panic if the Answer section is already non-empty.
     pub fn insert_answers(&mut self, records: Vec<Record>) {
         assert!(self.answers.is_empty());
         self.answers = records;
@@ -314,13 +314,13 @@ impl Message {
         self.authorities = records;
     }
 
-    /// Add an additional Record to the message
+    /// Add a record to the Additional section.
     pub fn add_additional(&mut self, record: Record) -> &mut Self {
         self.additionals.push(record);
         self
     }
 
-    /// Add all the records from the iterator to the additionals section of the Message
+    /// Add all the records from the iterator to the Additional section of the message.
     pub fn add_additionals<R, I>(&mut self, records: R) -> &mut Self
     where
         R: IntoIterator<Item = Record, IntoIter = I>,
@@ -333,7 +333,7 @@ impl Message {
         self
     }
 
-    /// Sets the additional to the specified set of Records.
+    /// Sets the Additional to the specified set of records.
     ///
     /// # Panics
     ///
@@ -418,47 +418,47 @@ impl Message {
         &self.header
     }
 
-    /// see `Header::id()`
+    /// See [`Header::id()`]
     pub fn id(&self) -> u16 {
         self.header.id()
     }
 
-    /// see `Header::message_type()`
+    /// See [`Header::message_type()`]
     pub fn message_type(&self) -> MessageType {
         self.header.message_type()
     }
 
-    /// see `Header::op_code()`
+    /// See [`Header::op_code()`]
     pub fn op_code(&self) -> OpCode {
         self.header.op_code()
     }
 
-    /// see `Header::authoritative()`
+    /// See [`Header::authoritative()`]
     pub fn authoritative(&self) -> bool {
         self.header.authoritative()
     }
 
-    /// see `Header::truncated()`
+    /// See [`Header::truncated()`]
     pub fn truncated(&self) -> bool {
         self.header.truncated()
     }
 
-    /// see `Header::recursion_desired()`
+    /// See [`Header::recursion_desired()`]
     pub fn recursion_desired(&self) -> bool {
         self.header.recursion_desired()
     }
 
-    /// see `Header::recursion_available()`
+    /// See [`Header::recursion_available()`]
     pub fn recursion_available(&self) -> bool {
         self.header.recursion_available()
     }
 
-    /// see `Header::authentic_data()`
+    /// See [`Header::authentic_data()`]
     pub fn authentic_data(&self) -> bool {
         self.header.authentic_data()
     }
 
-    /// see `Header::checking_disabled()`
+    /// See [`Header::checking_disabled()`]
     pub fn checking_disabled(&self) -> bool {
         self.header.checking_disabled()
     }
@@ -500,7 +500,7 @@ impl Message {
         &mut self.answers
     }
 
-    /// Removes all the answers from the Message
+    /// Removes the Answer section records from the message
     pub fn take_answers(&mut self) -> Vec<Record> {
         mem::take(&mut self.answers)
     }
@@ -537,7 +537,7 @@ impl Message {
         &mut self.additionals
     }
 
-    /// Remove the additional Records from the Message
+    /// Remove the Additional section records from the message
     pub fn take_additionals(&mut self) -> Vec<Record> {
         mem::take(&mut self.additionals)
     }
@@ -866,7 +866,7 @@ impl From<Message> for MessageParts {
 pub struct HeaderCounts {
     /// The number of queries in the Message
     pub query_count: usize,
-    /// The number of answers in the Message
+    /// The number of answer records in the Message
     pub answer_count: usize,
     /// The number of authority records in the Message
     pub authority_count: usize,

--- a/crates/proto/src/op/update_message.rs
+++ b/crates/proto/src/op/update_message.rs
@@ -95,7 +95,7 @@ impl UpdateMessage for Message {
     }
 
     fn add_update(&mut self, record: Record) {
-        self.add_name_server(record);
+        self.add_authority(record);
     }
 
     fn add_updates<R, I>(&mut self, records: R)
@@ -103,7 +103,7 @@ impl UpdateMessage for Message {
         R: IntoIterator<Item = Record, IntoIter = I>,
         I: Iterator<Item = Record>,
     {
-        self.add_name_servers(records);
+        self.add_authorities(records);
     }
 
     fn add_additional(&mut self, record: Record) {
@@ -119,7 +119,7 @@ impl UpdateMessage for Message {
     }
 
     fn updates(&self) -> &[Record] {
-        self.name_servers()
+        self.authorities()
     }
 
     fn additionals(&self) -> &[Record] {
@@ -583,7 +583,7 @@ pub fn zone_transfer(zone_origin: Name, last_soa: Option<SOA>) -> Message {
     if let Some(soa) = last_soa {
         // for IXFR, old SOA is put as authority to indicate last known version
         let record = Record::from_rdata(soa.mname().clone(), 0, RData::SOA(soa));
-        message.add_name_server(record);
+        message.add_authority(record);
     }
 
     // Extended dns

--- a/crates/proto/src/xfer/dns_response.rs
+++ b/crates/proto/src/xfer/dns_response.rs
@@ -177,7 +177,7 @@ impl DnsResponse {
 
     /// Retrieves the SOA from the response. This will only exist if it was an authoritative response.
     pub fn soa(&self) -> Option<RecordRef<'_, SOA>> {
-        self.name_servers()
+        self.authorities()
             .iter()
             .find_map(|record| RecordRef::try_from(record).ok())
     }
@@ -239,7 +239,7 @@ impl DnsResponse {
     /// ```
     pub fn negative_ttl(&self) -> Option<u32> {
         // TODO: should this ensure that the SOA zone matches the Queried Zone?
-        self.name_servers()
+        self.authorities()
             .iter()
             .filter_map(|record| record.data().as_soa().map(|soa| (record.ttl(), soa)))
             .next()
@@ -284,7 +284,7 @@ impl DnsResponse {
         let response_code = self.response_code();
         let ttl_from_soa = self.negative_ttl();
         let has_soa = ttl_from_soa.is_some();
-        let has_ns_records = self.name_servers().iter().any(|r| r.record_type().is_ns());
+        let has_ns_records = self.authorities().iter().any(|r| r.record_type().is_ns());
         let has_cname = self.answers().iter().any(|r| r.record_type().is_cname());
         let has_non_cname = self.answers().iter().any(|r| !r.record_type().is_cname());
         let has_additionals = self.additional_count() > 0;
@@ -768,9 +768,9 @@ mod tests {
         message.set_response_code(ResponseCode::NXDomain);
         message.add_query(an_query());
         message.add_answer(an_cname_record());
-        message.add_name_server(soa());
-        message.add_name_server(ns1_record());
-        message.add_name_server(ns2_record());
+        message.add_authority(soa());
+        message.add_authority(ns1_record());
+        message.add_authority(ns2_record());
         message.add_additional(ns1_a());
         message.add_additional(ns2_a());
 
@@ -787,7 +787,7 @@ mod tests {
         message.set_response_code(ResponseCode::NXDomain);
         message.add_query(an_query());
         message.add_answer(an_cname_record());
-        message.add_name_server(soa());
+        message.add_authority(soa());
 
         let response = DnsResponse::from_message(message).unwrap();
         let ty = response.negative_type();
@@ -816,8 +816,8 @@ mod tests {
         message.set_response_code(ResponseCode::NXDomain);
         message.add_query(an_query());
         message.add_answer(an_cname_record());
-        message.add_name_server(ns1_record());
-        message.add_name_server(ns2_record());
+        message.add_authority(ns1_record());
+        message.add_authority(ns2_record());
         message.add_additional(ns1_a());
         message.add_additional(ns2_a());
 
@@ -833,9 +833,9 @@ mod tests {
         let mut message = Message::query();
         message.set_response_code(ResponseCode::NoError);
         message.add_query(another_query());
-        message.add_name_server(soa());
-        message.add_name_server(ns1_record());
-        message.add_name_server(ns2_record());
+        message.add_authority(soa());
+        message.add_authority(ns1_record());
+        message.add_authority(ns2_record());
         message.add_additional(ns1_a());
         message.add_additional(ns2_a());
         let response = DnsResponse::from_message(message).unwrap();
@@ -850,7 +850,7 @@ mod tests {
         let mut message = Message::query();
         message.set_response_code(ResponseCode::NoError);
         message.add_query(another_query());
-        message.add_name_server(soa());
+        message.add_authority(soa());
 
         let response = DnsResponse::from_message(message).unwrap();
         let ty = response.negative_type();
@@ -878,8 +878,8 @@ mod tests {
         message.set_response_code(ResponseCode::NoError);
         message.add_query(an_query());
         message.add_answer(an_cname_record());
-        message.add_name_server(ns1_record());
-        message.add_name_server(ns2_record());
+        message.add_authority(ns1_record());
+        message.add_authority(ns2_record());
         message.add_additional(ns1_a());
         message.add_additional(ns2_a());
 
@@ -892,8 +892,8 @@ mod tests {
         let mut message = Message::query();
         message.set_response_code(ResponseCode::NoError);
         message.add_query(another_query());
-        message.add_name_server(ns1_record());
-        message.add_name_server(ns2_record());
+        message.add_authority(ns1_record());
+        message.add_authority(ns2_record());
         message.add_additional(ns1_a());
         message.add_additional(ns2_a());
 
@@ -909,7 +909,7 @@ mod tests {
         let mut message = Message::query();
         message.set_response_code(ResponseCode::NoError);
         message.add_query(Query::query(an_example(), RecordType::SOA));
-        message.add_name_server(soa());
+        message.add_authority(soa());
 
         let response = DnsResponse::from_message(message).unwrap();
 
@@ -921,7 +921,7 @@ mod tests {
         let mut message = Message::query();
         message.set_response_code(ResponseCode::NoError);
         message.add_query(Query::query(xx(), RecordType::ANY));
-        message.add_name_server(ns1_record());
+        message.add_authority(ns1_record());
         message.add_additional(ns1_a());
 
         let response = DnsResponse::from_message(message).unwrap();

--- a/crates/recursor/src/lib.rs
+++ b/crates/recursor/src/lib.rs
@@ -99,7 +99,7 @@ fn maybe_strip_dnssec_records(
     };
 
     response.answers_mut().retain(predicate);
-    response.name_servers_mut().retain(predicate);
+    response.authorities_mut().retain(predicate);
     response.additionals_mut().retain(predicate);
 
     response

--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -470,7 +470,7 @@ impl<P: ConnectionProvider> Recursor<P> {
                         backtrack: None,
                     })
                 } else if response.answers().is_empty()
-                    && !response.name_servers().is_empty()
+                    && !response.authorities().is_empty()
                     && response.response_code() == ResponseCode::NoError
                 {
                     let mut no_records = NoRecords::new(query.clone(), ResponseCode::NoError);
@@ -480,7 +480,7 @@ impl<P: ConnectionProvider> Recursor<P> {
                         .map(|record| Box::new(record.to_owned()));
                     no_records.authorities = Some(
                         response
-                            .name_servers()
+                            .authorities()
                             .iter()
                             .filter_map(|x| match x.record_type() {
                                 RecordType::SOA => None,
@@ -579,7 +579,7 @@ mod for_dnssec {
                 let mut msg = Message::query();
 
                 msg.add_answers(response.answers().iter().cloned());
-                msg.add_name_servers(response.name_servers().iter().cloned());
+                msg.add_authorities(response.authorities().iter().cloned());
                 msg.add_additionals(response.additionals().iter().cloned());
 
                 DnsResponse::from_message(msg)

--- a/crates/resolver/src/cache.rs
+++ b/crates/resolver/src/cache.rs
@@ -119,7 +119,7 @@ impl Entry {
                 let mut response = response.clone();
                 for section_fn in [
                     Message::answers_mut,
-                    Message::name_servers_mut,
+                    Message::authorities_mut,
                     Message::additionals_mut,
                 ] {
                     for record in section_fn(&mut response) {

--- a/crates/resolver/src/caching_client.rs
+++ b/crates/resolver/src/caching_client.rs
@@ -296,7 +296,7 @@ where
             let mut response = response.into_message();
             let answers = response.take_answers();
             let additionals = response.take_additionals();
-            let name_servers = response.take_name_servers();
+            let authorities = response.take_authorities();
 
             // set of names that still require resolution
             // TODO: this needs to be enhanced for SRV
@@ -307,7 +307,7 @@ where
                 .into_iter()
                 // Chained records will generally exist in the additionals section
                 .chain(additionals)
-                .chain(name_servers)
+                .chain(authorities)
                 .filter_map(|mut r| {
                     // because this resolved potentially recursively, we want the min TTL from the chain
                     let ttl = cname_ttl.min(r.ttl());

--- a/crates/server/src/server/mod.rs
+++ b/crates/server/src/server/mod.rs
@@ -587,7 +587,7 @@ impl<R: ResponseHandler> ResponseHandler for ReportingResponseHandler<R> {
 
         let rflags = response_info.flags();
         let answer_count = response_info.answer_count();
-        let authority_count = response_info.name_server_count();
+        let authority_count = response_info.authority_count();
         let additional_count = response_info.additional_count();
         let response_code = response_info.response_code();
 

--- a/fuzz/fuzz_targets/message.rs
+++ b/fuzz/fuzz_targets/message.rs
@@ -63,7 +63,7 @@ fn messages_equal(original: &Message, reparsed: &Message) -> bool {
     if !records_equal(original.answers(), reparsed.answers()) {
         return false;
     }
-    if !records_equal(original.name_servers(), reparsed.name_servers()) {
+    if !records_equal(original.authorities(), reparsed.authorities()) {
         return false;
     }
     if !records_equal(original.additionals(), reparsed.additionals()) {

--- a/fuzz/fuzz_targets/preserve_rdata.rs
+++ b/fuzz/fuzz_targets/preserve_rdata.rs
@@ -28,10 +28,10 @@ fuzz_target!(|data: &[u8]| {
 fn compare(original: &[u8], message: &Message, reencoded: &[u8]) {
     let query_count = u16::from_be_bytes(reencoded[4..6].try_into().unwrap());
     let answer_count = u16::from_be_bytes(reencoded[6..8].try_into().unwrap());
-    let name_server_count = u16::from_be_bytes(reencoded[8..10].try_into().unwrap());
+    let authority_count = u16::from_be_bytes(reencoded[8..10].try_into().unwrap());
     let additional_records_count = u16::from_be_bytes(reencoded[10..12].try_into().unwrap());
 
-    let rr_count = answer_count + name_server_count + additional_records_count;
+    let rr_count = answer_count + authority_count + additional_records_count;
     let mut original_rrs = match split_rrs(original, query_count, rr_count) {
         Ok(original_rrs) => original_rrs,
         Err(error_message) => {

--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -300,7 +300,7 @@ where
 pub fn print_response(response: &DnsResponse) {
     for (section_heading, section) in [
         ("; Answers", response.answers()),
-        ("; Authorities", response.name_servers()),
+        ("; Authorities", response.authorities()),
         ("; Additionals", response.additionals()),
     ] {
         println!("{section_heading}");

--- a/tests/integration-tests/src/mock_client.rs
+++ b/tests/integration-tests/src/mock_client.rs
@@ -216,13 +216,13 @@ pub fn build_request(query: Query) -> DnsRequest {
 pub fn message(
     query: Query,
     answers: Vec<Record>,
-    name_servers: Vec<Record>,
+    authorities: Vec<Record>,
     additionals: Vec<Record>,
 ) -> Message {
     let mut message = Message::query();
     message.add_query(query);
     message.insert_answers(answers);
-    message.insert_name_servers(name_servers);
+    message.insert_authorities(authorities);
     message.insert_additionals(additionals);
     message
 }

--- a/tests/integration-tests/src/mock_request_handler.rs
+++ b/tests/integration-tests/src/mock_request_handler.rs
@@ -93,7 +93,7 @@ async fn send_response(
     let message_response = message_response_builder.build(
         response_header,
         response.answers(),
-        response.name_servers(),
+        response.authorities(),
         [],
         response.additionals(),
     );

--- a/tests/integration-tests/tests/integration/catalog_tests.rs
+++ b/tests/integration-tests/tests/integration/catalog_tests.rs
@@ -85,7 +85,7 @@ pub fn create_records(records: &mut InMemoryAuthority) {
         0,
     );
 
-    let www_name: Name = Name::parse("www.test.com.", None).unwrap();
+    let www_name = Name::parse("www.test.com.", None).unwrap();
     records.upsert_mut(
         Record::from_rdata(www_name.clone(), 86400, RData::A(A::new(94, 184, 216, 34)))
             .set_dns_class(DNSClass::IN)
@@ -107,7 +107,7 @@ pub fn create_records(records: &mut InMemoryAuthority) {
 }
 
 pub fn create_test() -> InMemoryAuthority {
-    let origin: Name = Name::parse("test.com.", None).unwrap();
+    let origin = Name::parse("test.com.", None).unwrap();
 
     let mut records = InMemoryAuthority::empty(
         origin.clone(),
@@ -157,7 +157,7 @@ async fn test_catalog_lookup() {
     assert_eq!(result.message_type(), MessageType::Response);
     assert!(result.header().authoritative());
 
-    let answers: &[Record] = result.answers();
+    let answers = result.answers();
 
     assert!(!answers.is_empty());
     assert_eq!(answers.first().unwrap().record_type(), RecordType::A);
@@ -191,7 +191,7 @@ async fn test_catalog_lookup() {
     assert_eq!(result.message_type(), MessageType::Response);
     assert!(result.header().authoritative());
 
-    let answers: &[Record] = result.answers();
+    let answers = result.answers();
 
     assert!(!answers.is_empty());
     assert_eq!(answers.first().unwrap().record_type(), RecordType::A);
@@ -237,7 +237,7 @@ async fn test_catalog_lookup_soa() {
     assert_eq!(result.message_type(), MessageType::Response);
     assert!(result.header().authoritative());
 
-    let answers: &[Record] = result.answers();
+    let answers = result.answers();
 
     assert!(!answers.is_empty());
     assert_eq!(answers.first().unwrap().record_type(), RecordType::SOA);
@@ -304,7 +304,7 @@ async fn test_catalog_nx_soa() {
     assert_eq!(result.message_type(), MessageType::Response);
     assert!(result.header().authoritative());
 
-    let authorities: &[Record] = result.authorities();
+    let authorities = result.authorities();
 
     assert_eq!(authorities.len(), 1);
     assert_eq!(authorities.first().unwrap().record_type(), RecordType::SOA);
@@ -406,14 +406,14 @@ async fn test_axfr_allow_all() {
         .await;
     let result = response_handler.into_message().await;
 
-    let mut answers: Vec<Record> = result.answers().to_vec();
+    let mut answers = result.answers().to_vec();
 
     assert_eq!(answers.first().expect("no records found?"), &soa);
     assert_eq!(answers.last().expect("no records found?"), &soa);
 
     answers.sort();
 
-    let www_name: Name = Name::parse("www.test.com.", None).unwrap();
+    let www_name = Name::parse("www.test.com.", None).unwrap();
     let mut expected_set = vec![
         Record::from_rdata(
             origin.clone().into(),
@@ -728,7 +728,7 @@ async fn test_cname_additionals() {
     assert_eq!(result.message_type(), MessageType::Response);
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
-    let answers: &[Record] = result.answers();
+    let answers = result.answers();
     assert_eq!(answers.len(), 1);
     assert_eq!(answers.first().unwrap().record_type(), RecordType::CNAME);
     assert_eq!(
@@ -736,7 +736,7 @@ async fn test_cname_additionals() {
         &RData::CNAME(CNAME(Name::from_str("www.example.com.").unwrap()))
     );
 
-    let additionals: &[Record] = result.additionals();
+    let additionals = result.additionals();
     assert!(!additionals.is_empty());
     assert_eq!(additionals.first().unwrap().record_type(), RecordType::A);
     assert_eq!(
@@ -777,7 +777,7 @@ async fn test_multiple_cname_additionals() {
     assert_eq!(result.message_type(), MessageType::Response);
     assert_eq!(result.response_code(), ResponseCode::NoError);
 
-    let answers: &[Record] = result.answers();
+    let answers = result.answers();
     assert_eq!(answers.len(), 1);
     assert_eq!(answers.first().unwrap().record_type(), RecordType::CNAME);
     assert_eq!(
@@ -786,7 +786,7 @@ async fn test_multiple_cname_additionals() {
     );
 
     // we should have the intermediate record
-    let additionals: &[Record] = result.additionals();
+    let additionals = result.additionals();
     assert!(!additionals.is_empty());
     assert_eq!(
         additionals.first().unwrap().record_type(),
@@ -798,7 +798,7 @@ async fn test_multiple_cname_additionals() {
     );
 
     // final record should be the actual
-    let additionals: &[Record] = result.additionals();
+    let additionals = result.additionals();
     assert!(!additionals.is_empty());
     assert_eq!(additionals.last().unwrap().record_type(), RecordType::A);
     assert_eq!(

--- a/tests/integration-tests/tests/integration/catalog_tests.rs
+++ b/tests/integration-tests/tests/integration/catalog_tests.rs
@@ -166,8 +166,8 @@ async fn test_catalog_lookup() {
         &RData::A(A::new(93, 184, 215, 14))
     );
 
-    let ns = result.name_servers();
-    assert!(ns.is_empty());
+    let authorities = result.authorities();
+    assert!(authorities.is_empty());
 
     // other zone
     let mut question = Message::query();
@@ -255,7 +255,7 @@ async fn test_catalog_lookup_soa() {
     );
 
     // assert SOA requests get NS records
-    let mut ns: Vec<Record> = result.name_servers().to_vec();
+    let mut ns = result.authorities().to_vec();
     ns.sort();
 
     assert_eq!(ns.len(), 2);
@@ -304,12 +304,12 @@ async fn test_catalog_nx_soa() {
     assert_eq!(result.message_type(), MessageType::Response);
     assert!(result.header().authoritative());
 
-    let ns: &[Record] = result.name_servers();
+    let authorities: &[Record] = result.authorities();
 
-    assert_eq!(ns.len(), 1);
-    assert_eq!(ns.first().unwrap().record_type(), RecordType::SOA);
+    assert_eq!(authorities.len(), 1);
+    assert_eq!(authorities.first().unwrap().record_type(), RecordType::SOA);
     assert_eq!(
-        ns.first().unwrap().data(),
+        authorities.first().unwrap().data(),
         &RData::SOA(SOA::new(
             Name::parse("sns.dns.icann.org.", None).unwrap(),
             Name::parse("noc.dns.icann.org.", None).unwrap(),
@@ -355,7 +355,7 @@ async fn test_non_authoritive_nx_refused() {
     assert_eq!(result.message_type(), MessageType::Response);
     assert!(!result.header().authoritative());
 
-    assert_eq!(result.name_servers().len(), 0);
+    assert_eq!(result.authorities().len(), 0);
     assert_eq!(result.answers().len(), 0);
     assert_eq!(result.additionals().len(), 0);
 }
@@ -526,7 +526,7 @@ async fn test_axfr_deny_all() {
 
     assert_eq!(result.response_code(), ResponseCode::Refused);
     assert!(result.answers().is_empty());
-    assert!(result.name_servers().is_empty());
+    assert!(result.authorities().is_empty());
     assert!(result.additionals().is_empty());
 }
 
@@ -563,7 +563,7 @@ async fn test_axfr_deny_unsigned() {
 
     assert_eq!(result.response_code(), ResponseCode::Refused);
     assert!(result.answers().is_empty());
-    assert!(result.name_servers().is_empty());
+    assert!(result.authorities().is_empty());
     assert!(result.additionals().is_empty());
 }
 
@@ -923,13 +923,13 @@ mod dnssec {
             assert!(result.answers().is_empty());
 
             result
-                .name_servers()
+                .authorities()
                 .iter()
                 .find(|e| e.record_type() == RecordType::SOA)
                 .expect("authority section to contains SOA");
 
             let nsec3 = result
-                .name_servers()
+                .authorities()
                 .iter()
                 .find(|e| e.record_type() == RecordType::NSEC3)
                 .expect("result to contain NSEC3");

--- a/tests/integration-tests/tests/integration/invalid_nsec3_tests.rs
+++ b/tests/integration-tests/tests/integration/invalid_nsec3_tests.rs
@@ -174,7 +174,7 @@ async fn referral_opt_out_unsigned() {
     assert_eq!(response.answer_count(), 0);
     assert!(
         response
-            .name_servers()
+            .authorities()
             .iter()
             .any(|record| record.record_type().is_ns())
     );
@@ -334,12 +334,12 @@ async fn test_exclude_nsec3(
 
     let mut modified_response = original_response.clone();
     modified_response
-        .name_servers_mut()
+        .authorities_mut()
         .retain(|record| record.name() != &nsec3_name);
-    let new_count = modified_response.name_servers().len().try_into().unwrap();
-    modified_response.set_name_server_count(new_count);
+    let new_count = modified_response.authorities().len().try_into().unwrap();
+    modified_response.set_authority_count(new_count);
     assert!(
-        modified_response.name_servers().len() < original_response.name_servers().len(),
+        modified_response.authorities().len() < original_response.authorities().len(),
         "failed to remove expected NSEC3 record and signature at {nsec3_owner_name}: {modified_response:?}"
     );
 

--- a/tests/integration-tests/tests/integration/invalid_nsec_tests.rs
+++ b/tests/integration-tests/tests/integration/invalid_nsec_tests.rs
@@ -250,13 +250,13 @@ async fn test_exclude_nsec(
     nsec_owner_name: Name,
 ) {
     let mut modified_response = original_response.clone();
-    modified_response.name_servers_mut().retain(|record| {
+    modified_response.authorities_mut().retain(|record| {
         record.name() != &nsec_owner_name || record.record_type() != RecordType::NSEC
     });
-    let new_count = modified_response.name_servers().len().try_into().unwrap();
-    modified_response.set_name_server_count(new_count);
+    let new_count = modified_response.authorities().len().try_into().unwrap();
+    modified_response.set_authority_count(new_count);
     assert!(
-        modified_response.name_servers().len() < original_response.name_servers().len(),
+        modified_response.authorities().len() < original_response.authorities().len(),
         "failed to remove expected NSEC record at {nsec_owner_name}: {modified_response:?}"
     );
 

--- a/tests/integration-tests/tests/integration/server_future_tests.rs
+++ b/tests/integration-tests/tests/integration/server_future_tests.rs
@@ -111,11 +111,11 @@ async fn test_server_unknown_type() {
         RecordType::Unknown(65535)
     );
     assert!(client_result.answers().is_empty());
-    assert!(!client_result.name_servers().is_empty());
+    assert!(!client_result.authorities().is_empty());
     // SOA should be the first record in the response
     assert_eq!(
         client_result
-            .name_servers()
+            .authorities()
             .first()
             .expect("no SOA present")
             .record_type(),

--- a/tests/integration-tests/tests/integration/sqlite_authority_tests.rs
+++ b/tests/integration-tests/tests/integration/sqlite_authority_tests.rs
@@ -1219,7 +1219,7 @@ fn test_update_message(name: Name) -> Message {
     message
         .set_op_code(OpCode::Update)
         .add_query(q)
-        .add_name_server(add_rec);
+        .add_authority(add_rec);
     message
 }
 


### PR DESCRIPTION
The field representing the Authority section of messages has been named `name_servers` up to now, presumably after `NSCOUNT` in the header. I think it is clearer to use `authority` or `authorities`, after the name of the section itself.