### PR TITLE
Add test of DNSSEC validation with missing SOA RR

### DIFF
--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios.rs
@@ -1,5 +1,6 @@
 mod bogus;
 mod ede;
 mod insecure;
+mod no_soa;
 mod nsec3;
 mod secure;

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/no_soa.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/no_soa.rs
@@ -1,0 +1,47 @@
+use std::fs;
+
+use dns_test::{
+    FQDN, Implementation, Network, PEER, Resolver, Result,
+    client::{Client, DigSettings, DigStatus},
+    name_server::NameServer,
+    record::RecordType,
+    zone_file::SignSettings,
+};
+
+#[test]
+#[ignore = "hickory returns a validation error due to the missing SOA record even though the zone is insecure"]
+fn no_soa_insecure() -> Result<()> {
+    let target_fqdn = FQDN::TEST_DOMAIN;
+    let network = Network::new()?;
+
+    let mut root_ns = NameServer::new(&PEER, FQDN::ROOT, &network)?;
+    let leaf_ns = NameServer::new(&Implementation::Dnslib, FQDN::TEST_TLD, &network)?;
+    let script = fs::read_to_string("src/resolver/dns/scenarios/empty_response.py")?;
+    leaf_ns.cp("/script.py", &script)?;
+
+    root_ns.referral_nameserver(&leaf_ns);
+
+    let root_ns = root_ns.sign(SignSettings::default())?;
+
+    let root_hint = root_ns.root_hint();
+    let resolver = Resolver::new(&network, root_hint)
+        .trust_anchor(&root_ns.trust_anchor())
+        .start()?;
+    let client = Client::new(resolver.network())?;
+    let dig_settings = *DigSettings::default().recurse();
+
+    let _root_ns = root_ns.start()?;
+    let _leaf_ns = leaf_ns.start()?;
+
+    let response = client.dig(
+        dig_settings,
+        resolver.ipv4_addr(),
+        RecordType::A,
+        &target_fqdn,
+    )?;
+
+    assert_eq!(response.status, DigStatus::NOERROR);
+    assert!(response.answer.is_empty());
+
+    Ok(())
+}


### PR DESCRIPTION
This adds an ignored test for #3128. This is a copy of the test from #2950, but with DNSSEC validation enabled.