### PR TITLE
fix nightly unused_parens warns, tidy retry_dns_handle.rs

### DIFF
--- a/crates/client/src/client/dnssec_client.rs
+++ b/crates/client/src/client/dnssec_client.rs
@@ -68,7 +68,7 @@ impl Clone for DnssecClient {
 }
 
 impl DnsHandle for DnssecClient {
-    type Response = Pin<Box<(dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send + 'static)>>;
+    type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send + 'static>>;
 
     fn send(&self, request: DnsRequest) -> Self::Response {
         self.client.send(request)

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -412,7 +412,7 @@ impl Catalog {
     }
 
     /// Recursively searches the catalog for a matching authority
-    pub fn find(&self, name: &LowerName) -> Option<&Vec<Arc<(dyn Authority + 'static)>>> {
+    pub fn find(&self, name: &LowerName) -> Option<&Vec<Arc<dyn Authority + 'static>>> {
         debug!("searching authorities for: {name}");
         self.authorities.get(name).or_else(|| {
             if !name.is_root() {


### PR DESCRIPTION
Quick follow-up to https://github.com/hickory-dns/hickory-dns/pull/3180

Proactively takes care of a couple of nightly only warns, and cleans up the `retry_dns_handle.rs` to try and avoid so many `#[cfg]` annotations.