### PR TITLE
Add associated type to DnsHandle for runtime

### DIFF
--- a/bin/benches/comparison_benches.rs
+++ b/bin/benches/comparison_benches.rs
@@ -52,7 +52,7 @@ fn wrap_process(named: Child, server_port: u16) -> NamedProcess {
         let io_loop = Runtime::new().unwrap();
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, server_port));
         let stream = UdpClientStream::builder(addr, provider.clone()).build();
-        let client = Client::connect(stream);
+        let client = Client::<TokioRuntimeProvider>::connect(stream);
         let (mut client, bg) = io_loop.block_on(client).expect("failed to create client");
         io_loop.spawn(bg);
 
@@ -111,7 +111,7 @@ where
     S: DnsRequestSender,
 {
     let io_loop = Runtime::new().unwrap();
-    let client = Client::connect(stream);
+    let client = Client::<TokioRuntimeProvider>::connect(stream);
     let (mut client, bg) = io_loop.block_on(client).expect("failed to create client");
     io_loop.spawn(bg);
 

--- a/bin/tests/integration/named_https_tests.rs
+++ b/bin/tests/integration/named_https_tests.rs
@@ -67,7 +67,7 @@ fn test_example_https_toml_startup() {
         let provider = TokioRuntimeProvider::new();
         let https_builder = HttpsClientStreamBuilder::with_client_config(client_config, provider);
         let mp = https_builder.build(addr, Arc::from("ns.example.com"), Arc::from("/dns-query"));
-        let client = Client::connect(mp);
+        let client = Client::<TokioRuntimeProvider>::connect(mp);
 
         // ipv4 should succeed
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");

--- a/bin/tests/integration/named_metrics_tests.rs
+++ b/bin/tests/integration/named_metrics_tests.rs
@@ -607,7 +607,7 @@ fn test_updates() {
 async fn create_local_client(
     socket_ports: &SocketPorts,
     signer: Option<Arc<dyn MessageSigner>>,
-) -> Client {
+) -> Client<TokioRuntimeProvider> {
     let dns_port = socket_ports.get_v4(ServerProtocol::Dns(Protocol::Tcp));
     let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, dns_port.expect("no dns tcp port")));
 
@@ -715,7 +715,7 @@ fn verify_metric(metrics: &Scrape, name: &str, labels: &[(&str, &str)], value: O
 }
 
 async fn retry_client_lookup(
-    client: &mut Client,
+    client: &mut Client<TokioRuntimeProvider>,
     name: Name,
     class: DNSClass,
     rtype: RecordType,

--- a/bin/tests/integration/named_quic_tests.rs
+++ b/bin/tests/integration/named_quic_tests.rs
@@ -16,6 +16,7 @@ use tokio::runtime::Runtime;
 use crate::server_harness::{named_test_harness, query_a};
 use hickory_client::client::Client;
 use hickory_proto::quic::QuicClientStream;
+use hickory_proto::runtime::TokioRuntimeProvider;
 use hickory_proto::rustls::default_provider;
 use hickory_proto::xfer::Protocol;
 use test_support::subscribe;
@@ -52,7 +53,7 @@ fn test_example_quic_toml_startup() {
             .with_root_certificates(root_store)
             .with_no_client_auth();
 
-        let client = Client::connect(
+        let client = Client::<TokioRuntimeProvider>::connect(
             QuicClientStream::builder()
                 .crypto_config(client_config)
                 .build(addr, Arc::from("ns.example.com")),

--- a/bin/tests/integration/named_rustls_tests.rs
+++ b/bin/tests/integration/named_rustls_tests.rs
@@ -66,7 +66,7 @@ fn test_example_tls_toml_startup() {
                 config.clone(),
                 provider.clone(),
             );
-            let client = Client::new(stream, sender, None);
+            let client = Client::<TokioRuntimeProvider>::new(stream, sender, None);
 
             let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
             hickory_proto::runtime::spawn_bg(&io_loop, bg);
@@ -81,7 +81,7 @@ fn test_example_tls_toml_startup() {
                 config,
                 provider,
             );
-            let client = Client::new(stream, sender, None);
+            let client = Client::<TokioRuntimeProvider>::new(stream, sender, None);
 
             let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
             hickory_proto::runtime::spawn_bg(&io_loop, bg);

--- a/bin/tests/integration/named_test_rsa_dnssec.rs
+++ b/bin/tests/integration/named_test_rsa_dnssec.rs
@@ -12,7 +12,7 @@ use crate::server_harness::{named_test_harness, query_a, query_all_dnssec};
 use hickory_client::client::Client;
 use hickory_dns::dnssec::key_from_file;
 use hickory_proto::dnssec::{Algorithm, DnssecDnsHandle, TrustAnchors};
-use hickory_proto::runtime::{RuntimeProvider, TokioRuntimeProvider, TokioTime};
+use hickory_proto::runtime::{RuntimeProvider, TokioRuntimeProvider};
 use hickory_proto::tcp::TcpClientStream;
 use hickory_proto::xfer::{DnsExchangeBackground, DnsMultiplexer, Protocol};
 use test_support::subscribe;
@@ -35,12 +35,12 @@ async fn standard_tcp_conn<P: RuntimeProvider>(
     port: u16,
     provider: P,
 ) -> (
-    Client,
-    DnsExchangeBackground<DnsMultiplexer<TcpClientStream<P::Tcp>>, TokioTime>,
+    Client<P>,
+    DnsExchangeBackground<DnsMultiplexer<TcpClientStream<P::Tcp>>, P::Timer>,
 ) {
     let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
     let (stream, sender) = TcpClientStream::new(addr, None, None, provider);
-    Client::new(stream, sender, None)
+    Client::<P>::new(stream, sender, None)
         .await
         .expect("new Client failed")
 }

--- a/bin/tests/integration/named_tests.rs
+++ b/bin/tests/integration/named_tests.rs
@@ -31,7 +31,7 @@ fn test_example_toml_startup() {
         let tcp_port = socket_ports.get_v4(Protocol::Tcp);
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
-        let client = Client::new(Box::new(stream), sender, None);
+        let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
@@ -41,7 +41,7 @@ fn test_example_toml_startup() {
         // just tests that multiple queries work
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
-        let client = Client::new(Box::new(stream), sender, None);
+        let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
@@ -59,7 +59,7 @@ fn test_ipv4_only_toml_startup() {
         let tcp_port = socket_ports.get_v4(Protocol::Tcp);
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
-        let client = Client::new(Box::new(stream), sender, None);
+        let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
@@ -69,7 +69,7 @@ fn test_ipv4_only_toml_startup() {
 
         let addr = SocketAddr::from((Ipv6Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
-        let client = Client::new(Box::new(stream), sender, None);
+        let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         assert!(io_loop.block_on(client).is_err());
         //let (client, bg) = io_loop.block_on(client).expect("client failed to connect");
@@ -119,7 +119,7 @@ fn test_ipv4_and_ipv6_toml_startup() {
         let tcp_port = socket_ports.get_v4(Protocol::Tcp);
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
-        let client = Client::new(Box::new(stream), sender, None);
+        let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
@@ -129,7 +129,7 @@ fn test_ipv4_and_ipv6_toml_startup() {
         let tcp_port = socket_ports.get_v6(Protocol::Tcp);
         let addr = SocketAddr::from((Ipv6Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
-        let client = Client::new(Box::new(stream), sender, None);
+        let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
 
@@ -147,7 +147,7 @@ fn test_nodata_where_name_exists() {
         let tcp_port = socket_ports.get_v4(Protocol::Tcp);
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
-        let client = Client::new(Box::new(stream), sender, None);
+        let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
 
@@ -172,7 +172,7 @@ fn test_nxdomain_where_no_name_exists() {
         let tcp_port = socket_ports.get_v4(Protocol::Tcp);
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
-        let client = Client::new(Box::new(stream), sender, None);
+        let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
 
@@ -198,7 +198,7 @@ fn test_server_continues_on_bad_data_udp() {
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, udp_port.expect("no udp_port")));
 
         let stream = UdpClientStream::builder(addr, provider.clone()).build();
-        let client = Client::connect(stream);
+        let client = Client::<TokioRuntimeProvider>::connect(stream);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
 
@@ -215,7 +215,7 @@ fn test_server_continues_on_bad_data_udp() {
         // just tests that multiple queries work
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, udp_port.expect("no udp_port")));
         let stream = UdpClientStream::builder(addr, provider).build();
-        let client = Client::connect(stream);
+        let client = Client::<TokioRuntimeProvider>::connect(stream);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
@@ -233,7 +233,7 @@ fn test_server_continues_on_bad_data_tcp() {
         let tcp_port = socket_ports.get_v4(Protocol::Tcp);
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
-        let client = Client::new(Box::new(stream), sender, None);
+        let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
@@ -250,7 +250,7 @@ fn test_server_continues_on_bad_data_tcp() {
         // just tests that multiple queries work
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
-        let client = Client::new(Box::new(stream), sender, None);
+        let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
 
@@ -271,7 +271,7 @@ fn test_forward() {
         let tcp_port = socket_ports.get_v4(Protocol::Tcp);
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
-        let client = Client::new(Box::new(stream), sender, None);
+        let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
@@ -294,7 +294,7 @@ fn test_forward() {
         // just tests that multiple queries work
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
-        let client = Client::new(Box::new(stream), sender, None);
+        let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
@@ -325,7 +325,7 @@ fn test_allow_networks_toml_startup() {
         let tcp_port = socket_ports.get_v4(Protocol::Tcp);
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
-        let client = Client::new(Box::new(stream), sender, None);
+        let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
@@ -335,7 +335,7 @@ fn test_allow_networks_toml_startup() {
         let tcp_port = socket_ports.get_v6(Protocol::Tcp);
         let addr = SocketAddr::from((Ipv6Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
-        let client = Client::new(Box::new(stream), sender, None);
+        let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
 
@@ -353,7 +353,7 @@ fn test_deny_networks_toml_startup() {
         let tcp_port = socket_ports.get_v4(Protocol::Tcp);
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
-        let client = Client::new(Box::new(stream), sender, None);
+        let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
@@ -363,7 +363,7 @@ fn test_deny_networks_toml_startup() {
         let tcp_port = socket_ports.get_v6(Protocol::Tcp);
         let addr = SocketAddr::from((Ipv6Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
-        let client = Client::new(Box::new(stream), sender, None);
+        let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
 
@@ -381,7 +381,7 @@ fn test_deny_allow_networks_toml_startup() {
         let tcp_port = socket_ports.get_v4(Protocol::Tcp);
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
-        let client = Client::new(Box::new(stream), sender, None);
+        let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
@@ -391,7 +391,7 @@ fn test_deny_allow_networks_toml_startup() {
         let tcp_port = socket_ports.get_v6(Protocol::Tcp);
         let addr = SocketAddr::from((Ipv6Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
-        let client = Client::new(Box::new(stream), sender, None);
+        let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
         hickory_proto::runtime::spawn_bg(&io_loop, bg);
 

--- a/bin/tests/integration/server_harness/mod.rs
+++ b/bin/tests/integration/server_harness/mod.rs
@@ -20,14 +20,14 @@ use tracing::{info, warn};
 #[cfg(feature = "__dnssec")]
 use hickory_client::client::Client;
 use hickory_client::{client::ClientHandle, proto::xfer::DnsResponse};
-#[cfg(feature = "__dnssec")]
-use hickory_proto::dnssec::Algorithm;
 use hickory_proto::{
     ProtoError,
     op::ResponseCode,
     rr::{DNSClass, Name, RData, RecordType, rdata::A},
     xfer::Protocol,
 };
+#[cfg(feature = "__dnssec")]
+use hickory_proto::{dnssec::Algorithm, runtime::TokioRuntimeProvider};
 
 #[derive(Debug, Default)]
 pub struct SocketPort {
@@ -304,7 +304,11 @@ pub fn query_a_refused<C: ClientHandle>(io_loop: &mut Runtime, client: &mut C) {
 //  i.e. more complex checks live with the clients and authorities to validate deeper functionality
 #[allow(dead_code)]
 #[cfg(feature = "__dnssec")]
-pub fn query_all_dnssec(io_loop: &mut Runtime, client: Client, algorithm: Algorithm) {
+pub fn query_all_dnssec(
+    io_loop: &mut Runtime,
+    client: Client<TokioRuntimeProvider>,
+    algorithm: Algorithm,
+) {
     use hickory_proto::{
         dnssec::{
             PublicKey,

--- a/bin/tests/integration/server_harness/mut_message_client.rs
+++ b/bin/tests/integration/server_harness/mut_message_client.rs
@@ -25,6 +25,7 @@ impl<C: ClientHandle + Unpin> MutMessageHandle<C> {
 
 impl<C: ClientHandle + Unpin> DnsHandle for MutMessageHandle<C> {
     type Response = <C as DnsHandle>::Response;
+    type Runtime = C::Runtime;
 
     fn is_verifying_dnssec(&self) -> bool {
         true

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -50,7 +50,7 @@ use hickory_client::proto::xfer::DnsResponse;
 
 let address = SocketAddr::from(([8, 8, 8, 8], 53));
 let conn = UdpClientStream::builder(address, TokioRuntimeProvider::default()).build();
-let (mut client, bg) = Client::connect(conn).await.unwrap();
+let (mut client, bg) = Client::<TokioRuntimeProvider>::connect(conn).await.unwrap();
 tokio::spawn(bg);
 
 // Specify the name, note the final '.' which specifies it's an FQDN

--- a/crates/client/src/client/memoize_client_handle.rs
+++ b/crates/client/src/client/memoize_client_handle.rs
@@ -72,6 +72,7 @@ where
 
 impl<H: ClientHandle> DnsHandle for MemoizeClientHandle<H> {
     type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send>>;
+    type Runtime = H::Runtime;
 
     fn send(&self, request: DnsRequest) -> Self::Response {
         Box::pin(
@@ -94,16 +95,16 @@ mod test {
 
     use futures::lock::Mutex;
     use futures::*;
+
+    use crate::client::*;
     use hickory_proto::{
         ProtoError,
         op::{Message, MessageType, OpCode, Query},
         rr::RecordType,
-        xfer::{DnsHandle, DnsRequest, DnsResponse},
+        runtime::TokioRuntimeProvider,
+        xfer::{DnsHandle, DnsRequest, DnsResponse, FirstAnswer},
     };
     use test_support::subscribe;
-
-    use crate::client::*;
-    use hickory_proto::xfer::FirstAnswer;
 
     #[derive(Clone)]
     struct TestClient {
@@ -112,6 +113,7 @@ mod test {
 
     impl DnsHandle for TestClient {
         type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send>>;
+        type Runtime = TokioRuntimeProvider;
 
         fn send(&self, request: DnsRequest) -> Self::Response {
             let i = Arc::clone(&self.i);

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -105,7 +105,7 @@
 //!     //   the client is a handle to an unbounded queue for sending requests via the
 //!     //   background. The background must be scheduled to run before the client can
 //!     //   send any dns requests
-//!     let client = Client::new(stream, sender, None);
+//!     let client = Client::<TokioRuntimeProvider>::new(stream, sender, None);
 //!
 //!     // await the connection to be established
 //!     let (mut client, bg) = client.await.expect("connection failed");

--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -23,7 +23,7 @@ async fn readme_example() {
 
     let address = SocketAddr::from(([8, 8, 8, 8], 53));
     let conn = UdpClientStream::builder(address, TokioRuntimeProvider::default()).build();
-    let (mut client, bg) = Client::connect(conn).await.unwrap();
+    let (mut client, bg) = Client::<TokioRuntimeProvider>::connect(conn).await.unwrap();
     tokio::spawn(bg);
 
     // Specify the name, note the final '.' which specifies it's an FQDN

--- a/crates/proto/src/dnssec/handle.rs
+++ b/crates/proto/src/dnssec/handle.rs
@@ -894,6 +894,7 @@ impl<H: DnsHandle> DnssecDnsHandle<H> {
 #[cfg(any(feature = "std", feature = "no-std-rand"))]
 impl<H: DnsHandle> DnsHandle for DnssecDnsHandle<H> {
     type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send>>;
+    type Runtime = H::Runtime;
 
     fn is_verifying_dnssec(&self) -> bool {
         // This handler is always verifying...

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -44,16 +44,16 @@ use crate::{DnsMultiplexer, error::*};
 /// The variants of all supported connections for a `DnsExchange`.
 #[allow(missing_docs, clippy::large_enum_variant, clippy::type_complexity)]
 #[non_exhaustive]
-pub enum Connecting<R: RuntimeProvider> {
-    Udp(DnsExchangeConnect<UdpClientConnect<R>, UdpClientStream<R>, R>),
+pub enum Connecting<P: RuntimeProvider> {
+    Udp(DnsExchangeConnect<UdpClientConnect<P>, UdpClientStream<P>, P>),
     Tcp(
         DnsExchangeConnect<
             DnsMultiplexerConnect<
-                BoxFuture<'static, Result<TcpClientStream<R::Tcp>, ProtoError>>,
-                TcpClientStream<<R as RuntimeProvider>::Tcp>,
+                BoxFuture<'static, Result<TcpClientStream<P::Tcp>, ProtoError>>,
+                TcpClientStream<<P as RuntimeProvider>::Tcp>,
             >,
-            DnsMultiplexer<TcpClientStream<<R as RuntimeProvider>::Tcp>>,
-            R,
+            DnsMultiplexer<TcpClientStream<<P as RuntimeProvider>::Tcp>>,
+            P,
         >,
     ),
     #[cfg(feature = "__tls")]
@@ -62,20 +62,20 @@ pub enum Connecting<R: RuntimeProvider> {
             DnsMultiplexerConnect<
                 BoxFuture<
                     'static,
-                    Result<TlsClientStream<<R as RuntimeProvider>::Tcp>, ProtoError>,
+                    Result<TlsClientStream<<P as RuntimeProvider>::Tcp>, ProtoError>,
                 >,
-                TlsClientStream<<R as RuntimeProvider>::Tcp>,
+                TlsClientStream<<P as RuntimeProvider>::Tcp>,
             >,
-            DnsMultiplexer<TlsClientStream<<R as RuntimeProvider>::Tcp>>,
-            R,
+            DnsMultiplexer<TlsClientStream<<P as RuntimeProvider>::Tcp>>,
+            P,
         >,
     ),
     #[cfg(all(feature = "__https", feature = "tokio"))]
-    Https(DnsExchangeConnect<HttpsClientConnect<R::Tcp>, HttpsClientStream, R>),
+    Https(DnsExchangeConnect<HttpsClientConnect<P::Tcp>, HttpsClientStream, P>),
     #[cfg(all(feature = "__quic", feature = "tokio"))]
-    Quic(DnsExchangeConnect<QuicClientConnect, QuicClientStream, R>),
+    Quic(DnsExchangeConnect<QuicClientConnect, QuicClientStream, P>),
     #[cfg(all(feature = "__h3", feature = "tokio"))]
-    H3(DnsExchangeConnect<H3ClientConnect, H3ClientStream, R>),
+    H3(DnsExchangeConnect<H3ClientConnect, H3ClientStream, P>),
 }
 
 /// This is a generic Exchange implemented over multiplexed DNS connection providers.

--- a/crates/proto/src/xfer/dns_handle.rs
+++ b/crates/proto/src/xfer/dns_handle.rs
@@ -10,9 +10,12 @@
 use futures_util::stream::Stream;
 use tracing::debug;
 
-use crate::error::*;
-use crate::op::{Edns, Message, Query};
-use crate::xfer::{DnsRequest, DnsRequestOptions, DnsResponse, SerialMessage};
+use crate::{
+    error::*,
+    op::{Edns, Message, Query},
+    runtime::RuntimeProvider,
+    xfer::{DnsRequest, DnsRequestOptions, DnsResponse, SerialMessage},
+};
 
 // TODO: this should be configurable
 // > An EDNS buffer size of 1232 bytes will avoid fragmentation on nearly all current networks.
@@ -29,6 +32,9 @@ pub trait DnsStreamHandle: 'static + Send {
 pub trait DnsHandle: 'static + Clone + Send + Sync + Unpin {
     /// The associated response from the response stream, this should resolve to the Response messages
     type Response: Stream<Item = Result<DnsResponse, ProtoError>> + Send + Unpin + 'static;
+
+    /// The asynchronous runtime in use.
+    type Runtime: RuntimeProvider;
 
     /// Only returns true if and only if this DNS handle is validating DNSSEC.
     ///

--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -561,6 +561,7 @@ mod for_dnssec {
 
     impl<P: ConnectionProvider> DnsHandle for RecursorDnsHandle<P> {
         type Response = BoxStream<'static, Result<DnsResponse, ProtoError>>;
+        type Runtime = P::RuntimeProvider;
 
         fn send(&self, request: DnsRequest) -> Self::Response {
             let query = if let OpCode::Query = request.op_code() {

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -89,6 +89,7 @@ ipconfig = { workspace = true, optional = true }
 
 [dev-dependencies]
 futures-executor = { workspace = true, default-features = false, features = ["std"] }
+hickory-proto = { workspace = true, features = ["tokio"] }
 serde_json = { workspace = true }
 test-support.workspace = true
 tokio = { workspace = true, features = ["macros", "test-util"] }

--- a/crates/resolver/src/lookup_ip.rs
+++ b/crates/resolver/src/lookup_ip.rs
@@ -330,6 +330,7 @@ pub(crate) mod tests {
     use crate::proto::ProtoError;
     use crate::proto::op::Message;
     use crate::proto::rr::{Name, RData, Record};
+    use crate::proto::runtime::TokioRuntimeProvider;
     use crate::proto::xfer::{DnsHandle, DnsRequest, DnsResponse};
 
     use super::*;
@@ -341,6 +342,7 @@ pub(crate) mod tests {
 
     impl DnsHandle for MockDnsHandle {
         type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send + Unpin>>;
+        type Runtime = TokioRuntimeProvider;
 
         fn send(&self, _: DnsRequest) -> Self::Response {
             Box::pin(once(future::ready(

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -68,7 +68,7 @@ pub struct ConnectionFuture<R: RuntimeProvider> {
 }
 
 impl<R: RuntimeProvider> Future for ConnectionFuture<R> {
-    type Output = Result<DnsExchange, ProtoError>;
+    type Output = Result<DnsExchange<R>, ProtoError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         Poll::Ready(Ok(match &mut self.connect {
@@ -112,7 +112,7 @@ impl<R: RuntimeProvider> Future for ConnectionFuture<R> {
 }
 
 impl<P: RuntimeProvider> ConnectionProvider for P {
-    type Conn = DnsExchange;
+    type Conn = DnsExchange<P>;
     type FutureConn = ConnectionFuture<P>;
     type RuntimeProvider = P;
 

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -62,13 +62,13 @@ pub trait ConnectionProvider: 'static + Clone + Send + Sync + Unpin {
 
 /// Resolves to a new Connection
 #[must_use = "futures do nothing unless polled"]
-pub struct ConnectionFuture<R: RuntimeProvider> {
-    pub(crate) connect: Connecting<R>,
-    pub(crate) spawner: R::Handle,
+pub struct ConnectionFuture<P: RuntimeProvider> {
+    pub(crate) connect: Connecting<P>,
+    pub(crate) spawner: P::Handle,
 }
 
-impl<R: RuntimeProvider> Future for ConnectionFuture<R> {
-    type Output = Result<DnsExchange<R>, ProtoError>;
+impl<P: RuntimeProvider> Future for ConnectionFuture<P> {
+    type Output = Result<DnsExchange<P>, ProtoError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         Poll::Ready(Ok(match &mut self.connect {

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -103,6 +103,7 @@ impl<P: ConnectionProvider> NameServer<P> {
 
 impl<P: ConnectionProvider> DnsHandle for NameServer<P> {
     type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send>>;
+    type Runtime = P::RuntimeProvider;
 
     fn is_verifying_dnssec(&self) -> bool {
         #[cfg(feature = "__dnssec")]

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -81,6 +81,7 @@ impl<P: ConnectionProvider> NameServerPool<P> {
 
 impl<P: ConnectionProvider> DnsHandle for NameServerPool<P> {
     type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send>>;
+    type Runtime = P::RuntimeProvider;
 
     fn send(&self, request: DnsRequest) -> Self::Response {
         let state = self.state.clone();

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -350,6 +350,7 @@ enum LookupEither<P: ConnectionProvider> {
 
 impl<P: ConnectionProvider> DnsHandle for LookupEither<P> {
     type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send>>;
+    type Runtime = P::RuntimeProvider;
 
     fn is_verifying_dnssec(&self) -> bool {
         match self {
@@ -1164,8 +1165,8 @@ mod tests {
         assert!(is_sync_t::<Resolver<TokioRuntimeProvider>>());
 
         assert!(is_send_t::<DnsRequest>());
-        assert!(is_send_t::<LookupIpFuture<DnsExchange>>());
-        assert!(is_send_t::<LookupFuture<DnsExchange>>());
+        assert!(is_send_t::<LookupIpFuture<DnsExchange<TokioRuntimeProvider>>>());
+        assert!(is_send_t::<LookupFuture<DnsExchange<TokioRuntimeProvider>>>());
     }
 
     #[tokio::test]
@@ -1464,6 +1465,7 @@ mod tests {
 
     impl DnsHandle for MockDnsHandle {
         type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send>>;
+        type Runtime = TokioRuntimeProvider;
 
         fn send(&self, _: DnsRequest) -> Self::Response {
             Box::pin(once(future::ready(

--- a/tests/compatibility-tests/tests/integration/sig0_tests.rs
+++ b/tests/compatibility-tests/tests/integration/sig0_tests.rs
@@ -33,7 +33,9 @@ async fn test_get() {
     let (_process, port) = named_process();
     let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
     let conn = UdpClientStream::builder(socket, TokioRuntimeProvider::default()).build();
-    let (mut client, driver) = Client::connect(conn).await.expect("failed to connect");
+    let (mut client, driver) = Client::<TokioRuntimeProvider>::connect(conn)
+        .await
+        .expect("failed to connect");
     tokio::spawn(driver);
 
     let name = Name::from_str("www.example.com.").unwrap();
@@ -81,7 +83,9 @@ async fn test_create() {
     let conn = UdpClientStream::builder(socket, TokioRuntimeProvider::default())
         .with_signer(Some(Arc::new(signer)))
         .build();
-    let (mut client, driver) = Client::connect(conn).await.expect("failed to connect");
+    let (mut client, driver) = Client::<TokioRuntimeProvider>::connect(conn)
+        .await
+        .expect("failed to connect");
     tokio::spawn(driver);
 
     // create a record

--- a/tests/compatibility-tests/tests/integration/tsig_tests.rs
+++ b/tests/compatibility-tests/tests/integration/tsig_tests.rs
@@ -53,7 +53,9 @@ async fn test_create() {
     let stream = UdpClientStream::builder(socket, TokioRuntimeProvider::default())
         .with_signer(Some(signer()))
         .build();
-    let (mut client, driver) = Client::connect(stream).await.expect("failed to connect");
+    let (mut client, driver) = Client::<TokioRuntimeProvider>::connect(stream)
+        .await
+        .expect("failed to connect");
     tokio::spawn(driver);
 
     // create a record
@@ -106,7 +108,7 @@ async fn test_tsig_zone_transfer() {
         TcpClientStream::new(socket, None, None, TokioRuntimeProvider::default());
     let multiplexer = DnsMultiplexer::new(stream, sender, Some(signer()));
 
-    let (mut client, driver) = Client::connect(multiplexer)
+    let (mut client, driver) = Client::<TokioRuntimeProvider>::connect(multiplexer)
         .await
         .expect("failed to connect");
     tokio::spawn(driver);

--- a/tests/compatibility-tests/tests/integration/zone_transfer.rs
+++ b/tests/compatibility-tests/tests/integration/zone_transfer.rs
@@ -42,7 +42,7 @@ async fn test_zone_transfer() {
         TcpClientStream::new(socket, None, None, TokioRuntimeProvider::default());
     let multiplexer = DnsMultiplexer::new(stream, sender, None);
 
-    let (mut client, driver) = Client::connect(multiplexer)
+    let (mut client, driver) = Client::<TokioRuntimeProvider>::connect(multiplexer)
         .await
         .expect("failed to connect");
     tokio::spawn(driver);

--- a/tests/integration-tests/src/mock_client.rs
+++ b/tests/integration-tests/src/mock_client.rs
@@ -183,6 +183,7 @@ impl<O: OnSend> MockClientHandle<O> {
 
 impl<O: OnSend + Unpin> DnsHandle for MockClientHandle<O> {
     type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send>>;
+    type Runtime = MockRuntimeProvider;
 
     fn send(&self, _: DnsRequest) -> Self::Response {
         let mut messages = self.messages.lock().expect("failed to lock at messages");

--- a/tests/integration-tests/tests/integration/client_future_tests.rs
+++ b/tests/integration-tests/tests/integration/client_future_tests.rs
@@ -149,7 +149,7 @@ async fn test_query_https() {
     test_query(&mut client).await;
 }
 
-async fn test_query(client: &mut Client) {
+async fn test_query(client: &mut Client<TokioRuntimeProvider>) {
     let name = Name::from_ascii("WWW.example.com.").unwrap();
 
     let response = client
@@ -169,7 +169,7 @@ async fn test_query(client: &mut Client) {
     assert!(!response.answers().is_empty());
 }
 
-async fn test_query_edns(client: &mut Client) {
+async fn test_query_edns(client: &mut Client<TokioRuntimeProvider>) {
     let name = Name::from_ascii("WWW.example.com.").unwrap();
     let mut edns = Edns::new();
     // garbage subnet value, but lets check
@@ -228,7 +228,7 @@ async fn test_notify() {
     catalog.upsert(authority.origin().clone(), vec![Arc::new(authority)]);
 
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
-    let client = Client::new(stream, sender, None);
+    let client = Client::<TokioRuntimeProvider>::new(stream, sender, None);
     let (mut client, bg) = client.await.expect("client failed to connect");
     tokio::spawn(bg);
 
@@ -253,7 +253,7 @@ async fn test_notify() {
 #[cfg(all(feature = "__dnssec", feature = "sqlite"))]
 async fn create_sig0_ready_client() -> (
     (
-        Client,
+        Client<TokioRuntimeProvider>,
         DnsExchangeBackground<DnsMultiplexer<TestClientStream>, TokioTime>,
     ),
     Name,
@@ -962,7 +962,7 @@ async fn test_delete_all() {
     assert_eq!(result.answers().len(), 0);
 }
 
-async fn test_timeout_query(mut client: Client) {
+async fn test_timeout_query(mut client: Client<TokioRuntimeProvider>) {
     let name = Name::from_str("www.example.com").unwrap();
 
     let err = client
@@ -1025,7 +1025,7 @@ async fn test_timeout_query_tcp() {
         Some(std::time::Duration::from_millis(1)),
         TokioRuntimeProvider::new(),
     );
-    let client = Client::with_timeout(
+    let client = Client::<TokioRuntimeProvider>::with_timeout(
         Box::new(stream),
         sender,
         std::time::Duration::from_millis(1),

--- a/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
+++ b/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
@@ -193,7 +193,7 @@ where
 
 async fn with_nonet<F, Fut>(test: F)
 where
-    F: Fn(DnssecDnsHandle<MemoizeClientHandle<Client>>) -> Fut,
+    F: Fn(DnssecDnsHandle<MemoizeClientHandle<Client<TokioRuntimeProvider>>>) -> Fut,
     Fut: Future<Output = ()>,
 {
     let succeeded = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -250,7 +250,7 @@ where
 
 async fn with_udp<F, Fut>(test: F)
 where
-    F: Fn(DnssecDnsHandle<MemoizeClientHandle<Client>>) -> Fut,
+    F: Fn(DnssecDnsHandle<MemoizeClientHandle<Client<TokioRuntimeProvider>>>) -> Fut,
     Fut: Future<Output = ()>,
 {
     let succeeded = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -286,7 +286,7 @@ where
 
 async fn with_tcp<F, Fut>(test: F)
 where
-    F: Fn(DnssecDnsHandle<MemoizeClientHandle<Client>>) -> Fut,
+    F: Fn(DnssecDnsHandle<MemoizeClientHandle<Client<TokioRuntimeProvider>>>) -> Fut,
     Fut: Future<Output = ()>,
 {
     let succeeded = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));

--- a/tests/integration-tests/tests/integration/lookup_tests.rs
+++ b/tests/integration-tests/tests/integration/lookup_tests.rs
@@ -7,7 +7,7 @@ use std::{
 use hickory_proto::{
     op::Query,
     rr::{DNSClass, Name, RData, Record, RecordType, rdata::A},
-    runtime::TokioTime,
+    runtime::TokioRuntimeProvider,
     xfer::{DnsExchange, DnsMultiplexer, DnsResponse},
 };
 use hickory_resolver::{
@@ -31,7 +31,7 @@ async fn test_lookup() {
 
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
     let dns_conn = DnsMultiplexer::new(stream, sender, None);
-    let client = DnsExchange::connect::<_, _, TokioTime>(dns_conn);
+    let client = DnsExchange::<TokioRuntimeProvider>::connect(dns_conn);
 
     let (client, bg) = client.await.expect("client failed to connect");
     tokio::spawn(bg);
@@ -60,7 +60,7 @@ async fn test_lookup_hosts() {
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
     let dns_conn = DnsMultiplexer::new(stream, sender, None);
 
-    let client = DnsExchange::connect::<_, _, TokioTime>(dns_conn);
+    let client = DnsExchange::<TokioRuntimeProvider>::connect(dns_conn);
     let (client, bg) = client.await.expect("client connect failed");
     tokio::spawn(bg);
 
@@ -118,7 +118,7 @@ async fn test_lookup_ipv4_like() {
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
     let dns_conn = DnsMultiplexer::new(stream, sender, None);
 
-    let client = DnsExchange::connect::<_, _, TokioTime>(dns_conn);
+    let client = DnsExchange::<TokioRuntimeProvider>::connect(dns_conn);
     let (client, bg) = client.await.expect("client connect failed");
     tokio::spawn(bg);
 
@@ -148,7 +148,7 @@ async fn test_lookup_ipv4_like_fall_through() {
     let (stream, sender) = TestClientStream::new(Arc::new(StdMutex::new(catalog)));
     let dns_conn = DnsMultiplexer::new(stream, sender, None);
 
-    let client = DnsExchange::connect::<_, _, TokioTime>(dns_conn);
+    let client = DnsExchange::<TokioRuntimeProvider>::connect(dns_conn);
     let (client, bg) = client.await.expect("client connect failed");
     tokio::spawn(bg);
 

--- a/tests/integration-tests/tests/integration/retry_dns_handle_tests.rs
+++ b/tests/integration-tests/tests/integration/retry_dns_handle_tests.rs
@@ -8,6 +8,7 @@ use futures::{Stream, executor::block_on, future, stream};
 use hickory_proto::{
     DnsHandle, ProtoError, RetryDnsHandle,
     op::{Message, OpCode, ResponseCode},
+    runtime::TokioRuntimeProvider,
     xfer::{DnsRequest, DnsResponse, FirstAnswer},
 };
 use test_support::subscribe;
@@ -21,6 +22,7 @@ struct TestClient {
 
 impl DnsHandle for TestClient {
     type Response = Box<dyn Stream<Item = Result<DnsResponse, ProtoError>> + Send + Unpin>;
+    type Runtime = TokioRuntimeProvider;
 
     fn send(&self, _: DnsRequest) -> Self::Response {
         let i = self.attempts.load(Ordering::SeqCst);

--- a/tests/integration-tests/tests/integration/rfc4592_tests.rs
+++ b/tests/integration-tests/tests/integration/rfc4592_tests.rs
@@ -257,7 +257,7 @@ async fn no_synthesis_5() {
 /// subdel.example.          3600     NS    ns.example.com.
 /// subdel.example.          3600     NS    ns.example.net.
 /// ```
-async fn setup() -> (Client, Server<Catalog>) {
+async fn setup() -> (Client<TokioRuntimeProvider>, Server<Catalog>) {
     // Zone setup
     let origin = Name::parse("example.", None).unwrap();
 

--- a/tests/integration-tests/tests/integration/server_future_tests.rs
+++ b/tests/integration-tests/tests/integration/server_future_tests.rs
@@ -247,14 +247,14 @@ async fn test_server_www_tls() {
     server.await.unwrap();
 }
 
-async fn lazy_udp_client(addr: SocketAddr) -> Client {
+async fn lazy_udp_client(addr: SocketAddr) -> Client<TokioRuntimeProvider> {
     let conn = UdpClientStream::builder(addr, TokioRuntimeProvider::default()).build();
     let (client, driver) = Client::connect(conn).await.expect("failed to connect");
     tokio::spawn(driver);
     client
 }
 
-async fn lazy_tcp_client(addr: SocketAddr) -> Client {
+async fn lazy_tcp_client(addr: SocketAddr) -> Client<TokioRuntimeProvider> {
     let (stream, sender) = TcpClientStream::new(addr, None, None, TokioRuntimeProvider::default());
     let multiplexer = DnsMultiplexer::new(stream, sender, None);
     let (client, driver) = Client::connect(multiplexer)
@@ -274,7 +274,7 @@ async fn lazy_tls_client(
     ipaddr: SocketAddr,
     server_name: &str,
     cert_chain: Vec<CertificateDer<'static>>,
-) -> Client {
+) -> Client<TokioRuntimeProvider> {
     let mut root_store = RootCertStore::empty();
     let (_, ignored) = root_store.add_parsable_certificates(cert_chain);
     assert_eq!(ignored, 0, "bad certificate!");
@@ -305,7 +305,7 @@ async fn lazy_tls_client(
     client
 }
 
-async fn client_thread_www(future: impl Future<Output = Client>) {
+async fn client_thread_www(future: impl Future<Output = Client<TokioRuntimeProvider>>) {
     let name = Name::from_str("www.example.com.").unwrap();
 
     let mut client = future.await;

--- a/tests/integration-tests/tests/integration/truncation_tests.rs
+++ b/tests/integration-tests/tests/integration/truncation_tests.rs
@@ -34,7 +34,9 @@ async fn test_truncation() {
 
     // Create the UDP client.
     let stream = UdpClientStream::builder(nameserver, TokioRuntimeProvider::new()).build();
-    let (client, bg) = Client::connect(stream).await.unwrap();
+    let (client, bg) = Client::<TokioRuntimeProvider>::connect(stream)
+        .await
+        .unwrap();
 
     // Run the client exchange in the background.
     tokio::spawn(bg);

--- a/tests/integration-tests/tests/integration/validating_forwarder_tests.rs
+++ b/tests/integration-tests/tests/integration/validating_forwarder_tests.rs
@@ -252,7 +252,7 @@ async fn setup_authoritative_server(
 async fn setup_client_forwarder(
     name_server_addr: SocketAddr,
     public_key: Option<&PublicKeyBuf>,
-) -> (Client, Server<Catalog>) {
+) -> (Client<TokioRuntimeProvider>, Server<Catalog>) {
     // Server setup
     let mut config = NameServerConfig::udp(name_server_addr.ip());
     config.connections[0].port = name_server_addr.port();


### PR DESCRIPTION
This adds an associated type to the `DnsHandle` trait for the runtime provider in use, and adds generic type parameters to implementors and other types as needed. This is preparatory work for #3158.