### PR TITLE
Fix NSEC validation

### DIFF
--- a/bin/tests/integration/authority_battery/dnssec.rs
+++ b/bin/tests/integration/authority_battery/dnssec.rs
@@ -9,8 +9,7 @@ use futures_executor::block_on;
 use hickory_proto::{
     dnssec::{
         Algorithm, Verifier,
-        rdata::{DNSKEY, DNSSECRData, NSEC, RRSIG},
-        verify_nsec,
+        rdata::{DNSKEY, DNSSECRData, RRSIG},
     },
     op::{Header, MessageType, OpCode, Query},
     rr::{DNSClass, Name, RData, Record, RecordType},
@@ -240,16 +239,18 @@ pub fn test_nsec_nodata(authority: impl Authority, _: &[DNSKEY]) {
 
     // there should only be one, and it should match the www.example.com name
     assert_eq!(nsec_records.len(), 1);
-    assert_eq!(nsec_records.first().unwrap().name(), &name);
-
-    let query = Query::query(name, RecordType::TXT);
-    assert!(
-        verify_nsec(
-            &query,
-            &Name::from_str("example.com.").unwrap(),
-            &nsecs(&nsec_records)
-        )
-        .is_secure()
+    let nsec_record = &nsec_records[0];
+    assert_eq!(nsec_record.name(), &name);
+    let rdata = nsec_record.data().as_dnssec().unwrap().as_nsec().unwrap();
+    assert_eq!(rdata.next_domain_name(), &name.base_name());
+    assert_eq!(
+        rdata.type_bit_maps().collect::<Vec<_>>(),
+        [
+            RecordType::A,
+            RecordType::AAAA,
+            RecordType::RRSIG,
+            RecordType::NSEC,
+        ]
     );
 }
 
@@ -267,20 +268,24 @@ pub fn test_nsec_nxdomain_start(authority: impl Authority, _: &[DNSKEY]) {
 
     println!("nsec_records: {nsec_records:?}");
 
-    // there should only be one, and it should match the www.example.com name
-    assert!(!nsec_records.is_empty());
-    // because the first record is from the SOA, the wildcard isn't necessary
-    //  that is `example.com.` -> `bbb.example.com.` proves there is no wildcard.
+    // Because the first NSEC record is from the zone apex, a separate NSEC record for the wildcard
+    // isn't necessary. That is, `example.com.` -> `alias.example.com.` proves there is no wildcard.
     assert_eq!(nsec_records.len(), 1);
-
-    let query = Query::query(name, RecordType::A);
-    assert!(
-        verify_nsec(
-            &query,
-            &Name::from_str("example.com.").unwrap(),
-            &nsecs(&nsec_records)
-        )
-        .is_secure()
+    let nsec_record = &nsec_records[0];
+    assert_eq!(nsec_record.name(), &name.base_name());
+    let rdata = nsec_record.data().as_dnssec().unwrap().as_nsec().unwrap();
+    assert_eq!(rdata.next_domain_name().to_string(), "alias.example.com.");
+    assert_eq!(
+        rdata.type_bit_maps().collect::<Vec<_>>(),
+        [
+            RecordType::NS,
+            RecordType::SOA,
+            RecordType::MX,
+            RecordType::RRSIG,
+            RecordType::NSEC,
+            RecordType::DNSKEY,
+            RecordType::ANAME,
+        ]
     );
 }
 
@@ -298,19 +303,40 @@ pub fn test_nsec_nxdomain_middle(authority: impl Authority, _: &[DNSKEY]) {
 
     println!("nsec_records: {nsec_records:?}");
 
-    // there should only be one, and it should match the www.example.com name
-    assert!(!nsec_records.is_empty());
     // one record covers between the names, the other is for the wildcard proof.
     assert_eq!(nsec_records.len(), 2);
 
-    let query = Query::query(name, RecordType::A);
-    assert!(
-        verify_nsec(
-            &query,
-            &Name::from_str("example.com.").unwrap(),
-            &nsecs(&nsec_records)
-        )
-        .is_secure()
+    let nsec_record_1 = nsec_records
+        .iter()
+        .find(|record| record.name().to_string() == "bbb.example.com.")
+        .unwrap();
+    let rdata_1 = nsec_record_1.data().as_dnssec().unwrap().as_nsec().unwrap();
+    assert_eq!(
+        rdata_1.next_domain_name().to_string(),
+        "this.has.dots.example.com."
+    );
+    assert_eq!(
+        rdata_1.type_bit_maps().collect::<Vec<_>>(),
+        [RecordType::A, RecordType::RRSIG, RecordType::NSEC]
+    );
+
+    let nsec_record_2 = nsec_records
+        .iter()
+        .find(|record| record.name() == &name.base_name())
+        .unwrap();
+    let rdata_2 = nsec_record_2.data().as_dnssec().unwrap().as_nsec().unwrap();
+    assert_eq!(rdata_2.next_domain_name().to_string(), "alias.example.com.");
+    assert_eq!(
+        rdata_2.type_bit_maps().collect::<Vec<_>>(),
+        [
+            RecordType::NS,
+            RecordType::SOA,
+            RecordType::MX,
+            RecordType::RRSIG,
+            RecordType::NSEC,
+            RecordType::DNSKEY,
+            RecordType::ANAME,
+        ]
     );
 }
 
@@ -328,32 +354,43 @@ pub fn test_nsec_nxdomain_wraps_end(authority: impl Authority, _: &[DNSKEY]) {
 
     println!("nsec_records: {nsec_records:?}");
 
-    // there should only be one, and it should match the www.example.com name
-    assert!(!nsec_records.is_empty());
     // one record covers between the names, the other is for the wildcard proof.
     assert_eq!(nsec_records.len(), 2);
 
-    let query = Query::query(name, RecordType::A);
-    assert!(
-        verify_nsec(
-            &query,
-            &Name::from_str("example.com.").unwrap(),
-            &nsecs(&nsec_records)
-        )
-        .is_secure()
+    let nsec_record_1 = nsec_records
+        .iter()
+        .find(|record| record.name().to_string() == "www.example.com.")
+        .unwrap();
+    let rdata_1 = nsec_record_1.data().as_dnssec().unwrap().as_nsec().unwrap();
+    assert_eq!(rdata_1.next_domain_name(), &name.base_name());
+    assert_eq!(
+        rdata_1.type_bit_maps().collect::<Vec<_>>(),
+        [
+            RecordType::A,
+            RecordType::AAAA,
+            RecordType::RRSIG,
+            RecordType::NSEC,
+        ]
     );
-}
 
-fn nsecs<'a>(records: impl IntoIterator<Item = &'a Record>) -> Vec<(&'a Name, &'a NSEC)> {
-    records
-        .into_iter()
-        .filter_map(|rr| {
-            rr.data()
-                .as_dnssec()?
-                .as_nsec()
-                .map(|data| (rr.name(), data))
-        })
-        .collect()
+    let nsec_record_2 = nsec_records
+        .iter()
+        .find(|record| record.name() == &name.base_name())
+        .unwrap();
+    let rdata_2 = nsec_record_2.data().as_dnssec().unwrap().as_nsec().unwrap();
+    assert_eq!(rdata_2.next_domain_name().to_string(), "alias.example.com.");
+    assert_eq!(
+        rdata_2.type_bit_maps().collect::<Vec<_>>(),
+        [
+            RecordType::NS,
+            RecordType::SOA,
+            RecordType::MX,
+            RecordType::RRSIG,
+            RecordType::NSEC,
+            RecordType::DNSKEY,
+            RecordType::ANAME,
+        ]
+    );
 }
 
 pub fn verify(records: &[&Record], rrsig_records: &[Record<RRSIG>], keys: &[DNSKEY]) {

--- a/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
+++ b/conformance/packages/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
@@ -557,7 +557,6 @@ fn unauthenticated_nsec_covering_qname() -> Result<()> {
 }
 
 #[test]
-#[ignore = "hickory does not check record types present at the wildcard name"]
 fn missing_nsec_wildcard_name() -> Result<()> {
     let wildcard_fqdn = FQDN::EXAMPLE_SUBDOMAIN.push_label("*");
     let any_modified = AtomicBool::new(false);

--- a/conformance/packages/conformance-tests/src/resolver/nsec.rs
+++ b/conformance/packages/conformance-tests/src/resolver/nsec.rs
@@ -52,13 +52,11 @@ fn domain_exists_record_type_does_not_nsec() -> Result<()> {
     domain_exists_record_type_does_not(Nsec::_1)
 }
 
-#[ignore = "NSEC validation is incorrect"]
 #[test]
 fn wildcard_exists_record_type_does_not_nsec_middle_chain() -> Result<()> {
     wildcard_exists_record_type_does_not(Nsec::_1, "aaaaaa")
 }
 
-#[ignore = "NSEC validation is incorrect"]
 #[test]
 fn wildcard_exists_record_type_does_not_nsec_end_chain() -> Result<()> {
     wildcard_exists_record_type_does_not(Nsec::_1, "zzzzzz")

--- a/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
@@ -1337,8 +1337,7 @@ impl RrsigValidity {
 ///  corresponding RRSIG RR, a validator MUST ignore the settings of the
 ///  NSEC and RRSIG bits in an NSEC RR.
 /// ```
-#[doc(hidden)]
-pub fn verify_nsec(query: &Query, soa_name: &Name, nsecs: &[(&Name, &NSEC)]) -> Proof {
+fn verify_nsec(query: &Query, soa_name: &Name, nsecs: &[(&Name, &NSEC)]) -> Proof {
     // TODO: consider converting this to Result, and giving explicit reason for the failure
 
     // first look for a record with the same name

--- a/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
@@ -1340,73 +1340,120 @@ impl RrsigValidity {
 fn verify_nsec(query: &Query, soa_name: &Name, nsecs: &[(&Name, &NSEC)]) -> Proof {
     // TODO: consider converting this to Result, and giving explicit reason for the failure
 
-    // first look for a record with the same name
-    //  if they are, then the query_type should not exist in the NSEC record.
-    //  if we got an NSEC record of the same name, but it is listed in the NSEC types,
-    //    WTF? is that bad server, bad record
+    // Look for an NSEC record that matches the query name first. If such a record exists, then the
+    // query type and CNAME must mot be present at this name.
     if let Some((_, nsec_data)) = nsecs.iter().find(|(name, _)| query.name() == *name) {
-        if !nsec_data.type_set().contains(query.query_type()) {
-            return proof_log_yield(Proof::Secure, query.name(), "nsec1", "direct match");
-        } else {
-            return proof_log_yield(Proof::Bogus, query.name(), "nsec1", "direct match");
-        }
-    }
-
-    let verify_nsec_coverage = |query_name: &Name| -> bool {
-        nsecs.iter().any(|(nsec_name, nsec_data)| {
-            // the query name must be greater than nsec's label (or equal in the case of wildcard)
-            query_name >= nsec_name && {
-                // the query name is less than the next name
-                // or this record wraps the end, i.e. is the last record
-                query_name < nsec_data.next_domain_name()
-                    || nsec_data.next_domain_name() < nsec_name
-            }
-        })
-    };
-
-    // continue to validate there is no wildcard
-    if !verify_nsec_coverage(query.name()) {
-        return proof_log_yield(Proof::Bogus, query.name(), "nsec1", "no wildcard");
-    }
-
-    // validate ANY or *.domain record existence
-
-    // we need the wildcard proof, but make sure that it's still part of the zone.
-    let wildcard = query.name().base_name();
-    let wildcard = if soa_name.zone_of(&wildcard) {
-        wildcard
-    } else {
-        soa_name.clone()
-    };
-
-    // don't need to validate the same name again
-    if wildcard == *query.name() {
-        // this was validated by the nsec coverage over the query.name()
-        proof_log_yield(
-            Proof::Secure,
-            query.name(),
-            "nsec1",
-            "direct wildcard match",
-        )
-    } else {
-        // this is the final check, return it's value
-        //  if there is wildcard coverage, we're good.
-        if verify_nsec_coverage(&wildcard) {
-            proof_log_yield(
-                Proof::Secure,
-                query.name(),
-                "nsec1",
-                "covering wildcard match",
-            )
-        } else {
-            proof_log_yield(
+        if nsec_data.type_set().contains(query.query_type())
+            || nsec_data.type_set().contains(RecordType::CNAME)
+        {
+            return proof_log_yield(
                 Proof::Bogus,
                 query.name(),
                 "nsec1",
-                "covering wildcard match",
-            )
+                "direct match, record should be present",
+            );
+        } else {
+            return proof_log_yield(Proof::Secure, query.name(), "nsec1", "direct match");
         }
     }
+
+    if !soa_name.zone_of(query.name()) {
+        return proof_log_yield(
+            Proof::Bogus,
+            query.name(),
+            "nsec1",
+            "SOA record is for the wrong zone",
+        );
+    }
+
+    let Some((covering_nsec_name, covering_nsec_data)) =
+        nsecs.iter().find(|(nsec_name, nsec_data)| {
+            soa_name.zone_of(nsec_name)
+                && query.name() > nsec_name
+                && (query.name() < nsec_data.next_domain_name()
+                    || nsec_data.next_domain_name() == soa_name)
+        })
+    else {
+        return proof_log_yield(
+            Proof::Bogus,
+            query.name(),
+            "nsec1",
+            "no NSEC record matches or covers the query name",
+        );
+    };
+
+    // Identify the names that exist (including names of empty non terminals) that are parents of
+    // the query name. Pick the longest such name, because wildcard synthesis would start looking
+    // for a wildcard record there.
+    let mut next_closest_encloser = soa_name.clone();
+    for seed_name in [covering_nsec_name, covering_nsec_data.next_domain_name()] {
+        if !soa_name.zone_of(seed_name) {
+            // This is a sanity check, in case the next domain name is out-of-bailiwick.
+            continue;
+        }
+        let mut candidate_name = seed_name.clone();
+        while candidate_name.num_labels() > next_closest_encloser.num_labels() {
+            if candidate_name.zone_of(query.name()) {
+                next_closest_encloser = candidate_name;
+                break;
+            }
+            candidate_name = candidate_name.base_name();
+        }
+    }
+    let Ok(wildcard_name) = next_closest_encloser.prepend_label("*") else {
+        // This fails if the prepended label is invalid or if the wildcard name would be too long.
+        // However, we already know that the query name is not too long. The next closest enclosing
+        // name must be strictly shorter than the query name, since we know that there is no NSEC
+        // record matching the query name. Thus the query name must be as long or longer than this
+        // wildcard name we are trying to construct, because we removed at least one label from the
+        // query name, and tried to add a single-byte label. This error condition should thus be
+        // unreachable.
+        return proof_log_yield(
+            Proof::Bogus,
+            query.name(),
+            "nsec1",
+            "unreachable error constructing wildcard name",
+        );
+    };
+    debug!(%wildcard_name, "looking for NSEC for wildcard");
+
+    if let Some((_, wildcard_nsec_data)) = nsecs.iter().find(|(name, _)| &wildcard_name == *name) {
+        // Wildcard NSEC exists.
+        if wildcard_nsec_data.type_set().contains(query.query_type())
+            || wildcard_nsec_data.type_set().contains(RecordType::CNAME)
+        {
+            return proof_log_yield(
+                Proof::Bogus,
+                query.name(),
+                "nsec1",
+                "wildcard match, record should be present",
+            );
+        } else {
+            return proof_log_yield(Proof::Secure, query.name(), "nsec1", "wildcard match");
+        }
+    }
+
+    if nsecs.iter().any(|(nsec_name, nsec_data)| {
+        soa_name.zone_of(nsec_name)
+            && &wildcard_name > nsec_name
+            && (&wildcard_name < nsec_data.next_domain_name()
+                || nsec_data.next_domain_name() == soa_name)
+    }) {
+        // Covering NSEC records exist for both the query name and the wildcard name.
+        return proof_log_yield(
+            Proof::Secure,
+            query.name(),
+            "nsec1",
+            "no direct match, no wildcard",
+        );
+    }
+
+    proof_log_yield(
+        Proof::Bogus,
+        query.name(),
+        "nsec1",
+        "no NSEC record matches or covers the wildcard name",
+    )
 }
 
 /// Returns the current system time as Unix timestamp in seconds.

--- a/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
+++ b/crates/proto/src/dnssec/dnssec_dns_handle/mod.rs
@@ -26,7 +26,7 @@ use crate::{
         rdata::{DNSKEY, DNSSECRData, DS, NSEC, RRSIG},
     },
     error::{NoRecords, ProtoError, ProtoErrorKind},
-    op::{Edns, Message, OpCode, Query},
+    op::{Edns, Message, OpCode, Query, ResponseCode},
     rr::{Name, RData, Record, RecordType, SerialNumber, resource::RecordRef},
     xfer::{DnsRequest, DnsRequestOptions, DnsResponse, FirstAnswer, dns_handle::DnsHandle},
 };
@@ -230,7 +230,12 @@ impl<H: DnsHandle> DnssecDnsHandle<H> {
                 self.nsec3_soft_iteration_limit,
                 self.nsec3_hard_iteration_limit,
             ),
-            (false, true) => verify_nsec(&query, find_soa_name(&message)?, nsecs.as_slice()),
+            (false, true) => verify_nsec(
+                &query,
+                find_soa_name(&message)?,
+                message.response_code(),
+                nsecs.as_slice(),
+            ),
             (true, true) => {
                 warn!(
                     "response contains both NSEC and NSEC3 records\nQuery:\n{query:?}\nResponse:\n{message:?}"
@@ -1337,8 +1342,22 @@ impl RrsigValidity {
 ///  corresponding RRSIG RR, a validator MUST ignore the settings of the
 ///  NSEC and RRSIG bits in an NSEC RR.
 /// ```
-fn verify_nsec(query: &Query, soa_name: &Name, nsecs: &[(&Name, &NSEC)]) -> Proof {
+fn verify_nsec(
+    query: &Query,
+    soa_name: &Name,
+    response_code: ResponseCode,
+    nsecs: &[(&Name, &NSEC)],
+) -> Proof {
     // TODO: consider converting this to Result, and giving explicit reason for the failure
+
+    if response_code != ResponseCode::NXDomain && response_code != ResponseCode::NoError {
+        return proof_log_yield(
+            Proof::Bogus,
+            query.name(),
+            "nsec1",
+            "unsupported response code",
+        );
+    }
 
     // Look for an NSEC record that matches the query name first. If such a record exists, then the
     // query type and CNAME must mot be present at this name.
@@ -1352,8 +1371,15 @@ fn verify_nsec(query: &Query, soa_name: &Name, nsecs: &[(&Name, &NSEC)]) -> Proo
                 "nsec1",
                 "direct match, record should be present",
             );
-        } else {
+        } else if response_code == ResponseCode::NoError {
             return proof_log_yield(Proof::Secure, query.name(), "nsec1", "direct match");
+        } else {
+            return proof_log_yield(
+                Proof::Bogus,
+                query.name(),
+                "nsec1",
+                "nxdomain when direct match exists",
+            );
         }
     }
 
@@ -1428,8 +1454,15 @@ fn verify_nsec(query: &Query, soa_name: &Name, nsecs: &[(&Name, &NSEC)]) -> Proo
                 "nsec1",
                 "wildcard match, record should be present",
             );
-        } else {
+        } else if response_code == ResponseCode::NoError {
             return proof_log_yield(Proof::Secure, query.name(), "nsec1", "wildcard match");
+        } else {
+            return proof_log_yield(
+                Proof::Bogus,
+                query.name(),
+                "nsec1",
+                "nxdomain when wildcard match exists",
+            );
         }
     }
 
@@ -1440,12 +1473,16 @@ fn verify_nsec(query: &Query, soa_name: &Name, nsecs: &[(&Name, &NSEC)]) -> Proo
                 || nsec_data.next_domain_name() == soa_name)
     }) {
         // Covering NSEC records exist for both the query name and the wildcard name.
-        return proof_log_yield(
-            Proof::Secure,
-            query.name(),
-            "nsec1",
-            "no direct match, no wildcard",
-        );
+        if response_code == ResponseCode::NXDomain {
+            return proof_log_yield(
+                Proof::Secure,
+                query.name(),
+                "nsec1",
+                "no direct match, no wildcard",
+            );
+        } else {
+            return proof_log_yield(Proof::Bogus, query.name(), "nsec1", "expected NXDOMAIN");
+        }
     }
 
     proof_log_yield(

--- a/crates/proto/src/dnssec/dnssec_dns_handle/nsec3_validation.rs
+++ b/crates/proto/src/dnssec/dnssec_dns_handle/nsec3_validation.rs
@@ -439,11 +439,8 @@ fn closest_encloser_proof<'a>(
         Some((closest_encloser_index, closest_encloser_record)) if closest_encloser_index > 0 => {
             let closest_encloser_hash_info =
                 closest_encloser_candidates.swap_remove(closest_encloser_index);
-            let closest_encloser_wildcard_name = Name::new()
-                .append_label("*")
-                .unwrap()
-                .append_name(&closest_encloser_hash_info.name)
-                .expect("closest encloser name exists in the zone");
+            let closest_encloser_wildcard_name =
+                closest_encloser_hash_info.name.prepend_label("*").unwrap();
             let closest_encloser = Some((closest_encloser_hash_info, closest_encloser_record));
 
             let next_closer_hash_info =
@@ -508,11 +505,7 @@ fn closest_encloser_proof<'a>(
             // `*.soa_name` wildcard.
             // If the wildcard existed then the response code would be NoError
             // but we received `NXDomain`
-            let closest_encloser_wildcard_name = Name::new()
-                .append_label("*")
-                .unwrap()
-                .append_name(soa_name)
-                .expect("`soa_name` is an existing domain with a valid name");
+            let closest_encloser_wildcard_name = soa_name.prepend_label("*").unwrap();
             let wildcard_name_info =
                 HashedNameInfo::new(closest_encloser_wildcard_name, salt, iterations);
             let wildcard = find_covering_record(

--- a/crates/proto/src/dnssec/mod.rs
+++ b/crates/proto/src/dnssec/mod.rs
@@ -25,8 +25,6 @@ use crate::trace;
 mod algorithm;
 mod dnssec_dns_handle;
 pub use dnssec_dns_handle::DnssecDnsHandle;
-#[doc(hidden)]
-pub use dnssec_dns_handle::verify_nsec;
 /// Cryptographic backend implementations of DNSSEC traits.
 pub mod crypto;
 mod ec_public_key;


### PR DESCRIPTION
This closes #3143. I rewrote `verify_nsec()` to address the problems identified in that issue. I also made the function private, and rewrote an integration test that was depending on it.

The general flow of this function is now to check for an exact match, check for a covering record, identify the next closest enclosing name from the ancestors of the names in the covering NSEC record, and finally check for any NSEC record matching or covering the wildcard name below that next closest enclosing name. There isn't any verification algorithm suggested in RFC 4035, but my thinking is that this will identify where the RFC 1034 algorithm would have failed to find a name and checked for a wildcard. Code paths that return `Proof::Secure` are now properly guarded by checks of record types, when dealing with a direct match (including CNAME), and checks for appropriate response codes.

This fixes three conformance tests, added in #3172 and #3147.