### PR TITLE
Simplify objects in build_forwarded_response()

### DIFF
--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -825,22 +825,22 @@ async fn build_forwarded_response(
             let authorities = if let Some(authorities) = e.authorities() {
                 let authorities = authorities
                     .iter()
-                    .filter_map(|x| {
+                    .filter_map(|record| {
                         // if we have another record (probably a dnssec record) that
                         // matches the query name, but wasn't included in the answers
                         // section, change the NXDomain response to NoError
-                        if *x.name() == **query.name() {
+                        if *record.name() == **query.name() {
                             debug!(
                                 query_name = %query.name(),
-                                record = ?x,
+                                ?record,
                                 "changing response code from NXDomain to NoError due to other record",
                             );
                             response_header.set_response_code(ResponseCode::NoError);
                         }
 
-                        match x.record_type() {
+                        match record.record_type() {
                             RecordType::SOA => None,
-                            _ => Some(Arc::new(RecordSet::from(x.clone()))),
+                            _ => Some(Arc::new(RecordSet::from(record.clone()))),
                         }
                     })
                     .collect();
@@ -961,10 +961,10 @@ async fn build_forwarded_response(
     let authorities = if !lookup_options.dnssec_ok {
         let auth = authorities
             .into_iter()
-            .filter_map(|rrset| {
-                let record_type = rrset.record_type();
+            .filter_map(|record| {
+                let record_type = record.record_type();
                 if record_type == query.query_type() || !record_type.is_dnssec() {
-                    Some(Arc::new(RecordSet::from(rrset.clone())))
+                    Some(Arc::new(RecordSet::from(record.clone())))
                 } else {
                     None
                 }

--- a/crates/server/src/authority/catalog.rs
+++ b/crates/server/src/authority/catalog.rs
@@ -840,15 +840,12 @@ async fn build_forwarded_response(
 
                         match record.record_type() {
                             RecordType::SOA => None,
-                            _ => Some(Arc::new(RecordSet::from(record.clone()))),
+                            _ => Some(record.clone()),
                         }
                     })
                     .collect();
 
-                AuthLookup::answers(
-                    LookupRecords::many(LookupOptions::default(), authorities),
-                    None,
-                )
+                AuthLookup::answers(LookupRecords::Section(authorities), None)
             } else {
                 AuthLookup::default()
             };
@@ -964,14 +961,14 @@ async fn build_forwarded_response(
             .filter_map(|record| {
                 let record_type = record.record_type();
                 if record_type == query.query_type() || !record_type.is_dnssec() {
-                    Some(Arc::new(RecordSet::from(record.clone())))
+                    Some(record.clone())
                 } else {
                     None
                 }
             })
             .collect();
 
-        AuthLookup::answers(LookupRecords::many(LookupOptions::default(), auth), None)
+        AuthLookup::answers(LookupRecords::Section(auth), None)
     } else {
         authorities
     };


### PR DESCRIPTION
This refactors a couple places in `build_forwarded_response()` to use the simpler `LookupRecords::Section` instead of `LookupRecords::ManyRecords`, which required wrapping individual records in fictional `RecordSet`s.