### PR TITLE
Fix commented-out tests

### DIFF
--- a/bin/tests/integration/authority_battery/dnssec.rs
+++ b/bin/tests/integration/authority_battery/dnssec.rs
@@ -378,40 +378,39 @@ pub fn add_signers<A: DnssecAuthority>(authority: &mut A) -> Vec<DNSKEY> {
         block_on(authority.secure_zone()).expect("failed to sign zone");
     }
 
-    // // TODO: why are ecdsa tests failing in this context?
-    // // ecdsa_p256
-    // {
-    //     let key_config = KeyConfig {
-    //         key_path: "../../tests/test-data/test_configs/dnssec/ecdsa_p256.pem".to_string(),
-    //         password: None,
-    //         algorithm: Algorithm::ECDSAP256SHA256.to_string(),
-    //         signer_name: Some(signer_name.clone().to_string()),
-    //         is_zone_signing_key: Some(true),
-    //         is_zone_update_auth: Some(false),
-    //     };
+    // ecdsa_p256
+    {
+        let key_config = KeyConfig {
+            key_path: PathBuf::from("../tests/test-data/test_configs/dnssec/ecdsa_p256.pk8"),
+            algorithm: Algorithm::ECDSAP256SHA256,
+            signer_name: Some(signer_name.clone().to_string()),
+            purpose: KeyPurpose::ZoneSigning,
+        };
 
-    //     let signer = key_config.try_into_signer(signer_name.clone()).expect("failed to read key_config");
-    //     keys.push(signer.to_dnskey().expect("failed to create DNSKEY"));
-    //     authority.add_zone_signing_key(signer).expect("failed to add signer to zone");
-    //     authority.secure_zone().expect("failed to sign zone");
-    // }
+        let signer = key_config
+            .try_into_signer(signer_name.clone())
+            .expect("failed to read key_config");
+        keys.push(signer.to_dnskey().expect("failed to create DNSKEY"));
+        block_on(authority.add_zone_signing_key(signer)).expect("failed to add signer to zone");
+        block_on(authority.secure_zone()).expect("failed to sign zone");
+    }
 
-    // // ecdsa_p384
-    // {
-    //     let key_config = KeyConfig {
-    //         key_path: "../../tests/test-data/test_configs/dnssec/ecdsa_p384.pem".to_string(),
-    //         password: None,
-    //         algorithm: Algorithm::ECDSAP384SHA384.to_string(),
-    //         signer_name: Some(signer_name.clone().to_string()),
-    //         is_zone_signing_key: Some(true),
-    //         is_zone_update_auth: Some(false),
-    //     };
+    // ecdsa_p384
+    {
+        let key_config = KeyConfig {
+            key_path: PathBuf::from("../tests/test-data/test_configs/dnssec/ecdsa_p384.pk8"),
+            algorithm: Algorithm::ECDSAP384SHA384,
+            signer_name: Some(signer_name.clone().to_string()),
+            purpose: KeyPurpose::ZoneSigning,
+        };
 
-    //     let signer = key_config.try_into_signer(signer_name.clone()).expect("failed to read key_config");
-    //     keys.push(signer.to_dnskey().expect("failed to create DNSKEY"));
-    //     authority.add_zone_signing_key(signer).expect("failed to add signer to zone");
-    //     authority.secure_zone().expect("failed to sign zone");
-    // }
+        let signer = key_config
+            .try_into_signer(signer_name.clone())
+            .expect("failed to read key_config");
+        keys.push(signer.to_dnskey().expect("failed to create DNSKEY"));
+        block_on(authority.add_zone_signing_key(signer)).expect("failed to add signer to zone");
+        block_on(authority.secure_zone()).expect("failed to sign zone");
+    }
 
     // ed 25519
     #[cfg(feature = "__dnssec")]


### PR DESCRIPTION
This fixes a couple commented-out sections of a test battery. Private key loading was revamped a while back, so it now works for all algorithms.