### PR TITLE
Use stable rust in cargo-workspaces fallback build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,6 +194,7 @@ jobs:
         run: cargo binstall cargo-workspaces -y --version ${{ env.CARGO_WS_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUSTUP_TOOLCHAIN: stable
 
       - name: just std
         run: just std


### PR DESCRIPTION
This changes the `past-future` job to use a stable toolchain to build `cargo-workspaces` if precompiled binaries are not available. It is currently failing because some release artifacts were deleted, and our MSRV is too old for `cargo-workspaces` itself.