### PR TITLE
Ignore RRSIGs that claim NSEC/NSEC3 wildcards

### DIFF
--- a/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
@@ -855,6 +855,16 @@ fn verify_rrsig_with_keys(
 ) -> Option<(Proof, Option<u32>)> {
     let mut tag_count = HashMap::<u16, usize>::new();
 
+    if (rrset.record_type() == RecordType::NSEC || rrset.record_type() == RecordType::NSEC3)
+        && rrset.name().num_labels() != rrsig.data().input().num_labels
+    {
+        warn!(
+            "{} record signature claims to be expanded from a wildcard",
+            rrset.record_type()
+        );
+        return None;
+    }
+
     // DNSKEYs were already validated by the inner query in the above lookup
     let dnskeys = dnskey_message.answers().iter().filter_map(|r| {
         let dnskey = r.try_borrow::<DNSKEY>()?;


### PR DESCRIPTION
This adds a check for RRSIG records that cover NSEC or NSEC3 RRsets with a wildcard name that has been expanded. In order to address #2882, RRset validation will need to become re-entrant, since validating a wildcard expanded RRset requires validating one or more NSEC or NSEC3 RRsets. This PR gets out ahead of a possible infinite loop that could be triggered by a malicious server. Names of NSEC and NSEC3 records are spelled out in their respective RFCs, and neither can contain a wildcard label, so I think it should be fine to just ignore the relevant RRSIG, and treat the record as bogus.