### PR TITLE
util: tidy logging, add trace level support, fix library logging

### DIFF
--- a/util/src/bin/dns.rs
+++ b/util/src/bin/dns.rs
@@ -60,7 +60,7 @@ use hickory_proto::{
 /// This utility directly uses the hickory-client to perform actions with a single
 /// DNS server
 #[derive(Debug, Parser)]
-#[clap(name = "trust dns client", version)]
+#[clap(name = "hickory dns client", version)]
 struct Opts {
     /// Specify a nameserver to use, ip and port e.g. 8.8.8.8:53 or \[2001:4860:4860::8888\]:53 (port required)
     #[clap(short = 'n', long)]

--- a/util/src/bin/recurse.rs
+++ b/util/src/bin/recurse.rs
@@ -5,7 +5,7 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! The resolve program
+//! The recurse program
 
 // BINARY WARNINGS
 #![warn(

--- a/util/src/bin/recurse.rs
+++ b/util/src/bin/recurse.rs
@@ -52,21 +52,9 @@ struct Opts {
     #[clap(short = 'n', long, use_value_delimiter = true, value_delimiter(','))]
     nameservers: Vec<IpAddr>,
 
-    /// Enable debug and all logging
-    #[clap(long)]
-    debug: bool,
-
-    /// Enable info + warning + error logging
-    #[clap(long)]
-    info: bool,
-
-    /// Enable warning + error logging
-    #[clap(long)]
-    warn: bool,
-
-    /// Enable error logging
-    #[clap(long)]
-    error: bool,
+    /// Configure log verbosity.
+    #[clap(flatten)]
+    log_config: hickory_util::LogConfig,
 }
 
 /// Run the resolve program
@@ -75,19 +63,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut opts = Opts::parse();
 
     // enable logging early
-    let log_level = if opts.debug {
-        Some(tracing::Level::DEBUG)
-    } else if opts.info {
-        Some(tracing::Level::INFO)
-    } else if opts.warn {
-        Some(tracing::Level::WARN)
-    } else if opts.error {
-        Some(tracing::Level::ERROR)
-    } else {
-        None
-    };
-
-    hickory_util::logger(env!("CARGO_BIN_NAME"), log_level);
+    hickory_util::logger(env!("CARGO_BIN_NAME"), opts.log_config.level());
 
     // query parameters
     let mut name = opts.domainname;

--- a/util/src/bin/resolve.rs
+++ b/util/src/bin/resolve.rs
@@ -128,21 +128,9 @@ struct Opts {
     #[clap(long)]
     tcp: bool,
 
-    /// Enable debug and all logging
-    #[clap(long)]
-    debug: bool,
-
-    /// Enable info + warning + error logging
-    #[clap(long)]
-    info: bool,
-
-    /// Enable warning + error logging
-    #[clap(long)]
-    warn: bool,
-
-    /// Enable error logging
-    #[clap(long)]
-    error: bool,
+    /// Configure log verbosity.
+    #[clap(flatten)]
+    log_config: hickory_util::LogConfig,
 
     /// Set the time interval between requests (in seconds, useful with --file)
     #[clap(long, default_value = "1.0")]
@@ -249,19 +237,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let opts: Opts = Opts::parse();
 
     // enable logging early
-    let log_level = if opts.debug {
-        Some(tracing::Level::DEBUG)
-    } else if opts.info {
-        Some(tracing::Level::INFO)
-    } else if opts.warn {
-        Some(tracing::Level::WARN)
-    } else if opts.error {
-        Some(tracing::Level::ERROR)
-    } else {
-        None
-    };
-
-    hickory_util::logger(env!("CARGO_BIN_NAME"), log_level);
+    hickory_util::logger(env!("CARGO_BIN_NAME"), opts.log_config.level());
 
     // read system configuration
     let (sys_config, sys_options): (Option<ResolverConfig>, Option<ResolverOpts>) = if opts.system {

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -59,6 +59,10 @@ pub fn logger(bin: &str, level: Option<Level>) {
 /// Common CLI configuration for tracing log levels
 #[derive(Debug, Parser)]
 pub struct LogConfig {
+    /// Enable trace + debug + info + warning + error logging
+    #[clap(long)]
+    trace: bool,
+
     /// Enable debug + info + warning + error logging
     #[clap(long)]
     debug: bool,
@@ -78,7 +82,9 @@ pub struct LogConfig {
 
 impl LogConfig {
     pub fn level(&self) -> Option<Level> {
-        if self.debug {
+        if self.trace {
+            Some(Level::TRACE)
+        } else if self.debug {
             Some(Level::DEBUG)
         } else if self.info {
             Some(Level::INFO)

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -7,6 +7,8 @@
 
 use std::env;
 
+use clap::Parser;
+use tracing::Level;
 use tracing::metadata::LevelFilter;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -39,7 +41,7 @@ fn get_levels<T: ToString>(bin: &str, level: Option<T>) -> String {
 /// # Panic
 ///
 /// This will panic if the tracing subscriber can't be registered
-pub fn logger(bin: &str, level: Option<tracing::Level>) {
+pub fn logger(bin: &str, level: Option<Level>) {
     // Setup tracing for logging based on input
     let subscriber = EnvFilter::builder()
         .with_default_directive(LevelFilter::OFF.into())
@@ -52,4 +54,40 @@ pub fn logger(bin: &str, level: Option<tracing::Level>) {
         .with(formatter)
         .with(subscriber)
         .init();
+}
+
+/// Common CLI configuration for tracing log levels
+#[derive(Debug, Parser)]
+pub struct LogConfig {
+    /// Enable debug + info + warning + error logging
+    #[clap(long)]
+    debug: bool,
+
+    /// Enable info + warning + error logging
+    #[clap(long)]
+    info: bool,
+
+    /// Enable warning + error logging
+    #[clap(long)]
+    warn: bool,
+
+    /// Enable error logging
+    #[clap(long)]
+    error: bool,
+}
+
+impl LogConfig {
+    pub fn level(&self) -> Option<Level> {
+        if self.debug {
+            Some(Level::DEBUG)
+        } else if self.info {
+            Some(Level::INFO)
+        } else if self.warn {
+            Some(Level::WARN)
+        } else if self.error {
+            Some(Level::ERROR)
+        } else {
+            None
+        }
+    }
 }

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -82,18 +82,18 @@ pub struct LogConfig {
 
 impl LogConfig {
     pub fn level(&self) -> Option<Level> {
-        if self.trace {
-            Some(Level::TRACE)
+        Some(if self.trace {
+            Level::TRACE
         } else if self.debug {
-            Some(Level::DEBUG)
+            Level::DEBUG
         } else if self.info {
-            Some(Level::INFO)
+            Level::INFO
         } else if self.warn {
-            Some(Level::WARN)
+            Level::WARN
         } else if self.error {
-            Some(Level::ERROR)
+            Level::ERROR
         } else {
-            None
-        }
+            return None;
+        })
     }
 }

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -35,17 +35,15 @@ fn get_levels(bin: &str, cli_level: Option<Level>) -> String {
 /// # Panic
 ///
 /// This will panic if the tracing subscriber can't be registered
-pub fn logger(bin: &str, level: Option<Level>) {
+pub fn logger(bin: &str, cli_level: Option<Level>) {
     // Setup tracing for logging based on input
     let subscriber = EnvFilter::builder()
         .with_default_directive(LevelFilter::OFF.into())
-        .parse(get_levels(bin, level))
+        .parse(get_levels(bin, cli_level))
         .expect("failed to configure tracing/logging");
 
-    let formatter = tracing_subscriber::fmt::layer().compact();
-
     tracing_subscriber::registry()
-        .with(formatter)
+        .with(tracing_subscriber::fmt::layer().compact())
         .with(subscriber)
         .init();
 }

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -20,7 +20,7 @@ fn get_levels(bin: &str, cli_level: Option<Level>) -> String {
     };
 
     let level_str = format!(
-        "{bin}={level},hickory_dns={level}",
+        "{bin}={level},hickory={level}",
         level = cli_level.to_string().to_lowercase(),
     );
 

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -12,27 +12,21 @@ use tracing::Level;
 use tracing::metadata::LevelFilter;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
-fn get_env() -> String {
-    env::var("RUST_LOG").unwrap_or_default()
-}
+fn get_levels(bin: &str, cli_level: Option<Level>) -> String {
+    let env_level = env::var("RUST_LOG").ok();
 
-fn get_levels<T: ToString>(bin: &str, level: Option<T>) -> String {
-    let hickory_crates = level.map(|level| {
-        format!(
-            "{bin}={level},hickory_dns={level}",
-            bin = bin,
-            level = level.to_string().to_lowercase(),
-        )
-    });
+    let Some(cli_level) = cli_level else {
+        return env_level.unwrap_or_default();
+    };
 
-    if let Some(hickory_crates) = hickory_crates {
-        format!(
-            "{hickory_crates},{env}",
-            hickory_crates = hickory_crates,
-            env = get_env()
-        )
-    } else {
-        get_env()
+    let level_str = format!(
+        "{bin}={level},hickory_dns={level}",
+        level = cli_level.to_string().to_lowercase(),
+    );
+
+    match env_level {
+        Some(env_level) => format!("{level_str},{env_level}"),
+        None => level_str,
     }
 }
 


### PR DESCRIPTION
I wasn't able to get any useful information out of the `recurse.rs` utility when setting `--debug` and it sent me down a bit of a rabbit hole. 

The TL;DR is that I think the util `get_levels()` helper should be using `hickory={level}` not `hickory_dns={level}` to try and configure the sub-crate logging levels alongside the utility binary. With that change in place I see `hickory_proto`, `hickory_resolver`, `hickory_recursor`, etc log lines at the expected level.

<details>
<summary>Before this branch:</summary>

```
$ git rev-parse HEAD
1a0ba919996c0fa7e489f684c705d642dc759b0f

$ cargo run -p hickory-util --bin recurse -- --debug -t A example.com
<snipped>
Recursing for example.com. A from roots
Success for query Message {
    header: Header {
        id: 36923,
        message_type: Response,
        op_code: Query,
        authoritative: true,
        truncation: false,
        recursion_desired: false,
        recursion_available: false,
        authentic_data: false,
        checking_disabled: false,
        response_code: NoError,
        query_count: 1,
        answer_count: 6,
        authority_count: 0,
        additional_count: 0,
    },
    queries: [
        Query {
            name: Name("example.com."),
            query_type: A,
            query_class: IN,
        },
    ],
    answers: [
        Record {
            name_labels: Name("example.com."),
            dns_class: IN,
            ttl: 300,
            rdata: A(
                A(
                    23.192.228.80,
                ),
            ),
        },
        Record {
            name_labels: Name("example.com."),
            dns_class: IN,
            ttl: 300,
            rdata: A(
                A(
                    23.192.228.84,
                ),
            ),
        },
        Record {
            name_labels: Name("example.com."),
            dns_class: IN,
            ttl: 300,
            rdata: A(
                A(
                    23.215.0.136,
                ),
            ),
        },
        Record {
            name_labels: Name("example.com."),
            dns_class: IN,
            ttl: 300,
            rdata: A(
                A(
                    23.215.0.138,
                ),
            ),
        },
        Record {
            name_labels: Name("example.com."),
            dns_class: IN,
            ttl: 300,
            rdata: A(
                A(
                    96.7.128.175,
                ),
            ),
        },
        Record {
            name_labels: Name("example.com."),
            dns_class: IN,
            ttl: 300,
            rdata: A(
                A(
                    96.7.128.198,
                ),
            ),
        },
    ],
    authorities: [],
    additionals: [],
    signature: Unsigned,
    edns: None,
}
	example.com. 300 IN A 23.192.228.80
	example.com. 300 IN A 23.192.228.84
	example.com. 300 IN A 23.215.0.136
	example.com. 300 IN A 23.215.0.138
	example.com. 300 IN A 96.7.128.175
	example.com. 300 IN A 96.7.128.198
```
</details>

<details>
<summary>Wtith this branch:</summary>

```
$ cargo run -p hickory-util --bin recurse -- --debug -t A example.com
<snipped>
2025-07-23T17:38:39.310403Z DEBUG hickory_recursor::recursor_dns_handle: Using cache sizes 1024/1048576
Recursing for example.com. A from roots
2025-07-23T17:38:39.310637Z DEBUG hickory_recursor::recursor_dns_handle: using roots for com. nameservers
2025-07-23T17:38:39.310651Z  INFO hickory_recursor::recursor_pool: querying . for com. IN NS
2025-07-23T17:38:39.310657Z DEBUG hickory_proto::xfer::dns_handle: querying: com. NS
2025-07-23T17:38:39.310670Z DEBUG hickory_resolver::name_server::name_server_pool: sending request: [Query { name: Name("com."), query_type: NS, query_class: IN }]
2025-07-23T17:38:39.310715Z DEBUG hickory_resolver::name_server::name_server: reconnecting: ConnectionConfig { port: 53, protocol: Udp, bind_addr: None }
2025-07-23T17:38:39.310747Z DEBUG hickory_proto::xfer: enqueueing message:QUERY:[Query { name: Name("com."), query_type: NS, query_class: IN }]
2025-07-23T17:38:39.310801Z DEBUG hickory_proto::udp::udp_client_stream: final message: ; header 45796:QUERY::NoError:QUERY:0/0/0
; query
;; com. IN NS

2025-07-23T17:38:39.310866Z DEBUG hickory_proto::udp::udp_stream: created socket successfully
2025-07-23T17:38:39.338845Z DEBUG hickory_proto::udp::udp_client_stream: received message id: 45796
2025-07-23T17:38:39.338884Z DEBUG hickory_proto::error: response: ; header 45796:RESPONSE:TC:NoError:QUERY:0/13/12
; query
;; com. IN NS
; answers 0
; authorities 13
com. 172800 IN NS l.gtld-servers.net.
com. 172800 IN NS j.gtld-servers.net.
com. 172800 IN NS h.gtld-servers.net.
com. 172800 IN NS d.gtld-servers.net.
com. 172800 IN NS b.gtld-servers.net.
com. 172800 IN NS f.gtld-servers.net.
com. 172800 IN NS k.gtld-servers.net.
com. 172800 IN NS m.gtld-servers.net.
com. 172800 IN NS i.gtld-servers.net.
com. 172800 IN NS g.gtld-servers.net.
com. 172800 IN NS a.gtld-servers.net.
com. 172800 IN NS c.gtld-servers.net.
com. 172800 IN NS e.gtld-servers.net.
; additionals 12
l.gtld-servers.net. 172800 IN A 192.41.162.30
l.gtld-servers.net. 172800 IN AAAA 2001:500:d937::30
j.gtld-servers.net. 172800 IN A 192.48.79.30
j.gtld-servers.net. 172800 IN AAAA 2001:502:7094::30
h.gtld-servers.net. 172800 IN A 192.54.112.30
h.gtld-servers.net. 172800 IN AAAA 2001:502:8cc::30
d.gtld-servers.net. 172800 IN A 192.31.80.30
d.gtld-servers.net. 172800 IN AAAA 2001:500:856e::30
b.gtld-servers.net. 172800 IN A 192.33.14.30
b.gtld-servers.net. 172800 IN AAAA 2001:503:231d::2:30
f.gtld-servers.net. 172800 IN A 192.35.51.30
f.gtld-servers.net. 172800 IN AAAA 2001:503:d414::30

2025-07-23T17:38:39.338968Z DEBUG hickory_resolver::name_server::name_server_pool: truncated response received, retrying over TCP
2025-07-23T17:38:39.338986Z DEBUG hickory_resolver::name_server::name_server: reconnecting: ConnectionConfig { port: 53, protocol: Tcp, bind_addr: None }
2025-07-23T17:38:39.368094Z DEBUG hickory_proto::xfer: enqueueing message:QUERY:[Query { name: Name("com."), query_type: NS, query_class: IN }]
2025-07-23T17:38:39.368244Z DEBUG hickory_proto::xfer::dns_multiplexer: sending message id=23728
2025-07-23T17:38:39.368271Z DEBUG hickory_proto::xfer::dns_multiplexer: final message: ; header 23728:QUERY::NoError:QUERY:0/0/0
; query
;; com. IN NS

2025-07-23T17:38:39.368318Z DEBUG hickory_proto::tcp::tcp_stream: sending message len: 21 to: [2001:500:9f::42]:53
2025-07-23T17:38:39.395315Z DEBUG hickory_proto::tcp::tcp_stream: in ReadTcpState::LenBytes: 0
2025-07-23T17:38:39.395362Z DEBUG hickory_proto::tcp::tcp_stream: got length: 817
2025-07-23T17:38:39.395373Z DEBUG hickory_proto::tcp::tcp_stream: move ReadTcpState::Bytes: 817
2025-07-23T17:38:39.395380Z DEBUG hickory_proto::tcp::tcp_stream: in ReadTcpState::Bytes: 817
2025-07-23T17:38:39.395385Z DEBUG hickory_proto::tcp::tcp_stream: reset ReadTcpState::LenBytes: 0
2025-07-23T17:38:39.395391Z DEBUG hickory_proto::tcp::tcp_stream: returning bytes
2025-07-23T17:38:39.395399Z DEBUG hickory_proto::tcp::tcp_stream: returning buffer
2025-07-23T17:38:39.395649Z DEBUG hickory_proto::error: response: ; header 23728:RESPONSE::NoError:QUERY:0/13/26
; query
;; com. IN NS
; answers 0
; authorities 13
com. 172800 IN NS a.gtld-servers.net.
com. 172800 IN NS b.gtld-servers.net.
com. 172800 IN NS c.gtld-servers.net.
com. 172800 IN NS d.gtld-servers.net.
com. 172800 IN NS e.gtld-servers.net.
com. 172800 IN NS f.gtld-servers.net.
com. 172800 IN NS g.gtld-servers.net.
com. 172800 IN NS h.gtld-servers.net.
com. 172800 IN NS i.gtld-servers.net.
com. 172800 IN NS j.gtld-servers.net.
com. 172800 IN NS k.gtld-servers.net.
com. 172800 IN NS l.gtld-servers.net.
com. 172800 IN NS m.gtld-servers.net.
; additionals 26
a.gtld-servers.net. 172800 IN A 192.5.6.30
a.gtld-servers.net. 172800 IN AAAA 2001:503:a83e::2:30
b.gtld-servers.net. 172800 IN A 192.33.14.30
b.gtld-servers.net. 172800 IN AAAA 2001:503:231d::2:30
c.gtld-servers.net. 172800 IN A 192.26.92.30
c.gtld-servers.net. 172800 IN AAAA 2001:503:83eb::30
d.gtld-servers.net. 172800 IN A 192.31.80.30
d.gtld-servers.net. 172800 IN AAAA 2001:500:856e::30
e.gtld-servers.net. 172800 IN A 192.12.94.30
e.gtld-servers.net. 172800 IN AAAA 2001:502:1ca1::30
f.gtld-servers.net. 172800 IN A 192.35.51.30
f.gtld-servers.net. 172800 IN AAAA 2001:503:d414::30
g.gtld-servers.net. 172800 IN A 192.42.93.30
g.gtld-servers.net. 172800 IN AAAA 2001:503:eea3::30
h.gtld-servers.net. 172800 IN A 192.54.112.30
h.gtld-servers.net. 172800 IN AAAA 2001:502:8cc::30
i.gtld-servers.net. 172800 IN A 192.43.172.30
i.gtld-servers.net. 172800 IN AAAA 2001:503:39c1::30
j.gtld-servers.net. 172800 IN A 192.48.79.30
j.gtld-servers.net. 172800 IN AAAA 2001:502:7094::30
k.gtld-servers.net. 172800 IN A 192.52.178.30
k.gtld-servers.net. 172800 IN AAAA 2001:503:d2d::30
l.gtld-servers.net. 172800 IN A 192.41.162.30
l.gtld-servers.net. 172800 IN AAAA 2001:500:d937::30
m.gtld-servers.net. 172800 IN A 192.55.83.30
m.gtld-servers.net. 172800 IN AAAA 2001:501:b1f9::30

2025-07-23T17:38:39.396294Z DEBUG hickory_recursor::recursor_dns_handle: found nameservers for com.
2025-07-23T17:38:39.396334Z  INFO hickory_recursor::recursor_pool: querying com. for example.com. IN NS
2025-07-23T17:38:39.396341Z DEBUG hickory_proto::xfer::dns_handle: querying: example.com. NS
2025-07-23T17:38:39.396358Z DEBUG hickory_resolver::name_server::name_server_pool: sending request: [Query { name: Name("example.com."), query_type: NS, query_class: IN }]
2025-07-23T17:38:39.396426Z DEBUG hickory_resolver::name_server::name_server: reconnecting: ConnectionConfig { port: 53, protocol: Udp, bind_addr: None }
2025-07-23T17:38:39.396511Z DEBUG hickory_proto::xfer: enqueueing message:QUERY:[Query { name: Name("example.com."), query_type: NS, query_class: IN }]
2025-07-23T17:38:39.396593Z DEBUG hickory_proto::udp::udp_client_stream: final message: ; header 14126:QUERY::NoError:QUERY:0/0/0
; query
;; example.com. IN NS

2025-07-23T17:38:39.396711Z DEBUG hickory_proto::udp::udp_stream: created socket successfully
2025-07-23T17:38:39.473534Z DEBUG hickory_proto::udp::udp_client_stream: received message id: 14126
2025-07-23T17:38:39.473696Z DEBUG hickory_proto::error: response: ; header 14126:RESPONSE::NoError:QUERY:0/2/0
; query
;; example.com. IN NS
; answers 0
; authorities 2
example.com. 172800 IN NS a.iana-servers.net.
example.com. 172800 IN NS b.iana-servers.net.
; additionals 0

2025-07-23T17:38:39.473872Z DEBUG hickory_recursor::recursor_dns_handle: glue not found for a.iana-servers.net.
2025-07-23T17:38:39.473891Z DEBUG hickory_recursor::recursor_dns_handle: glue not found for b.iana-servers.net.
2025-07-23T17:38:39.473897Z DEBUG hickory_recursor::recursor_dns_handle: need glue for example.com.
2025-07-23T17:38:39.473915Z DEBUG hickory_recursor::recursor_dns_handle: using roots for net. nameservers
2025-07-23T17:38:39.473926Z  INFO hickory_recursor::recursor_pool: querying . for net. IN NS
2025-07-23T17:38:39.473932Z DEBUG hickory_proto::xfer::dns_handle: querying: net. NS
2025-07-23T17:38:39.473946Z DEBUG hickory_resolver::name_server::name_server_pool: sending request: [Query { name: Name("net."), query_type: NS, query_class: IN }]
2025-07-23T17:38:39.474017Z DEBUG hickory_resolver::name_server::name_server: reconnecting: ConnectionConfig { port: 53, protocol: Udp, bind_addr: None }
2025-07-23T17:38:39.474085Z DEBUG hickory_proto::xfer: enqueueing message:QUERY:[Query { name: Name("net."), query_type: NS, query_class: IN }]
2025-07-23T17:38:39.474145Z DEBUG hickory_proto::udp::udp_client_stream: final message: ; header 41517:QUERY::NoError:QUERY:0/0/0
; query
;; net. IN NS

2025-07-23T17:38:39.474229Z DEBUG hickory_proto::udp::udp_stream: created socket successfully
2025-07-23T17:38:39.498970Z DEBUG hickory_proto::udp::udp_client_stream: received message id: 41517
2025-07-23T17:38:39.499057Z DEBUG hickory_proto::error: response: ; header 41517:RESPONSE::NoError:QUERY:0/13/15
; query
;; net. IN NS
; answers 0
; authorities 13
net. 172800 IN NS m.gtld-servers.net.
net. 172800 IN NS h.gtld-servers.net.
net. 172800 IN NS j.gtld-servers.net.
net. 172800 IN NS c.gtld-servers.net.
net. 172800 IN NS e.gtld-servers.net.
net. 172800 IN NS l.gtld-servers.net.
net. 172800 IN NS g.gtld-servers.net.
net. 172800 IN NS b.gtld-servers.net.
net. 172800 IN NS d.gtld-servers.net.
net. 172800 IN NS f.gtld-servers.net.
net. 172800 IN NS k.gtld-servers.net.
net. 172800 IN NS i.gtld-servers.net.
net. 172800 IN NS a.gtld-servers.net.
; additionals 15
m.gtld-servers.net. 172800 IN A 192.55.83.30
l.gtld-servers.net. 172800 IN A 192.41.162.30
k.gtld-servers.net. 172800 IN A 192.52.178.30
j.gtld-servers.net. 172800 IN A 192.48.79.30
i.gtld-servers.net. 172800 IN A 192.43.172.30
h.gtld-servers.net. 172800 IN A 192.54.112.30
g.gtld-servers.net. 172800 IN A 192.42.93.30
f.gtld-servers.net. 172800 IN A 192.35.51.30
e.gtld-servers.net. 172800 IN A 192.12.94.30
d.gtld-servers.net. 172800 IN A 192.31.80.30
c.gtld-servers.net. 172800 IN A 192.26.92.30
b.gtld-servers.net. 172800 IN A 192.33.14.30
a.gtld-servers.net. 172800 IN A 192.5.6.30
m.gtld-servers.net. 172800 IN AAAA 2001:501:b1f9::30
l.gtld-servers.net. 172800 IN AAAA 2001:500:d937::30

2025-07-23T17:38:39.499515Z DEBUG hickory_recursor::recursor_dns_handle: found nameservers for net.
2025-07-23T17:38:39.499571Z  INFO hickory_recursor::recursor_pool: querying net. for iana-servers.net. IN NS
2025-07-23T17:38:39.499579Z DEBUG hickory_proto::xfer::dns_handle: querying: iana-servers.net. NS
2025-07-23T17:38:39.499591Z DEBUG hickory_resolver::name_server::name_server_pool: sending request: [Query { name: Name("iana-servers.net."), query_type: NS, query_class: IN }]
2025-07-23T17:38:39.499630Z DEBUG hickory_resolver::name_server::name_server: reconnecting: ConnectionConfig { port: 53, protocol: Udp, bind_addr: None }
2025-07-23T17:38:39.499693Z DEBUG hickory_proto::xfer: enqueueing message:QUERY:[Query { name: Name("iana-servers.net."), query_type: NS, query_class: IN }]
2025-07-23T17:38:39.499773Z DEBUG hickory_proto::udp::udp_client_stream: final message: ; header 33429:QUERY::NoError:QUERY:0/0/0
; query
;; iana-servers.net. IN NS

2025-07-23T17:38:39.499923Z DEBUG hickory_proto::udp::udp_stream: created socket successfully
2025-07-23T17:38:39.576139Z DEBUG hickory_proto::udp::udp_client_stream: received message id: 33429
2025-07-23T17:38:39.576222Z DEBUG hickory_proto::error: response: ; header 33429:RESPONSE::NoError:QUERY:0/4/6
; query
;; iana-servers.net. IN NS
; answers 0
; authorities 4
iana-servers.net. 172800 IN NS ns.icann.org.
iana-servers.net. 172800 IN NS a.iana-servers.net.
iana-servers.net. 172800 IN NS b.iana-servers.net.
iana-servers.net. 172800 IN NS c.iana-servers.net.
; additionals 6
a.iana-servers.net. 172800 IN A 199.43.135.53
a.iana-servers.net. 172800 IN AAAA 2001:500:8f::53
b.iana-servers.net. 172800 IN A 199.43.133.53
b.iana-servers.net. 172800 IN AAAA 2001:500:8d::53
c.iana-servers.net. 172800 IN A 199.43.134.53
c.iana-servers.net. 172800 IN AAAA 2001:500:8e::53

2025-07-23T17:38:39.576423Z DEBUG hickory_recursor::recursor_dns_handle: glue not found for ns.icann.org.
2025-07-23T17:38:39.576593Z DEBUG hickory_recursor::recursor_dns_handle: found nameservers for iana-servers.net.
2025-07-23T17:38:39.576619Z  INFO hickory_recursor::recursor_pool: querying iana-servers.net. for a.iana-servers.net. IN NS
2025-07-23T17:38:39.576628Z DEBUG hickory_proto::xfer::dns_handle: querying: a.iana-servers.net. NS
2025-07-23T17:38:39.576641Z DEBUG hickory_resolver::name_server::name_server_pool: sending request: [Query { name: Name("a.iana-servers.net."), query_type: NS, query_class: IN }]
2025-07-23T17:38:39.576665Z DEBUG hickory_resolver::name_server::name_server: reconnecting: ConnectionConfig { port: 53, protocol: Udp, bind_addr: None }
2025-07-23T17:38:39.576710Z DEBUG hickory_proto::xfer: enqueueing message:QUERY:[Query { name: Name("a.iana-servers.net."), query_type: NS, query_class: IN }]
2025-07-23T17:38:39.576800Z DEBUG hickory_proto::udp::udp_client_stream: final message: ; header 41425:QUERY::NoError:QUERY:0/0/0
; query
;; a.iana-servers.net. IN NS

2025-07-23T17:38:39.576919Z DEBUG hickory_proto::udp::udp_stream: created socket successfully
2025-07-23T17:38:39.605445Z DEBUG hickory_proto::udp::udp_client_stream: received message id: 41425
2025-07-23T17:38:39.605620Z DEBUG hickory_proto::error: response: ; header 41425:RESPONSE:AA:NoError:QUERY:0/1/0
; query
;; a.iana-servers.net. IN NS
; answers 0
; authorities 1
iana-servers.net. 3600 IN SOA sns.dns.icann.org. noc.dns.icann.org. 2022092387 10800 3600 604800 3600
; additionals 0

2025-07-23T17:38:39.605800Z  WARN hickory_recursor::recursor_dns_handle: lookup error: no records found for Query { name: Name("a.iana-servers.net."), query_type: NS, query_class: IN }
2025-07-23T17:38:39.605842Z DEBUG hickory_recursor::recursor_dns_handle: returning cached pool for iana-servers.net.
2025-07-23T17:38:39.605883Z  INFO hickory_recursor::recursor_pool: querying iana-servers.net. for b.iana-servers.net. IN NS
2025-07-23T17:38:39.605892Z DEBUG hickory_proto::xfer::dns_handle: querying: b.iana-servers.net. NS
2025-07-23T17:38:39.605906Z DEBUG hickory_resolver::name_server::name_server_pool: sending request: [Query { name: Name("b.iana-servers.net."), query_type: NS, query_class: IN }]
2025-07-23T17:38:39.605938Z DEBUG hickory_resolver::name_server::name_server: reconnecting: ConnectionConfig { port: 53, protocol: Udp, bind_addr: None }
2025-07-23T17:38:39.605996Z DEBUG hickory_proto::xfer: enqueueing message:QUERY:[Query { name: Name("b.iana-servers.net."), query_type: NS, query_class: IN }]
2025-07-23T17:38:39.606069Z DEBUG hickory_proto::udp::udp_client_stream: final message: ; header 17026:QUERY::NoError:QUERY:0/0/0
; query
;; b.iana-servers.net. IN NS

2025-07-23T17:38:39.606153Z DEBUG hickory_proto::udp::udp_stream: created socket successfully
2025-07-23T17:38:39.634428Z DEBUG hickory_proto::udp::udp_client_stream: received message id: 17026
2025-07-23T17:38:39.634608Z DEBUG hickory_proto::error: response: ; header 17026:RESPONSE:AA:NoError:QUERY:0/1/0
; query
;; b.iana-servers.net. IN NS
; answers 0
; authorities 1
iana-servers.net. 3600 IN SOA sns.dns.icann.org. noc.dns.icann.org. 2022092387 10800 3600 604800 3600
; additionals 0

2025-07-23T17:38:39.634725Z  WARN hickory_recursor::recursor_dns_handle: lookup error: no records found for Query { name: Name("b.iana-servers.net."), query_type: NS, query_class: IN }
2025-07-23T17:38:39.634765Z  INFO hickory_recursor::recursor_pool: querying iana-servers.net. for a.iana-servers.net. IN A
2025-07-23T17:38:39.634774Z DEBUG hickory_proto::xfer::dns_handle: querying: a.iana-servers.net. A
2025-07-23T17:38:39.634795Z DEBUG hickory_resolver::name_server::name_server_pool: sending request: [Query { name: Name("a.iana-servers.net."), query_type: A, query_class: IN }]
2025-07-23T17:38:39.634829Z DEBUG hickory_resolver::name_server::name_server: reconnecting: ConnectionConfig { port: 53, protocol: Udp, bind_addr: None }
2025-07-23T17:38:39.634901Z DEBUG hickory_proto::xfer: enqueueing message:QUERY:[Query { name: Name("a.iana-servers.net."), query_type: A, query_class: IN }]
2025-07-23T17:38:39.634924Z  INFO hickory_recursor::recursor_pool: querying iana-servers.net. for a.iana-servers.net. IN AAAA
2025-07-23T17:38:39.634932Z DEBUG hickory_proto::xfer::dns_handle: querying: a.iana-servers.net. AAAA
2025-07-23T17:38:39.634940Z DEBUG hickory_resolver::name_server::name_server_pool: sending request: [Query { name: Name("a.iana-servers.net."), query_type: AAAA, query_class: IN }]
2025-07-23T17:38:39.634985Z DEBUG hickory_resolver::name_server::name_server: existing connection: ConnectionConfig { port: 53, protocol: Udp, bind_addr: None }
2025-07-23T17:38:39.634991Z DEBUG hickory_proto::xfer: enqueueing message:QUERY:[Query { name: Name("a.iana-servers.net."), query_type: AAAA, query_class: IN }]
2025-07-23T17:38:39.635011Z  INFO hickory_recursor::recursor_pool: querying iana-servers.net. for b.iana-servers.net. IN A
2025-07-23T17:38:39.635019Z DEBUG hickory_proto::xfer::dns_handle: querying: b.iana-servers.net. A
2025-07-23T17:38:39.635009Z DEBUG hickory_proto::udp::udp_client_stream: final message: ; header 27377:QUERY::NoError:QUERY:0/0/0
; query
;; a.iana-servers.net. IN A

2025-07-23T17:38:39.635028Z DEBUG hickory_resolver::name_server::name_server_pool: sending request: [Query { name: Name("b.iana-servers.net."), query_type: A, query_class: IN }]
2025-07-23T17:38:39.635048Z DEBUG hickory_resolver::name_server::name_server: existing connection: ConnectionConfig { port: 53, protocol: Udp, bind_addr: None }
2025-07-23T17:38:39.635049Z DEBUG hickory_proto::udp::udp_client_stream: final message: ; header 27537:QUERY::NoError:QUERY:0/0/0
; query
;; a.iana-servers.net. IN AAAA

2025-07-23T17:38:39.635053Z DEBUG hickory_proto::xfer: enqueueing message:QUERY:[Query { name: Name("b.iana-servers.net."), query_type: A, query_class: IN }]
2025-07-23T17:38:39.635072Z DEBUG hickory_proto::udp::udp_client_stream: final message: ; header 14476:QUERY::NoError:QUERY:0/0/0
; query
;; b.iana-servers.net. IN A

2025-07-23T17:38:39.635083Z  INFO hickory_recursor::recursor_pool: querying iana-servers.net. for b.iana-servers.net. IN AAAA
2025-07-23T17:38:39.635090Z DEBUG hickory_proto::xfer::dns_handle: querying: b.iana-servers.net. AAAA
2025-07-23T17:38:39.635097Z DEBUG hickory_resolver::name_server::name_server_pool: sending request: [Query { name: Name("b.iana-servers.net."), query_type: AAAA, query_class: IN }]
2025-07-23T17:38:39.635111Z DEBUG hickory_resolver::name_server::name_server: existing connection: ConnectionConfig { port: 53, protocol: Udp, bind_addr: None }
2025-07-23T17:38:39.635115Z DEBUG hickory_proto::xfer: enqueueing message:QUERY:[Query { name: Name("b.iana-servers.net."), query_type: AAAA, query_class: IN }]
2025-07-23T17:38:39.635150Z DEBUG hickory_proto::udp::udp_client_stream: final message: ; header 5101:QUERY::NoError:QUERY:0/0/0
; query
;; b.iana-servers.net. IN AAAA

2025-07-23T17:38:39.635183Z DEBUG hickory_proto::udp::udp_stream: created socket successfully
2025-07-23T17:38:39.635308Z DEBUG hickory_proto::udp::udp_stream: created socket successfully
2025-07-23T17:38:39.635331Z DEBUG hickory_proto::udp::udp_stream: created socket successfully
2025-07-23T17:38:39.635381Z DEBUG hickory_proto::udp::udp_stream: created socket successfully
2025-07-23T17:38:39.683674Z DEBUG hickory_proto::udp::udp_client_stream: received message id: 14476
2025-07-23T17:38:39.683757Z DEBUG hickory_proto::error: response: ; header 14476:RESPONSE:AA:NoError:QUERY:1/0/0
; query
;; b.iana-servers.net. IN A
; answers 1
b.iana-servers.net. 1800 IN A 199.43.133.53
; authorities 0
; additionals 0

2025-07-23T17:38:39.683835Z DEBUG hickory_recursor::recursor_dns_handle: append_ips_from_lookup: A or AAAA response: DnsResponse { message: Message { header: Header { id: 14476, message_type: Response, op_code: Query, authoritative: true, truncation: false, recursion_desired: false, recursion_available: false, authentic_data: false, checking_disabled: false, response_code: NoError, query_count: 1, answer_count: 1, authority_count: 0, additional_count: 0 }, queries: [Query { name: Name("b.iana-servers.net."), query_type: A, query_class: IN }], answers: [Record { name_labels: Name("b.iana-servers.net."), dns_class: IN, ttl: 1800, rdata: A(A(199.43.133.53)) }], authorities: [], additionals: [], signature: Unsigned, edns: None }, buffer: [56, 140, 132, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 98, 12, 105, 97, 110, 97, 45, 115, 101, 114, 118, 101, 114, 115, 3, 110, 101, 116, 0, 0, 1, 0, 1, 192, 12, 0, 1, 0, 1, 0, 0, 7, 8, 0, 4, 199, 43, 133, 53] }
2025-07-23T17:38:39.694280Z DEBUG hickory_proto::udp::udp_client_stream: received message id: 27377
2025-07-23T17:38:39.694317Z DEBUG hickory_proto::error: response: ; header 27377:RESPONSE:AA:NoError:QUERY:1/0/0
; query
;; a.iana-servers.net. IN A
; answers 1
a.iana-servers.net. 1800 IN A 199.43.135.53
; authorities 0
; additionals 0

2025-07-23T17:38:39.694366Z DEBUG hickory_recursor::recursor_dns_handle: append_ips_from_lookup: A or AAAA response: DnsResponse { message: Message { header: Header { id: 27377, message_type: Response, op_code: Query, authoritative: true, truncation: false, recursion_desired: false, recursion_available: false, authentic_data: false, checking_disabled: false, response_code: NoError, query_count: 1, answer_count: 1, authority_count: 0, additional_count: 0 }, queries: [Query { name: Name("a.iana-servers.net."), query_type: A, query_class: IN }], answers: [Record { name_labels: Name("a.iana-servers.net."), dns_class: IN, ttl: 1800, rdata: A(A(199.43.135.53)) }], authorities: [], additionals: [], signature: Unsigned, edns: None }, buffer: [106, 241, 132, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 97, 12, 105, 97, 110, 97, 45, 115, 101, 114, 118, 101, 114, 115, 3, 110, 101, 116, 0, 0, 1, 0, 1, 192, 12, 0, 1, 0, 1, 0, 0, 7, 8, 0, 4, 199, 43, 135, 53] }
2025-07-23T17:38:39.694409Z DEBUG hickory_proto::udp::udp_client_stream: received message id: 27537
2025-07-23T17:38:39.694428Z DEBUG hickory_proto::error: response: ; header 27537:RESPONSE:AA:NoError:QUERY:1/0/0
; query
;; a.iana-servers.net. IN AAAA
; answers 1
a.iana-servers.net. 1800 IN AAAA 2001:500:8f::53
; authorities 0
; additionals 0

2025-07-23T17:38:39.694457Z DEBUG hickory_recursor::recursor_dns_handle: append_ips_from_lookup: A or AAAA response: DnsResponse { message: Message { header: Header { id: 27537, message_type: Response, op_code: Query, authoritative: true, truncation: false, recursion_desired: false, recursion_available: false, authentic_data: false, checking_disabled: false, response_code: NoError, query_count: 1, answer_count: 1, authority_count: 0, additional_count: 0 }, queries: [Query { name: Name("a.iana-servers.net."), query_type: AAAA, query_class: IN }], answers: [Record { name_labels: Name("a.iana-servers.net."), dns_class: IN, ttl: 1800, rdata: AAAA(AAAA(2001:500:8f::53)) }], authorities: [], additionals: [], signature: Unsigned, edns: None }, buffer: [107, 145, 132, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 97, 12, 105, 97, 110, 97, 45, 115, 101, 114, 118, 101, 114, 115, 3, 110, 101, 116, 0, 0, 28, 0, 1, 192, 12, 0, 28, 0, 1, 0, 0, 7, 8, 0, 16, 32, 1, 5, 0, 0, 143, 0, 0, 0, 0, 0, 0, 0, 0, 0, 83] }
2025-07-23T17:38:39.694494Z DEBUG hickory_proto::udp::udp_client_stream: received message id: 5101
2025-07-23T17:38:39.694510Z DEBUG hickory_proto::error: response: ; header 5101:RESPONSE:AA:NoError:QUERY:1/0/0
; query
;; b.iana-servers.net. IN AAAA
; answers 1
b.iana-servers.net. 1800 IN AAAA 2001:500:8d::53
; authorities 0
; additionals 0

2025-07-23T17:38:39.694537Z DEBUG hickory_recursor::recursor_dns_handle: append_ips_from_lookup: A or AAAA response: DnsResponse { message: Message { header: Header { id: 5101, message_type: Response, op_code: Query, authoritative: true, truncation: false, recursion_desired: false, recursion_available: false, authentic_data: false, checking_disabled: false, response_code: NoError, query_count: 1, answer_count: 1, authority_count: 0, additional_count: 0 }, queries: [Query { name: Name("b.iana-servers.net."), query_type: AAAA, query_class: IN }], answers: [Record { name_labels: Name("b.iana-servers.net."), dns_class: IN, ttl: 1800, rdata: AAAA(AAAA(2001:500:8d::53)) }], authorities: [], additionals: [], signature: Unsigned, edns: None }, buffer: [19, 237, 132, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 98, 12, 105, 97, 110, 97, 45, 115, 101, 114, 118, 101, 114, 115, 3, 110, 101, 116, 0, 0, 28, 0, 1, 192, 12, 0, 28, 0, 1, 0, 0, 7, 8, 0, 16, 32, 1, 5, 0, 0, 141, 0, 0, 0, 0, 0, 0, 0, 0, 0, 83] }
2025-07-23T17:38:39.694623Z DEBUG hickory_recursor::recursor_dns_handle: found nameservers for example.com.
2025-07-23T17:38:39.694653Z DEBUG hickory_recursor::recursor_dns_handle: found zone example.com. for example.com. IN A
2025-07-23T17:38:39.694702Z  INFO hickory_recursor::recursor_pool: querying example.com. for example.com. IN A
2025-07-23T17:38:39.694711Z DEBUG hickory_proto::xfer::dns_handle: querying: example.com. A
2025-07-23T17:38:39.694724Z DEBUG hickory_resolver::name_server::name_server_pool: sending request: [Query { name: Name("example.com."), query_type: A, query_class: IN }]
2025-07-23T17:38:39.694745Z DEBUG hickory_resolver::name_server::name_server: reconnecting: ConnectionConfig { port: 53, protocol: Udp, bind_addr: None }
2025-07-23T17:38:39.694919Z DEBUG hickory_proto::xfer: enqueueing message:QUERY:[Query { name: Name("example.com."), query_type: A, query_class: IN }]
2025-07-23T17:38:39.695029Z DEBUG hickory_proto::udp::udp_client_stream: final message: ; header 43487:QUERY::NoError:QUERY:0/0/0
; query
;; example.com. IN A

2025-07-23T17:38:39.695197Z DEBUG hickory_proto::udp::udp_stream: created socket successfully
2025-07-23T17:38:39.724878Z DEBUG hickory_proto::udp::udp_client_stream: received message id: 43487
2025-07-23T17:38:39.724914Z DEBUG hickory_proto::error: response: ; header 43487:RESPONSE:AA:NoError:QUERY:6/2/0
; query
;; example.com. IN A
; answers 6
example.com. 300 IN A 23.192.228.80
example.com. 300 IN A 23.192.228.84
example.com. 300 IN A 23.215.0.136
example.com. 300 IN A 23.215.0.138
example.com. 300 IN A 96.7.128.175
example.com. 300 IN A 96.7.128.198
; authorities 2
example.com. 86400 IN NS a.iana-servers.net.
example.com. 86400 IN NS b.iana-servers.net.
; additionals 0

Success for query Message {
    header: Header {
        id: 43487,
        message_type: Response,
        op_code: Query,
        authoritative: true,
        truncation: false,
        recursion_desired: false,
        recursion_available: false,
        authentic_data: false,
        checking_disabled: false,
        response_code: NoError,
        query_count: 1,
        answer_count: 6,
        authority_count: 2,
        additional_count: 0,
    },
    queries: [
        Query {
            name: Name("example.com."),
            query_type: A,
            query_class: IN,
        },
    ],
    answers: [
        Record {
            name_labels: Name("example.com."),
            dns_class: IN,
            ttl: 300,
            rdata: A(
                A(
                    23.192.228.80,
                ),
            ),
        },
        Record {
            name_labels: Name("example.com."),
            dns_class: IN,
            ttl: 300,
            rdata: A(
                A(
                    23.192.228.84,
                ),
            ),
        },
        Record {
            name_labels: Name("example.com."),
            dns_class: IN,
            ttl: 300,
            rdata: A(
                A(
                    23.215.0.136,
                ),
            ),
        },
        Record {
            name_labels: Name("example.com."),
            dns_class: IN,
            ttl: 300,
            rdata: A(
                A(
                    23.215.0.138,
                ),
            ),
        },
        Record {
            name_labels: Name("example.com."),
            dns_class: IN,
            ttl: 300,
            rdata: A(
                A(
                    96.7.128.175,
                ),
            ),
        },
        Record {
            name_labels: Name("example.com."),
            dns_class: IN,
            ttl: 300,
            rdata: A(
                A(
                    96.7.128.198,
                ),
            ),
        },
    ],
    authorities: [
        Record {
            name_labels: Name("example.com."),
            dns_class: IN,
            ttl: 86400,
            rdata: NS(
                NS(
                    Name("a.iana-servers.net."),
                ),
            ),
        },
        Record {
            name_labels: Name("example.com."),
            dns_class: IN,
            ttl: 86400,
            rdata: NS(
                NS(
                    Name("b.iana-servers.net."),
                ),
            ),
        },
    ],
    additionals: [],
    signature: Unsigned,
    edns: None,
}
	example.com. 300 IN A 23.192.228.80
	example.com. 300 IN A 23.192.228.84
	example.com. 300 IN A 23.215.0.136
	example.com. 300 IN A 23.215.0.138
	example.com. 300 IN A 96.7.128.175
	example.com. 300 IN A 96.7.128.198
2025-07-23T17:38:39.725352Z DEBUG hickory_proto::xfer::dns_exchange: io_stream is done, shutting down
2025-07-23T17:38:39.725376Z DEBUG hickory_proto::xfer::dns_exchange: io_stream is done, shutting down
2025-07-23T17:38:39.725404Z DEBUG hickory_proto::xfer::dns_exchange: io_stream is done, shutting down
2025-07-23T17:38:39.725405Z DEBUG hickory_proto::xfer: ignoring send error on disconnected stream
2025-07-23T17:38:39.725415Z DEBUG hickory_proto::xfer::dns_exchange: io_stream is done, shutting down
2025-07-23T17:38:39.725422Z DEBUG hickory_proto::xfer::dns_exchange: io_stream is done, shutting down
2025-07-23T17:38:39.725431Z DEBUG hickory_proto::xfer::dns_exchange: io_stream is done, shutting down
2025-07-23T17:38:39.725433Z DEBUG hickory_proto::xfer::dns_multiplexer: stream is done: TCP([2001:500:9f::42]:53)
2025-07-23T17:38:39.725440Z DEBUG hickory_proto::xfer::dns_exchange: io_stream is done, shutting down
2025-07-23T17:38:39.725436Z DEBUG hickory_proto::xfer::dns_exchange: io_stream is done, shutting down
2025-07-23T17:38:39.725461Z DEBUG hickory_proto::xfer::dns_exchange: io_stream is done, shutting down
```
</details>