### PR TITLE
e2e-tests: remove unused serde_json dev-dep

### DIFF
--- a/tests/e2e-tests/Cargo.lock
+++ b/tests/e2e-tests/Cargo.lock
@@ -153,7 +153,6 @@ version = "0.0.0"
 dependencies = [
  "dns-test",
  "minijinja",
- "serde_json",
 ]
 
 [[package]]

--- a/tests/e2e-tests/Cargo.toml
+++ b/tests/e2e-tests/Cargo.toml
@@ -11,4 +11,3 @@ exclude = ["../../conformance/package/dns-test"]
 [dev-dependencies]
 dns-test.path = "../../conformance/packages/dns-test"
 minijinja = "2"
-serde_json = "1"


### PR DESCRIPTION
This snuck in by accident with the DoT probing scenario test in https://github.com/hickory-dns/hickory-dns/pull/3188 