### PR TITLE
Result handling cleanup

### DIFF
--- a/bin/tests/integration/named_test_rsa_dnssec.rs
+++ b/bin/tests/integration/named_test_rsa_dnssec.rs
@@ -152,7 +152,7 @@ fn test_dnssec_restart_with_update_journal() {
     let server_path = env::var("TDNS_WORKSPACE_ROOT").unwrap_or_else(|_| "..".to_owned());
     let server_path = Path::new(&server_path);
     let journal = server_path.join("tests/test-data/test_configs/example.com_dnssec_update.jrnl");
-    std::fs::remove_file(&journal).ok();
+    let _ = std::fs::remove_file(&journal);
 
     generic_test(
         "dnssec_with_update.toml",

--- a/bin/tests/integration/store_sqlite_tests.rs
+++ b/bin/tests/integration/store_sqlite_tests.rs
@@ -19,10 +19,10 @@ fn sqlite(zone_path: &Path, module: &str, test_name: &str) -> SqliteAuthority {
         .join(module.replace("::", "_"))
         .join(test_name)
         .join("authority_battery.jrnl");
-    fs::create_dir_all(journal_path.parent().unwrap()).ok();
+    let _ = fs::create_dir_all(journal_path.parent().unwrap());
 
     // cleanup anything from previous test
-    fs::remove_file(&journal_path).ok();
+    let _ = fs::remove_file(&journal_path);
 
     let config = SqliteConfig {
         zone_path: zone_path.to_owned(),
@@ -51,10 +51,10 @@ fn sqlite_update(zone_path: &Path, module: &str, test_name: &str) -> SqliteAutho
         .join(module.replace("::", "_"))
         .join(test_name)
         .join("authority_battery.jrnl");
-    fs::create_dir_all(journal_path.parent().unwrap()).ok();
+    let _ = fs::create_dir_all(journal_path.parent().unwrap());
 
     // cleanup anything from previous test
-    fs::remove_file(&journal_path).ok();
+    let _ = fs::remove_file(&journal_path);
 
     let config = SqliteConfig {
         zone_path: zone_path.to_owned(),

--- a/bin/tests/integration/txt_tests.rs
+++ b/bin/tests/integration/txt_tests.rs
@@ -61,8 +61,8 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
 "#;
 
     let records = Parser::new(ZONE, None, Some(Name::from_str("isi.edu.").unwrap())).parse();
-    if records.is_err() {
-        panic!("failed to parse: {:?}", records.err())
+    if let Err(error) = records {
+        panic!("failed to parse: {error:?}")
     }
 
     let (origin, records) = records.unwrap();
@@ -437,8 +437,8 @@ a       A       127.0.0.1
 
     let records = Parser::new(ZONE, None, Some(Name::from_str("isi.edu").unwrap())).parse();
 
-    if records.is_err() {
-        panic!("failed to parse: {:?}", records.err())
+    if let Err(error) = records {
+        panic!("failed to parse: {error:?}")
     }
 
     let (origin, records) = records.unwrap();
@@ -475,8 +475,8 @@ b       A       127.0.0.2
 
     let records = Parser::new(ZONE, None, Some(Name::from_str("isi.edu").unwrap())).parse();
 
-    if records.is_err() {
-        panic!("failed to parse: {:?}", records.err())
+    if let Err(error) = records {
+        panic!("failed to parse: {error:?}")
     }
 
     let (origin, records) = records.unwrap();
@@ -512,8 +512,8 @@ a       A       127.0.0.1
 
     let records = Parser::new(ZONE, None, Some(Name::from_str("isi.edu").unwrap())).parse();
 
-    if records.is_err() {
-        panic!("failed to parse: {:?}", records.err())
+    if let Err(error) = records {
+        panic!("failed to parse: {error:?}")
     }
 
     let (origin, records) = records.unwrap();
@@ -541,8 +541,8 @@ fn test_named_root() {
 
     let records = Parser::new(ZONE, None, Some(Name::root())).parse();
 
-    if records.is_err() {
-        panic!("failed to parse: {:?}", records.err())
+    if let Err(error) = records {
+        panic!("failed to parse: {error:?}")
     }
 
     let (_, records) = records.unwrap();

--- a/crates/client/src/client/rc_stream.rs
+++ b/crates/client/src/client/rc_stream.rs
@@ -100,10 +100,10 @@ mod tests {
 
         let rc = rc_stream(once(future));
 
-        let i = block_on(rc.clone().first_answer()).ok().unwrap();
+        let i = block_on(rc.clone().first_answer()).unwrap();
         assert_eq!(i, 1);
 
-        let i = block_on(rc.first_answer()).ok().unwrap();
+        let i = block_on(rc.first_answer()).unwrap();
         assert_eq!(i, 1);
     }
 
@@ -113,10 +113,10 @@ mod tests {
 
         let rc = rc_stream(once(future));
 
-        let i = block_on(rc.clone().first_answer()).err().unwrap();
+        let i = block_on(rc.clone().first_answer()).unwrap_err();
         assert!(matches!(i.kind(), ProtoErrorKind::Busy));
 
-        let i = block_on(rc.first_answer()).err().unwrap();
+        let i = block_on(rc.first_answer()).unwrap_err();
         assert!(matches!(i.kind(), ProtoErrorKind::Busy));
     }
 }

--- a/crates/proto/src/multicast/mdns_stream.rs
+++ b/crates/proto/src/multicast/mdns_stream.rs
@@ -559,7 +559,7 @@ pub(crate) mod tests {
         // FIXME: this is hardcoded to index 5 for ipv6, which isn't going to be correct in most cases...
         let (stream, mut sender) =
             MdnsStream::new(mdns_addr, MdnsQueryType::OneShot, Some(1), None, Some(5));
-        let mut stream = io_loop.block_on(stream).ok().unwrap().into_future();
+        let mut stream = io_loop.block_on(stream).unwrap().into_future();
         let mut timeout = future::lazy(|_| tokio::time::sleep(Duration::from_millis(100)))
             .flatten()
             .boxed();
@@ -695,7 +695,7 @@ pub(crate) mod tests {
         // FIXME: this is hardcoded to index 5 for ipv6, which isn't going to be correct in most cases...
         let (stream, mut sender) =
             MdnsStream::new(mdns_addr, MdnsQueryType::OneShot, Some(1), None, Some(5));
-        let mut stream = io_loop.block_on(stream).ok().unwrap().into_future();
+        let mut stream = io_loop.block_on(stream).unwrap().into_future();
         let mut timeout = future::lazy(|_| tokio::time::sleep(Duration::from_millis(100)))
             .flatten()
             .boxed();

--- a/crates/proto/src/quic/quic_stream.rs
+++ b/crates/proto/src/quic/quic_stream.rs
@@ -176,9 +176,9 @@ impl QuicStream {
 
         // assert that the message id is 0, this is a bad dns-over-quic packet if not
         if message.id() != 0 {
-            self.reset(DoqErrorCode::ProtocolError)
-                .map_err(|_| debug!("stream already closed"))
-                .ok();
+            if let Err(error) = self.reset(DoqErrorCode::ProtocolError) {
+                debug!(%error, "stream already closed");
+            }
             return Err(ProtoErrorKind::QuicMessageIdNot0(message.id()).into());
         }
 
@@ -203,9 +203,9 @@ impl QuicStream {
         if let Err(e) = self.receive_stream.read_exact(&mut bytes[..len]).await {
             debug!("received bad packet len: {} bytes: {:?}", len, bytes);
 
-            self.reset(DoqErrorCode::ProtocolError)
-                .map_err(|_| debug!("stream already closed"))
-                .ok();
+            if let Err(error) = self.reset(DoqErrorCode::ProtocolError) {
+                debug!(%error, "stream already closed");
+            }
             return Err(e.into());
         }
 

--- a/crates/proto/src/serialize/txt/zone.rs
+++ b/crates/proto/src/serialize/txt/zone.rs
@@ -265,8 +265,8 @@ impl<'a> Parser<'a> {
                             Token::CharData(mut data) => {
                                 // if it's a number it's a ttl
                                 let result: ParseResult<u32> = Self::parse_time(&data);
-                                if result.is_ok() {
-                                    cx.ttl = result.ok();
+                                if let Ok(ttl) = result {
+                                    cx.ttl = Some(ttl);
                                     State::TtlClassType // hm, should this go to just ClassType?
                                 } else {
                                     // if can parse DNSClass, then class

--- a/crates/proto/src/tests/udp.rs
+++ b/crates/proto/src/tests/udp.rs
@@ -205,7 +205,7 @@ pub async fn udp_client_stream_test(server_addr: IpAddr, provider: impl RuntimeP
     let stream = UdpClientStream::builder(server_addr, provider)
         .with_timeout(Some(Duration::from_millis(500)))
         .build();
-    let mut stream = stream.await.ok().unwrap();
+    let mut stream = stream.await.unwrap();
     let mut worked_once = false;
 
     for i in 0..send_recv_times {

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -421,11 +421,10 @@ where
                         Poll::Pending => return Poll::Pending,
                     } {
                         // ignoring errors... best effort send...
-                        outbound_message
+                        let _ = outbound_message
                             .into_parts()
                             .1
-                            .send_response(error.clone().into())
-                            .ok();
+                            .send_response(error.clone().into());
                     }
 
                     return Poll::Ready(Err(error.clone()));

--- a/tests/compatibility-tests/src/lib.rs
+++ b/tests/compatibility-tests/src/lib.rs
@@ -51,7 +51,7 @@ impl Drop for NamedProcess {
         self.thread_notice.store(true, Ordering::Release);
 
         println!("----> cleanup work dir: {}", self.working_dir);
-        fs::remove_dir_all(&self.working_dir).ok();
+        let _ = fs::remove_dir_all(&self.working_dir);
     }
 }
 


### PR DESCRIPTION
This cleans up some non-idiomatic uses of `ok()` and `err()`.