### PR TITLE
proto: clean up ProtoError

### DIFF
--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -376,7 +376,7 @@ pub struct ZoneConfig {
 
 impl ZoneConfig {
     #[warn(clippy::wildcard_enum_match_arm)] // make sure all cases are handled despite of non_exhaustive
-    pub async fn load(&self, zone_dir: &Path) -> Result<Vec<Arc<dyn ZoneHandler>>, String> {
+    pub async fn load(&self, zone_dir: &Path) -> Result<Vec<Arc<dyn ZoneHandler>>, ProtoError> {
         debug!("loading zone with config: {self:#?}");
 
         let zone_name = self
@@ -436,7 +436,7 @@ impl ZoneConfig {
                                 .await?;
                             Arc::new(handler)
                         }
-                        _ => return empty_stores_error(),
+                        _ => return Err(ProtoError::from(EMPTY_STORES)),
                     };
 
                     handlers.push(handler);
@@ -483,7 +483,7 @@ impl ZoneConfig {
 
                             Arc::new(recursor)
                         }
-                        _ => return empty_stores_error(),
+                        _ => return Err(ProtoError::from(EMPTY_STORES)),
                     };
 
                     handlers.push(handler);
@@ -511,9 +511,7 @@ impl ZoneConfig {
     }
 }
 
-fn empty_stores_error<T>() -> Result<T, String> {
-    Result::Err("empty [[zones.stores]] in config".to_owned())
-}
+const EMPTY_STORES: &str = "empty [[zones.stores]] in config";
 
 #[derive(Deserialize, Debug)]
 #[serde(tag = "zone_type")]

--- a/crates/proto/src/dnssec/nsec3.rs
+++ b/crates/proto/src/dnssec/nsec3.rs
@@ -942,7 +942,7 @@ impl Nsec3HashAlgorithm {
                     name.emit(&mut encoder)?;
                 }
 
-                Digest::iterated(salt, &buf, DigestType::SHA1, iterations)
+                Ok(Digest::iterated(salt, &buf, DigestType::SHA1, iterations)?)
             }
         }
     }

--- a/crates/proto/src/dnssec/rdata/cdnskey.rs
+++ b/crates/proto/src/dnssec/rdata/cdnskey.rs
@@ -14,11 +14,13 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ProtoError, ProtoErrorKind,
+    ProtoError,
     dnssec::{Algorithm, PublicKeyBuf},
     error::ProtoResult,
     rr::{RData, RecordData, RecordDataDecodable, RecordType},
-    serialize::binary::{BinDecoder, BinEncodable, BinEncoder, Restrict, RestrictedMath},
+    serialize::binary::{
+        BinDecoder, BinEncodable, BinEncoder, DecodeError, Restrict, RestrictedMath,
+    },
 };
 
 use super::DNSSECRData;
@@ -150,7 +152,7 @@ impl<'r> RecordDataDecodable<'r> for CDNSKEY {
         let _protocol = decoder
             .read_u8()?
             .verify_unwrap(|protocol| *protocol == 3)
-            .map_err(|protocol| ProtoError::from(ProtoErrorKind::DnsKeyProtocolNot3(protocol)))?;
+            .map_err(DecodeError::DnsKeyProtocolNot3)?;
 
         let algorithm_value = decoder.read_u8()?.unverified(/* no further validation required */);
         let algorithm = match algorithm_value {

--- a/crates/proto/src/dnssec/rdata/dnskey.rs
+++ b/crates/proto/src/dnssec/rdata/dnskey.rs
@@ -18,10 +18,11 @@ use crate::{
         Algorithm, DigestType, PublicKey, PublicKeyBuf, Verifier,
         crypto::{Digest, decode_public_key},
     },
-    error::{ProtoError, ProtoErrorKind, ProtoResult},
+    error::{ProtoError, ProtoResult},
     rr::{Name, RecordData, RecordDataDecodable, RecordType, record_data::RData},
     serialize::binary::{
-        BinDecodable, BinDecoder, BinEncodable, BinEncoder, NameEncoding, Restrict, RestrictedMath,
+        BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, NameEncoding, Restrict,
+        RestrictedMath,
     },
 };
 
@@ -387,7 +388,7 @@ impl<'r> RecordDataDecodable<'r> for DNSKEY {
 
                 *protocol == 3
             })
-            .map_err(|protocol| ProtoError::from(ProtoErrorKind::DnsKeyProtocolNot3(protocol)))?;
+            .map_err(DecodeError::DnsKeyProtocolNot3)?;
 
         let algorithm: Algorithm = Algorithm::read(decoder)?;
 

--- a/crates/proto/src/dnssec/rdata/dnskey.rs
+++ b/crates/proto/src/dnssec/rdata/dnskey.rs
@@ -273,7 +273,7 @@ impl DNSKEY {
             }
         }
 
-        Digest::new(&buf, digest_type)
+        Ok(Digest::new(&buf, digest_type)?)
     }
 
     /// The key tag is calculated as a hash to more quickly lookup a DNSKEY.

