### PR TITLE
Change response code for AXFR in SqliteAuthority

### DIFF
--- a/crates/server/src/store/sqlite/mod.rs
+++ b/crates/server/src/store/sqlite/mod.rs
@@ -574,7 +574,7 @@ impl<P: RuntimeProvider + Send + Sync> SqliteAuthority<P> {
     ) -> (Result<(), ResponseCode>, Option<Box<dyn ResponseSigner>>) {
         match self.axfr_policy {
             // Deny without checking any signatures.
-            AxfrPolicy::Deny => (Err(ResponseCode::NotAuth), None),
+            AxfrPolicy::Deny => (Err(ResponseCode::Refused), None),
             // Allow without checking any signatures.
             AxfrPolicy::AllowAll => (Ok(()), None),
             // Allow only if a valid signature is present.
@@ -587,7 +587,7 @@ impl<P: RuntimeProvider + Send + Sync> SqliteAuthority<P> {
                 }
                 MessageSignature::Unsigned => {
                     warn!("AXFR request was not signed");
-                    (Err(ResponseCode::NotAuth), None)
+                    (Err(ResponseCode::Refused), None)
                 }
             },
         }

--- a/tests/integration-tests/tests/integration/catalog_tests.rs
+++ b/tests/integration-tests/tests/integration/catalog_tests.rs
@@ -562,7 +562,7 @@ async fn test_axfr_deny_all_sqlite() {
         .await;
     let response = response_handler.into_message().await;
 
-    assert_eq!(response.response_code(), ResponseCode::NotAuth);
+    assert_eq!(response.response_code(), ResponseCode::Refused);
     assert!(response.answers().is_empty());
     assert!(response.authorities().is_empty());
     assert!(response.additionals().is_empty());

--- a/tests/integration-tests/tests/integration/sqlite_authority_tests.rs
+++ b/tests/integration-tests/tests/integration/sqlite_authority_tests.rs
@@ -1572,7 +1572,7 @@ async fn test_axfr_deny_all() {
         .unwrap_err();
     assert!(matches!(
         err,
-        LookupError::ResponseCode(ResponseCode::NotAuth)
+        LookupError::ResponseCode(ResponseCode::Refused)
     ))
 }
 
@@ -1603,7 +1603,7 @@ async fn test_axfr_deny_unsigned() {
         .unwrap_err();
     assert!(matches!(
         err,
-        LookupError::ResponseCode(ResponseCode::NotAuth)
+        LookupError::ResponseCode(ResponseCode::Refused)
     ))
 }
 


### PR DESCRIPTION
This changes the response code that `SqliteAuthority` uses when rejecting an `AXFR` query from `NotAuth` to `Refused`, in order to better align with `InMemoryAuthority`.