### PR TITLE
Upgrade rustls-platform-verifier to 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,7 +2000,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2241,7 +2241,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2284,9 +2284,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
+checksum = "eda84358ed17f1f354cf4b1909ad346e6c7bc2513e8c40eb08e0157aa13a9070"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -2299,8 +2299,8 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "webpki-root-certs",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3078,15 +3078,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
-dependencies = [
- "webpki-root-certs 1.0.2",
-]
-
-[[package]]
-name = "webpki-root-certs"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
@@ -3143,7 +3134,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ pin-project-lite = "0.2"
 # cryptography
 aws-lc-rs = { version = "1.12.3", default-features = false, features = ["prebuilt-nasm"] }
 rustls = { version = "0.23.23", default-features = false, features = ["logging", "std", "tls12"] }
-rustls-platform-verifier = "0.5"
+rustls-platform-verifier = "0.6"
 rustls-pki-types = "1.10"
 tokio-rustls = { version = "0.26", default-features = false }
 webpki-roots = "1"

--- a/crates/proto/src/h2/h2_client_stream.rs
+++ b/crates/proto/src/h2/h2_client_stream.rs
@@ -795,7 +795,7 @@ mod tests {
     }
 
     fn client_config_h2() -> ClientConfig {
-        let mut config = client_config();
+        let mut config = client_config().unwrap();
         config.alpn_protocols = vec![ALPN_H2.to_vec()];
         config
     }

--- a/crates/proto/src/h3/h3_client_stream.rs
+++ b/crates/proto/src/h3/h3_client_stream.rs
@@ -403,7 +403,10 @@ impl H3ClientStreamBuilder {
             name_server,
             server_name.clone(),
             ALPN_H3,
-            self.crypto_config.unwrap_or_else(|| client_config()),
+            match self.crypto_config {
+                Some(crypto_config) => crypto_config,
+                None => client_config()?,
+            },
             self.transport_config,
             endpoint,
         )
