### PR TITLE
Tidy up server crate SSL_KEYLOG_FILE configuration

### DIFF
--- a/crates/server/src/server/h2_handler.rs
+++ b/crates/server/src/server/h2_handler.rs
@@ -21,10 +21,11 @@ use tokio_rustls::TlsAcceptor;
 use tracing::{debug, error, warn};
 
 use super::{
-    ResponseInfo, ServerContext, is_unrecoverable_socket_error, reap_tasks,
+    ResponseInfo, ServerContext, default_tls_server_config, is_unrecoverable_socket_error,
+    reap_tasks,
     request_handler::RequestHandler,
     response_handler::{ResponseHandler, encode_fallback_servfail_response},
-    sanitize_src_address, default_tls_server_config,
+    sanitize_src_address,
 };
 use crate::{
     authority::MessageResponse,
@@ -40,17 +41,14 @@ pub(super) async fn handle_h2(
     dns_hostname: Option<String>,
     http_endpoint: String,
     cx: Arc<ServerContext<impl RequestHandler>>,
-    ssl_keylog_enabled: bool,
 ) -> Result<(), ProtoError> {
-    let tls_acceptor = TlsAcceptor::from(Arc::new(default_tls_server_config(
-        b"h2",
-        server_cert_resolver,
-        ssl_keylog_enabled,
-    )?));
     handle_h2_with_acceptor(
         listener,
         handshake_timeout,
-        tls_acceptor,
+        TlsAcceptor::from(Arc::new(default_tls_server_config(
+            b"h2",
+            server_cert_resolver,
+        )?)),
         dns_hostname,
         http_endpoint,
         cx,

--- a/crates/server/src/server/h2_handler.rs
+++ b/crates/server/src/server/h2_handler.rs
@@ -24,7 +24,7 @@ use super::{
     ResponseInfo, ServerContext, is_unrecoverable_socket_error, reap_tasks,
     request_handler::RequestHandler,
     response_handler::{ResponseHandler, encode_fallback_servfail_response},
-    sanitize_src_address, tls_server_config,
+    sanitize_src_address, default_tls_server_config,
 };
 use crate::{
     authority::MessageResponse,
@@ -42,7 +42,7 @@ pub(super) async fn handle_h2(
     cx: Arc<ServerContext<impl RequestHandler>>,
     ssl_keylog_enabled: bool,
 ) -> Result<(), ProtoError> {
-    let tls_acceptor = TlsAcceptor::from(Arc::new(tls_server_config(
+    let tls_acceptor = TlsAcceptor::from(Arc::new(default_tls_server_config(
         b"h2",
         server_cert_resolver,
         ssl_keylog_enabled,

--- a/crates/server/src/server/h3_handler.rs
+++ b/crates/server/src/server/h3_handler.rs
@@ -41,10 +41,21 @@ pub(super) async fn handle_h3(
     dns_hostname: Option<String>,
     cx: Arc<ServerContext<impl RequestHandler>>,
 ) -> Result<(), ProtoError> {
-    let dns_hostname: Option<Arc<str>> = dns_hostname.map(|n| n.into());
-
     debug!("registered h3: {:?}", socket);
-    let mut server = H3Server::with_socket(socket, server_cert_resolver)?;
+    handle_h3_with_server(
+        H3Server::with_socket(socket, server_cert_resolver)?,
+        dns_hostname,
+        cx,
+    )
+    .await
+}
+
+pub(super) async fn handle_h3_with_server(
+    mut server: H3Server,
+    dns_hostname: Option<String>,
+    cx: Arc<ServerContext<impl RequestHandler>>,
+) -> Result<(), ProtoError> {
+    let dns_hostname = dns_hostname.map(|n| n.into());
 
     let mut inner_join_set = JoinSet::new();
     loop {

--- a/crates/server/src/server/mod.rs
+++ b/crates/server/src/server/mod.rs
@@ -126,6 +126,9 @@ impl<T: RequestHandler> Server<T> {
     /// To make the server more resilient to DOS issues, there is a timeout. Care should be taken
     ///  to not make this too low depending on use cases.
     ///
+    /// The TLS `ServerConfig` should be configured with TLS 1.3 support and the DoT ALPN protocol
+    /// enabled.
+    ///
     /// # Arguments
     /// * `listener` - a bound TCP (needs to be on a different port from standard TCP connections) socket
     /// * `timeout` - timeout duration of incoming requests, any connection that does not send

--- a/crates/server/src/server/mod.rs
+++ b/crates/server/src/server/mod.rs
@@ -175,7 +175,7 @@ impl<T: RequestHandler> Server<T> {
         server_cert_resolver: Arc<dyn ResolvesServerCert>,
         ssl_keylog_enabled: bool,
     ) -> io::Result<()> {
-        let config = tls_server_config(b"dot", server_cert_resolver, ssl_keylog_enabled)?;
+        let config = default_tls_server_config(b"dot", server_cert_resolver, ssl_keylog_enabled)?;
         Self::register_tls_listener_with_tls_config(self, listener, timeout, Arc::new(config))
     }
 
@@ -659,8 +659,9 @@ fn reap_tasks(join_set: &mut JoinSet<()>) {
     while join_set.try_join_next().is_some() {}
 }
 
+/// Construct a default `ServerConfig` for the given ALPN protocol and server cert resolver.
 #[cfg(feature = "__tls")]
-fn tls_server_config(
+pub fn default_tls_server_config(
     protocol: &[u8],
     server_cert_resolver: Arc<dyn ResolvesServerCert>,
     ssl_keylog_enabled: bool,

--- a/crates/server/src/server/quic_handler.rs
+++ b/crates/server/src/server/quic_handler.rs
@@ -35,10 +35,21 @@ pub(super) async fn handle_quic(
     dns_hostname: Option<String>,
     cx: Arc<ServerContext<impl RequestHandler>>,
 ) -> Result<(), ProtoError> {
-    let dns_hostname: Option<Arc<str>> = dns_hostname.map(|n| n.into());
+    debug!(?socket, "registered quic");
+    handle_quic_with_server(
+        QuicServer::with_socket(socket, server_cert_resolver)?,
+        dns_hostname,
+        cx,
+    )
+    .await
+}
 
-    debug!("registered quic: {:?}", socket);
-    let mut server = QuicServer::with_socket(socket, server_cert_resolver)?;
+pub(super) async fn handle_quic_with_server(
+    mut server: QuicServer,
+    dns_hostname: Option<String>,
+    cx: Arc<ServerContext<impl RequestHandler>>,
+) -> Result<(), ProtoError> {
+    let dns_hostname = dns_hostname.map(|n| n.into());
 
     let mut inner_join_set = JoinSet::new();
     loop {

--- a/tests/e2e-tests/Cargo.lock
+++ b/tests/e2e-tests/Cargo.lock
@@ -139,6 +139,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "minijinja",
+ "rcgen",
  "serde",
  "serde_json",
  "serde_with",
@@ -167,7 +168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -193,13 +194,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.13.3+wasi-0.2.2",
  "windows-targets",
 ]
 
@@ -494,6 +506,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
+name = "pem"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+dependencies = [
+ "base64",
+ "serde",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +546,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0068c5b3cab1d4e271e0bb6539c87563c43411cad90b057b15c79958fbeb41f7"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,7 +582,16 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
@@ -663,10 +721,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -717,6 +775,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +802,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -820,6 +890,15 @@ name = "windows-link"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -916,6 +995,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
+
+[[package]]
 name = "yoke"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +1047,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zerovec"

--- a/tests/integration-tests/tests/integration/server_future_tests.rs
+++ b/tests/integration-tests/tests/integration/server_future_tests.rs
@@ -383,7 +383,7 @@ async fn server_thread_tls(
     // let pkcs12 = ((pkcs12.cert, pkcs12.chain), pkcs12.pkey);
 
     server
-        .register_tls_listener(tls_listener, Duration::from_secs(30), cert_chain, false)
+        .register_tls_listener(tls_listener, Duration::from_secs(30), cert_chain)
         .expect("failed to register TLS");
 
     while server_continue.load(Ordering::Relaxed) {


### PR DESCRIPTION
Follow-up from https://github.com/hickory-dns/hickory-dns/pull/3184

Avoid polluting the server crate APIs with a bool for `SSL_KEYLOG_FILE` support. Instead, lean on the ability wired through the various server APIs to allow providing a pre-configured rustls `ServerConfig` that can have keylog support enabled as one of many possible customizations. 

Accomplishing this requires some up-front work to allow greater control of the `rustls::ServerConfig` used for DoQ, DoH and DoH3 servers.