### PR TITLE
Fix client integration tests

### DIFF
--- a/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
+++ b/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
@@ -95,11 +95,11 @@ where
     assert_eq!(response.response_code(), ResponseCode::NXDomain);
 }
 
-// TODO: NSEC response code wrong in Hickory DNS? Issue #53
-// #[test]
-// fn test_nsec_query_type_nonet() {
-//   with_nonet(test_nsec_query_type);
-// }
+#[tokio::test]
+async fn test_nsec_query_type_nonet() {
+    subscribe();
+    with_nonet(test_nsec_query_type).await;
+}
 
 #[tokio::test]
 #[ignore = "flaky test against internet server"]
@@ -284,7 +284,6 @@ where
     join.join().unwrap();
 }
 
-// TODO: just make this a Tokio test?
 async fn with_tcp<F, Fut>(test: F)
 where
     F: Fn(DnssecDnsHandle<MemoizeClientHandle<Client>>) -> Fut,

--- a/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
+++ b/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
@@ -243,7 +243,7 @@ where
     let client = MemoizeClientHandle::new(client);
     let secure_client = DnssecDnsHandle::with_trust_anchor(client, trust_anchor);
 
-    test(secure_client);
+    test(secure_client).await;
     succeeded.store(true, std::sync::atomic::Ordering::Relaxed);
     join.join().unwrap();
 }
@@ -279,7 +279,7 @@ where
     let client = MemoizeClientHandle::new(client);
     let secure_client = DnssecDnsHandle::new(client);
 
-    test(secure_client);
+    test(secure_client).await;
     succeeded.store(true, std::sync::atomic::Ordering::Relaxed);
     join.join().unwrap();
 }
@@ -316,7 +316,7 @@ where
     let client = MemoizeClientHandle::new(client);
     let secure_client = DnssecDnsHandle::new(client);
 
-    test(secure_client);
+    test(secure_client).await;
     succeeded.store(true, std::sync::atomic::Ordering::Relaxed);
     join.join().unwrap();
 }


### PR DESCRIPTION
I tried running some DNSSEC client tests with logging turned up, and noticed that the client query was not actually taking place. This PR fixes the tests by awaiting futures returned when calling test functions that are passed in.

FWIW, rustc cannot produce a warning to catch this mistake as-written, but it does warn when I replace the type variables and where clauses with `impl AsyncFn`. See https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=323890d55918c263ce3ed0f9e53d94e8. Note that `AsyncFn` was only just stabilized in 1.85.