### PR TITLE
Send minimal responses to queries with QTYPE=ANY

### DIFF
--- a/crates/server/src/authority/mod.rs
+++ b/crates/server/src/authority/mod.rs
@@ -28,8 +28,7 @@ mod message_response;
 pub(crate) mod metrics;
 
 pub use self::auth_lookup::{
-    AnyRecords, AuthLookup, AuthLookupIter, AxfrRecords, LookupRecords, LookupRecordsIter,
-    ZoneTransfer,
+    AuthLookup, AuthLookupIter, AxfrRecords, LookupRecords, LookupRecordsIter, ZoneTransfer,
 };
 pub use self::authority::{Authority, AxfrPolicy, LookupControlFlow, LookupOptions};
 #[cfg(feature = "__dnssec")]


### PR DESCRIPTION
This changes the authoritative server to only pick one RRset to send in response to ANY queries. Limiting responses to ANY queries mitigates their use in DoS reflection attacks. This also brings us a step further in simplifying `LookupRecords` and decoupling the `Authority` trait interface from internal implementation details of the authoritative server.

This closes #3171.