### PR TITLE
udp client: compare req and res IP in canonical before rejecting the response

### DIFF
--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -303,7 +303,9 @@ async fn send_serial_message_inner<S: DnsUdpSocket + Send>(
         let request_target = msg.addr();
 
         // Comparing the IP and Port directly as internal information about the link is stored with the IpAddr, see https://github.com/hickory-dns/hickory-dns/issues/2081
-        if src.ip() != request_target.ip() || src.port() != request_target.port() {
+        if src.ip().to_canonical() != request_target.ip().to_canonical()
+            || src.port() != request_target.port()
+        {
             warn!(
                 "ignoring response from {} because it does not match name_server: {}.",
                 src, request_target,


### PR DESCRIPTION
as discussed https://github.com/hickory-dns/hickory-dns/issues/2730#issuecomment-3183377068