### PR TITLE
Add separate Authority method for AXFR

### DIFF
--- a/crates/server/src/authority/auth_lookup.rs
+++ b/crates/server/src/authority/auth_lookup.rs
@@ -344,7 +344,6 @@ pub enum LookupRecords {
     },
     /// Vec of disjoint record sets
     ManyRecords(LookupOptions, Vec<Arc<RecordSet>>),
-    // TODO: need a better option for very large zone xfrs...
     /// A generic lookup response where anything is desired
     AnyRecords(AnyRecords),
     /// A section from a response message

--- a/crates/server/src/authority/auth_lookup.rs
+++ b/crates/server/src/authority/auth_lookup.rs
@@ -420,3 +420,30 @@ impl From<AnyRecords> for LookupRecords {
         Self::AnyRecords(rrset_records)
     }
 }
+
+/// A copy of all data in a zone.
+///
+/// This is used in the AXFR sub-protocol.
+#[derive(Debug)]
+pub struct ZoneTransfer {
+    /// The SOA record, plus its RRSIG.
+    ///
+    /// This is sent at the start of the first message of the response.
+    pub start_soa: LookupRecords,
+    /// All the records in the zone.
+    pub records: LookupRecords,
+    /// The SOA record again.
+    ///
+    /// This is sent at the end of the last message of the response.
+    pub end_soa: LookupRecords,
+}
+
+impl ZoneTransfer {
+    /// Iterate over all the records, starting and ending with the SOA record.
+    pub fn iter(&self) -> impl Iterator<Item = &Record> {
+        self.start_soa
+            .iter()
+            .chain(self.records.iter())
+            .chain(self.end_soa.iter())
+    }
+}

