### PR TITLE
conformance: update dns-test README for explore.rs

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -30,19 +30,33 @@ To start a small DNS network using the `dns-test` framework run this command and
 $ cargo run --example explore
 ```
 
-By default, this will use `unbound` as the resolver. You can switch the resolver to `hickory-dns` using the `DNS_TEST_SUBJECT` environment variable:
+By default, this will use `unbound` as the resolver and forwarder, and `nsd` as the nameservers. You can switch the resolver/forwarder to `hickory-dns` using the `DNS_TEST_SUBJECT` environment variable:
 
 ``` shell
 $ DNS_TEST_SUBJECT="hickory https://github.com/hickory-dns/hickory-dns dnssec-aws-lc-rs" cargo run --example explore
 ```
 
+You can switch the nameserver to `hickory-dns` using the `DNS_TEST_PEER` environment variable:
+
+```shell
+$ DNS_TEST_PEER="hickory https://github.com/hickory-dns/hickory-dns dnssec-aws-lc-rs" cargo run --example explore
+```
+
+To use `hickory-dns` for both, set both the `DNS_TEST_PEER` and `DNS_TEST_SUBJECT` environment variables.
+
+
 ### Environment variables
 
-- `DNS_TEST_SUBJECT`. This variable controls what the `dns_test::subject` function returns. The variable can contain one of these values:
+- `DNS_TEST_SUBJECT`. This variable controls the choice of recursive resolver and forwarder. The variable can contain one of these values:
   - `unbound`
   - `bind`
   - `hickory $REPOSITORY $DNSSEC_FEATURE`. where `$REPOSITORY` is a placeholder for a git repository, and `$DNSSEC_FEATURE` is `dnssec-ring` or `dnssec-aws-lc-rs`. Examples values for `$REPOSITORY`: `https://github.com/hickory-dns/hickory-dns`; `/home/user/git-repos/hickory-dns`. NOTE: when using a local repository, changes that have not been committed, regardless of whether they are staged or not, will **not** be included in the `hickory-dns` build.
-  
+
+- `DNS_TEST_PEER`. This variable controls the choice of authoritative nameservers. The variable can contain one of these values:
+  - `unbound` (note: uses `nsd`)
+  - `bind`
+  - `hickory $REPOSITORY $DNSSEC_FEATURE`. where `$REPOSITORY` is a placeholder for a git repository, and `$DNSSEC_FEATURE` is `dnssec-ring` or `dnssec-aws-lc-rs`. Examples values for `$REPOSITORY`: `https://github.com/hickory-dns/hickory-dns`; `/home/user/git-repos/hickory-dns`. NOTE: when using a local repository, changes that have not been committed, regardless of whether they are staged or not, will **not** be included in the `hickory-dns` build.
+
 - `DNS_TEST_VERBOSE_DOCKER_BUILD`. Setting this variable prints the output of the `docker build` invocations that the framework does to the console. This is useful to verify that image caching is working; for example if you set `DNS_TEST_SUBJECT` to a local `hickory-dns` repository then consecutively running the `explore` example and/or `conformance-tests` test suite **must** not rebuild `hickory-dns` provided that you have not *committed* any new change to the local repository.
 
 - `DNS_TEST_SKIP_DOCKER_BUILD`. Setting this variable skips running `docker build`. This should only be used if containers have been built recently.
@@ -114,13 +128,13 @@ This is a collection of tests that check the conformance of a DNS implementation
 
 ### Running the test suite
 
-To run the conformance tests against `unbound` run:
+To run the conformance tests using `unbound` and `nsd` run:
 
 ``` console
 $ cargo test -p conformance-tests -- --include-ignored
 ```
 
-To run the conformance tests against `hickory-dns` run:
+To run the conformance tests using `hickory-dns` and `nsd` run:
 
 ``` console
 $ DNS_TEST_SUBJECT="hickory /path/to/repository dnssec-aws-lc-rs" cargo test -p conformance-tests


### PR DESCRIPTION
Clarify that the `DNS_TEST_SUBJECT` env var controls the recursive resolver & forwarder implementation choice.

Add mention of the `DNS_TEST_PEER` env var that controls the authoritative server implementation choice. Also note that using `unbound` for this gets you `nsd` since `unbound` isn't an auth. server.