### PR TITLE
Try running CI with windows-2025 image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2025]
     env:
       RUST_LOG: trace
     steps:
@@ -57,7 +57,7 @@ jobs:
         run: just all-features
 
       - name: just test-docs
-        if: ${{ !cancelled() && matrix.os != 'windows-latest' }} # uses all features, avoid openssl
+        if: ${{ !cancelled() && matrix.os != 'windows-2025' }} # uses all features, avoid openssl
         run: just test-docs
 
   wasm:


### PR DESCRIPTION
GitHub is migrating the `windows-latest` label in September, so I'm making this PR to test out our Windows CI job with the new image ahead of time.