### PR TITLE
Store validated responses in a separate cache

### DIFF
--- a/crates/recursor/src/recursor_dns_handle.rs
+++ b/crates/recursor/src/recursor_dns_handle.rs
@@ -562,11 +562,6 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
         }
     }
 
-    #[cfg(feature = "__dnssec")]
-    pub(crate) fn response_cache(&self) -> &ResponseCache {
-        &self.response_cache
-    }
-
     #[cfg(all(feature = "__dnssec", feature = "metrics"))]
     pub(crate) fn cache_metrics(&self) -> &RecursorCacheMetrics {
         &self.cache_metrics


### PR DESCRIPTION
This changes the validating recursor to use separate response caches for responses received from authoritative servers and responses produced by `<RecursorDnsHandle as DnsHandle>::send()`. I think it's incorrect to commingle responses inserted there, which have been through a few forms of post-processing, with responses directly from authoritative servers. After this change, we only call `insert()` on each cache in one place.

This fixes a couple problems I ran into. First, the tests in #3154 for cached queries no longer show even more duplicate records versus the non-cached tests when I integrate these changes. We are still adding too many records, but each cache hit round trip no longer worsens the problem. Secondly, I was trying to fix #3125 by distinguishing between referral responses and authoritative responses, but got tripped up by entries inserted in `<RecursorDnsHandle as DnsHandle>::send()`. These responses have confusing values in their header flags. I'd like to be able to rely on AA there, so this change will make that bug fix easier.