### PR TITLE
FutureExt::now_or_never() -> JoinSet::try_join_next()

### DIFF
--- a/crates/proto/src/runtime.rs
+++ b/crates/proto/src/runtime.rs
@@ -116,7 +116,6 @@ mod tokio_runtime {
     use alloc::sync::Arc;
     use std::sync::Mutex;
 
-    use futures_util::FutureExt;
     #[cfg(feature = "__quic")]
     use quinn::Runtime;
     use tokio::net::{TcpSocket, TcpStream, UdpSocket as TokioUdpSocket};
@@ -211,10 +210,7 @@ mod tokio_runtime {
 
     /// Reap finished tasks from a `JoinSet`, without awaiting or blocking.
     fn reap_tasks(join_set: &mut JoinSet<Result<(), ProtoError>>) {
-        while FutureExt::now_or_never(join_set.join_next())
-            .flatten()
-            .is_some()
-        {}
+        while join_set.try_join_next().is_some() {}
     }
 
     #[cfg(feature = "__quic")]

--- a/crates/server/src/server/mod.rs
+++ b/crates/server/src/server/mod.rs
@@ -17,7 +17,7 @@ use std::{
 #[cfg(feature = "__tls")]
 use crate::proto::rustls::tls_from_stream;
 use bytes::Bytes;
-use futures_util::{FutureExt, StreamExt};
+use futures_util::StreamExt;
 use hickory_proto::ProtoErrorKind;
 use ipnet::IpNet;
 #[cfg(feature = "__tls")]
@@ -531,10 +531,7 @@ async fn handle_tls(
 
 /// Reap finished tasks from a `JoinSet`, without awaiting or blocking.
 fn reap_tasks(join_set: &mut JoinSet<()>) {
-    while FutureExt::now_or_never(join_set.join_next())
-        .flatten()
-        .is_some()
-    {}
+    while join_set.try_join_next().is_some() {}
 }
 
 #[cfg(feature = "__tls")]


### PR DESCRIPTION
I've been spending a bit of time trying to understand more of the network socket flow and was looking at [`FutureExt::now_or_never()`](https://docs.rs/futures/latest/futures/future/trait.FutureExt.html#method.now_or_never) in the task reaping code. The mechanics make me think there's a simpler way to achieve the same thing with [`JoinSet::try_join_next()`](https://docs.rs/tokio/latest/tokio/task/struct.JoinSet.html#method.try_join_next) (_... unless I'm overlooking something, in which case, happy to be corrected/learn something new!_) 
