### PR TITLE
Fix documentation of DNS_TEST_SUBJECT

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -33,7 +33,7 @@ $ cargo run --example explore
 By default, this will use `unbound` as the resolver. You can switch the resolver to `hickory-dns` using the `DNS_TEST_SUBJECT` environment variable:
 
 ``` shell
-$ DNS_TEST_SUBJECT="hickory https://github.com/hickory-dns/hickory-dns" cargo run --example explore
+$ DNS_TEST_SUBJECT="hickory https://github.com/hickory-dns/hickory-dns dnssec-aws-lc-rs" cargo run --example explore
 ```
 
 ### Environment variables
@@ -123,7 +123,7 @@ $ cargo test -p conformance-tests -- --include-ignored
 To run the conformance tests against `hickory-dns` run:
 
 ``` console
-$ DNS_TEST_SUBJECT="hickory /path/to/repository" cargo test -p conformance-tests
+$ DNS_TEST_SUBJECT="hickory /path/to/repository dnssec-aws-lc-rs" cargo test -p conformance-tests
 ```
 
 ### Test organization

--- a/conformance/packages/dns-test/src/lib.rs
+++ b/conformance/packages/dns-test/src/lib.rs
@@ -135,8 +135,8 @@ fn parse_implementation(env_var: &str) -> Implementation {
             let Ok([_, url, dnssec_feature]) = <[&str; 3]>::try_from(tokens) else {
                 panic!(
                     "the syntax of {env_var} is 'hickory $URL $DNSSEC_FEATURE', e.g. \
-                    'hickory /tmp/hickory aws-lc-rs' or \
-                    'hickory https://github.com/owner/repo ring'"
+                    'hickory /tmp/hickory dnssec-aws-lc-rs' or \
+                    'hickory https://github.com/owner/repo dnssec-ring'"
                 )
             };
             Implementation::Hickory {


### PR DESCRIPTION
This fixes the documentation of the `DNS_TEST_SUBJECT` environment variable in places where it was out of date.