### PR TITLE
Simplify and replace future combinators

### DIFF
--- a/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
@@ -15,7 +15,7 @@ use std::{
 };
 
 use futures_util::{
-    future::{self, TryFutureExt},
+    future::{self, FutureExt},
     stream::{self, Stream, StreamExt},
 };
 use tracing::{debug, error, trace, warn};
@@ -743,12 +743,20 @@ impl<H: DnsHandle> DnssecDnsHandle<H> {
                 Some(
                     self.lookup(query.clone(), options)
                         .first_answer()
-                        .map_err(|proto| {
-                            ProofError::new(Proof::Bogus, ProofErrorKind::Proto { query, proto })
-                        })
-                        .map_ok(move |message| {
-                            verify_rrsig_with_keys(message, rrsig, rrset, current_time)
-                                .map(|(proof, adjusted_ttl)| (proof, adjusted_ttl, Some(i)))
+                        .map(move |result| match result {
+                            Ok(message) => {
+                                if let Some((proof, adjusted_ttl)) =
+                                    verify_rrsig_with_keys(message, rrsig, rrset, current_time)
+                                {
+                                    Ok(Some((proof, adjusted_ttl, Some(i))))
+                                } else {
+                                    Ok(None)
+                                }
+                            }
+                            Err(proto) => Err(ProofError::new(
+                                Proof::Bogus,
+                                ProofErrorKind::Proto { query, proto },
+                            )),
                         }),
                 )
             })

--- a/crates/proto/src/h3/h3_client_stream.rs
+++ b/crates/proto/src/h3/h3_client_stream.rs
@@ -16,8 +16,10 @@ use core::task::{Context, Poll};
 use std::net::SocketAddr;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use futures_util::future::FutureExt;
-use futures_util::stream::Stream;
+use futures_util::{
+    future::{BoxFuture, FutureExt},
+    stream::Stream,
+};
 use h3::client::SendRequest;
 use h3_quinn::OpenStreams;
 use http::header::{self, CONTENT_LENGTH};
@@ -450,9 +452,7 @@ impl Default for H3ClientStreamBuilder {
 }
 
 /// A future that resolves to an H3ClientStream
-pub struct H3ClientConnect(
-    Pin<Box<dyn Future<Output = Result<H3ClientStream, ProtoError>> + Send>>,
-);
+pub struct H3ClientConnect(BoxFuture<'static, Result<H3ClientStream, ProtoError>>);
 
 impl Future for H3ClientConnect {
     type Output = Result<H3ClientStream, ProtoError>;
@@ -463,7 +463,7 @@ impl Future for H3ClientConnect {
 }
 
 /// A future that resolves to
-pub struct H3ClientResponse(Pin<Box<dyn Future<Output = Result<DnsResponse, ProtoError>> + Send>>);
+pub struct H3ClientResponse(BoxFuture<'static, Result<DnsResponse, ProtoError>>);
 
 impl Future for H3ClientResponse {
     type Output = Result<DnsResponse, ProtoError>;

--- a/crates/proto/src/multicast/mdns_client_stream.rs
+++ b/crates/proto/src/multicast/mdns_client_stream.rs
@@ -12,7 +12,10 @@ use core::pin::Pin;
 use core::task::{Context, Poll};
 use std::net::{Ipv4Addr, SocketAddr};
 
-use futures_util::stream::{Stream, StreamExt, TryStreamExt};
+use futures_util::{
+    future::BoxFuture,
+    stream::{Stream, StreamExt, TryStreamExt},
+};
 
 use crate::BufDnsStreamHandle;
 use crate::error::ProtoError;
@@ -108,9 +111,7 @@ impl Stream for MdnsClientStream {
 }
 
 /// A future that resolves to an MdnsClientStream
-pub struct MdnsClientConnect(
-    Pin<Box<dyn Future<Output = Result<MdnsClientStream, ProtoError>> + Send>>,
-);
+pub struct MdnsClientConnect(BoxFuture<'static, Result<MdnsClientStream, ProtoError>>);
 
 impl Future for MdnsClientConnect {
     type Output = Result<MdnsClientStream, ProtoError>;

--- a/crates/proto/src/multicast/mdns_stream.rs
+++ b/crates/proto/src/multicast/mdns_stream.rs
@@ -307,7 +307,7 @@ impl Stream for MdnsStream {
                     ))
                 };
 
-                self.rcving_mcast = Some(Box::pin(receive_future.boxed()));
+                self.rcving_mcast = Some(Box::pin(receive_future));
             }
         }
     }

--- a/crates/proto/src/quic/quic_client_stream.rs
+++ b/crates/proto/src/quic/quic_client_stream.rs
@@ -14,7 +14,10 @@ use core::{
 };
 use std::{io, net::SocketAddr};
 
-use futures_util::{future::FutureExt, stream::Stream};
+use futures_util::{
+    future::{BoxFuture, FutureExt},
+    stream::Stream,
+};
 use quinn::{
     ClientConfig, Connection, Endpoint, TransportConfig, VarInt, crypto::rustls::QuicClientConfig,
 };
@@ -354,9 +357,7 @@ impl Default for QuicClientStreamBuilder {
 }
 
 /// A future that resolves to an QuicClientStream
-pub struct QuicClientConnect(
-    Pin<Box<dyn Future<Output = Result<QuicClientStream, ProtoError>> + Send>>,
-);
+pub struct QuicClientConnect(BoxFuture<'static, Result<QuicClientStream, ProtoError>>);
 
 impl Future for QuicClientConnect {
     type Output = Result<QuicClientStream, ProtoError>;
@@ -367,9 +368,7 @@ impl Future for QuicClientConnect {
 }
 
 /// A future that resolves to
-pub struct QuicClientResponse(
-    Pin<Box<dyn Future<Output = Result<DnsResponse, ProtoError>> + Send>>,
-);
+pub struct QuicClientResponse(BoxFuture<'static, Result<DnsResponse, ProtoError>>);
 
 impl Future for QuicClientResponse {
     type Output = Result<DnsResponse, ProtoError>;

--- a/crates/proto/src/rustls/tls_client_stream.rs
+++ b/crates/proto/src/rustls/tls_client_stream.rs
@@ -14,7 +14,6 @@ use core::pin::Pin;
 use std::io;
 use std::net::SocketAddr;
 
-use futures_util::TryFutureExt;
 use rustls::{ClientConfig, pki_types::ServerName};
 
 use crate::error::ProtoError;
@@ -42,7 +41,7 @@ pub fn tls_client_connect<P: RuntimeProvider>(
     client_config: Arc<ClientConfig>,
     provider: P,
 ) -> (
-    Pin<Box<dyn Future<Output = Result<TlsClientStream<P::Tcp>, ProtoError>> + Send + Unpin>>,
+    Pin<Box<dyn Future<Output = Result<TlsClientStream<P::Tcp>, ProtoError>> + Send>>,
     BufDnsStreamHandle,
 ) {
     tls_client_connect_with_bind_addr(name_server, None, server_name, client_config, provider)
@@ -63,17 +62,16 @@ pub fn tls_client_connect_with_bind_addr<P: RuntimeProvider>(
     client_config: Arc<ClientConfig>,
     provider: P,
 ) -> (
-    Pin<Box<dyn Future<Output = Result<TlsClientStream<P::Tcp>, ProtoError>> + Send + Unpin>>,
+    Pin<Box<dyn Future<Output = Result<TlsClientStream<P::Tcp>, ProtoError>> + Send>>,
     BufDnsStreamHandle,
 ) {
     let (stream_future, sender) =
         tls_connect_with_bind_addr(name_server, bind_addr, server_name, client_config, provider);
 
-    let new_future = Box::pin(
-        stream_future
-            .map_ok(TcpClientStream::from_stream)
-            .map_err(ProtoError::from),
-    );
+    let new_future = Box::pin(async {
+        let tcp_stream = stream_future.await?;
+        Ok(TcpClientStream::from_stream(tcp_stream))
+    });
 
     (new_future, sender)
 }
@@ -91,7 +89,7 @@ pub fn tls_client_connect_with_future<S, F>(
     server_name: ServerName<'static>,
     client_config: Arc<ClientConfig>,
 ) -> (
-    Pin<Box<dyn Future<Output = Result<TlsClientStream<S>, ProtoError>> + Send + Unpin>>,
+    Pin<Box<dyn Future<Output = Result<TlsClientStream<S>, ProtoError>> + Send>>,
     BufDnsStreamHandle,
 )
 where
@@ -101,11 +99,10 @@ where
     let (stream_future, sender) =
         tls_connect_with_future(future, socket_addr, server_name, client_config);
 
-    let new_future = Box::pin(
-        stream_future
-            .map_ok(TcpClientStream::from_stream)
-            .map_err(ProtoError::from),
-    );
+    let new_future = Box::pin(async {
+        let tcp_stream = stream_future.await?;
+        Ok(TcpClientStream::from_stream(tcp_stream))
+    });
 
     (new_future, sender)
 }

--- a/crates/proto/src/rustls/tls_client_stream.rs
+++ b/crates/proto/src/rustls/tls_client_stream.rs
@@ -10,10 +10,10 @@
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use core::future::Future;
-use core::pin::Pin;
 use std::io;
 use std::net::SocketAddr;
 
+use futures_util::future::BoxFuture;
 use rustls::{ClientConfig, pki_types::ServerName};
 
 use crate::error::ProtoError;
@@ -41,7 +41,7 @@ pub fn tls_client_connect<P: RuntimeProvider>(
     client_config: Arc<ClientConfig>,
     provider: P,
 ) -> (
-    Pin<Box<dyn Future<Output = Result<TlsClientStream<P::Tcp>, ProtoError>> + Send>>,
+    BoxFuture<'static, Result<TlsClientStream<P::Tcp>, ProtoError>>,
     BufDnsStreamHandle,
 ) {
     tls_client_connect_with_bind_addr(name_server, None, server_name, client_config, provider)
@@ -62,7 +62,7 @@ pub fn tls_client_connect_with_bind_addr<P: RuntimeProvider>(
     client_config: Arc<ClientConfig>,
     provider: P,
 ) -> (
-    Pin<Box<dyn Future<Output = Result<TlsClientStream<P::Tcp>, ProtoError>> + Send>>,
+    BoxFuture<'static, Result<TlsClientStream<P::Tcp>, ProtoError>>,
     BufDnsStreamHandle,
 ) {
     let (stream_future, sender) =
@@ -82,14 +82,13 @@ pub fn tls_client_connect_with_bind_addr<P: RuntimeProvider>(
 ///
 /// * `future` - A future producing DnsTcpStream
 /// * `dns_name` - The DNS name associated with a certificate
-#[allow(clippy::type_complexity)]
 pub fn tls_client_connect_with_future<S, F>(
     future: F,
     socket_addr: SocketAddr,
     server_name: ServerName<'static>,
     client_config: Arc<ClientConfig>,
 ) -> (
-    Pin<Box<dyn Future<Output = Result<TlsClientStream<S>, ProtoError>> + Send>>,
+    BoxFuture<'static, Result<TlsClientStream<S>, ProtoError>>,
     BufDnsStreamHandle,
 )
 where

--- a/crates/proto/src/rustls/tls_stream.rs
+++ b/crates/proto/src/rustls/tls_stream.rs
@@ -10,10 +10,10 @@
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use core::future::Future;
-use core::pin::Pin;
 use std::io;
 use std::net::SocketAddr;
 
+use futures_util::future::BoxFuture;
 use rustls::ClientConfig;
 use rustls::pki_types::ServerName;
 use tokio::net::TcpStream as TokioTcpStream;
@@ -79,15 +79,9 @@ pub fn tls_connect<P: RuntimeProvider>(
     client_config: Arc<ClientConfig>,
     provider: P,
 ) -> (
-    Pin<
-        Box<
-            dyn Future<
-                    Output = Result<
-                        TlsStream<AsyncIoTokioAsStd<TokioTlsClientStream<P::Tcp>>>,
-                        io::Error,
-                    >,
-                > + Send,
-        >,
+    BoxFuture<
+        'static,
+        Result<TlsStream<AsyncIoTokioAsStd<TokioTlsClientStream<P::Tcp>>>, io::Error>,
     >,
     BufDnsStreamHandle,
 ) {
@@ -109,15 +103,9 @@ pub fn tls_connect_with_bind_addr<P: RuntimeProvider>(
     client_config: Arc<ClientConfig>,
     provider: P,
 ) -> (
-    Pin<
-        Box<
-            dyn Future<
-                    Output = Result<
-                        TlsStream<AsyncIoTokioAsStd<TokioTlsClientStream<P::Tcp>>>,
-                        io::Error,
-                    >,
-                > + Send,
-        >,
+    BoxFuture<
+        'static,
+        Result<TlsStream<AsyncIoTokioAsStd<TokioTlsClientStream<P::Tcp>>>, io::Error>,
     >,
     BufDnsStreamHandle,
 ) {
@@ -153,16 +141,7 @@ pub fn tls_connect_with_future<S, F>(
     server_name: ServerName<'static>,
     client_config: Arc<ClientConfig>,
 ) -> (
-    Pin<
-        Box<
-            dyn Future<
-                    Output = Result<
-                        TlsStream<AsyncIoTokioAsStd<TokioTlsClientStream<S>>>,
-                        io::Error,
-                    >,
-                > + Send,
-        >,
-    >,
+    BoxFuture<'static, Result<TlsStream<AsyncIoTokioAsStd<TokioTlsClientStream<S>>>, io::Error>>,
     BufDnsStreamHandle,
 )
 where

--- a/crates/proto/src/tcp/tcp_client_stream.rs
+++ b/crates/proto/src/tcp/tcp_client_stream.rs
@@ -7,13 +7,12 @@
 
 use alloc::boxed::Box;
 use core::fmt::{self, Display};
-use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll};
 use core::time::Duration;
 use std::net::SocketAddr;
 
-use futures_util::{StreamExt, stream::Stream};
+use futures_util::{StreamExt, future::BoxFuture, stream::Stream};
 use tracing::warn;
 
 use crate::BufDnsStreamHandle;
@@ -39,14 +38,13 @@ where
 
 impl<S: DnsTcpStream> TcpClientStream<S> {
     /// Create a new TcpClientStream
-    #[allow(clippy::type_complexity)]
     pub fn new<P: RuntimeProvider<Tcp = S>>(
         peer_addr: SocketAddr,
         bind_addr: Option<SocketAddr>,
         timeout: Option<Duration>,
         provider: P,
     ) -> (
-        Pin<Box<dyn Future<Output = Result<Self, ProtoError>> + Send + 'static>>,
+        BoxFuture<'static, Result<Self, ProtoError>>,
         BufDnsStreamHandle,
     ) {
         let (sender, outbound_messages) = BufDnsStreamHandle::new(peer_addr);

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -188,7 +188,7 @@ impl<P: RuntimeProvider> DnsRequestSender for UdpClientStream<P> {
         let avoid_local_ports = self.avoid_local_ports.clone();
         let os_port_selection = self.os_port_selection;
 
-        P::Timer::timeout::<Pin<Box<dyn Future<Output = Result<DnsResponse, ProtoError>> + Send>>>(
+        P::Timer::timeout(
             self.timeout,
             Box::pin(async move {
                 let socket = NextRandomUdpSocket::new(

--- a/crates/proto/src/udp/udp_stream.rs
+++ b/crates/proto/src/udp/udp_stream.rs
@@ -15,8 +15,11 @@ use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use async_trait::async_trait;
-use futures_util::stream::Stream;
-use futures_util::{future::Future, ready};
+use futures_util::{
+    future::{BoxFuture, Future},
+    ready,
+    stream::Stream,
+};
 use tracing::{debug, trace, warn};
 
 use crate::runtime::{RuntimeProvider, Time};
@@ -108,7 +111,6 @@ impl<P: RuntimeProvider> UdpStream<P> {
     ///
     /// A tuple of a Future of a Stream which will handle sending and receiving messages, and a
     ///  handle which can be used to send messages into the stream.
-    #[allow(clippy::type_complexity)]
     pub fn new(
         remote_addr: SocketAddr,
         bind_addr: Option<SocketAddr>,
@@ -116,7 +118,7 @@ impl<P: RuntimeProvider> UdpStream<P> {
         os_port_selection: bool,
         provider: P,
     ) -> (
-        Pin<Box<dyn Future<Output = Result<Self, io::Error>> + Send>>,
+        BoxFuture<'static, Result<Self, io::Error>>,
         BufDnsStreamHandle,
     ) {
         let (message_sender, outbound_messages) = BufDnsStreamHandle::new(remote_addr);

--- a/crates/recursor/src/recursor_pool.rs
+++ b/crates/recursor/src/recursor_pool.rs
@@ -12,7 +12,10 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures_util::{Future, FutureExt, StreamExt, future::Shared};
+use futures_util::{
+    Future, FutureExt, StreamExt,
+    future::{BoxFuture, Shared},
+};
 use hickory_resolver::name_server::NameServerPool;
 use parking_lot::Mutex;
 use tracing::info;
@@ -24,11 +27,8 @@ use crate::proto::{
 };
 use crate::resolver::{Name, name_server::ConnectionProvider};
 
-#[allow(clippy::type_complexity)]
 #[derive(Clone)]
-pub(crate) struct SharedLookup(
-    Shared<Pin<Box<dyn Future<Output = Option<Result<DnsResponse, ProtoError>>> + Send + 'static>>>,
-);
+pub(crate) struct SharedLookup(Shared<BoxFuture<'static, Option<Result<DnsResponse, ProtoError>>>>);
 
 impl Future for SharedLookup {
     type Output = Result<DnsResponse, ProtoError>;

--- a/crates/resolver/src/caching_client.rs
+++ b/crates/resolver/src/caching_client.rs
@@ -9,11 +9,10 @@
 
 use std::{
     borrow::Cow,
-    future::Future,
-    pin::Pin,
     time::{Duration, Instant},
 };
 
+use futures_util::future::BoxFuture;
 use once_cell::sync::Lazy;
 
 use crate::{
@@ -103,7 +102,7 @@ where
         &self,
         query: Query,
         options: DnsRequestOptions,
-    ) -> Pin<Box<dyn Future<Output = Result<Lookup, ProtoError>> + Send>> {
+    ) -> BoxFuture<'static, Result<Lookup, ProtoError>> {
         Box::pin(Self::inner_lookup(
             query,
             options,
@@ -422,7 +421,7 @@ enum Records {
     Exists(Vec<Record>),
     /// Future lookup for recursive cname records
     CnameChain {
-        next: Pin<Box<dyn Future<Output = Result<Lookup, ProtoError>> + Send>>,
+        next: BoxFuture<'static, Result<Lookup, ProtoError>>,
     },
 }
 

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -92,32 +92,24 @@
 //! to a server, for example:
 //!
 //! ```rust,no_run
-//! # fn main() {
 //! # #[cfg(feature = "tokio")]
-//! # {
-//! # use std::net::*;
+//! # #[tokio::main]
+//! # async fn main() {
+//! # use std::net::TcpStream;
 //! # use tokio::runtime::Runtime;
 //! # use hickory_resolver::Resolver;
 //! # use hickory_resolver::proto::runtime::TokioRuntimeProvider;
-//! # use hickory_resolver::config::*;
-//! # use futures_util::TryFutureExt;
-//! #
-//! # let mut io_loop = Runtime::new().unwrap();
+//! # use hickory_resolver::config::ResolverConfig;
 //! #
 //! # let resolver = Resolver::builder_with_config(
 //! #     ResolverConfig::default(),
 //! #     TokioRuntimeProvider::default()
 //! # ).build();
 //! #
-//! let ips = io_loop.block_on(resolver.lookup_ip("www.example.com.")).unwrap();
-//!
-//! let result = io_loop.block_on(async {
-//!     let ip = ips.iter().next().unwrap();
-//!     TcpStream::connect((ip, 443))
-//! })
-//! .and_then(|conn| Ok(conn) /* do something with the connection... */)
-//! .unwrap();
-//! # }
+//! let ips = resolver.lookup_ip("www.example.com.").await.unwrap();
+//! let ip = ips.iter().next().unwrap();
+//! let conn = TcpStream::connect((ip, 443)).unwrap();
+//! /* do something with the connection... */
 //! # }
 //! ```
 //!

--- a/crates/resolver/src/lookup_ip.rs
+++ b/crates/resolver/src/lookup_ip.rs
@@ -16,7 +16,10 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Instant;
 
-use futures_util::{FutureExt, future, future::Either};
+use futures_util::{
+    FutureExt,
+    future::{self, BoxFuture, Either},
+};
 use tracing::debug;
 
 use crate::proto::ProtoError;
@@ -98,7 +101,7 @@ pub struct LookupIpFuture<C: DnsHandle + 'static> {
     names: Vec<Name>,
     strategy: LookupIpStrategy,
     options: DnsRequestOptions,
-    query: Pin<Box<dyn Future<Output = Result<Lookup, ProtoError>> + Send>>,
+    query: BoxFuture<'static, Result<Lookup, ProtoError>>,
     hosts: Arc<Hosts>,
     finally_ip_addr: Option<RData>,
 }

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -14,7 +14,6 @@ use std::sync::{
 };
 use std::time::Duration;
 
-use futures_util::future::FutureExt;
 use futures_util::stream::{FuturesUnordered, Stream, StreamExt, once};
 use hickory_proto::NoRecords;
 use hickory_proto::op::ResponseCode;
@@ -188,10 +187,9 @@ impl<P: ConnectionProvider> PoolState<P> {
 
             let mut requests = par_conns
                 .into_iter()
-                .map(|conn| {
-                    conn.send(request.clone())
-                        .first_answer()
-                        .map(|result| result.map_err(|e| (conn, e)))
+                .map(|conn| async {
+                    let result = conn.send(request.clone()).first_answer().await;
+                    result.map_err(|e| (conn, e))
                 })
                 .collect::<FuturesUnordered<_>>();
 

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -12,7 +12,10 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use futures_util::{FutureExt, Stream, future};
+use futures_util::{
+    FutureExt, Stream,
+    future::{self, BoxFuture},
+};
 use hickory_proto::rr::rdata;
 use tracing::debug;
 
@@ -487,7 +490,7 @@ where
     names: Vec<Name>,
     record_type: RecordType,
     options: DnsRequestOptions,
-    query: Pin<Box<dyn Future<Output = Result<Lookup, ProtoError>> + Send>>,
+    query: BoxFuture<'static, Result<Lookup, ProtoError>>,
 }
 
 impl<C> LookupFuture<C>
@@ -538,7 +541,7 @@ where
             ProtoError::from(ProtoErrorKind::Message("can not lookup for no names"))
         });
 
-        let query: Pin<Box<dyn Future<Output = Result<Lookup, ProtoError>> + Send>> = match name {
+        let query = match name {
             Ok(name) => {
                 let query = Query::query(name, record_type);
 

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -1426,9 +1426,9 @@ mod tests {
         type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send>>;
 
         fn send(&self, _: DnsRequest) -> Self::Response {
-            Box::pin(once(
-                future::ready(self.messages.lock().unwrap().pop().unwrap_or_else(empty)).boxed(),
-            ))
+            Box::pin(once(future::ready(
+                self.messages.lock().unwrap().pop().unwrap_or_else(empty),
+            )))
         }
     }
 

--- a/crates/resolver/src/tls.rs
+++ b/crates/resolver/src/tls.rs
@@ -11,6 +11,7 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use futures_util::future::BoxFuture;
 use rustls::pki_types::ServerName;
 
 use crate::proto::BufDnsStreamHandle;
@@ -19,14 +20,13 @@ use crate::proto::rustls::TlsClientStream;
 use crate::proto::rustls::tls_client_stream::tls_client_connect_with_future;
 use crate::proto::tcp::DnsTcpStream;
 
-#[allow(clippy::type_complexity)]
 pub(crate) fn new_tls_stream_with_future<S, F>(
     future: F,
     socket_addr: SocketAddr,
     server_name: ServerName<'static>,
     mut tls_config: rustls::ClientConfig,
 ) -> (
-    Pin<Box<dyn Future<Output = Result<TlsClientStream<S>, ProtoError>> + Send>>,
+    BoxFuture<'static, Result<TlsClientStream<S>, ProtoError>>,
     BufDnsStreamHandle,
 )
 where

--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -101,12 +101,10 @@ impl TestResponseHandler {
         })
     }
 
-    pub fn into_message(self) -> impl Future<Output = Message> {
-        let bytes = self.into_inner();
-        bytes.map(|b| {
-            let mut decoder = BinDecoder::new(&b);
-            Message::read(&mut decoder).expect("could not decode message")
-        })
+    pub async fn into_message(self) -> Message {
+        let bytes = self.into_inner().await;
+        let mut decoder = BinDecoder::new(&bytes);
+        Message::read(&mut decoder).expect("could not decode message")
     }
 }
 

--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -15,7 +15,8 @@ use std::{
 };
 
 use futures::{
-    Future, FutureExt, future,
+    Future, FutureExt,
+    future::{self, BoxFuture},
     stream::{Stream, StreamExt},
 };
 #[cfg(feature = "__dnssec")]
@@ -55,11 +56,10 @@ pub struct TestClientStream {
 }
 
 impl TestClientStream {
-    #[allow(clippy::type_complexity)]
     pub fn new(
         catalog: Arc<Mutex<Catalog>>,
     ) -> (
-        Pin<Box<dyn Future<Output = Result<Self, ProtoError>> + Send>>,
+        BoxFuture<'static, Result<Self, ProtoError>>,
         BufDnsStreamHandle,
     ) {
         let (message_sender, outbound_messages) = BufDnsStreamHandle::new(([0, 0, 0, 0], 0).into());
@@ -199,9 +199,8 @@ pub struct NeverReturnsClientStream {
 
 #[allow(dead_code)]
 impl NeverReturnsClientStream {
-    #[allow(clippy::type_complexity)]
     pub fn new() -> (
-        Pin<Box<dyn Future<Output = Result<Self, ProtoError>> + Send>>,
+        BoxFuture<'static, Result<Self, ProtoError>>,
         BufDnsStreamHandle,
     ) {
         let (message_sender, outbound_messages) = BufDnsStreamHandle::new(([0, 0, 0, 0], 0).into());

--- a/tests/integration-tests/src/mock_client.rs
+++ b/tests/integration-tests/src/mock_client.rs
@@ -12,8 +12,11 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
-use futures::stream::{Stream, once};
-use futures::{AsyncRead, AsyncWrite, future};
+use futures::{
+    AsyncRead, AsyncWrite,
+    future::{self, BoxFuture},
+    stream::{Stream, once},
+};
 
 use hickory_proto::ProtoError;
 use hickory_proto::op::{Message, Query};
@@ -239,7 +242,7 @@ pub trait OnSend: Clone + Send + Sync + 'static {
     fn on_send<E>(
         &self,
         response: Result<DnsResponse, E>,
-    ) -> Pin<Box<dyn Future<Output = Result<DnsResponse, E>> + Send>>
+    ) -> BoxFuture<'static, Result<DnsResponse, E>>
     where
         E: From<ProtoError> + Send + 'static,
     {

--- a/tests/integration-tests/tests/integration/client_tests.rs
+++ b/tests/integration-tests/tests/integration/client_tests.rs
@@ -1,14 +1,12 @@
-#[cfg(all(feature = "__dnssec", feature = "sqlite"))]
-use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-#[cfg(all(feature = "__dnssec", feature = "sqlite"))]
-use std::pin::Pin;
 #[cfg(feature = "__dnssec")]
 use std::str::FromStr;
 #[cfg(all(feature = "__dnssec", feature = "sqlite"))]
 use std::sync::{Arc, Mutex as StdMutex};
 
 use futures::TryStreamExt;
+#[cfg(all(feature = "__dnssec", feature = "sqlite"))]
+use futures::future::BoxFuture;
 #[cfg(all(feature = "__dnssec", feature = "sqlite"))]
 use time::Duration;
 
@@ -59,12 +57,11 @@ impl TestClientConnection {
         }
     }
 
-    #[allow(clippy::type_complexity)]
     fn to_multiplexer(
         &self,
         signer: Option<Arc<dyn MessageSigner>>,
     ) -> DnsMultiplexerConnect<
-        Pin<Box<dyn Future<Output = Result<TestClientStream, ProtoError>> + Send>>,
+        BoxFuture<'static, Result<TestClientStream, ProtoError>>,
         TestClientStream,
     > {
         let (client_stream, handle) = TestClientStream::new(self.catalog.clone());

--- a/tests/integration-tests/tests/integration/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/integration/name_server_pool_tests.rs
@@ -1,7 +1,6 @@
-use std::future::{Future, poll_fn};
+use std::future::poll_fn;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr};
-use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::{
     Arc,
@@ -9,7 +8,7 @@ use std::sync::{
 };
 use std::task::Poll;
 
-use futures::executor::block_on;
+use futures::{executor::block_on, future::BoxFuture};
 
 use hickory_integration::mock_client::*;
 use hickory_proto::op::{Query, ResponseCode};
@@ -751,7 +750,7 @@ impl OnSend for OnSendBarrier {
     fn on_send<E>(
         &self,
         response: Result<DnsResponse, E>,
-    ) -> Pin<Box<dyn Future<Output = Result<DnsResponse, E>> + Send>>
+    ) -> BoxFuture<'static, Result<DnsResponse, E>>
     where
         E: From<ProtoError> + Send + 'static,
     {


### PR DESCRIPTION
This replaces all `TryFutureExt::map_ok()` and `TryFutureExt::map_err()` uses with async-await and regular control flow, or a `FutureExt::map()` call in one case where we need an `Unpin` future for `select_ok()`. Some `FutureExt::map()` uses are replaced with straight-line async code as well. All `Box<dyn Future + Unpin>` types were replaced with `Pin<Box<dyn Future>>`, because we may as well leverage the box allocation itself to satisfy pinning requirements. This also removes some unnecessary `FutureExt::boxed()` calls where they aren't needed (including some cases that nested two boxes). I rewrote all pinned boxed future types with the `futures_util::futures::BoxFuture` type alias.