### PR TITLE
ProtoErrorKind cleanup

### DIFF
--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -187,10 +187,6 @@ pub enum ProtoErrorKind {
     #[error("no connections available")]
     NoConnections,
 
-    /// No error was specified
-    #[error("no error specified")]
-    NoError,
-
     /// Not all records were able to be written
     #[non_exhaustive]
     #[error("not all records could be written, wrote: {count}")]
@@ -788,7 +784,6 @@ impl Clone for ProtoErrorKind {
             Message(msg) => Message(msg),
             Msg(ref msg) => Msg(msg.clone()),
             NoConnections => NoConnections,
-            NoError => NoError,
             NotAllRecordsWritten { count } => NotAllRecordsWritten { count },
             NoRecordsFound(ref inner) => NoRecordsFound(inner.clone()),
             RequestRefused => RequestRefused,

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -152,7 +152,7 @@ pub enum ProtoErrorKind {
     #[error("label bytes exceed 63: {0}")]
     LabelBytesTooLong(usize),
 
-    /// Label bytes exceeded the limit of 63
+    /// Pointer points to an index within or after the current name
     #[non_exhaustive]
     #[error("label points to data not prior to idx: {idx} ptr: {ptr}")]
     PointerNotPriorToLabel {
@@ -302,7 +302,7 @@ pub enum ProtoErrorKind {
     #[error("error writing to quic read: {0}")]
     QuinnReadError(#[from] quinn::ReadExactError),
 
-    /// A Quinn (QUIC) read error occurred
+    /// A Quinn (QUIC) stream error occurred
     #[cfg(feature = "__quic")]
     #[error("referenced a closed QUIC stream: {0}")]
     QuinnStreamError(#[from] quinn::ClosedStream),

--- a/crates/proto/src/serialize/binary/decoder.rs
+++ b/crates/proto/src/serialize/binary/decoder.rs
@@ -47,7 +47,7 @@ pub enum DecodeError {
     #[error("the index passed to BinDecoder::slice_from must be greater than the decoder position")]
     InvalidPreviousIndex,
 
-    /// Pointer points to an index within or after the current label
+    /// Pointer points to an index within or after the current name
     #[error("label points to data not prior to idx: {idx} ptr: {ptr}")]
     PointerNotPriorToLabel {
         /// index of the label containing this pointer

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -305,7 +305,6 @@ impl NameServerStats {
             | ProtoErrorKind::QuinnTlsConfigError(_) => self.record_connection_failure(),
             #[cfg(feature = "__tls")]
             ProtoErrorKind::RustlsError(_) => self.record_connection_failure(),
-            ProtoErrorKind::NoError => self.record_rtt(rtt),
             _ => {}
         }
     }


### PR DESCRIPTION
This removes `ProtoErrorKind::NoError` and fixes some copied documentation.