### PR TITLE
bin: disable the banner by default

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -27,7 +27,7 @@ categories.workspace = true
 license.workspace = true
 
 [features]
-default = ["sqlite", "resolver", "rustls-platform-verifier", "ascii-art"]
+default = ["sqlite", "resolver", "rustls-platform-verifier"]
 
 # if enabled, the hickory-dns binary will print ascii-art on start, disable to reduce the binary size
 ascii-art = []


### PR DESCRIPTION
While I appreciate a little whimsy, I think the verbosity is a little too annoying when trying to actually read logs.