--- a/crates/proto/src/dnssec/rdata/nsec3.rs
+++ b/crates/proto/src/dnssec/rdata/nsec3.rs
@@ -302,7 +302,7 @@ impl<'r> RecordDataDecodable<'r> for NSEC3 {
     fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> ProtoResult<Self> {
         let start_idx = decoder.index();
 
-        let hash_algorithm = Nsec3HashAlgorithm::from_u8(
+        let hash_algorithm = Nsec3HashAlgorithm::try_from(
             decoder.read_u8()?.unverified(/*Algorithm verified as safe*/),
         )?;
         let flags: u8 = decoder

--- a/crates/proto/src/dnssec/rdata/nsec3.rs
+++ b/crates/proto/src/dnssec/rdata/nsec3.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{
     dnssec::Nsec3HashAlgorithm,
-    error::{ProtoError, ProtoErrorKind, ProtoResult},
+    error::{ProtoError, ProtoResult},
     rr::{RData, RecordData, RecordDataDecodable, RecordType, RecordTypeSet, domain::Label},
     serialize::binary::*,
 };
@@ -308,7 +308,7 @@ impl<'r> RecordDataDecodable<'r> for NSEC3 {
         let flags: u8 = decoder
             .read_u8()?
             .verify_unwrap(|flags| flags & 0b1111_1110 == 0)
-            .map_err(|flags| ProtoError::from(ProtoErrorKind::UnrecognizedNsec3Flags(flags)))?;
+            .map_err(DecodeError::UnrecognizedNsec3Flags)?;
 
         let opt_out: bool = flags & 0b0000_0001 == 0b0000_0001;
         let iterations: u16 = decoder.read_u16()?.unverified(/*valid as any u16*/);

--- a/crates/proto/src/dnssec/rdata/nsec3param.rs
+++ b/crates/proto/src/dnssec/rdata/nsec3param.rs
@@ -184,7 +184,7 @@ impl BinEncodable for NSEC3PARAM {
 
 impl<'r> BinDecodable<'r> for NSEC3PARAM {
     fn read(decoder: &mut BinDecoder<'r>) -> ProtoResult<Self> {
-        let hash_algorithm = Nsec3HashAlgorithm::from_u8(
+        let hash_algorithm = Nsec3HashAlgorithm::try_from(
             decoder.read_u8()?.unverified(/*Algorithm verified as safe*/),
         )?;
         let flags: u8 = decoder

--- a/crates/proto/src/dnssec/rdata/nsec3param.rs
+++ b/crates/proto/src/dnssec/rdata/nsec3param.rs
@@ -15,9 +15,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     dnssec::Nsec3HashAlgorithm,
-    error::{ProtoError, ProtoErrorKind, ProtoResult},
+    error::{ProtoError, ProtoResult},
     rr::{RData, RecordData, RecordType},
-    serialize::binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder},
+    serialize::binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError},
 };
 
 use super::DNSSECRData;
@@ -190,7 +190,7 @@ impl<'r> BinDecodable<'r> for NSEC3PARAM {
         let flags: u8 = decoder
             .read_u8()?
             .verify_unwrap(|flags| flags & 0b1111_1110 == 0)
-            .map_err(|flags| ProtoError::from(ProtoErrorKind::UnrecognizedNsec3Flags(flags)))?;
+            .map_err(DecodeError::UnrecognizedNsec3Flags)?;
 
         let opt_out: bool = flags & 0b0000_0001 == 0b0000_0001;
         let iterations: u16 = decoder.read_u16()?.unverified(/*valid as any u16*/);

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -147,19 +147,6 @@ impl ProtoError {
 
         Ordering::Equal
     }
-
-    /// Whether the query should be retried after this error
-    pub fn should_retry(&self) -> bool {
-        !matches!(
-            self.kind(),
-            ProtoErrorKind::NoConnections | ProtoErrorKind::Dns(DnsError::NoRecordsFound { .. })
-        )
-    }
-
-    /// Whether this error should count as an attempt
-    pub fn attempted(&self) -> bool {
-        !matches!(self.kind(), ProtoErrorKind::Busy)
-    }
 }
 
 impl fmt::Display for ProtoError {

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -107,16 +107,6 @@ pub enum ProtoErrorKind {
         error: Box<ProtoError>,
     },
 
-    /// The length of rdata read was not as expected
-    #[non_exhaustive]
-    #[error("incorrect rdata length read: {read} expected: {len}")]
-    IncorrectRDataLengthRead {
-        /// The amount of read data
-        read: usize,
-        /// The expected length of the data
-        len: usize,
-    },
-
     /// The maximum buffer size was exceeded
     #[error("maximum buffer size exceeded: {0}")]
     MaxBufferSizeExceeded(usize),
@@ -502,7 +492,6 @@ impl Clone for ProtoErrorKind {
                 header,
                 error: error.clone(),
             },
-            IncorrectRDataLengthRead { read, len } => IncorrectRDataLengthRead { read, len },
             MaxBufferSizeExceeded(max) => MaxBufferSizeExceeded(max),
             MaxRecordLimitExceeded { count, record_type } => {
                 MaxRecordLimitExceeded { count, record_type }

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -249,7 +249,7 @@ impl From<ProtoError> for wasm_bindgen_crate::JsValue {
 }
 
 /// The error kind for errors that get returned in the crate
-#[derive(Debug, EnumAsInner, Error)]
+#[derive(Clone, Debug, EnumAsInner, Error)]
 #[non_exhaustive]
 pub enum ProtoErrorKind {
     /// A UDP response was received with an incorrect transaction id, likely indicating a
@@ -409,58 +409,6 @@ impl From<io::Error> for ProtoErrorKind {
         match e.kind() {
             io::ErrorKind::TimedOut => Self::Timeout,
             _ => Self::Io(e.into()),
-        }
-    }
-}
-
-impl Clone for ProtoErrorKind {
-    fn clone(&self) -> Self {
-        use self::ProtoErrorKind::*;
-        match *self {
-            BadTransactionId => BadTransactionId,
-            Busy => Busy,
-            CharacterDataTooLong { max, len } => CharacterDataTooLong { max, len },
-            #[cfg(feature = "__dnssec")]
-            Crypto(op) => Crypto(op),
-            Decode(ref e) => Decode(e.clone()),
-            Dns(ref e) => Dns(e.clone()),
-            FormError { header, ref error } => FormError {
-                header,
-                error: error.clone(),
-            },
-            MaxBufferSizeExceeded(max) => MaxBufferSizeExceeded(max),
-            Message(msg) => Message(msg),
-            Msg(ref msg) => Msg(msg.clone()),
-            NoConnections => NoConnections,
-            NotAllRecordsWritten { count } => NotAllRecordsWritten { count },
-            #[cfg(feature = "std")]
-            Io(ref e) => Io(e.clone()),
-            Timeout => Timeout,
-            UrlParsing(ref e) => UrlParsing(*e),
-            Utf8(ref e) => Utf8(*e),
-            FromUtf8(ref e) => FromUtf8(e.clone()),
-            ParseInt(ref e) => ParseInt(e.clone()),
-            #[cfg(feature = "__quic")]
-            QuinnConnect(ref e) => QuinnConnect(e.clone()),
-            #[cfg(feature = "__quic")]
-            QuinnConnection(ref e) => QuinnConnection(e.clone()),
-            #[cfg(feature = "__quic")]
-            QuinnWriteError(ref e) => QuinnWriteError(e.clone()),
-            #[cfg(feature = "__quic")]
-            QuicMessageIdNot0(val) => QuicMessageIdNot0(val),
-            #[cfg(feature = "__quic")]
-            QuinnReadError(ref e) => QuinnReadError(e.clone()),
-            #[cfg(feature = "__quic")]
-            QuinnStreamError(ref e) => QuinnStreamError(e.clone()),
-            #[cfg(feature = "__quic")]
-            QuinnConfigError(ref e) => QuinnConfigError(e.clone()),
-            #[cfg(feature = "__quic")]
-            QuinnTlsConfigError(ref e) => QuinnTlsConfigError(e.clone()),
-            #[cfg(feature = "__quic")]
-            QuinnUnknownStreamError => QuinnUnknownStreamError,
-            #[cfg(feature = "__tls")]
-            RustlsError(ref e) => RustlsError(e.clone()),
-            QueryCaseMismatch => QueryCaseMismatch,
         }
     }
 }

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -98,10 +98,6 @@ pub enum ProtoErrorKind {
     #[error("DNS error: {0}")]
     Dns(#[from] DnsError),
 
-    /// EDNS resource record label is not the root label, although required
-    #[error("edns resource record label must be the root label (.): {0}")]
-    EdnsNameNotRoot(crate::rr::Name),
-
     /// Format error in Message Parsing
     #[error("message format error: {error}")]
     FormError {
@@ -502,7 +498,6 @@ impl Clone for ProtoErrorKind {
             CharacterDataTooLong { max, len } => CharacterDataTooLong { max, len },
             Decode(ref e) => Decode(e.clone()),
             Dns(ref e) => Dns(e.clone()),
-            EdnsNameNotRoot(ref found) => EdnsNameNotRoot(found.clone()),
             FormError { header, ref error } => FormError {
                 header,
                 error: error.clone(),

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -142,10 +142,6 @@ pub enum ProtoErrorKind {
     #[error("ring error: {0}")]
     Ring(#[from] Unspecified),
 
-    /// A tokio timer error
-    #[error("timer error")]
-    Timer,
-
     /// A request timed out
     #[error("request timed out")]
     Timeout,
@@ -446,7 +442,6 @@ impl Clone for ProtoErrorKind {
             #[cfg(feature = "__dnssec")]
             Ring(ref _e) => Ring(Unspecified),
             Timeout => Timeout,
-            Timer => Timer,
             UrlParsing(ref e) => UrlParsing(*e),
             Utf8(ref e) => Utf8(*e),
             FromUtf8(ref e) => FromUtf8(e.clone()),

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -81,18 +81,6 @@ impl ProtoError {
         &self.kind
     }
 
-    /// If this is a ProtoErrorKind::Busy
-    #[inline]
-    pub fn is_busy(&self) -> bool {
-        matches!(self.kind, ProtoErrorKind::Busy)
-    }
-
-    /// Returns true if this error represents NoConnections
-    #[inline]
-    pub fn is_no_connections(&self) -> bool {
-        matches!(self.kind, ProtoErrorKind::NoConnections)
-    }
-
     /// Returns true if the domain does not exist
     #[inline]
     pub fn is_nx_domain(&self) -> bool {
@@ -121,18 +109,6 @@ impl ProtoError {
             ProtoErrorKind::Dns(DnsError::NoRecordsFound(NoRecords { soa, .. })) => soa,
             _ => None,
         }
-    }
-
-    /// Returns true if this is a std::io::Error
-    #[inline]
-    #[cfg(feature = "std")]
-    pub fn is_io(&self) -> bool {
-        matches!(self.kind, ProtoErrorKind::Io(..))
-    }
-
-    #[cfg(feature = "std")]
-    pub(crate) fn as_dyn(&self) -> &(dyn std::error::Error + 'static) {
-        self
     }
 
     /// Compare two errors to see if one contains a server response.

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -137,10 +137,6 @@ pub enum ProtoErrorKind {
     #[error("io error: {0}")]
     Io(Arc<io::Error>),
 
-    /// A request was Refused due to some access check
-    #[error("request refused")]
-    RequestRefused,
-
     /// A ring error
     #[cfg(feature = "__dnssec")]
     #[error("ring error: {0}")]
@@ -445,7 +441,6 @@ impl Clone for ProtoErrorKind {
             Msg(ref msg) => Msg(msg.clone()),
             NoConnections => NoConnections,
             NotAllRecordsWritten { count } => NotAllRecordsWritten { count },
-            RequestRefused => RequestRefused,
             #[cfg(feature = "std")]
             Io(ref e) => Io(e.clone()),
             #[cfg(feature = "__dnssec")]

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -111,15 +111,6 @@ pub enum ProtoErrorKind {
     #[error("maximum buffer size exceeded: {0}")]
     MaxBufferSizeExceeded(usize),
 
-    /// Maximum record limit was exceeded
-    #[error("maximum record limit for {record_type} exceeded: {count} records")]
-    MaxRecordLimitExceeded {
-        /// number of records
-        count: usize,
-        /// The record type that triggered the error.
-        record_type: RecordType,
-    },
-
     /// An error with an arbitrary message, referenced as &'static str
     #[error("{0}")]
     Message(&'static str),
@@ -493,9 +484,6 @@ impl Clone for ProtoErrorKind {
                 error: error.clone(),
             },
             MaxBufferSizeExceeded(max) => MaxBufferSizeExceeded(max),
-            MaxRecordLimitExceeded { count, record_type } => {
-                MaxRecordLimitExceeded { count, record_type }
-            }
             Message(msg) => Message(msg),
             Msg(ref msg) => Msg(msg.clone()),
             NoConnections => NoConnections,

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -473,9 +473,6 @@ impl Clone for ProtoErrorKind {
 #[derive(Clone, Debug, EnumAsInner, Error)]
 #[non_exhaustive]
 pub enum DnsError {
-    /// A request was refused due to some access check
-    #[error("request refused")]
-    Refused,
     /// Received an error response code from the server
     #[error("error response: {0}")]
     ResponseCode(ResponseCode),
@@ -503,7 +500,7 @@ impl DnsError {
         debug!("response: {}", *response);
 
         match response.response_code() {
-                Refused => Err(Self::Refused),
+                Refused => Err(Self::ResponseCode(Refused)),
                 code @ ServFail
                 | code @ FormErr
                 | code @ NotImp

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -131,30 +131,6 @@ pub enum ProtoErrorKind {
         count: usize,
     },
 
-    /// An unknown dns class was found
-    #[error("dns class string unknown: {0}")]
-    UnknownDnsClassStr(String),
-
-    /// An unknown dns class value was found
-    #[error("dns class value unknown: {0}")]
-    UnknownDnsClassValue(u16),
-
-    /// An unknown record type string was found
-    #[error("record type string unknown: {0}")]
-    UnknownRecordTypeStr(String),
-
-    /// An unknown record type value was found
-    #[error("record type value unknown: {0}")]
-    UnknownRecordTypeValue(u16),
-
-    /// Unrecognized nsec3 flags were found
-    #[error("nsec3 flags should be 0b0000000*: {0:b}")]
-    UnrecognizedNsec3Flags(u8),
-
-    /// Unrecognized csync flags were found
-    #[error("csync flags should be 0b000000**: {0:b}")]
-    UnrecognizedCsyncFlags(u16),
-
     // foreign
     /// An error got returned from IO
     #[cfg(feature = "std")]
@@ -481,12 +457,6 @@ impl Clone for ProtoErrorKind {
             NoConnections => NoConnections,
             NotAllRecordsWritten { count } => NotAllRecordsWritten { count },
             RequestRefused => RequestRefused,
-            UnknownDnsClassStr(ref value) => UnknownDnsClassStr(value.clone()),
-            UnknownDnsClassValue(value) => UnknownDnsClassValue(value),
-            UnknownRecordTypeStr(ref value) => UnknownRecordTypeStr(value.clone()),
-            UnknownRecordTypeValue(value) => UnknownRecordTypeValue(value),
-            UnrecognizedNsec3Flags(flags) => UnrecognizedNsec3Flags(flags),
-            UnrecognizedCsyncFlags(flags) => UnrecognizedCsyncFlags(flags),
             #[cfg(feature = "std")]
             Io(ref e) => Io(e.clone()),
             Poisoned => Poisoned,

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -98,10 +98,6 @@ pub enum ProtoErrorKind {
     #[error("DNS error: {0}")]
     Dns(#[from] DnsError),
 
-    /// DNS protocol version doesn't have the expected version 3
-    #[error("dns key value unknown, must be 3: {0}")]
-    DnsKeyProtocolNot3(u8),
-
     /// EDNS resource record label is not the root label, although required
     #[error("edns resource record label must be the root label (.): {0}")]
     EdnsNameNotRoot(crate::rr::Name),
@@ -506,7 +502,6 @@ impl Clone for ProtoErrorKind {
             CharacterDataTooLong { max, len } => CharacterDataTooLong { max, len },
             Decode(ref e) => Decode(e.clone()),
             Dns(ref e) => Dns(e.clone()),
-            DnsKeyProtocolNot3(protocol) => DnsKeyProtocolNot3(protocol),
             EdnsNameNotRoot(ref found) => EdnsNameNotRoot(found.clone()),
             FormError { header, ref error } => FormError {
                 header,

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -11,7 +11,9 @@
 
 use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
-use alloc::string::{String, ToString};
+use alloc::string::String;
+#[cfg(feature = "wasm-bindgen")]
+use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::cmp::Ordering;
@@ -236,12 +238,6 @@ impl From<ProtoError> for io::Error {
             ProtoErrorKind::Timeout => Self::new(io::ErrorKind::TimedOut, e),
             _ => Self::other(e),
         }
-    }
-}
-
-impl From<ProtoError> for String {
-    fn from(e: ProtoError) -> Self {
-        e.to_string()
     }
 }
 

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -131,10 +131,6 @@ pub enum ProtoErrorKind {
         count: usize,
     },
 
-    /// An unknown digest type was found
-    #[error("digest type value unknown: {0}")]
-    UnknownDigestTypeValue(u8),
-
     /// An unknown dns class was found
     #[error("dns class string unknown: {0}")]
     UnknownDnsClassStr(String),
@@ -485,7 +481,6 @@ impl Clone for ProtoErrorKind {
             NoConnections => NoConnections,
             NotAllRecordsWritten { count } => NotAllRecordsWritten { count },
             RequestRefused => RequestRefused,
-            UnknownDigestTypeValue(value) => UnknownDigestTypeValue(value),
             UnknownDnsClassStr(ref value) => UnknownDnsClassStr(value.clone()),
             UnknownDnsClassValue(value) => UnknownDnsClassValue(value),
             UnknownRecordTypeStr(ref value) => UnknownRecordTypeStr(value.clone()),

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -80,10 +80,6 @@ pub enum ProtoErrorKind {
     #[error("resource too busy")]
     Busy,
 
-    /// An error caused by a canceled future
-    #[error("future was canceled: {0:?}")]
-    Canceled(futures_channel::oneshot::Canceled),
-
     /// Character data length exceeded the limit
     #[non_exhaustive]
     #[error("char data length exceeds {max}: {len}")]
@@ -553,7 +549,6 @@ impl Clone for ProtoErrorKind {
         match *self {
             BadTransactionId => BadTransactionId,
             Busy => Busy,
-            Canceled(ref c) => Canceled(*c),
             CharacterDataTooLong { max, len } => CharacterDataTooLong { max, len },
             Dns(ref e) => Dns(e.clone()),
             LabelOverlapsWithOther { label, other } => LabelOverlapsWithOther { label, other },

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -67,10 +67,6 @@ pub(crate) type ProtoResult<T> = ::core::result::Result<T, ProtoError>;
 #[derive(Debug, EnumAsInner, Error)]
 #[non_exhaustive]
 pub enum ProtoErrorKind {
-    /// Query count is not one
-    #[error("there should only be one query per request, got: {0}")]
-    BadQueryCount(usize),
-
     /// A UDP response was received with an incorrect transaction id, likely indicating a
     /// cache-poisoning attempt.
     #[error("bad transaction id received")]
@@ -555,7 +551,6 @@ impl Clone for ProtoErrorKind {
     fn clone(&self) -> Self {
         use self::ProtoErrorKind::*;
         match *self {
-            BadQueryCount(count) => BadQueryCount(count),
             BadTransactionId => BadTransactionId,
             Busy => Busy,
             Canceled(ref c) => Canceled(*c),

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -131,10 +131,6 @@ pub enum ProtoErrorKind {
         count: usize,
     },
 
-    /// An unknown algorithm type was found
-    #[error("algorithm type value unknown: {0}")]
-    UnknownAlgorithmTypeValue(u8),
-
     /// An unknown digest type was found
     #[error("digest type value unknown: {0}")]
     UnknownDigestTypeValue(u8),
@@ -489,7 +485,6 @@ impl Clone for ProtoErrorKind {
             NoConnections => NoConnections,
             NotAllRecordsWritten { count } => NotAllRecordsWritten { count },
             RequestRefused => RequestRefused,
-            UnknownAlgorithmTypeValue(value) => UnknownAlgorithmTypeValue(value),
             UnknownDigestTypeValue(value) => UnknownDigestTypeValue(value),
             UnknownDnsClassStr(ref value) => UnknownDnsClassStr(value.clone()),
             UnknownDnsClassValue(value) => UnknownDnsClassValue(value),

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -17,7 +17,7 @@ use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::fmt;
 #[cfg(feature = "std")]
-use std::{io, sync};
+use std::io;
 
 #[cfg(feature = "backtrace")]
 pub use backtrace::Backtrace as ExtBacktrace;
@@ -136,10 +136,6 @@ pub enum ProtoErrorKind {
     #[cfg(feature = "std")]
     #[error("io error: {0}")]
     Io(Arc<io::Error>),
-
-    /// Any sync poised error
-    #[error("lock poisoned error")]
-    Poisoned,
 
     /// A request was Refused due to some access check
     #[error("request refused")]
@@ -409,13 +405,6 @@ impl From<io::Error> for ProtoErrorKind {
 }
 
 #[cfg(feature = "std")]
-impl<T> From<sync::PoisonError<T>> for ProtoError {
-    fn from(_e: sync::PoisonError<T>) -> Self {
-        ProtoErrorKind::Poisoned.into()
-    }
-}
-
-#[cfg(feature = "std")]
 impl From<ProtoError> for io::Error {
     fn from(e: ProtoError) -> Self {
         match e.kind() {
@@ -459,7 +448,6 @@ impl Clone for ProtoErrorKind {
             RequestRefused => RequestRefused,
             #[cfg(feature = "std")]
             Io(ref e) => Io(e.clone()),
-            Poisoned => Poisoned,
             #[cfg(feature = "__dnssec")]
             Ring(ref _e) => Ring(Unspecified),
             Timeout => Timeout,

--- a/crates/proto/src/error.rs
+++ b/crates/proto/src/error.rs
@@ -616,68 +616,6 @@ impl NoRecords {
     }
 }
 
-impl From<AuthorityData> for NoRecords {
-    fn from(value: AuthorityData) -> Self {
-        let response_code = match value.is_nx_domain() {
-            true => ResponseCode::NXDomain,
-            false => ResponseCode::NoError,
-        };
-
-        Self {
-            query: value.query,
-            soa: value.soa,
-            ns: None,
-            negative_ttl: None,
-            response_code,
-            authorities: value.authorities,
-        }
-    }
-}
-
-/// Data from the authority section of a response.
-#[derive(Clone, Debug)]
-pub struct AuthorityData {
-    /// Query
-    pub query: Box<Query>,
-    /// SOA
-    pub soa: Option<Box<Record<SOA>>>,
-    /// No records found?
-    no_records_found: bool,
-    /// IS nx domain?
-    nx_domain: bool,
-    /// Authority records
-    pub authorities: Option<Arc<[Record]>>,
-}
-
-impl AuthorityData {
-    /// Construct a new AuthorityData
-    pub fn new(
-        query: Box<Query>,
-        soa: Option<Box<Record<SOA>>>,
-        no_records_found: bool,
-        nx_domain: bool,
-        authorities: Option<Arc<[Record]>>,
-    ) -> Self {
-        Self {
-            query,
-            soa,
-            no_records_found,
-            nx_domain,
-            authorities,
-        }
-    }
-
-    /// are there records?
-    pub fn is_no_records_found(&self) -> bool {
-        self.no_records_found
-    }
-
-    /// is this nxdomain?
-    pub fn is_nx_domain(&self) -> bool {
-        self.nx_domain
-    }
-}
-
 /// Data needed to process a NS-record-based referral.
 #[derive(Clone, Debug)]
 pub struct ForwardNSData {

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -90,7 +90,7 @@ pub use crate::xfer::dns_multiplexer::DnsMultiplexer;
 #[doc(hidden)]
 #[cfg(feature = "std")]
 pub use crate::xfer::retry_dns_handle::RetryDnsHandle;
-pub use error::{AuthorityData, ForwardNSData, NoRecords, ProtoError, ProtoErrorKind};
+pub use error::{AuthorityData, DnsError, ForwardNSData, NoRecords, ProtoError, ProtoErrorKind};
 #[cfg(feature = "backtrace")]
 pub use error::{ENABLE_BACKTRACE, ExtBacktrace};
 

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -90,7 +90,7 @@ pub use crate::xfer::dns_multiplexer::DnsMultiplexer;
 #[doc(hidden)]
 #[cfg(feature = "std")]
 pub use crate::xfer::retry_dns_handle::RetryDnsHandle;
-pub use error::{AuthorityData, DnsError, ForwardNSData, NoRecords, ProtoError, ProtoErrorKind};
+pub use error::{DnsError, ForwardNSData, NoRecords, ProtoError, ProtoErrorKind};
 #[cfg(feature = "backtrace")]
 pub use error::{ENABLE_BACKTRACE, ExtBacktrace};
 

--- a/crates/proto/src/rr/domain/label.rs
+++ b/crates/proto/src/rr/domain/label.rs
@@ -20,6 +20,7 @@ use tinyvec::TinyVec;
 use tracing::debug;
 
 use crate::error::*;
+use crate::serialize::binary::DecodeError;
 
 const WILDCARD: &[u8] = b"*";
 const IDNA_PREFIX: &[u8] = b"xn--";
@@ -41,7 +42,7 @@ impl Label {
             return Err("Label requires a minimum length of 1".into());
         }
         if bytes.len() > 63 {
-            return Err(ProtoErrorKind::LabelBytesTooLong(bytes.len()).into());
+            return Err(DecodeError::LabelBytesTooLong(bytes.len()).into());
         };
         Ok(Self(TinyVec::from(bytes)))
     }
@@ -76,7 +77,7 @@ impl Label {
     /// This will return an Error if the label is not an ascii string
     pub fn from_ascii(s: &str) -> ProtoResult<Self> {
         if s.len() > 63 {
-            return Err(ProtoErrorKind::LabelBytesTooLong(s.len()).into());
+            return Err(DecodeError::LabelBytesTooLong(s.len()).into());
         }
 
         if s.as_bytes() == WILDCARD {
@@ -405,8 +406,8 @@ mod tests {
         eprintln!("{error:?}");
         assert!(error.is_err());
         match error.unwrap_err().kind() {
-            ProtoErrorKind::LabelBytesTooLong(n) if *n == len => (),
-            ProtoErrorKind::LabelBytesTooLong(e) => {
+            ProtoErrorKind::Decode(DecodeError::LabelBytesTooLong(n)) if *n == len => (),
+            ProtoErrorKind::Decode(DecodeError::LabelBytesTooLong(e)) => {
                 panic!(
                     "LabelTooLongError error don't report expected size {} of the label provided.",
                     e

--- a/crates/proto/src/rr/rdata/csync.rs
+++ b/crates/proto/src/rr/rdata/csync.rs
@@ -146,7 +146,7 @@ impl<'r> RecordDataDecodable<'r> for CSYNC {
         let flags: u16 = decoder
             .read_u16()?
             .verify_unwrap(|flags| flags & 0b1111_1100 == 0)
-            .map_err(|flags| ProtoError::from(ProtoErrorKind::UnrecognizedCsyncFlags(flags)))?;
+            .map_err(DecodeError::UnrecognizedCsyncFlags)?;
 
         let immediate: bool = flags & 0b0000_0001 == 0b0000_0001;
         let soa_minimum: bool = flags & 0b0000_0010 == 0b0000_0010;

--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -32,7 +32,9 @@ use crate::{
         },
         record_type::RecordType,
     },
-    serialize::binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder, Restrict},
+    serialize::binary::{
+        BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, Restrict,
+    },
 };
 
 #[cfg(feature = "__dnssec")]
@@ -895,7 +897,7 @@ impl RData {
             .map(|u| u as usize)
             .verify_unwrap(|rdata_length| read == *rdata_length)
             .map_err(|rdata_length| {
-                ProtoError::from(ProtoErrorKind::IncorrectRDataLengthRead {
+                ProtoError::from(DecodeError::IncorrectRDataLengthRead {
                     read,
                     len: rdata_length,
                 })

--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{trace, warn};
 
 use crate::{
-    error::{ProtoError, ProtoErrorKind, ProtoResult},
+    error::{ProtoError, ProtoResult},
     rr::{
         RecordData, RecordDataDecodable,
         rdata::{
@@ -795,7 +795,7 @@ impl RData {
                 ANAME::read(decoder).map(Self::ANAME)
             }
             rt @ RecordType::ANY | rt @ RecordType::AXFR | rt @ RecordType::IXFR => {
-                return Err(ProtoErrorKind::UnknownRecordTypeValue(rt.into()).into());
+                return Err(DecodeError::UnknownRecordTypeValue(rt.into()).into());
             }
             RecordType::CAA => {
                 trace!("reading CAA");

--- a/crates/proto/src/rr/resource.rs
+++ b/crates/proto/src/rr/resource.rs
@@ -16,9 +16,11 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "__dnssec")]
 use crate::dnssec::{Proof, Proven};
 use crate::{
-    error::{ProtoError, ProtoErrorKind, ProtoResult},
+    error::{ProtoError, ProtoResult},
     rr::{Name, RData, RecordData, RecordType, dns_class::DNSClass},
-    serialize::binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder, Restrict},
+    serialize::binary::{
+        BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, Restrict,
+    },
 };
 
 #[cfg(feature = "mdns")]
@@ -418,7 +420,7 @@ impl<'r> BinDecodable<'r> for Record<RData> {
         let class: DNSClass = if record_type == RecordType::OPT {
             // verify that the OPT record is Root
             if !name_labels.is_root() {
-                return Err(ProtoErrorKind::EdnsNameNotRoot(name_labels).into());
+                return Err(DecodeError::EdnsNameNotRoot(name_labels).into());
             }
 
             //  DNS Class is overloaded for OPT records in EDNS - RFC 6891

--- a/crates/proto/src/rustls/tls_client_stream.rs
+++ b/crates/proto/src/rustls/tls_client_stream.rs
@@ -16,7 +16,6 @@ use std::net::SocketAddr;
 use futures_util::future::BoxFuture;
 use rustls::{ClientConfig, pki_types::ServerName};
 
-use crate::error::ProtoError;
 use crate::runtime::RuntimeProvider;
 use crate::runtime::iocompat::{AsyncIoStdAsTokio, AsyncIoTokioAsStd};
 use crate::rustls::tls_stream::{tls_connect_with_bind_addr, tls_connect_with_future};
@@ -41,7 +40,7 @@ pub fn tls_client_connect<P: RuntimeProvider>(
     client_config: Arc<ClientConfig>,
     provider: P,
 ) -> (
-    BoxFuture<'static, Result<TlsClientStream<P::Tcp>, ProtoError>>,
+    BoxFuture<'static, Result<TlsClientStream<P::Tcp>, io::Error>>,
     BufDnsStreamHandle,
 ) {
     tls_client_connect_with_bind_addr(name_server, None, server_name, client_config, provider)
@@ -62,7 +61,7 @@ pub fn tls_client_connect_with_bind_addr<P: RuntimeProvider>(
     client_config: Arc<ClientConfig>,
     provider: P,
 ) -> (
-    BoxFuture<'static, Result<TlsClientStream<P::Tcp>, ProtoError>>,
+    BoxFuture<'static, Result<TlsClientStream<P::Tcp>, io::Error>>,
     BufDnsStreamHandle,
 ) {
     let (stream_future, sender) =
@@ -85,7 +84,7 @@ pub fn tls_client_connect_with_future<S, F>(
     server_name: ServerName<'static>,
     client_config: Arc<ClientConfig>,
 ) -> (
-    BoxFuture<'static, Result<TlsClientStream<S>, ProtoError>>,
+    BoxFuture<'static, Result<TlsClientStream<S>, io::Error>>,
     BufDnsStreamHandle,
 )
 where

--- a/crates/proto/src/serialize/binary/decoder.rs
+++ b/crates/proto/src/serialize/binary/decoder.rs
@@ -18,7 +18,7 @@ use alloc::{borrow::ToOwned, vec::Vec};
 
 use thiserror::Error;
 
-use crate::serialize::binary::Restrict;
+use crate::{rr::Name, serialize::binary::Restrict};
 
 /// This is non-destructive to the inner buffer, b/c for pointer types we need to perform a reverse
 ///  seek to lookup names
@@ -36,13 +36,17 @@ pub(crate) type DecodeResult<T> = Result<T, DecodeError>;
 
 /// An error that can occur deep in a decoder
 /// This type is kept very small so that function that use it inline often
-#[derive(Clone, Copy, Debug, Error)]
+#[derive(Clone, Debug, Error)]
 #[non_exhaustive]
 pub enum DecodeError {
     /// DNS key protocol version doesn't have the expected version 3
     #[cfg(feature = "__dnssec")]
     #[error("dns key value unknown, must be 3: {0}")]
     DnsKeyProtocolNot3(u8),
+
+    /// EDNS resource record label is not the root label, although required
+    #[error("edns resource record label must be the root label (.): {0}")]
+    EdnsNameNotRoot(Name),
 
     /// Insufficient data in the buffer for a read operation
     #[error("unexpected end of input reached")]

--- a/crates/proto/src/serialize/binary/decoder.rs
+++ b/crates/proto/src/serialize/binary/decoder.rs
@@ -48,6 +48,16 @@ pub enum DecodeError {
     #[error("edns resource record label must be the root label (.): {0}")]
     EdnsNameNotRoot(Name),
 
+    /// The length of rdata read was not as expected
+    #[non_exhaustive]
+    #[error("incorrect rdata length read: {read} expected: {len}")]
+    IncorrectRDataLengthRead {
+        /// The amount of read data
+        read: usize,
+        /// The expected length of the data
+        len: usize,
+    },
+
     /// Insufficient data in the buffer for a read operation
     #[error("unexpected end of input reached")]
     InsufficientBytes,

--- a/crates/proto/src/serialize/binary/decoder.rs
+++ b/crates/proto/src/serialize/binary/decoder.rs
@@ -39,6 +39,11 @@ pub(crate) type DecodeResult<T> = Result<T, DecodeError>;
 #[derive(Clone, Copy, Debug, Error)]
 #[non_exhaustive]
 pub enum DecodeError {
+    /// DNS key protocol version doesn't have the expected version 3
+    #[cfg(feature = "__dnssec")]
+    #[error("dns key value unknown, must be 3: {0}")]
+    DnsKeyProtocolNot3(u8),
+
     /// Insufficient data in the buffer for a read operation
     #[error("unexpected end of input reached")]
     InsufficientBytes,

--- a/crates/proto/src/serialize/binary/decoder.rs
+++ b/crates/proto/src/serialize/binary/decoder.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use alloc::{borrow::ToOwned, vec::Vec};
+use alloc::{borrow::ToOwned, string::String, vec::Vec};
 
 use thiserror::Error;
 
@@ -99,6 +99,30 @@ pub enum DecodeError {
     /// An unknown digest algorithm was found
     #[error("unknown digest algorithm: {0}")]
     UnknownDigestAlgorithm(u8),
+
+    /// An unknown dns class was found
+    #[error("dns class string unknown: {0}")]
+    UnknownDnsClassStr(String),
+
+    /// An unknown dns class value was found
+    #[error("dns class value unknown: {0}")]
+    UnknownDnsClassValue(u16),
+
+    /// An unknown record type string was found
+    #[error("record type string unknown: {0}")]
+    UnknownRecordTypeStr(String),
+
+    /// An unknown record type value was found
+    #[error("record type value unknown: {0}")]
+    UnknownRecordTypeValue(u16),
+
+    /// Unrecognized nsec3 flags were found
+    #[error("nsec3 flags should be 0b0000000*: {0:b}")]
+    UnrecognizedNsec3Flags(u8),
+
+    /// Unrecognized csync flags were found
+    #[error("csync flags should be 0b000000**: {0:b}")]
+    UnrecognizedCsyncFlags(u16),
 
     /// An unknown algorithm type was found
     #[error("unknown NSEC3 hash algorithm: {0}")]

--- a/crates/proto/src/serialize/binary/decoder.rs
+++ b/crates/proto/src/serialize/binary/decoder.rs
@@ -95,6 +95,10 @@ pub enum DecodeError {
         /// Start of the other label
         other: usize,
     },
+
+    /// An unknown algorithm type was found
+    #[error("unknown NSEC3 hash algorithm: {0}")]
+    UnknownNsec3HashAlgorithm(u8),
 }
 
 impl<'a> BinDecoder<'a> {

--- a/crates/proto/src/serialize/binary/decoder.rs
+++ b/crates/proto/src/serialize/binary/decoder.rs
@@ -96,6 +96,10 @@ pub enum DecodeError {
         other: usize,
     },
 
+    /// An unknown digest algorithm was found
+    #[error("unknown digest algorithm: {0}")]
+    UnknownDigestAlgorithm(u8),
+
     /// An unknown algorithm type was found
     #[error("unknown NSEC3 hash algorithm: {0}")]
     UnknownNsec3HashAlgorithm(u8),

--- a/crates/proto/src/serialize/txt/errors.rs
+++ b/crates/proto/src/serialize/txt/errors.rs
@@ -6,7 +6,7 @@ use crate::trace;
 use crate::{
     error::{ProtoError, ProtoErrorKind},
     rr::RecordType,
-    serialize::txt::Token,
+    serialize::{binary::DecodeError, txt::Token},
 };
 
 #[cfg(feature = "backtrace")]
@@ -166,6 +166,12 @@ impl From<&'static str> for ParseError {
 impl From<String> for ParseError {
     fn from(msg: String) -> Self {
         ParseErrorKind::Msg(msg).into()
+    }
+}
+
+impl From<DecodeError> for ParseError {
+    fn from(e: DecodeError) -> Self {
+        ParseErrorKind::from(ProtoError::from(e)).into()
     }
 }
 

--- a/crates/proto/src/tcp/tcp_client_stream.rs
+++ b/crates/proto/src/tcp/tcp_client_stream.rs
@@ -10,6 +10,7 @@ use core::fmt::{self, Display};
 use core::pin::Pin;
 use core::task::{Context, Poll};
 use core::time::Duration;
+use std::io;
 use std::net::SocketAddr;
 
 use futures_util::{StreamExt, future::BoxFuture, stream::Stream};
@@ -45,7 +46,7 @@ impl<S: DnsTcpStream> TcpClientStream<S> {
         timeout: Option<Duration>,
         provider: P,
     ) -> (
-        BoxFuture<'static, Result<Self, ProtoError>>,
+        BoxFuture<'static, Result<Self, io::Error>>,
         BufDnsStreamHandle,
     ) {
         let (sender, outbound_messages) = BufDnsStreamHandle::new(peer_addr);

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -13,6 +13,7 @@ use core::pin::Pin;
 use core::task::{Context, Poll};
 use core::time::Duration;
 use std::collections::HashSet;
+use std::io;
 use std::net::SocketAddr;
 
 use futures_util::{future::Future, stream::Stream};
@@ -246,7 +247,7 @@ pub struct UdpClientConnect<P> {
 }
 
 impl<P: RuntimeProvider> Future for UdpClientConnect<P> {
-    type Output = Result<UdpClientStream<P>, ProtoError>;
+    type Output = Result<UdpClientStream<P>, io::Error>;
 
     fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
         // TODO: this doesn't need to be a future?

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -247,13 +247,13 @@ where
 
                     return Poll::Ready(Ok(()));
                 }
-                Poll::Ready(Some(Err(err))) => {
+                Poll::Ready(Some(Err(error))) => {
                     debug!(
-                        error = err.as_dyn(),
+                        %error,
                         "io_stream hit an error, shutting down"
                     );
 
-                    return Poll::Ready(Err(err));
+                    return Poll::Ready(Err(error));
                 }
             }
 
@@ -396,7 +396,7 @@ where
                         }
                         Poll::Pending => return Poll::Pending,
                         Poll::Ready(Err(error)) => {
-                            debug!(error = error.as_dyn(), "stream errored while connecting");
+                            debug!(%error, "stream errored while connecting");
                             next = Self::FailAll {
                                 error,
                                 outbound_messages: outbound_messages

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -202,7 +202,7 @@ where
 
     /// Closes all outstanding completes with a closed stream error
     fn stream_closed_close_all(&mut self, error: ProtoError) {
-        debug!(error = error.as_dyn(), stream = %self.stream);
+        debug!(%error, stream = %self.stream);
 
         for (_, active_request) in self.active_requests.drain() {
             // complete the request, it's failed...
@@ -323,14 +323,14 @@ where
                     Err(err) => return err.into(),
                 };
             }
-            Err(e) => {
+            Err(error) => {
                 debug!(
                     id = %active_request.request_id(),
-                    error = e.as_dyn(),
+                    %error,
                     "error message"
                 );
                 // complete with the error, don't add to the map of active requests
-                return e.into();
+                return error.into();
             }
         }
 
@@ -389,7 +389,7 @@ where
                             Entry::Vacant(..) => debug!("unexpected request_id: {}", response.id()),
                         },
                         // TODO: return src address for diagnostics
-                        Err(error) => debug!(error = error.as_dyn(), "error decoding message"),
+                        Err(error) => debug!(%error, "error decoding message"),
                     }
                 }
                 Poll::Ready(err) => {

--- a/crates/recursor/src/error.rs
+++ b/crates/recursor/src/error.rs
@@ -15,14 +15,14 @@ use enum_as_inner::EnumAsInner;
 use thiserror::Error;
 use tracing::warn;
 
-#[cfg(feature = "backtrace")]
-use crate::proto::{ExtBacktrace, trace};
 use crate::proto::{
-    ForwardNSData, ProtoErrorKind,
+    DnsError, ForwardNSData, ProtoErrorKind,
     op::ResponseCode,
     rr::{Name, Record, rdata::SOA},
     {AuthorityData, NoRecords, ProtoError},
 };
+#[cfg(feature = "backtrace")]
+use crate::proto::{ExtBacktrace, trace};
 
 /// The error kind for errors that get returned in the crate
 #[derive(Debug, EnumAsInner, Error)]
@@ -206,7 +206,7 @@ impl From<Error> for String {
 impl From<ProtoError> for Error {
     fn from(e: ProtoError) -> Self {
         let no_records = match e.kind() {
-            ProtoErrorKind::NoRecordsFound(no_records) => no_records,
+            ProtoErrorKind::Dns(DnsError::NoRecordsFound(no_records)) => no_records,
             _ => return ErrorKind::Proto(e).into(),
         };
 

--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -32,7 +32,7 @@ use crate::{
 use crate::{
     ErrorKind,
     proto::{
-        NoRecords, ProtoError,
+        DnsError, NoRecords, ProtoError,
         dnssec::{DnssecDnsHandle, TrustAnchors},
         op::{DnsRequestOptions, ResponseCode},
         rr::RecordType,
@@ -473,14 +473,14 @@ impl<P: ConnectionProvider> Recursor<P> {
                 // to preserve SOA and DNSSEC records, and to keep those records in the authorities
                 // section of the response.
                 if response.response_code() == ResponseCode::NXDomain {
-                    let Err(proto_err) = ProtoError::from_response(response) else {
+                    let Err(dns_error) = DnsError::from_response(response) else {
                         return Err(Error::from(
                             "unable to build ProtoError from response {response:?}",
                         ));
                     };
 
                     Err(Error {
-                        kind: ErrorKind::Proto(proto_err),
+                        kind: ErrorKind::Proto(ProtoError::from(dns_error)),
                         #[cfg(feature = "backtrace")]
                         backtrack: None,
                     })

--- a/crates/recursor/src/recursor_dns_handle.rs
+++ b/crates/recursor/src/recursor_dns_handle.rs
@@ -22,7 +22,6 @@ use tracing::{debug, info, trace, warn};
 use crate::{
     Error, ErrorKind,
     proto::{
-        ProtoErrorKind,
         op::{Message, Query},
         rr::{
             RData,
@@ -299,13 +298,10 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
             let count = cname_limit.fetch_add(1, Ordering::Relaxed) + 1;
             if count > MAX_CNAME_LOOKUPS {
                 warn!("cname limit exceeded for query {query}");
-                return Err(ErrorKind::Proto(
-                    ProtoErrorKind::MaxRecordLimitExceeded {
-                        count: count as usize,
-                        record_type: RecordType::CNAME,
-                    }
-                    .into(),
-                )
+                return Err(ErrorKind::MaxRecordLimitExceeded {
+                    count: count as usize,
+                    record_type: RecordType::CNAME,
+                }
                 .into());
             }
 

--- a/crates/resolver/src/cache.rs
+++ b/crates/resolver/src/cache.rs
@@ -13,7 +13,7 @@ use serde::Deserialize;
 
 use crate::config;
 use crate::proto::{
-    NoRecords, ProtoError, ProtoErrorKind,
+    DnsError, NoRecords, ProtoError, ProtoErrorKind,
     op::{Message, Query},
     rr::RecordType,
 };
@@ -58,7 +58,7 @@ impl ResponseCache {
                     .clamp(positive_min_ttl, positive_max_ttl)
             }
             Err(e) => {
-                let ProtoErrorKind::NoRecordsFound(no_records) = e.kind() else {
+                let ProtoErrorKind::Dns(DnsError::NoRecordsFound(no_records)) = e.kind() else {
                     return;
                 };
                 let (negative_min_ttl, negative_max_ttl) = self
@@ -130,10 +130,10 @@ impl Entry {
             }
             Err(e) => {
                 let mut e = e.clone();
-                if let ProtoErrorKind::NoRecordsFound(NoRecords {
+                if let ProtoErrorKind::Dns(DnsError::NoRecordsFound(NoRecords {
                     negative_ttl: Some(ttl),
                     ..
-                }) = &mut e.kind
+                })) = &mut e.kind
                 {
                     *ttl = ttl.saturating_sub(elapsed);
                 }

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -176,15 +176,10 @@ impl<P: ConnectionProvider> NameServerState<P> {
 
         match response {
             Ok(response) => {
-                // First evaluate if the message succeeded.
+                self.set_status(Status::Established);
                 let result = DnsError::from_response(response);
                 self.stats.record(rtt, &result);
-                let response = result?;
-
-                // take the remote edns options and store them
-                self.set_status(Status::Established);
-
-                Ok(response)
+                Ok(result?)
             }
             Err(error) => {
                 debug!(ip = %self.ip, config = ?self.config, %error, "failed to connect to name server");

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -1123,7 +1123,6 @@ mod tests {
 
     use futures_util::stream::once;
     use futures_util::{Stream, future};
-    use hickory_proto::xfer::DnsExchange;
     use test_support::subscribe;
     use tokio::runtime::Runtime;
 
@@ -1143,7 +1142,8 @@ mod tests {
     use crate::config::{CLOUDFLARE, GOOGLE, ResolverConfig, ResolverOpts};
     use crate::proto::op::{DnsRequest, DnsResponse, Message};
     use crate::proto::rr::rdata::A;
-    use crate::proto::{NoRecords, ProtoError, ProtoErrorKind};
+    use crate::proto::xfer::DnsExchange;
+    use crate::proto::{DnsError, NoRecords, ProtoError, ProtoErrorKind};
 
     fn is_send_t<T: Send>() -> bool {
         true
@@ -1436,11 +1436,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_empty_no_response() {
-        if let ProtoErrorKind::NoRecordsFound(NoRecords {
+        if let ProtoErrorKind::Dns(DnsError::NoRecordsFound(NoRecords {
             query,
             negative_ttl,
             ..
-        }) = LookupFuture::lookup(
+        })) = LookupFuture::lookup(
             vec![Name::root()],
             RecordType::A,
             DnsRequestOptions::default(),

--- a/crates/server/src/server/mod.rs
+++ b/crates/server/src/server/mod.rs
@@ -8,7 +8,7 @@
 //! `Server` component for hosting a domain name servers operations.
 
 use std::{
-    io,
+    fmt, io,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::Arc,
     time::Duration,
@@ -18,7 +18,6 @@ use std::{
 use crate::proto::rustls::tls_from_stream;
 use bytes::Bytes;
 use futures_util::StreamExt;
-use hickory_proto::{ProtoErrorKind, runtime::TokioTime};
 use ipnet::IpNet;
 #[cfg(feature = "__tls")]
 use rustls::{ServerConfig, server::ResolvesServerCert};
@@ -42,6 +41,7 @@ use crate::{
         BufDnsStreamHandle, ProtoError,
         op::{Header, LowerQuery, MessageType, ResponseCode, SerialMessage},
         rr::Record,
+        runtime::TokioTime,
         runtime::{TokioRuntimeProvider, iocompat::AsyncIoTokioAsStd},
         serialize::binary::{BinDecodable, BinDecoder},
         tcp::TcpStream,
@@ -812,7 +812,7 @@ impl<T: RequestHandler> ServerContext<T> {
                 header,
                 queries,
                 ResponseCode::Refused,
-                Box::new(ProtoErrorKind::RequestRefused.into()),
+                "request refused",
                 response_handler,
             )
             .await;
@@ -918,7 +918,7 @@ async fn error_response_handler(
     header: Header,
     queries: Queries,
     response_code: ResponseCode,
-    error: Box<ProtoError>,
+    error: impl fmt::Display,
     response_handler: impl ResponseHandler,
 ) {
     // debug for more info on why the message parsing failed

--- a/crates/server/src/server/request_handler.rs
+++ b/crates/server/src/server/request_handler.rs
@@ -21,7 +21,7 @@ use crate::{
         xfer::Protocol,
     },
     server::ResponseHandler,
-    zone_handler::MessageRequest,
+    zone_handler::{LookupError, MessageRequest},
 };
 
 /// An incoming request to the DNS catalog
@@ -74,7 +74,7 @@ impl Request {
     /// Return just the header and request information from the Request Message
     ///
     /// Returns an error if there is not exactly one query
-    pub fn request_info(&self) -> Result<RequestInfo<'_>, ProtoError> {
+    pub fn request_info(&self) -> Result<RequestInfo<'_>, LookupError> {
         Ok(RequestInfo {
             src: self.src,
             protocol: self.protocol,

--- a/crates/server/src/store/blocklist.rs
+++ b/crates/server/src/store/blocklist.rs
@@ -440,7 +440,7 @@ impl ZoneHandler for BlocklistZoneHandler {
     ) {
         let request_info = match request.request_info() {
             Ok(info) => info,
-            Err(e) => return (LookupControlFlow::Break(Err(LookupError::from(e))), None),
+            Err(e) => return (LookupControlFlow::Break(Err(e)), None),
         };
         (
             self.lookup(

--- a/crates/server/src/store/forwarder.rs
+++ b/crates/server/src/store/forwarder.rs
@@ -270,7 +270,7 @@ impl<P: ConnectionProvider> ZoneHandler for ForwardZoneHandler<P> {
     ) {
         let request_info = match request.request_info() {
             Ok(info) => info,
-            Err(e) => return (LookupControlFlow::Break(Err(LookupError::from(e))), None),
+            Err(e) => return (LookupControlFlow::Break(Err(e)), None),
         };
         (
             self.lookup(

--- a/crates/server/src/store/in_memory/mod.rs
+++ b/crates/server/src/store/in_memory/mod.rs
@@ -507,7 +507,7 @@ impl<P: RuntimeProvider + Send + Sync> ZoneHandler for InMemoryZoneHandler<P> {
     ) {
         let request_info = match request.request_info() {
             Ok(info) => info,
-            Err(e) => return (LookupControlFlow::Break(Err(LookupError::from(e))), None),
+            Err(e) => return (LookupControlFlow::Break(Err(e)), None),
         };
         debug!("searching InMemoryZoneHandler for: {}", request_info.query);
 
@@ -557,7 +557,7 @@ impl<P: RuntimeProvider + Send + Sync> ZoneHandler for InMemoryZoneHandler<P> {
     )> {
         let request_info = match request.request_info() {
             Ok(info) => info,
-            Err(e) => return Some((Err(LookupError::from(e)), None)),
+            Err(e) => return Some((Err(e), None)),
         };
 
         if request_info.query.query_type() == RecordType::AXFR {

--- a/crates/server/src/store/recursor.rs
+++ b/crates/server/src/store/recursor.rs
@@ -161,7 +161,7 @@ impl<P: RuntimeProvider> ZoneHandler for RecursiveZoneHandler<P> {
     ) {
         let request_info = match request.request_info() {
             Ok(info) => info,
-            Err(e) => return (LookupControlFlow::Break(Err(LookupError::from(e))), None),
+            Err(e) => return (LookupControlFlow::Break(Err(e)), None),
         };
         (
             self.lookup(

--- a/crates/server/src/store/sqlite/mod.rs
+++ b/crates/server/src/store/sqlite/mod.rs
@@ -1122,7 +1122,7 @@ impl<P: RuntimeProvider + Send + Sync> ZoneHandler for SqliteZoneHandler<P> {
     ) {
         let request_info = match request.request_info() {
             Ok(info) => info,
-            Err(e) => return (LookupControlFlow::Break(Err(LookupError::from(e))), None),
+            Err(e) => return (LookupControlFlow::Break(Err(e)), None),
         };
 
         if request_info.query.query_type() == RecordType::AXFR {

--- a/crates/server/src/zone_handler/catalog.rs
+++ b/crates/server/src/zone_handler/catalog.rs
@@ -19,7 +19,7 @@ use crate::zone_handler::metrics::CatalogMetrics;
 use crate::{dnssec::NxProofKind, proto::dnssec::DnssecSummary, zone_handler::Nsec3QueryInfo};
 #[cfg(all(feature = "__dnssec", feature = "recursor"))]
 use crate::{
-    proto::{ProtoError, ProtoErrorKind},
+    proto::{DnsError, ProtoError, ProtoErrorKind},
     recursor,
     recursor::ErrorKind,
 };
@@ -1082,9 +1082,9 @@ async fn build_forwarded_response(
             kind:
                 ErrorKind::Proto(ProtoError {
                     kind:
-                        ProtoErrorKind::Nsec {
+                        ProtoErrorKind::Dns(DnsError::Nsec {
                             response, proof, ..
-                        },
+                        }),
                     ..
                 }),
             ..

--- a/crates/server/src/zone_handler/mod.rs
+++ b/crates/server/src/zone_handler/mod.rs
@@ -378,6 +378,9 @@ impl<E: std::fmt::Display> LookupControlFlow<AuthLookup, E> {
 #[derive(Debug, EnumAsInner, Error)]
 #[non_exhaustive]
 pub enum LookupError {
+    /// The query had an invalid number of queries
+    #[error("there should only be one query per request, got {0}")]
+    BadQueryCount(usize),
     /// A record at the same Name as the query exists, but not of the queried RecordType
     #[error("The name exists, but not for the record requested")]
     NameExists,

--- a/crates/server/src/zone_handler/mod.rs
+++ b/crates/server/src/zone_handler/mod.rs
@@ -26,7 +26,7 @@ use crate::proto::op::{Edns, ResponseCode, ResponseSigner};
 #[cfg(feature = "__dnssec")]
 use crate::proto::rr::Name;
 use crate::proto::rr::{LowerName, Record, RecordSet, RecordType, RrsetRecords, rdata::SOA};
-use crate::proto::{NoRecords, ProtoError, ProtoErrorKind};
+use crate::proto::{DnsError, NoRecords, ProtoError, ProtoErrorKind};
 #[cfg(feature = "recursor")]
 use crate::recursor::ErrorKind;
 use crate::server::{Request, RequestInfo};
@@ -437,18 +437,19 @@ impl LookupError {
     pub fn authorities(&self) -> Option<Arc<[Record]>> {
         match self {
             Self::ProtoError(e) => match e.kind() {
-                ProtoErrorKind::NoRecordsFound(NoRecords { authorities, .. }) => {
-                    authorities.clone()
-                }
+                ProtoErrorKind::Dns(DnsError::NoRecordsFound(NoRecords {
+                    authorities, ..
+                })) => authorities.clone(),
                 _ => None,
             },
             #[cfg(feature = "recursor")]
             Self::RecursiveError(e) => match e.kind() {
                 ErrorKind::Negative(fwd) => fwd.authorities.clone(),
                 ErrorKind::Proto(proto) => match proto.kind() {
-                    ProtoErrorKind::NoRecordsFound(NoRecords { authorities, .. }) => {
-                        authorities.clone()
-                    }
+                    ProtoErrorKind::Dns(DnsError::NoRecordsFound(NoRecords {
+                        authorities,
+                        ..
+                    })) => authorities.clone(),
                     _ => None,
                 },
                 _ => None,

--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -59,7 +59,7 @@ impl TestClientStream {
     pub fn new(
         catalog: Arc<Mutex<Catalog>>,
     ) -> (
-        BoxFuture<'static, Result<Self, ProtoError>>,
+        BoxFuture<'static, Result<Self, io::Error>>,
         BufDnsStreamHandle,
     ) {
         let (message_sender, outbound_messages) = BufDnsStreamHandle::new(([0, 0, 0, 0], 0).into());
@@ -198,7 +198,7 @@ pub struct NeverReturnsClientStream {
 #[allow(dead_code)]
 impl NeverReturnsClientStream {
     pub fn new() -> (
-        BoxFuture<'static, Result<Self, ProtoError>>,
+        BoxFuture<'static, Result<Self, io::Error>>,
         BufDnsStreamHandle,
     ) {
         let (message_sender, outbound_messages) = BufDnsStreamHandle::new(([0, 0, 0, 0], 0).into());

--- a/tests/integration-tests/tests/integration/chained_zone_handler_tests.rs
+++ b/tests/integration-tests/tests/integration/chained_zone_handler_tests.rs
@@ -230,7 +230,7 @@ impl ZoneHandler for TestZoneHandler {
     ) {
         let request_info = match request.request_info() {
             Ok(info) => info,
-            Err(e) => return (LookupControlFlow::Break(Err(LookupError::from(e))), None),
+            Err(e) => return (LookupControlFlow::Break(Err(e)), None),
         };
         (
             self.lookup(

--- a/tests/integration-tests/tests/integration/invalid_nsec3_tests.rs
+++ b/tests/integration-tests/tests/integration/invalid_nsec3_tests.rs
@@ -17,7 +17,7 @@ use hickory_integration::{
     print_response, setup_dnssec_client_server,
 };
 use hickory_proto::{
-    ProtoErrorKind,
+    DnsError, ProtoErrorKind,
     dnssec::{
         Algorithm, DigestType, Nsec3HashAlgorithm, Proof, SigSigner, SigningKey,
         crypto::Ed25519SigningKey,
@@ -362,7 +362,7 @@ async fn test_exclude_nsec3(
         .query(query_name.clone(), DNSClass::IN, query_type)
         .await
         .unwrap_err();
-    let ProtoErrorKind::Nsec { proof, .. } = error.kind() else {
+    let ProtoErrorKind::Dns(DnsError::Nsec { proof, .. }) = error.kind() else {
         panic!("wrong proto error kind {error}");
     };
     assert_eq!(proof, &Proof::Bogus);

--- a/tests/integration-tests/tests/integration/invalid_nsec_tests.rs
+++ b/tests/integration-tests/tests/integration/invalid_nsec_tests.rs
@@ -12,7 +12,7 @@ use hickory_integration::{
     print_response, setup_dnssec_client_server,
 };
 use hickory_proto::{
-    ProtoErrorKind,
+    DnsError, ProtoErrorKind,
     dnssec::{
         Algorithm, DigestType, Proof, SigSigner, SigningKey,
         crypto::Ed25519SigningKey,
@@ -279,7 +279,7 @@ async fn test_exclude_nsec(
         .query(query_name.clone(), DNSClass::IN, query_type)
         .await
         .unwrap_err();
-    let ProtoErrorKind::Nsec { proof, .. } = error.kind() else {
+    let ProtoErrorKind::Dns(DnsError::Nsec { proof, .. }) = error.kind() else {
         panic!("wrong proto error kind {error}");
     };
     assert_eq!(proof, &Proof::Bogus);

--- a/tests/integration-tests/tests/integration/lookup_tests.rs
+++ b/tests/integration-tests/tests/integration/lookup_tests.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use hickory_proto::{
+    DnsError,
     op::{DnsResponse, Query},
     rr::{DNSClass, Name, RData, Record, RecordType, rdata::A},
     runtime::TokioRuntimeProvider,
@@ -471,7 +472,7 @@ async fn test_forward_soa() {
         panic!("Expected Error type for {lookup:?}");
     };
 
-    let ProtoErrorKind::NoRecordsFound(no_records) = e.kind() else {
+    let ProtoErrorKind::Dns(DnsError::NoRecordsFound(no_records)) = e.kind() else {
         panic!("Unexpected kind: {e:?}");
     };
 
@@ -510,7 +511,7 @@ async fn test_forward_ns() {
         panic!("Expected Error type for {lookup:?}");
     };
 
-    let ProtoErrorKind::NoRecordsFound(no_records) = e.kind() else {
+    let ProtoErrorKind::Dns(DnsError::NoRecordsFound(no_records)) = e.kind() else {
         panic!("Unexpected kind: {e:?}");
     };
 

--- a/tests/integration-tests/tests/integration/retry_dns_handle_tests.rs
+++ b/tests/integration-tests/tests/integration/retry_dns_handle_tests.rs
@@ -6,7 +6,7 @@ use std::sync::{
 use futures::{Stream, executor::block_on, future, stream};
 
 use hickory_proto::{
-    DnsHandle, ProtoError, RetryDnsHandle,
+    DnsError, DnsHandle, ProtoError, RetryDnsHandle,
     op::{DnsRequest, DnsResponse, Message, OpCode, ResponseCode},
     runtime::TokioRuntimeProvider,
     xfer::FirstAnswer,
@@ -62,12 +62,12 @@ fn dont_retry_on_negative_response() {
     subscribe();
     let mut response = Message::response(10, OpCode::Update);
     response.set_response_code(ResponseCode::NoError);
-    let error = ProtoError::from_response(DnsResponse::from_message(response).unwrap())
+    let error = DnsError::from_response(DnsResponse::from_message(response).unwrap())
         .expect_err("NODATA should be an error");
     let client = RetryDnsHandle::new(
         TestClient {
             retries: 1,
-            error_response: error,
+            error_response: error.into(),
             attempts: Arc::new(AtomicU16::new(0)),
         },
         2,

--- a/util/src/bin/resolve.rs
+++ b/util/src/bin/resolve.rs
@@ -36,7 +36,7 @@ use tokio::task::JoinSet;
 use tokio::time::MissedTickBehavior;
 
 use hickory_proto::{
-    ProtoError, ProtoErrorKind,
+    DnsError, ProtoError, ProtoErrorKind,
     rr::{Record, RecordData, RecordType},
     runtime::TokioRuntimeProvider,
 };
@@ -162,7 +162,7 @@ fn print_ok(lookup: Lookup) {
 
 fn print_error(error: ProtoError) {
     let no_records = match error.kind() {
-        ProtoErrorKind::NoRecordsFound(no_records) => no_records,
+        ProtoErrorKind::Dns(DnsError::NoRecordsFound(no_records)) => no_records,
         _ => {
             println!("{error:?}");
             return;


### PR DESCRIPTION
An attempt to clean up the pile of stuff in `ProtoError`/`ProtoErrorKind`, in preparation for

- #3221

I think being more intentional about our error types will improve correctness (as seen in the first commit, where some dubious code in the resolver becomes more correct).

I moved a bunch of stuff into `DecodeError` and later noticed we also have `ParseError`. I think some of the variants I moved into `DecodeError` might actually belong in `ParseError` but that seems lower priority since it doesn't affect the proto crate split.