### PR TITLE
server: simplify time handling

### DIFF
--- a/bin/tests/integration/authority_battery/basic.rs
+++ b/bin/tests/integration/authority_battery/basic.rs
@@ -11,6 +11,7 @@ use hickory_proto::{
         Name, RData, Record, RecordType,
         rdata::{A as A4, AAAA},
     },
+    runtime::{Time, TokioTime},
     xfer::Protocol,
 };
 use hickory_server::{
@@ -497,7 +498,11 @@ pub fn test_update_errors(authority: impl Authority) {
     .unwrap();
 
     // this is expected to fail, i.e. updates are not allowed
-    assert!(block_on(authority.update(&request)).0.is_err());
+    assert!(
+        block_on(authority.update(&request, TokioTime::current_time()))
+            .0
+            .is_err()
+    );
 }
 
 #[allow(clippy::uninlined_format_args)]

--- a/bin/tests/integration/authority_battery/dynamic_update.rs
+++ b/bin/tests/integration/authority_battery/dynamic_update.rs
@@ -19,6 +19,7 @@ use hickory_proto::{
         DNSClass, Name, RData, Record, RecordSet, RecordType,
         rdata::{A as A4, AAAA},
     },
+    runtime::{Time, TokioTime},
     serialize::binary::BinEncodable,
     xfer::Protocol,
 };
@@ -43,7 +44,7 @@ fn update_authority(
     )
     .unwrap();
 
