### PR TITLE
David/plumb recursive response message

### DIFF
--- a/bin/tests/integration/authority_battery/basic.rs
+++ b/bin/tests/integration/authority_battery/basic.rs
@@ -102,7 +102,7 @@ pub fn test_ns_lookup(authority: impl Authority) {
         .0
         .unwrap();
 
-    let additionals = dbg!(lookup.additionals().expect("no additionals in response"));
+    let additionals = lookup.additionals().expect("no additionals in response");
 
     let ns = lookup
         .into_iter()
@@ -139,7 +139,7 @@ pub fn test_mx(authority: impl Authority) {
         .0
         .unwrap();
 
-    let additionals = dbg!(lookup.additionals().expect("no additionals in response"));
+    let additionals = lookup.additionals().expect("no additionals in response");
 
     let mx = lookup
         .into_iter()
@@ -350,8 +350,6 @@ pub fn test_aname(authority: impl Authority) {
         .0
         .unwrap();
 
-    let additionals = lookup.additionals().expect("no additionals from ANAME");
-
     let aname = lookup
         .into_iter()
         .next()
@@ -363,16 +361,18 @@ pub fn test_aname(authority: impl Authority) {
     assert_eq!(Name::from_str("www.example.com.").unwrap(), aname.0);
 
     // check that additionals contain the info
-    let a = additionals
-        .iter()
+    let a = lookup
+        .additionals()
+        .expect("no additionals from ANAME")
         .find(|r| r.record_type() == RecordType::A)
         .map(Record::data)
         .and_then(RData::as_a)
         .expect("A not found");
     assert_eq!(A4::new(127, 0, 0, 1), *a);
 
-    let aaaa = additionals
-        .iter()
+    let aaaa = lookup
+        .additionals()
+        .unwrap()
         .find(|r| r.record_type() == RecordType::AAAA)
         .map(Record::data)
         .and_then(RData::as_aaaa)
@@ -758,7 +758,7 @@ pub fn test_srv(authority: impl Authority) {
         .0
         .unwrap();
 
-    let additionals = dbg!(lookup.additionals().expect("no additionals in response"));
+    let additionals = lookup.additionals().expect("no additionals in response");
 
     let srv = lookup
         .into_iter()

--- a/bin/tests/integration/in_memory.rs
+++ b/bin/tests/integration/in_memory.rs
@@ -108,8 +108,10 @@ fn test_cname_loop() {
         &RData::CNAME(CNAME(Name::from_str("foo.example.com.").unwrap()))
     );
 
-    let additionals = lookup.additionals().expect("Should be additional records");
-    let additionals: Vec<&Record> = additionals.iter().collect();
+    let additionals: Vec<&Record> = lookup
+        .additionals()
+        .expect("Should be additional records")
+        .collect();
     assert_eq!(additionals.len(), 1);
     let record = additionals[0];
     assert_eq!(record.name(), &Name::from_str("foo.example.com.").unwrap());
@@ -135,8 +137,10 @@ fn test_cname_loop() {
         &RData::CNAME(CNAME(Name::from_str("boz.example.com.").unwrap()))
     );
 
-    let additionals = lookup.additionals().expect("Should be additional records");
-    let additionals: Vec<&Record> = additionals.iter().collect();
+    let additionals: Vec<&Record> = lookup
+        .additionals()
+        .expect("Should be additional records")
+        .collect();
     assert_eq!(additionals.len(), 2);
     let record = additionals[0];
     assert_eq!(record.name(), &Name::from_str("boz.example.com.").unwrap());

--- a/crates/server/src/store/recursor.rs
+++ b/crates/server/src/store/recursor.rs
@@ -17,7 +17,7 @@ use std::{
     io::{self, Read},
     net::IpAddr,
     path::{Path, PathBuf},
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 use ipnet::IpNet;
@@ -40,7 +40,7 @@ use crate::{
         serialize::txt::{ParseError, Parser},
     },
     recursor::{DnssecPolicy, Recursor},
-    resolver::{TtlConfig, lookup::Lookup},
+    resolver::TtlConfig,
     server::Request,
 };
 
@@ -153,22 +153,7 @@ impl<P: RuntimeProvider> Authority for RecursiveAuthority<P> {
             Ok(response) => response,
             Err(error) => return LookupControlFlow::Continue(Err(LookupError::from(error))),
         };
-        let records = response
-            .answers()
-            .iter()
-            .cloned()
-            .collect::<Arc<[Record]>>();
-        let min_ttl = records
-            .iter()
-            .map(|record| record.ttl())
-            .min()
-            .unwrap_or_default();
-        let valid_until = now + Duration::from_secs(min_ttl.into());
-        LookupControlFlow::Continue(Ok(AuthLookup::from(Lookup::new_with_deadline(
-            query,
-            records,
-            valid_until,
-        ))))
+        LookupControlFlow::Continue(Ok(AuthLookup::Response(response)))
     }
 
     async fn search(


### PR DESCRIPTION
This adds a new variant to `AuthLookup` that stores an entire DNS message, and a corresponding variant to `LookupRecords` that stores a vector of records. It also changes the `RecursiveAuthority` to return this new variant, instead of returning just the Answer section in a `Lookup`.

As a result, we can now return Additional section records. Returning Authority section records will require `build_forwarded_response()` in a subsequent PR.