### PR TITLE
Bump h2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,9 +700,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
This PR bumps the `h2` dependency from `v0.4.10` -> `v0.4.11`

Release `v0.4.11` of `h2` includes a change to the way clients handle connections closed by the server with a `go_away` messages that resolves the issue described in #3064.