@@ -504,7 +507,7 @@ mod tests {
 
         let request = DnsRequest::new(request, DnsRequestOptions::default());
 
-        let mut client_config = client_config();
+        let mut client_config = client_config().unwrap();
         client_config.key_log = Arc::new(KeyLogFile::new());
 
         let mut h3 = H3ClientStream::builder()
@@ -572,7 +575,7 @@ mod tests {
 
         let request = DnsRequest::new(request, DnsRequestOptions::default());
 
-        let mut client_config = client_config();
+        let mut client_config = client_config().unwrap();
         client_config.key_log = Arc::new(KeyLogFile::new());
 
         let mut h3 = H3ClientStream::builder()
@@ -644,7 +647,7 @@ mod tests {
 
         let request = DnsRequest::new(request, DnsRequestOptions::default());
 
-        let mut client_config = client_config();
+        let mut client_config = client_config().unwrap();
         client_config.key_log = Arc::new(KeyLogFile::new());
 
         let connect = H3ClientStream::builder()
@@ -708,7 +711,7 @@ mod tests {
         // use google
         let google = SocketAddr::from(([8, 8, 8, 8], 443));
 
-        let mut client_config = client_config();
+        let mut client_config = client_config().unwrap();
         client_config.key_log = Arc::new(KeyLogFile::new());
 
         let h3 = H3ClientStream::builder()

--- a/crates/proto/src/h3/h3_client_stream.rs
+++ b/crates/proto/src/h3/h3_client_stream.rs
@@ -58,7 +58,12 @@ impl Display for H3ClientStream {
 impl H3ClientStream {
     /// Builder for H3ClientStream
     pub fn builder() -> H3ClientStreamBuilder {
-        H3ClientStreamBuilder::default()
+        H3ClientStreamBuilder {
+            crypto_config: client_config(),
+            transport_config: Arc::new(super::transport()),
+            bind_addr: None,
+            disable_grease: false,
+        }
     }
 
     async fn inner_send(
@@ -437,17 +442,6 @@ impl H3ClientStreamBuilder {
             shutdown_tx,
             is_shutdown: false,
         })
-    }
-}
-
-impl Default for H3ClientStreamBuilder {
-    fn default() -> Self {
-        Self {
-            crypto_config: client_config(),
-            transport_config: Arc::new(super::transport()),
-            bind_addr: None,
-            disable_grease: false,
-        }
     }
 }
 

--- a/crates/proto/src/h3/h3_client_stream.rs
+++ b/crates/proto/src/h3/h3_client_stream.rs
@@ -53,7 +53,7 @@ impl H3ClientStream {
     /// Builder for H3ClientStream
     pub fn builder() -> H3ClientStreamBuilder {
         H3ClientStreamBuilder {
-            crypto_config: client_config(),
+            crypto_config: None,
             transport_config: Arc::new(super::transport()),
             bind_addr: None,
             disable_grease: false,
@@ -298,7 +298,7 @@ impl Display for H3ClientStream {
 /// A H3 connection builder for DNS-over-HTTP/3
 #[derive(Clone)]
 pub struct H3ClientStreamBuilder {
-    crypto_config: rustls::ClientConfig,
+    crypto_config: Option<rustls::ClientConfig>,
     transport_config: Arc<TransportConfig>,
     bind_addr: Option<SocketAddr>,
     disable_grease: bool,
@@ -307,7 +307,7 @@ pub struct H3ClientStreamBuilder {
 impl H3ClientStreamBuilder {
     /// Constructs a new H3ClientStreamBuilder with the associated ClientConfig
     pub fn crypto_config(mut self, crypto_config: rustls::ClientConfig) -> Self {
-        self.crypto_config = crypto_config;
+        self.crypto_config = Some(crypto_config);
         self
     }
 
@@ -403,7 +403,7 @@ impl H3ClientStreamBuilder {
             name_server,
             server_name.clone(),
             ALPN_H3,
-            self.crypto_config,
+            self.crypto_config.unwrap_or_else(|| client_config()),
             self.transport_config,
             endpoint,
         )

--- a/crates/proto/src/h3/h3_client_stream.rs
+++ b/crates/proto/src/h3/h3_client_stream.rs
@@ -49,12 +49,6 @@ pub struct H3ClientStream {
     is_shutdown: bool,
 }
 
-impl Display for H3ClientStream {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(formatter, "H3({},{})", self.name_server, self.server_name)
-    }
-}
-
 impl H3ClientStream {
     /// Builder for H3ClientStream
     pub fn builder() -> H3ClientStreamBuilder {
@@ -292,6 +286,12 @@ impl Stream for H3ClientStream {
         }
 
         Poll::Ready(Some(Ok(())))
+    }
+}
+
+impl Display for H3ClientStream {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(formatter, "H3({},{})", self.name_server, self.server_name)
     }
 }
 

--- a/crates/proto/src/quic/quic_client_stream.rs
+++ b/crates/proto/src/quic/quic_client_stream.rs
@@ -278,7 +278,7 @@ impl QuicClientStreamBuilder {
         let crypto_config = if let Some(crypto_config) = self.crypto_config {
             crypto_config
         } else {
-            client_config()
+            client_config()?
         };
 
         let quic_connection = connect_quic(

--- a/crates/proto/src/rustls/mod.rs
+++ b/crates/proto/src/rustls/mod.rs
@@ -27,13 +27,13 @@ pub use self::tls_client_stream::{
 pub use self::tls_stream::{TlsStream, tls_connect, tls_connect_with_bind_addr, tls_from_stream};
 
 /// Make a new [`ClientConfig`] with the default settings
-pub fn client_config() -> ClientConfig {
+pub fn client_config() -> Result<ClientConfig, rustls::Error> {
     let builder = ClientConfig::builder_with_provider(Arc::new(default_provider()))
         .with_safe_default_protocol_versions()
         .unwrap();
 
     #[cfg(feature = "rustls-platform-verifier")]
-    let builder = builder.with_platform_verifier();
+    let builder = builder.with_platform_verifier()?;
     #[cfg(not(feature = "rustls-platform-verifier"))]
     let builder = builder.with_root_certificates({
         #[cfg_attr(not(feature = "webpki-roots"), allow(unused_mut))]
@@ -43,7 +43,7 @@ pub fn client_config() -> ClientConfig {
         root_store
     });
 
-    builder.with_no_client_auth()
+    Ok(builder.with_no_client_auth())
 }
 
 /// Instantiate a new [`CryptoProvider`] for use with rustls

--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -208,7 +208,7 @@ impl<P: ConnectionProvider> Recursor<P> {
             Arc::new(avoid_local_udp_ports),
             ttl_config,
             case_randomization,
-            Arc::new(TlsConfig::new()),
+            Arc::new(TlsConfig::new()?),
             conn_provider,
         );
 

--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -23,7 +23,10 @@ use crate::{
         runtime::TokioRuntimeProvider,
     },
     recursor_dns_handle::RecursorDnsHandle,
-    resolver::{TtlConfig, name_server::ConnectionProvider},
+    resolver::{
+        TtlConfig,
+        name_server::{ConnectionProvider, TlsConfig},
+    },
 };
 #[cfg(feature = "__dnssec")]
 use crate::{
@@ -205,6 +208,7 @@ impl<P: ConnectionProvider> Recursor<P> {
             Arc::new(avoid_local_udp_ports),
             ttl_config,
             case_randomization,
+            Arc::new(TlsConfig::new()),
             conn_provider,
         );
 

--- a/crates/recursor/src/recursor_dns_handle.rs
+++ b/crates/recursor/src/recursor_dns_handle.rs
@@ -732,7 +732,7 @@ mod tests {
             Arc::new(HashSet::new()),
             TtlConfig::default(),
             false,
-            Arc::new(TlsConfig::new()),
+            Arc::new(TlsConfig::new().unwrap()),
             TokioRuntimeProvider::default(),
         );
 

--- a/crates/resolver/README.md
+++ b/crates/resolver/README.md
@@ -44,7 +44,7 @@ let resolver = Resolver::builder_with_config(
     ResolverConfig::udp_and_tcp(&GOOGLE),
     TokioRuntimeProvider::default(),
 )
-.build();
+.build().unwrap();
 
 // On Unix/Posix systems, this will read the /etc/resolv.conf
 // let resolver = TokioResolver::builder(TokioRuntimeProvider::default()).unwrap().build();

--- a/crates/resolver/examples/custom_provider.rs
+++ b/crates/resolver/examples/custom_provider.rs
@@ -96,7 +96,9 @@ async fn run() {
         ResolverConfig::udp_and_tcp(&GOOGLE),
         PrintProvider::default(),
     )
-    .build();
+    .build()
+    .unwrap();
+
     lookup_test(resolver).await;
 
     #[cfg(feature = "__https")]
@@ -105,7 +107,8 @@ async fn run() {
             ResolverConfig::https(&CLOUDFLARE),
             PrintProvider::default(),
         )
-        .build();
+        .build()
+        .unwrap();
         lookup_test(resolver2).await;
     }
 

--- a/crates/resolver/examples/flush_cache.rs
+++ b/crates/resolver/examples/flush_cache.rs
@@ -19,7 +19,8 @@ async fn tokio_main() {
             Arc::new(
                 TokioResolver::builder(TokioRuntimeProvider::default())
                     .expect("failed to create resolver")
-                    .build(),
+                    .build()
+                    .unwrap(),
             )
         }
 

--- a/crates/resolver/examples/global_resolver.rs
+++ b/crates/resolver/examples/global_resolver.rs
@@ -36,7 +36,7 @@ static GLOBAL_DNS_RESOLVER: Lazy<TokioResolver> = Lazy::new(|| {
             {
                 // use the system resolver configuration
                 TokioResolver::builder(TokioRuntimeProvider::default())
-                    .map(|builder| builder.build())
+                    .map(|builder| builder.build().unwrap())
             }
 
             // For other operating systems, we can use one of the preconfigured definitions

--- a/crates/resolver/examples/multithreaded_runtime.rs
+++ b/crates/resolver/examples/multithreaded_runtime.rs
@@ -24,6 +24,7 @@ fn run() {
             TokioResolver::builder(TokioRuntimeProvider::default())
                 .expect("failed to create resolver")
                 .build()
+                .unwrap()
         }
 
         // For other operating systems, we can use one of the preconfigured definitions

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -20,8 +20,6 @@ use serde::{Deserialize, Serialize};
 #[cfg(any(feature = "__https", feature = "__h3"))]
 use crate::proto::http::DEFAULT_DNS_QUERY_PATH;
 use crate::proto::rr::Name;
-#[cfg(feature = "__tls")]
-use crate::proto::rustls::client_config;
 use crate::proto::xfer::Protocol;
 
 /// Configuration for the upstream nameservers to use for resolution
@@ -535,13 +533,6 @@ pub struct ResolverOpts {
     /// prevent those prompts from being displayed. If os_port_selection is true, avoid_local_udp_ports
     /// will be ignored.
     pub os_port_selection: bool,
-    /// Optional configuration for the TLS client.
-    ///
-    /// The correct ALPN for the corresponding protocol is automatically
-    /// inserted if none was specified.
-    #[cfg(feature = "__tls")]
-    #[cfg_attr(feature = "serde", serde(skip, default = "client_config"))]
-    pub tls_config: rustls::ClientConfig,
     /// Enable case randomization.
     ///
     /// Randomize the case of letters in query names, and require that responses preserve the case
@@ -586,8 +577,6 @@ impl Default for ResolverOpts {
             recursion_desired: default_recursion_desired(),
             avoid_local_udp_ports: Arc::default(),
             os_port_selection: false,
-            #[cfg(feature = "__tls")]
-            tls_config: client_config(),
             case_randomization: false,
             trust_anchor: None,
         }

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -45,7 +45,7 @@
 //! use hickory_resolver::Resolver;
 //! // Use the host OS'es `/etc/resolv.conf`
 //! # #[cfg(unix)]
-//! let resolver = Resolver::builder_tokio().unwrap().build();
+//! let resolver = Resolver::builder_tokio().unwrap().build().unwrap();
 //! # #[cfg(unix)]
 //! let response = resolver.lookup_ip("www.example.com.").await.unwrap();
 //! # })
@@ -73,7 +73,7 @@
 //! let resolver = Resolver::builder_with_config(
 //!     ResolverConfig::udp_and_tcp(&GOOGLE),
 //!     TokioRuntimeProvider::default()
-//! ).build();
+//! ).build().unwrap();
 //!
 //! // Lookup the IP addresses associated with a name.
 //! // This returns a future that will lookup the IP addresses, it must be run in the Core to
@@ -108,7 +108,7 @@
 //! # let resolver = Resolver::builder_with_config(
 //! #     ResolverConfig::default(),
 //! #     TokioRuntimeProvider::default()
-//! # ).build();
+//! # ).build().unwrap();
 //! # io_loop.block_on(async {
 //! let ips = resolver.lookup_ip("www.example.com.").await.unwrap();
 //!

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -262,11 +262,11 @@ pub struct TlsConfig {
 
 impl TlsConfig {
     /// Create a new `TlsConfig` with default settings.
-    pub fn new() -> Self {
-        Self {
+    pub fn new() -> Result<Self, ProtoError> {
+        Ok(Self {
             #[cfg(feature = "__tls")]
-            config: client_config(),
-        }
+            config: client_config()?,
+        })
     }
 }
 
@@ -343,7 +343,7 @@ mod tests {
         subscribe();
 
         // AdGuard requires SNI.
-        let config = client_config();
+        let config = client_config().unwrap();
 
         let group = ServerGroup {
             ips: &[

--- a/crates/resolver/src/name_server/mod.rs
+++ b/crates/resolver/src/name_server/mod.rs
@@ -8,7 +8,7 @@
 //! A module with associated items for working with nameservers
 
 mod connection_provider;
-pub use connection_provider::ConnectionProvider;
+pub use connection_provider::{ConnectionProvider, TlsConfig};
 #[allow(clippy::module_inception)]
 mod name_server;
 pub use name_server::NameServer;

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -21,7 +21,7 @@ use tokio::time::{Duration, Instant};
 use tracing::debug;
 
 use crate::config::{ConnectionConfig, NameServerConfig, ResolverOpts};
-use crate::name_server::connection_provider::ConnectionProvider;
+use crate::name_server::connection_provider::{ConnectionProvider, TlsConfig};
 use crate::proto::{
     NoRecords, ProtoError, ProtoErrorKind,
     op::ResponseCode,
@@ -40,6 +40,7 @@ impl<P: ConnectionProvider> NameServer<P> {
         server_config: &NameServerConfig,
         config: ConnectionConfig,
         options: Arc<ResolverOpts>,
+        tls: Arc<TlsConfig>,
         connection_provider: P,
     ) -> Self {
         Self {
@@ -47,6 +48,7 @@ impl<P: ConnectionProvider> NameServer<P> {
                 server_config,
                 config,
                 options,
+                tls,
                 None,
                 connection_provider,
             )),
@@ -58,6 +60,7 @@ impl<P: ConnectionProvider> NameServer<P> {
         server_config: &NameServerConfig,
         config: ConnectionConfig,
         options: Arc<ResolverOpts>,
+        tls: Arc<TlsConfig>,
         client: P::Conn,
         connection_provider: P,
     ) -> Self {
@@ -66,6 +69,7 @@ impl<P: ConnectionProvider> NameServer<P> {
                 server_config,
                 config,
                 options,
+                tls,
                 Some(client),
                 connection_provider,
             )),
@@ -133,6 +137,7 @@ struct NameServerState<P: ConnectionProvider> {
     ip: IpAddr,
     config: ConnectionConfig,
     options: Arc<ResolverOpts>,
+    tls: Arc<TlsConfig>,
     client: AsyncMutex<Option<P::Conn>>,
     status: AtomicU8,
     stats: NameServerStats,
@@ -145,6 +150,7 @@ impl<P: ConnectionProvider> NameServerState<P> {
         server_config: &NameServerConfig,
         config: ConnectionConfig,
         options: Arc<ResolverOpts>,
+        tls: Arc<TlsConfig>,
         client: Option<P::Conn>,
         connection_provider: P,
     ) -> Self {
@@ -152,6 +158,7 @@ impl<P: ConnectionProvider> NameServerState<P> {
             ip: server_config.ip,
             config,
             options,
+            tls,
             client: AsyncMutex::new(client),
             status: AtomicU8::new(Status::Init.into()),
             stats: NameServerStats::default(),
@@ -209,6 +216,7 @@ impl<P: ConnectionProvider> NameServerState<P> {
                 self.ip,
                 &self.config,
                 &self.options,
+                &self.tls,
             )?)
             .await?;
 
@@ -483,6 +491,7 @@ mod tests {
             &config,
             connection_config,
             Arc::new(ResolverOpts::default()),
+            Arc::new(TlsConfig::new()),
             TokioRuntimeProvider::default(),
         );
 
@@ -513,6 +522,7 @@ mod tests {
             &config,
             connection_config,
             Arc::new(options),
+            Arc::new(TlsConfig::new()),
             TokioRuntimeProvider::default(),
         );
 
@@ -579,6 +589,7 @@ mod tests {
             &config,
             connection_config,
             Arc::new(resolver_opts),
+            Arc::new(TlsConfig::new()),
             provider,
         );
 

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -491,7 +491,7 @@ mod tests {
             &config,
             connection_config,
             Arc::new(ResolverOpts::default()),
-            Arc::new(TlsConfig::new()),
+            Arc::new(TlsConfig::new().unwrap()),
             TokioRuntimeProvider::default(),
         );
 
@@ -522,7 +522,7 @@ mod tests {
             &config,
             connection_config,
             Arc::new(options),
-            Arc::new(TlsConfig::new()),
+            Arc::new(TlsConfig::new().unwrap()),
             TokioRuntimeProvider::default(),
         );
 
@@ -589,7 +589,7 @@ mod tests {
             &config,
             connection_config,
             Arc::new(resolver_opts),
-            Arc::new(TlsConfig::new()),
+            Arc::new(TlsConfig::new().unwrap()),
             provider,
         );
 

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -271,7 +271,7 @@ mod tests {
         let pool = NameServerPool::tokio_from_config(
             &resolver_config,
             Arc::new(ResolverOpts::default()),
-            Arc::new(TlsConfig::new()),
+            Arc::new(TlsConfig::new().unwrap()),
             TokioRuntimeProvider::new(),
         );
 
@@ -327,7 +327,7 @@ mod tests {
             &tcp,
             connection_config,
             opts.clone(),
-            Arc::new(TlsConfig::new()),
+            Arc::new(TlsConfig::new().unwrap()),
             conn_provider,
         );
         let name_servers = vec![name_server];

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -461,7 +461,7 @@ impl<P: ConnectionProvider> ResolverBuilder<P> {
             options.clone(),
             Arc::new(match tls {
                 Some(config) => config,
-                None => TlsConfig::new(),
+                None => TlsConfig::new()?,
             }),
             provider,
         );

--- a/crates/resolver/src/tests.rs
+++ b/crates/resolver/src/tests.rs
@@ -16,7 +16,8 @@ async fn readme_example() {
         ResolverConfig::udp_and_tcp(&GOOGLE),
         TokioRuntimeProvider::default(),
     )
-    .build();
+    .build()
+    .unwrap();
 
     // On Unix/Posix systems, this will read the /etc/resolv.conf
     // let resolver = TokioResolver::builder(TokioRuntimeProvider::default()).unwrap().build();

--- a/crates/server/src/store/forwarder.rs
+++ b/crates/server/src/store/forwarder.rs
@@ -144,7 +144,7 @@ impl<P: ConnectionProvider> ForwardAuthorityBuilder<P> {
         }
 
         *resolver_builder.options_mut() = options;
-        let resolver = resolver_builder.build();
+        let resolver = resolver_builder.build().map_err(|err| err.to_string())?;
 
         info!(%origin, "forward resolver configured");
 

--- a/tests/integration-tests/src/mock_client.rs
+++ b/tests/integration-tests/src/mock_client.rs
@@ -28,7 +28,7 @@ use hickory_proto::tcp::DnsTcpStream;
 use hickory_proto::udp::DnsUdpSocket;
 use hickory_proto::xfer::{DnsHandle, DnsRequest, DnsResponse};
 use hickory_resolver::config::{ConnectionConfig, ResolverOpts};
-use hickory_resolver::name_server::ConnectionProvider;
+use hickory_resolver::name_server::{ConnectionProvider, TlsConfig};
 
 pub struct TcpPlaceholder;
 
@@ -136,6 +136,7 @@ impl<O: OnSend + Unpin> ConnectionProvider for MockConnProvider<O> {
         _: IpAddr,
         _config: &ConnectionConfig,
         _options: &ResolverOpts,
+        _tls: &TlsConfig,
     ) -> Result<Self::FutureConn, io::Error> {
         println!("MockConnProvider::new_connection");
         Ok(Box::pin(future::ok(MockClientHandle::mock_on_send(

--- a/tests/integration-tests/tests/integration/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/integration/name_server_pool_tests.rs
@@ -18,7 +18,7 @@ use hickory_proto::{NoRecords, ProtoError, ProtoErrorKind};
 use hickory_resolver::config::{
     ConnectionConfig, NameServerConfig, ProtocolConfig, ResolverOpts, ServerOrderingStrategy,
 };
-use hickory_resolver::name_server::{NameServer, NameServerPool};
+use hickory_resolver::name_server::{NameServer, NameServerPool, TlsConfig};
 use test_support::subscribe;
 
 const DEFAULT_SERVER_ADDR: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
@@ -115,6 +115,7 @@ fn mock_nameserver_on_send_nx<O: OnSend + Unpin>(
         &config,
         connection_config,
         Arc::new(options),
+        Arc::new(TlsConfig::new()),
         client,
         conn_provider,
     )

--- a/tests/integration-tests/tests/integration/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/integration/name_server_pool_tests.rs
@@ -115,7 +115,7 @@ fn mock_nameserver_on_send_nx<O: OnSend + Unpin>(
         &config,
         connection_config,
         Arc::new(options),
-        Arc::new(TlsConfig::new()),
+        Arc::new(TlsConfig::new().unwrap()),
         client,
         conn_provider,
     )

--- a/util/src/bin/dns.rs
+++ b/util/src/bin/dns.rs
@@ -505,7 +505,7 @@ async fn tls(opts: Opts, provider: impl RuntimeProvider) -> Result<(), Box<dyn s
         .expect("tls_dns_name is required tls connections");
     println!("; using tls:{nameserver} dns_name:{dns_name}");
 
-    let mut config = client_config();
+    let mut config = client_config()?;
     if opts.do_not_verify_nameserver_cert {
         self::do_not_verify_nameserver_cert(&mut config);
     }
@@ -554,7 +554,7 @@ async fn https(
         .expect("http_endpoint is required for https connections");
     println!("; using https:{nameserver} dns_name:{dns_name}");
 
-    let mut config = client_config();
+    let mut config = client_config()?;
     if opts.do_not_verify_nameserver_cert {
         self::do_not_verify_nameserver_cert(&mut config);
     }
@@ -595,7 +595,7 @@ async fn quic(opts: Opts) -> Result<(), Box<dyn std::error::Error>> {
         .expect("tls_dns_name is required quic connections");
     println!("; using quic:{nameserver} dns_name:{dns_name}");
 
-    let mut config = client_config();
+    let mut config = client_config()?;
     if opts.do_not_verify_nameserver_cert {
         self::do_not_verify_nameserver_cert(&mut config);
     }
@@ -637,7 +637,7 @@ async fn h3(opts: Opts) -> Result<(), Box<dyn std::error::Error>> {
         .expect("http_endpoint is required for H3 connections");
     println!("; using h3:{nameserver} dns_name:{dns_name}");
 
-    let mut config = client_config();
+    let mut config = client_config()?;
     if opts.do_not_verify_nameserver_cert {
         self::do_not_verify_nameserver_cert(&mut config);
     }

--- a/util/src/bin/resolve.rs
+++ b/util/src/bin/resolve.rs
@@ -334,7 +334,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut resolver_builder =
         TokioResolver::builder_with_config(config, TokioRuntimeProvider::default());
     *resolver_builder.options_mut() = options;
-    let resolver_arc = Arc::new(resolver_builder.build());
+    let resolver_arc = Arc::new(resolver_builder.build()?);
 
     if let Some(domainname) = &opts.domainname {
         log_query(domainname, opts.ty, &name_servers, &opts);


### PR DESCRIPTION
rustls-platform-verifier 0.5 hid some fallibility in the internal implementation of the `Verifier`, which could cause errors to be implicitly ignored. I fixed this in 0.6, meaning that construction of the platform verifier is now explicitly fallible. This is a bit of a pain to deal with because the current setup was very much built around the infallibility of the certificate verifier construction. I think the approach in this PR does a decent job of keeping the public facing API the same, while adding some necessary complexity in rarely used API paths (notably the `ConnectionProvider` trait).