-    block_on(authority.update(&request)).0
+    block_on(authority.update(&request, TokioTime::current_time())).0
 }
 
 pub fn test_create(mut authority: impl Authority, keys: &[SigSigner]) {

--- a/bin/tests/integration/authority_battery/dynamic_update.rs
+++ b/bin/tests/integration/authority_battery/dynamic_update.rs
@@ -23,7 +23,7 @@ use hickory_proto::{
     xfer::Protocol,
 };
 use hickory_server::{
-    authority::{Authority, DnssecAuthority, LookupOptions, MessageRequest, UpdateResult},
+    authority::{Authority, DnssecAuthority, LookupOptions, MessageRequest},
     server::Request,
 };
 
@@ -33,7 +33,7 @@ fn update_authority(
     mut message: Message,
     key: &SigSigner,
     authority: &mut impl Authority,
-) -> UpdateResult<bool> {
+) -> Result<bool, ResponseCode> {
     message.finalize(key, 1).expect("failed to sign message");
     let bytes = message.to_bytes().unwrap();
     let request = Request::from_bytes(

--- a/crates/server/src/authority/authority.rs
+++ b/crates/server/src/authority/authority.rs
@@ -238,12 +238,14 @@ pub trait Authority: Send + Sync {
     /// This will return `None` if the next authority in the authority chain should be used instead.
     async fn zone_transfer(
         &self,
-        request: &Request,
-        lookup_options: LookupOptions,
+        _request: &Request,
+        _lookup_options: LookupOptions,
     ) -> Option<(
         Result<ZoneTransfer, LookupError>,
         Option<Box<dyn ResponseSigner>>,
-    )>;
+    )> {
+        Some((Err(LookupError::from(ResponseCode::NotImp)), None))
+    }
 
     /// Returns the kind of non-existence proof used for this zone.
     #[cfg(feature = "__dnssec")]

--- a/crates/server/src/authority/authority.rs
+++ b/crates/server/src/authority/authority.rs
@@ -13,7 +13,7 @@ use cfg_if::cfg_if;
 use serde::Deserialize;
 
 use crate::{
-    authority::{AuthLookup, LookupError, UpdateResult, ZoneTransfer, ZoneType},
+    authority::{AuthLookup, LookupError, ZoneTransfer, ZoneType},
     proto::{
         op::{Edns, ResponseCode, message::ResponseSigner},
         rr::{LowerName, RecordSet, RecordType, RrsetRecords},
@@ -87,7 +87,7 @@ pub trait Authority: Send + Sync {
     async fn update(
         &self,
         _update: &Request,
-    ) -> (UpdateResult<bool>, Option<Box<dyn ResponseSigner>>) {
+    ) -> (Result<bool, ResponseCode>, Option<Box<dyn ResponseSigner>>) {
         (Err(ResponseCode::NotImp), None)
     }
 

--- a/crates/server/src/authority/authority.rs
+++ b/crates/server/src/authority/authority.rs
@@ -15,7 +15,7 @@ use serde::Deserialize;
 use crate::{
     authority::{AuthLookup, LookupError, UpdateResult, ZoneTransfer, ZoneType},
     proto::{
-        op::{Edns, message::ResponseSigner},
+        op::{Edns, ResponseCode, message::ResponseSigner},
         rr::{LowerName, RecordSet, RecordType, RrsetRecords},
     },
     server::{Request, RequestInfo},
@@ -86,8 +86,10 @@ pub trait Authority: Send + Sync {
     /// Perform a dynamic update of a zone
     async fn update(
         &self,
-        update: &Request,
-    ) -> (UpdateResult<bool>, Option<Box<dyn ResponseSigner>>);
+        _update: &Request,
+    ) -> (UpdateResult<bool>, Option<Box<dyn ResponseSigner>>) {
+        (Err(ResponseCode::NotImp), None)
+    }
 
     /// Get the origin of this zone, i.e. example.com is the origin for www.example.com
     fn origin(&self) -> &LowerName;

--- a/crates/server/src/authority/authority.rs
+++ b/crates/server/src/authority/authority.rs
@@ -87,6 +87,7 @@ pub trait Authority: Send + Sync {
     async fn update(
         &self,
         _update: &Request,
+        _now: u64,
     ) -> (Result<bool, ResponseCode>, Option<Box<dyn ResponseSigner>>) {
         (Err(ResponseCode::NotImp), None)
     }
@@ -240,6 +241,7 @@ pub trait Authority: Send + Sync {
         &self,
         _request: &Request,
         _lookup_options: LookupOptions,
+        _now: u64,
     ) -> Option<(
         Result<ZoneTransfer, LookupError>,
         Option<Box<dyn ResponseSigner>>,

--- a/crates/server/src/authority/mod.rs
+++ b/crates/server/src/authority/mod.rs
@@ -37,9 +37,6 @@ pub use self::catalog::Catalog;
 pub use self::message_request::{MessageRequest, Queries, UpdateRequest};
 pub use self::message_response::{MessageResponse, MessageResponseBuilder};
 
-/// Result of an Update operation
-pub type UpdateResult<T> = Result<T, ResponseCode>;
-
 /// A query could not be fulfilled
 #[derive(Debug, EnumAsInner, Error)]
 #[non_exhaustive]

--- a/crates/server/src/server/mod.rs
+++ b/crates/server/src/server/mod.rs
@@ -18,7 +18,7 @@ use std::{
 use crate::proto::rustls::tls_from_stream;
 use bytes::Bytes;
 use futures_util::StreamExt;
-use hickory_proto::ProtoErrorKind;
+use hickory_proto::{ProtoErrorKind, runtime::TokioTime};
 use ipnet::IpNet;
 #[cfg(feature = "__tls")]
 use rustls::{ServerConfig, server::ResolvesServerCert};
@@ -905,7 +905,9 @@ impl<T: RequestHandler> ServerContext<T> {
             metrics: ResponseHandlerMetrics::default(),
         };
 
-        self.handler.handle_request(&request, reporter).await;
+        self.handler
+            .handle_request::<_, TokioTime>(&request, reporter)
+            .await;
     }
 }
 

--- a/crates/server/src/server/request_handler.rs
+++ b/crates/server/src/server/request_handler.rs
@@ -8,6 +8,7 @@
 //! Request Handler for incoming requests
 
 use bytes::Bytes;
+use hickory_proto::runtime::Time;
 use std::net::SocketAddr;
 
 #[cfg(feature = "testing")]
@@ -181,7 +182,7 @@ pub trait RequestHandler: Send + Sync + Unpin + 'static {
     ///
     /// * `request` - the requested action to perform.
     /// * `response_handle` - handle to which a return message should be sent
-    async fn handle_request<R: ResponseHandler>(
+    async fn handle_request<R: ResponseHandler, T: Time>(
         &self,
         request: &Request,
         response_handle: R,

--- a/crates/server/src/store/blocklist.rs
+++ b/crates/server/src/store/blocklist.rs
@@ -30,10 +30,10 @@ use crate::{authority::Nsec3QueryInfo, dnssec::NxProofKind};
 use crate::{
     authority::{
         AuthLookup, Authority, AxfrPolicy, LookupControlFlow, LookupError, LookupOptions,
-        UpdateResult, ZoneTransfer, ZoneType,
+        ZoneTransfer, ZoneType,
     },
     proto::{
-        op::{Query, ResponseCode, message::ResponseSigner},
+        op::{Query, message::ResponseSigner},
         rr::{
             LowerName, Name, RData, Record, RecordType,
             rdata::{A, AAAA, TXT},
@@ -326,13 +326,6 @@ impl Authority for BlocklistAuthority {
 
     fn axfr_policy(&self) -> AxfrPolicy {
         AxfrPolicy::Deny
-    }
-
-    async fn update(
-        &self,
-        _update: &Request,
-    ) -> (UpdateResult<bool>, Option<Box<dyn ResponseSigner>>) {
-        (Err(ResponseCode::NotImp), None)
     }
 
     fn origin(&self) -> &LowerName {

--- a/crates/server/src/store/blocklist.rs
+++ b/crates/server/src/store/blocklist.rs
@@ -455,6 +455,7 @@ impl Authority for BlocklistAuthority {
         &self,
         _request: &Request,
         _lookup_options: LookupOptions,
+        _now: u64,
     ) -> Option<(
         Result<ZoneTransfer, LookupError>,
         Option<Box<dyn ResponseSigner>>,

--- a/crates/server/src/store/file.rs
+++ b/crates/server/src/store/file.rs
@@ -19,7 +19,7 @@ use crate::store::metrics::PersistentStoreMetrics;
 use crate::{
     authority::{
         AuthLookup, Authority, AxfrPolicy, LookupControlFlow, LookupError, LookupOptions,
-        UpdateResult, ZoneTransfer, ZoneType,
+        ZoneTransfer, ZoneType,
     },
     proto::{
         op::message::ResponseSigner,
@@ -131,15 +131,6 @@ impl Authority for FileAuthority {
     /// Return the policy for determining if AXFR requests are allowed
     fn axfr_policy(&self) -> AxfrPolicy {
         self.in_memory.axfr_policy()
-    }
-
-    /// Perform a dynamic update of a zone
-    async fn update(
-        &self,
-        _update: &Request,
-    ) -> (UpdateResult<bool>, Option<Box<dyn ResponseSigner>>) {
-        use crate::proto::op::ResponseCode;
-        (Err(ResponseCode::NotImp), None)
     }
 
     /// Get the origin of this zone, i.e. example.com is the origin for www.example.com

--- a/crates/server/src/store/file.rs
+++ b/crates/server/src/store/file.rs
@@ -191,11 +191,14 @@ impl Authority for FileAuthority {
         &self,
         request: &Request,
         lookup_options: LookupOptions,
+        now: u64,
     ) -> Option<(
         Result<ZoneTransfer, LookupError>,
         Option<Box<dyn ResponseSigner>>,
     )> {
-        self.in_memory.zone_transfer(request, lookup_options).await
+        self.in_memory
+            .zone_transfer(request, lookup_options, now)
+            .await
     }
 
     /// Get the NS, NameServer, record for the zone

--- a/crates/server/src/store/forwarder.rs
+++ b/crates/server/src/store/forwarder.rs
@@ -20,8 +20,7 @@ use tracing::{debug, info};
 use crate::{authority::Nsec3QueryInfo, dnssec::NxProofKind, proto::dnssec::TrustAnchors};
 use crate::{
     authority::{
-        AuthLookup, Authority, AxfrPolicy, LookupControlFlow, LookupError, LookupOptions,
-        ZoneType,
+        AuthLookup, Authority, AxfrPolicy, LookupControlFlow, LookupError, LookupOptions, ZoneType,
     },
     proto::{
         op::message::ResponseSigner,

--- a/crates/server/src/store/forwarder.rs
+++ b/crates/server/src/store/forwarder.rs
@@ -21,7 +21,7 @@ use crate::{authority::Nsec3QueryInfo, dnssec::NxProofKind, proto::dnssec::Trust
 use crate::{
     authority::{
         AuthLookup, Authority, AxfrPolicy, LookupControlFlow, LookupError, LookupOptions,
-        ZoneTransfer, ZoneType,
+        ZoneType,
     },
     proto::{
         op::message::ResponseSigner,
@@ -282,22 +282,6 @@ impl<P: ConnectionProvider> Authority for ForwardAuthority<P> {
             .await,
             None,
         )
-    }
-
-    async fn zone_transfer(
-        &self,
-        _request: &Request,
-        _lookup_options: LookupOptions,
-    ) -> Option<(
-        Result<ZoneTransfer, LookupError>,
-        Option<Box<dyn ResponseSigner>>,
-    )> {
-        Some((
-            Err(LookupError::from(io::Error::other(
-                "zone transfer is unimplemented for the forwarder",
-            ))),
-            None,
-        ))
     }
 
     async fn nsec_records(

--- a/crates/server/src/store/forwarder.rs
+++ b/crates/server/src/store/forwarder.rs
@@ -21,10 +21,10 @@ use crate::{authority::Nsec3QueryInfo, dnssec::NxProofKind, proto::dnssec::Trust
 use crate::{
     authority::{
         AuthLookup, Authority, AxfrPolicy, LookupControlFlow, LookupError, LookupOptions,
-        UpdateResult, ZoneTransfer, ZoneType,
+        ZoneTransfer, ZoneType,
     },
     proto::{
-        op::{ResponseCode, message::ResponseSigner},
+        op::{message::ResponseSigner},
         rr::{LowerName, Name, RecordType},
         runtime::TokioRuntimeProvider,
     },
@@ -224,13 +224,6 @@ impl<P: ConnectionProvider> Authority for ForwardAuthority<P> {
         {
             false
         }
-    }
-
-    async fn update(
-        &self,
-        _update: &Request,
-    ) -> (UpdateResult<bool>, Option<Box<dyn ResponseSigner>>) {
-        (Err(ResponseCode::NotImp), None)
     }
 
     /// Get the origin of this zone, i.e. example.com is the origin for www.example.com

--- a/crates/server/src/store/forwarder.rs
+++ b/crates/server/src/store/forwarder.rs
@@ -24,7 +24,7 @@ use crate::{
         ZoneTransfer, ZoneType,
     },
     proto::{
-        op::{message::ResponseSigner},
+        op::message::ResponseSigner,
         rr::{LowerName, Name, RecordType},
         runtime::TokioRuntimeProvider,
     },

--- a/crates/server/src/store/in_memory/mod.rs
+++ b/crates/server/src/store/in_memory/mod.rs
@@ -26,7 +26,7 @@ use tracing::{debug, info};
 use crate::{
     authority::{
         AuthLookup, Authority, AxfrPolicy, AxfrRecords, LookupControlFlow, LookupError,
-        LookupOptions, LookupRecords, UpdateResult, ZoneTransfer, ZoneType,
+        LookupOptions, LookupRecords, ZoneTransfer, ZoneType,
     },
     proto::{
         op::{ResponseCode, message::ResponseSigner},
@@ -345,70 +345,6 @@ impl<P: RuntimeProvider + Send + Sync> Authority for InMemoryAuthority<P> {
     /// Return the policy for determining if AXFR requests are allowed
     fn axfr_policy(&self) -> AxfrPolicy {
         self.axfr_policy
-    }
-
-    /// Takes the UpdateMessage, extracts the Records, and applies the changes to the record set.
-    ///
-    /// [RFC 2136](https://tools.ietf.org/html/rfc2136), DNS Update, April 1997
-    ///
-    /// ```text
-    ///
-    /// 3.4 - Process Update Section
-    ///
-    ///   Next, the Update Section is processed as follows.
-    ///
-    /// 3.4.2 - Update
-    ///
-    ///   The Update Section is parsed into RRs and these RRs are processed in
-    ///   order.
-    ///
-    /// 3.4.2.1. If any system failure (such as an out of memory condition,
-    ///   or a hardware error in persistent storage) occurs during the
-    ///   processing of this section, signal SERVFAIL to the requestor and undo
-    ///   all updates applied to the zone during this transaction.
-    ///
-    /// 3.4.2.2. Any Update RR whose CLASS is the same as ZCLASS is added to
-    ///   the zone.  In case of duplicate RDATAs (which for SOA RRs is always
-    ///   the case, and for WKS RRs is the case if the ADDRESS and PROTOCOL
-    ///   fields both match), the Zone RR is replaced by Update RR.  If the
-    ///   TYPE is SOA and there is no Zone SOA RR, or the new SOA.SERIAL is
-    ///   lower (according to [RFC1982]) than or equal to the current Zone SOA
-    ///   RR's SOA.SERIAL, the Update RR is ignored.  In the case of a CNAME
-    ///   Update RR and a non-CNAME Zone RRset or vice versa, ignore the CNAME
-    ///   Update RR, otherwise replace the CNAME Zone RR with the CNAME Update
-    ///   RR.
-    ///
-    /// 3.4.2.3. For any Update RR whose CLASS is ANY and whose TYPE is ANY,
-    ///   all Zone RRs with the same NAME are deleted, unless the NAME is the
-    ///   same as ZNAME in which case only those RRs whose TYPE is other than
-    ///   SOA or NS are deleted.  For any Update RR whose CLASS is ANY and
-    ///   whose TYPE is not ANY all Zone RRs with the same NAME and TYPE are
-    ///   deleted, unless the NAME is the same as ZNAME in which case neither
-    ///   SOA or NS RRs will be deleted.
-    ///
-    /// 3.4.2.4. For any Update RR whose class is NONE, any Zone RR whose
-    ///   NAME, TYPE, RDATA and RDLENGTH are equal to the Update RR is deleted,
-    ///   unless the NAME is the same as ZNAME and either the TYPE is SOA or
-    ///   the TYPE is NS and the matching Zone RR is the only NS remaining in
-    ///   the RRset, in which case this Update RR is ignored.
-    ///
-    /// 3.4.2.5. Signal NOERROR to the requestor.
-    /// ```
-    ///
-    /// # Arguments
-    ///
-    /// * `update` - The `UpdateMessage` records will be extracted and used to perform the update
-    ///              actions as specified in the above RFC.
-    ///
-    /// # Return value
-    ///
-    /// true if any of additions, updates or deletes were made to the zone, false otherwise. Err is
-    ///  returned in the case of bad data, etc.
-    async fn update(
-        &self,
-        _update: &Request,
-    ) -> (UpdateResult<bool>, Option<Box<dyn ResponseSigner>>) {
-        (Err(ResponseCode::NotImp), None)
     }
 
     /// Get the origin of this zone, i.e. example.com is the origin for www.example.com

--- a/crates/server/src/store/in_memory/mod.rs
+++ b/crates/server/src/store/in_memory/mod.rs
@@ -550,6 +550,7 @@ impl<P: RuntimeProvider + Send + Sync> Authority for InMemoryAuthority<P> {
         &self,
         request: &Request,
         lookup_options: LookupOptions,
+        _now: u64,
     ) -> Option<(
         Result<ZoneTransfer, LookupError>,
         Option<Box<dyn ResponseSigner>>,

--- a/crates/server/src/store/recursor.rs
+++ b/crates/server/src/store/recursor.rs
@@ -30,13 +30,12 @@ use crate::authority::ZoneTransfer;
 use crate::{authority::Nsec3QueryInfo, dnssec::NxProofKind, proto::dnssec::TrustAnchors};
 use crate::{
     authority::{
-        AuthLookup, Authority, AxfrPolicy, LookupControlFlow, LookupError, LookupOptions,
-        UpdateResult, ZoneType,
+        AuthLookup, Authority, AxfrPolicy, LookupControlFlow, LookupError, LookupOptions, ZoneType,
     },
     error::ConfigError,
     proto::{
+        op::Query,
         op::message::ResponseSigner,
-        op::{Query, ResponseCode},
         rr::{LowerName, Name, RData, Record, RecordSet, RecordType},
         runtime::RuntimeProvider,
         serialize::txt::{ParseError, Parser},
@@ -116,13 +115,6 @@ impl<P: RuntimeProvider> Authority for RecursiveAuthority<P> {
 
     fn can_validate_dnssec(&self) -> bool {
         self.recursor.is_validating()
-    }
-
-    async fn update(
-        &self,
-        _update: &Request,
-    ) -> (UpdateResult<bool>, Option<Box<dyn ResponseSigner>>) {
-        (Err(ResponseCode::NotImp), None)
     }
 
     /// Get the origin of this zone, i.e. example.com is the origin for www.example.com

--- a/crates/server/src/store/recursor.rs
+++ b/crates/server/src/store/recursor.rs
@@ -25,7 +25,6 @@ use ipnet::IpNet;
 use serde::Deserialize;
 use tracing::{debug, info};
 
-use crate::authority::ZoneTransfer;
 #[cfg(feature = "__dnssec")]
 use crate::{authority::Nsec3QueryInfo, dnssec::NxProofKind, proto::dnssec::TrustAnchors};
 use crate::{
@@ -173,22 +172,6 @@ impl<P: RuntimeProvider> Authority for RecursiveAuthority<P> {
             .await,
             None,
         )
-    }
-
-    async fn zone_transfer(
-        &self,
-        _request: &Request,
-        _lookup_options: LookupOptions,
-    ) -> Option<(
-        Result<ZoneTransfer, LookupError>,
-        Option<Box<dyn ResponseSigner>>,
-    )> {
-        Some((
-            Err(LookupError::from(io::Error::other(
-                "zone transfer is unimplemented for the recursor",
-            ))),
-            None,
-        ))
     }
 
     async fn nsec_records(

--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -164,7 +164,7 @@ impl Stream for TestClientStream {
                     self.catalog
                         .lock()
                         .unwrap()
-                        .handle_request(&request, response_handler.clone()),
+                        .handle_request::<_, TokioTime>(&request, response_handler.clone()),
                 );
 
                 let buf = block_on(response_handler.into_inner());

--- a/tests/integration-tests/src/mock_request_handler.rs
+++ b/tests/integration-tests/src/mock_request_handler.rs
@@ -6,6 +6,7 @@ use hickory_proto::rr::DNSClass;
 use hickory_proto::{
     op::{Header, MessageType, ResponseCode},
     rr::{LowerName, RecordType},
+    runtime::Time,
     xfer::DnsResponse,
 };
 use hickory_resolver::Name;
@@ -44,7 +45,7 @@ impl MockHandler {
 
 #[async_trait]
 impl RequestHandler for MockHandler {
-    async fn handle_request<R: ResponseHandler>(
+    async fn handle_request<R: ResponseHandler, T: Time>(
         &self,
         request: &Request,
         mut response_handle: R,

--- a/tests/integration-tests/tests/integration/catalog_tests.rs
+++ b/tests/integration-tests/tests/integration/catalog_tests.rs
@@ -9,6 +9,7 @@ use hickory_proto::{
             opt::{EdnsCode, EdnsOption, NSIDPayload},
         },
     },
+    runtime::{Time, TokioTime},
     serialize::binary::BinEncodable,
     xfer::Protocol,
 };
@@ -154,7 +155,12 @@ async fn test_catalog_lookup() {
 
     let response_handler = TestResponseHandler::new();
     catalog
-        .lookup(&question_req, None, response_handler.clone())
+        .lookup(
+            &question_req,
+            None,
+            TokioTime::current_time(),
+            response_handler.clone(),
+        )
         .await;
     let result = response_handler.into_message().await;
 
@@ -188,7 +194,12 @@ async fn test_catalog_lookup() {
 
     let response_handler = TestResponseHandler::new();
     catalog
-        .lookup(&question_req, None, response_handler.clone())
+        .lookup(
+            &question_req,
+            None,
+            TokioTime::current_time(),
+            response_handler.clone(),
+        )
         .await;
     let result = response_handler.into_message().await;
 
@@ -234,7 +245,12 @@ async fn test_catalog_lookup_soa() {
 
     let response_handler = TestResponseHandler::new();
     catalog
-        .lookup(&question_req, None, response_handler.clone())
+        .lookup(
+            &question_req,
+            None,
+            TokioTime::current_time(),
+            response_handler.clone(),
+        )
         .await;
     let result = response_handler.into_message().await;
 
@@ -301,7 +317,12 @@ async fn test_catalog_nx_soa() {
 
     let response_handler = TestResponseHandler::new();
     catalog
-        .lookup(&question_req, None, response_handler.clone())
+        .lookup(
+            &question_req,
+            None,
+            TokioTime::current_time(),
+            response_handler.clone(),
+        )
         .await;
     let result = response_handler.into_message().await;
 
@@ -352,7 +373,12 @@ async fn test_non_authoritive_nx_refused() {
 
     let response_handler = TestResponseHandler::new();
     catalog
-        .lookup(&question_req, None, response_handler.clone())
+        .lookup(
+            &question_req,
+            None,
+            TokioTime::current_time(),
+            response_handler.clone(),
+        )
         .await;
     let result = response_handler.into_message().await;
 
@@ -407,7 +433,12 @@ async fn test_axfr_allow_all() {
 
     let response_handler = TestResponseHandler::new();
     catalog
-        .lookup(&question_req, None, response_handler.clone())
+        .lookup(
+            &question_req,
+            None,
+            TokioTime::current_time(),
+            response_handler.clone(),
+        )
         .await;
     let result = response_handler.into_message().await;
 
@@ -525,7 +556,12 @@ async fn test_axfr_deny_all() {
 
     let response_handler = TestResponseHandler::new();
     catalog
-        .lookup(&question_req, None, response_handler.clone())
+        .lookup(
+            &question_req,
+            None,
+            TokioTime::current_time(),
+            response_handler.clone(),
+        )
         .await;
     let result = response_handler.into_message().await;
 
@@ -558,7 +594,12 @@ async fn test_axfr_deny_all_sqlite() {
 
     let response_handler = TestResponseHandler::new();
     catalog
-        .lookup(&request, None, response_handler.clone())
+        .lookup(
+            &request,
+            None,
+            TokioTime::current_time(),
+            response_handler.clone(),
+        )
         .await;
     let response = response_handler.into_message().await;
 
@@ -595,7 +636,12 @@ async fn test_axfr_deny_unsigned() {
 
     let response_handler = TestResponseHandler::new();
     catalog
-        .lookup(&question_req, None, response_handler.clone())
+        .lookup(
+            &question_req,
+            None,
+            TokioTime::current_time(),
+            response_handler.clone(),
+        )
         .await;
     let result = response_handler.into_message().await;
 
@@ -620,7 +666,7 @@ async fn test_nsid_disabled_requested() {
 
     let response_handler = TestResponseHandler::new();
     let _ = catalog
-        .handle_request(&question_req, response_handler.clone())
+        .handle_request::<_, TokioTime>(&question_req, response_handler.clone())
         .await;
     let response = response_handler.into_message().await;
     assert_eq!(response.response_code(), ResponseCode::NoError);
@@ -656,7 +702,7 @@ async fn test_nsid_enabled_not_requested() {
 
     let response_handler = TestResponseHandler::new();
     let _ = catalog
-        .handle_request(&question_req, response_handler.clone())
+        .handle_request::<_, TokioTime>(&question_req, response_handler.clone())
         .await;
     let response = response_handler.into_message().await;
     assert_eq!(response.response_code(), ResponseCode::NoError);
@@ -693,7 +739,7 @@ async fn test_nsid_enabled_and_requested() {
 
     let response_handler = TestResponseHandler::new();
     let _ = catalog
-        .handle_request(&question_req, response_handler.clone())
+        .handle_request::<_, TokioTime>(&question_req, response_handler.clone())
         .await;
     let response = response_handler.into_message().await;
     assert_eq!(response.response_code(), ResponseCode::NoError);
@@ -759,7 +805,12 @@ async fn test_cname_additionals() {
 
     let response_handler = TestResponseHandler::new();
     catalog
-        .lookup(&question_req, None, response_handler.clone())
+        .lookup(
+            &question_req,
+            None,
+            TokioTime::current_time(),
+            response_handler.clone(),
+        )
         .await;
     let result = response_handler.into_message().await;
 
@@ -808,7 +859,12 @@ async fn test_multiple_cname_additionals() {
 
     let response_handler = TestResponseHandler::new();
     catalog
-        .lookup(&question_req, None, response_handler.clone())
+        .lookup(
+            &question_req,
+            None,
+            TokioTime::current_time(),
+            response_handler.clone(),
+        )
         .await;
     let result = response_handler.into_message().await;
 
@@ -875,7 +931,7 @@ async fn test_update_forwarder() {
 
     let response_handler = TestResponseHandler::new();
     catalog
-        .handle_request(&request, response_handler.clone())
+        .handle_request::<_, TokioTime>(&request, response_handler.clone())
         .await;
     let response = response_handler.into_message().await;
 
@@ -943,7 +999,12 @@ mod dnssec {
 
         let response_handler = TestResponseHandler::new();
         catalog
-            .lookup(&question_req, None, response_handler.clone())
+            .lookup(
+                &question_req,
+                None,
+                TokioTime::current_time(),
+                response_handler.clone(),
+            )
             .await;
         response_handler.into_message().await
     }

--- a/tests/integration-tests/tests/integration/chained_authority_tests.rs
+++ b/tests/integration-tests/tests/integration/chained_authority_tests.rs
@@ -13,7 +13,7 @@ use hickory_server::{authority::Nsec3QueryInfo, dnssec::NxProofKind};
 use hickory_server::{
     authority::{
         AuthLookup, Authority, AxfrPolicy, Catalog, LookupControlFlow, LookupError, LookupOptions,
-        LookupRecords, UpdateResult, ZoneTransfer, ZoneType,
+        LookupRecords, ZoneTransfer, ZoneType,
     },
     server::{Request, RequestInfo, ResponseInfo},
 };
@@ -183,13 +183,6 @@ impl Authority for TestAuthority {
 
     fn axfr_policy(&self) -> AxfrPolicy {
         AxfrPolicy::Deny
-    }
-
-    async fn update(
-        &self,
-        _update: &Request,
-    ) -> (UpdateResult<bool>, Option<Box<dyn ResponseSigner>>) {
-        (Err(ResponseCode::NotImp), None)
     }
 
     async fn nsec_records(

--- a/tests/integration-tests/tests/integration/chained_authority_tests.rs
+++ b/tests/integration-tests/tests/integration/chained_authority_tests.rs
@@ -13,7 +13,7 @@ use hickory_server::{authority::Nsec3QueryInfo, dnssec::NxProofKind};
 use hickory_server::{
     authority::{
         AuthLookup, Authority, AxfrPolicy, Catalog, LookupControlFlow, LookupError, LookupOptions,
-        LookupRecords, ZoneTransfer, ZoneType,
+        LookupRecords, ZoneType,
     },
     server::{Request, RequestInfo, ResponseInfo},
 };
@@ -242,17 +242,6 @@ impl Authority for TestAuthority {
             .await,
             None,
         )
-    }
-
-    async fn zone_transfer(
-        &self,
-        _request: &Request,
-        _lookup_options: LookupOptions,
-    ) -> Option<(
-        Result<ZoneTransfer, LookupError>,
-        Option<Box<dyn ResponseSigner>>,
-    )> {
-        unimplemented!()
     }
 
     async fn consult(

--- a/tests/integration-tests/tests/integration/chained_authority_tests.rs
+++ b/tests/integration-tests/tests/integration/chained_authority_tests.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use hickory_integration::TestResponseHandler;
 use hickory_proto::{
-    op::message::ResponseSigner,
-    op::{Message, MessageType, Query, ResponseCode},
+    op::{Message, MessageType, Query, ResponseCode, message::ResponseSigner},
     rr::{LowerName, Name, RData, Record, RecordSet, RecordType, rdata::A},
+    runtime::{Time, TokioTime},
     serialize::binary::BinEncodable,
     xfer::Protocol,
 };
@@ -350,9 +350,10 @@ async fn do_query(catalog: &Catalog, query_name: &str) -> (ResponseInfo, TestRes
     let question_req =
         Request::from_bytes(question_bytes, ([127, 0, 0, 1], 5553).into(), Protocol::Udp).unwrap();
     let response_handler = TestResponseHandler::new();
+    let now = TokioTime::current_time();
 
     let res = catalog
-        .lookup(&question_req, None, response_handler.clone())
+        .lookup(&question_req, None, now, response_handler.clone())
         .await;
     (res, response_handler)
 }


### PR DESCRIPTION
From reviewing

- #3228

and as noted before in https://github.com/hickory-dns/hickory-dns/pull/3158#issuecomment-3205615317, I'm not sure the current usage of `RuntimeProvider` makes sense for the server crate (which has a mandatory dependency on Tokio today).