### PR TITLE
Cleanup: Add clear_system_defaults method to reset resolver domain and search paths (Fixes #1899)

### DIFF
--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -162,6 +162,12 @@ impl ResolverConfig {
     pub fn name_servers(&self) -> &[NameServerConfig] {
         &self.name_servers
     }
+
+    /// Clear the name servers
+    pub fn clear_system_defaults(&mut self) {
+        self.domain = Some(Name::root()); // Set to root domain ('.')
+        self.search.clear();              // Remove all search domains
+    }
 }
 
 /// Configuration for the NameServer

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -924,3 +924,30 @@ mod tests {
         assert_eq!(code.trust_anchor, json.trust_anchor);
     }
 }
+
+mod system_defaults {
+    use super::*;
+
+    #[test]
+    fn test_clear_system_defaults() {
+        let mut config = ResolverConfig::default();
+        // Set a domain and add a search domain
+        let domain = Name::from_ascii("example.com.").unwrap();
+        config.set_domain(domain);
+        let search = Name::from_ascii("search.example.com.").unwrap();
+        config.add_search(search);
+
+        // Verify initial state
+        assert!(config.domain().is_some());
+        assert_eq!(config.domain().unwrap().to_string(), "example.com.");
+        assert_eq!(config.search().len(), 2); // domain + search domain
+
+        // Clear system defaults
+        config.clear_system_defaults();
+
+        // Verify the domain is now root and search is cleared
+        assert!(config.domain().is_some());
+        assert_eq!(config.domain().unwrap().to_string(), ".");
+        assert_eq!(config.search().len(), 0);
+    }
+}


### PR DESCRIPTION
Introduces a new method, clear_system_defaults, to the resolver configuration struct. The method resets the resolver’s domain to the root (.) and clears all search domains. This enables library users to programmatically remove inherited system search/domain paths, preventing unintended DNS suffix expansion (such as those described in [#1899](https://github.com/hickory-dns/hickory-dns/issues/1899)).