--- a/crates/server/src/authority/auth_lookup.rs
+++ b/crates/server/src/authority/auth_lookup.rs
@@ -268,12 +268,12 @@ impl<'r> Iterator for AnyRecordsIter<'r> {
             if let Some(records) = &mut self.records {
                 let record = records
                     .by_ref()
-                    .filter(|rr_set| {
-                        query_type == RecordType::ANY || rr_set.record_type() != RecordType::SOA
+                    .filter(|record| {
+                        query_type == RecordType::ANY || record.record_type() != RecordType::SOA
                     })
-                    .find(|rr_set| {
+                    .find(|record| {
                         query_type == RecordType::AXFR
-                            || &LowerName::from(rr_set.name()) == query_name
+                            || &LowerName::from(record.name()) == query_name
                     });
 
                 if record.is_some() {

--- a/crates/server/src/authority/authority.rs
+++ b/crates/server/src/authority/authority.rs
@@ -13,7 +13,7 @@ use cfg_if::cfg_if;
 use serde::Deserialize;
 
 use crate::{
-    authority::{AuthLookup, LookupError, UpdateResult, ZoneType},
+    authority::{AuthLookup, LookupError, UpdateResult, ZoneTransfer, ZoneType},
     proto::{
         op::{Edns, message::ResponseSigner},
         rr::{LowerName, RecordSet, RecordType, RrsetRecords},
@@ -230,6 +230,18 @@ pub trait Authority: Send + Sync {
         self.lookup(self.origin(), RecordType::SOA, None, lookup_options)
             .await
     }
+
+    /// Returns all records in the zone.
+    ///
+    /// This will return `None` if the next authority in the authority chain should be used instead.
+    async fn zone_transfer(
+        &self,
+        request: &Request,
+        lookup_options: LookupOptions,
+    ) -> Option<(
+        Result<ZoneTransfer, LookupError>,
+        Option<Box<dyn ResponseSigner>>,
+    )>;
 
     /// Returns the kind of non-existence proof used for this zone.
     #[cfg(feature = "__dnssec")]

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -8,7 +8,7 @@
 // TODO, I've implemented this as a separate entity from the cache, but I wonder if the cache
 //  should be the only "front-end" for lookups, where if that misses, then we go to the catalog
 //  then, if requested, do a recursive lookup... i.e. the catalog would only point to files.
-use std::{borrow::Borrow, collections::HashMap, io, iter, sync::Arc};
+use std::{collections::HashMap, io, iter, sync::Arc};
 
 use tracing::{debug, error, info, trace, warn};
 
@@ -403,12 +403,10 @@ impl Catalog {
             .await
         } else {
             lookup(
-                request_info.clone(),
+                request_info,
                 authorities,
                 request,
-                response_edns
-                    .as_ref()
-                    .map(|arc| Borrow::<Edns>::borrow(arc).clone()),
+                response_edns.clone(),
                 response_handle.clone(),
                 #[cfg(feature = "metrics")]
                 &self.metrics,

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -406,8 +406,8 @@ impl Catalog {
         .await;
 
         match result {
-            Ok(lookup) => lookup,
-            Err(_e) => ResponseInfo::serve_failed(request),
+            Ok(response_info) => response_info,
+            Err(_) => ResponseInfo::serve_failed(request),
         }
     }
 

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -437,7 +437,6 @@ async fn lookup<R: ResponseHandler + Unpin>(
     let lookup_options = LookupOptions::from_edns(edns);
     let request_id = request.id();
 
-    // log algorithms being requested
     if lookup_options.dnssec_ok {
         info!("request: {request_id} lookup_options: {lookup_options:?}");
     }

--- a/crates/server/src/authority/mod.rs
+++ b/crates/server/src/authority/mod.rs
@@ -28,7 +28,7 @@ mod message_response;
 pub(crate) mod metrics;
 
 pub use self::auth_lookup::{
-    AnyRecords, AuthLookup, AuthLookupIter, LookupRecords, LookupRecordsIter,
+    AnyRecords, AuthLookup, AuthLookupIter, LookupRecords, LookupRecordsIter, ZoneTransfer,
 };
 pub use self::authority::{Authority, AxfrPolicy, LookupControlFlow, LookupOptions};
 #[cfg(feature = "__dnssec")]

--- a/crates/server/src/authority/mod.rs
+++ b/crates/server/src/authority/mod.rs
@@ -28,7 +28,8 @@ mod message_response;
 pub(crate) mod metrics;
 
 pub use self::auth_lookup::{
-    AnyRecords, AuthLookup, AuthLookupIter, LookupRecords, LookupRecordsIter, ZoneTransfer,
+    AnyRecords, AuthLookup, AuthLookupIter, AxfrRecords, LookupRecords, LookupRecordsIter,
+    ZoneTransfer,
 };
 pub use self::authority::{Authority, AxfrPolicy, LookupControlFlow, LookupOptions};
 #[cfg(feature = "__dnssec")]

--- a/crates/server/src/store/blocklist.rs
+++ b/crates/server/src/store/blocklist.rs
@@ -30,7 +30,7 @@ use crate::{authority::Nsec3QueryInfo, dnssec::NxProofKind};
 use crate::{
     authority::{
         AuthLookup, Authority, AxfrPolicy, LookupControlFlow, LookupError, LookupOptions,
-        UpdateResult, ZoneType,
+        UpdateResult, ZoneTransfer, ZoneType,
     },
     proto::{
         op::{Query, ResponseCode, message::ResponseSigner},
@@ -456,6 +456,17 @@ impl Authority for BlocklistAuthority {
             .await,
             None,
         )
+    }
+
+    async fn zone_transfer(
+        &self,
+        _request: &Request,
+        _lookup_options: LookupOptions,
+    ) -> Option<(
+        Result<ZoneTransfer, LookupError>,
+        Option<Box<dyn ResponseSigner>>,
+    )> {
+        None
     }
 
     async fn nsec_records(

--- a/crates/server/src/store/file.rs
+++ b/crates/server/src/store/file.rs
@@ -18,7 +18,8 @@ use serde::Deserialize;
 use crate::store::metrics::PersistentStoreMetrics;
 use crate::{
     authority::{
-        AuthLookup, Authority, AxfrPolicy, LookupControlFlow, LookupOptions, UpdateResult, ZoneType,
+        AuthLookup, Authority, AxfrPolicy, LookupControlFlow, LookupError, LookupOptions,
+        UpdateResult, ZoneTransfer, ZoneType,
     },
     proto::{
         op::message::ResponseSigner,
@@ -193,6 +194,17 @@ impl Authority for FileAuthority {
         Option<Box<dyn ResponseSigner>>,
     ) {
         self.in_memory.search(request, lookup_options).await
+    }
+
+    async fn zone_transfer(
+        &self,
+        request: &Request,
+        lookup_options: LookupOptions,
+    ) -> Option<(
+        Result<ZoneTransfer, LookupError>,
+        Option<Box<dyn ResponseSigner>>,
+    )> {
+        self.in_memory.zone_transfer(request, lookup_options).await
     }
 
     /// Get the NS, NameServer, record for the zone

--- a/crates/server/src/store/forwarder.rs
+++ b/crates/server/src/store/forwarder.rs
@@ -21,7 +21,7 @@ use crate::{authority::Nsec3QueryInfo, dnssec::NxProofKind, proto::dnssec::Trust
 use crate::{
     authority::{
         AuthLookup, Authority, AxfrPolicy, LookupControlFlow, LookupError, LookupOptions,
-        UpdateResult, ZoneType,
+        UpdateResult, ZoneTransfer, ZoneType,
     },
     proto::{
         op::{ResponseCode, message::ResponseSigner},
@@ -289,6 +289,22 @@ impl<P: ConnectionProvider> Authority for ForwardAuthority<P> {
             .await,
             None,
         )
+    }
+
+    async fn zone_transfer(
+        &self,
+        _request: &Request,
+        _lookup_options: LookupOptions,
+    ) -> Option<(
+        Result<ZoneTransfer, LookupError>,
+        Option<Box<dyn ResponseSigner>>,
+    )> {
+        Some((
+            Err(LookupError::from(io::Error::other(
+                "zone transfer is unimplemented for the forwarder",
+            ))),
+            None,
+        ))
     }
 
     async fn nsec_records(

--- a/crates/server/src/store/in_memory/mod.rs
+++ b/crates/server/src/store/in_memory/mod.rs
@@ -22,7 +22,7 @@ use tracing::{debug, info};
 
 use crate::{
     authority::{
-        AnyRecords, AuthLookup, Authority, AxfrPolicy, LookupControlFlow, LookupError,
+        AnyRecords, AuthLookup, Authority, AxfrPolicy, AxfrRecords, LookupControlFlow, LookupError,
         LookupOptions, LookupRecords, UpdateResult, ZoneTransfer, ZoneType,
     },
     proto::{
@@ -625,12 +625,10 @@ impl Authority for InMemoryAuthority {
             LookupRecords::Empty
         };
 
-        let records = LookupRecords::AnyRecords(AnyRecords::new(
-            lookup_options,
+        let records = AxfrRecords::new(
+            lookup_options.dnssec_ok,
             self.inner.read().await.records.values().cloned().collect(),
-            request_info.query.query_type(),
-            request_info.query.name().clone(),
-        ));
+        );
 
         Some((
             Ok(ZoneTransfer {

--- a/crates/server/src/store/in_memory/mod.rs
+++ b/crates/server/src/store/in_memory/mod.rs
@@ -431,7 +431,6 @@ impl Authority for InMemoryAuthority {
                 LookupRecords::AnyRecords(AnyRecords::new(
                     lookup_options,
                     inner.records.values().cloned().collect(),
-                    query_type,
                     name.clone(),
                 )),
                 None,

--- a/crates/server/src/store/recursor.rs
+++ b/crates/server/src/store/recursor.rs
@@ -24,6 +24,7 @@ use ipnet::IpNet;
 use serde::Deserialize;
 use tracing::{debug, info};
 
+use crate::authority::ZoneTransfer;
 #[cfg(feature = "__dnssec")]
 use crate::{authority::Nsec3QueryInfo, dnssec::NxProofKind, proto::dnssec::TrustAnchors};
 use crate::{
@@ -179,6 +180,22 @@ impl<P: RuntimeProvider> Authority for RecursiveAuthority<P> {
             .await,
             None,
         )
+    }
+
+    async fn zone_transfer(
+        &self,
+        _request: &Request,
+        _lookup_options: LookupOptions,
+    ) -> Option<(
+        Result<ZoneTransfer, LookupError>,
+        Option<Box<dyn ResponseSigner>>,
+    )> {
+        Some((
+            Err(LookupError::from(io::Error::other(
+                "zone transfer is unimplemented for the recursor",
+            ))),
+            None,
+        ))
     }
 
     async fn nsec_records(

--- a/tests/integration-tests/tests/integration/chained_authority_tests.rs
+++ b/tests/integration-tests/tests/integration/chained_authority_tests.rs
@@ -13,7 +13,7 @@ use hickory_server::{authority::Nsec3QueryInfo, dnssec::NxProofKind};
 use hickory_server::{
     authority::{
         AuthLookup, Authority, AxfrPolicy, Catalog, LookupControlFlow, LookupError, LookupOptions,
-        LookupRecords, UpdateResult, ZoneType,
+        LookupRecords, UpdateResult, ZoneTransfer, ZoneType,
     },
     server::{Request, RequestInfo, ResponseInfo},
 };
@@ -249,6 +249,17 @@ impl Authority for TestAuthority {
             .await,
             None,
         )
+    }
+
+    async fn zone_transfer(
+        &self,
+        _request: &Request,
+        _lookup_options: LookupOptions,
+    ) -> Option<(
+        Result<ZoneTransfer, LookupError>,
+        Option<Box<dyn ResponseSigner>>,
+    )> {
+        unimplemented!()
     }
 
     async fn consult(

--- a/tests/integration-tests/tests/integration/sqlite_authority_tests.rs
+++ b/tests/integration-tests/tests/integration/sqlite_authority_tests.rs
@@ -1536,8 +1536,9 @@ async fn test_axfr_allow_all() {
     .unwrap();
 
     let result = authority
-        .search(&request, LookupOptions::default())
+        .zone_transfer(&request, LookupOptions::default())
         .await
+        .unwrap()
         .0
         .unwrap();
 
@@ -1562,9 +1563,11 @@ async fn test_axfr_deny_all() {
     .unwrap();
 
     let err = authority
-        .search(&request, LookupOptions::default())
+        .zone_transfer(&request, LookupOptions::default())
         .await
+        .unwrap()
         .0
+        .map(|_| ())
         .unwrap_err();
     assert!(matches!(
         err,
@@ -1591,9 +1594,11 @@ async fn test_axfr_deny_unsigned() {
     .unwrap();
 
     let err = authority
-        .search(&request, LookupOptions::default())
+        .zone_transfer(&request, LookupOptions::default())
         .await
+        .unwrap()
         .0
+        .map(|_| ())
         .unwrap_err();
     assert!(matches!(
         err,
@@ -1630,7 +1635,10 @@ async fn test_axfr_allow_tsig_signed() {
     let request =
         Request::from_bytes(bytes, SocketAddr::from(([127, 0, 0, 1], 53)), Protocol::Udp).unwrap();
 
-    let (resp, resp_signer) = authority.search(&request, LookupOptions::default()).await;
+    let (resp, resp_signer) = authority
+        .zone_transfer(&request, LookupOptions::default())
+        .await
+        .unwrap();
 
     // We should get results back.
     assert_eq!(resp.unwrap().iter().count(), 12);


### PR DESCRIPTION
This splits AXFR handling off into a different `Authority` method, in line with the first bullet point of #3169. `AuthLookup::AXFR` is split off into a separate struct, and `AnyRecords` is split into two structs, as it was previously used for both `ANY` and `AXFR` pseudo-type queries.

This PR simplifies the return types of `Authority` methods and removes an internal `Authority::lookup()` call, paving the way for future improvements to the `Authority` trait, and lays the groundwork for fixing issues with `AXFR` support.