### PR TITLE
conformance: drop conformance tests against ring from CI

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -50,9 +50,6 @@ jobs:
       - name: run conformance tests against hickory-dns
         run: just conformance-hickory
 
-      - name: run conformance tests against hickory-dns (with ring)
-        run: just conformance-hickory-ring
-
       - name: check that all the tests that now pass with hickory-dns are not marked as `#[ignore]`-d
         run: just conformance-ignored
 


### PR DESCRIPTION
Should save 4.5 minutes for the conformance runs (currently 21 minutes). I don't think this is worth it -- there's very little code involved in abstracting over aws-lc-rs vs ring and we do have non-conformance test coverage for that.