### PR TITLE
Catalog: Send error responses in more edge cases

### DIFF
--- a/crates/server/src/zone_handler/message_response.rs
+++ b/crates/server/src/zone_handler/message_response.rs
@@ -35,10 +35,10 @@ where
     soa: Soa,
     additionals: Additionals,
     signature: MessageSignature,
-    edns: Option<Edns>,
+    edns: Option<&'q Edns>,
 }
 
-impl<'a, A, N, S, D> MessageResponse<'_, 'a, A, N, S, D>
+impl<'q, 'a, A, N, S, D> MessageResponse<'q, 'a, A, N, S, D>
 where
     A: Iterator<Item = &'a Record> + Send + 'a,
     N: Iterator<Item = &'a Record> + Send + 'a,
@@ -56,14 +56,14 @@ where
     }
 
     /// Set the EDNS options for the Response
-    pub fn set_edns(&mut self, edns: Edns) -> &mut Self {
+    pub fn set_edns(&mut self, edns: &'q Edns) -> &mut Self {
         self.edns = Some(edns);
         self
     }
 
     /// Gets a reference to the EDNS options for the Response.
-    pub fn edns(&self) -> &Option<Edns> {
-        &self.edns
+    pub fn edns(&self) -> Option<&'q Edns> {
+        self.edns
     }
 
     /// Set the message signature
@@ -85,7 +85,7 @@ where
             &mut self.answers,
             &mut authorities,
             &mut self.additionals,
-            self.edns.as_ref(),
+            self.edns,
             &self.signature,
             encoder,
         )
@@ -97,7 +97,7 @@ where
 pub struct MessageResponseBuilder<'q> {
     queries: &'q Queries,
     signature: MessageSignature,
-    edns: Option<Edns>,
+    edns: Option<&'q Edns>,
 }
 
 impl<'q> MessageResponseBuilder<'q> {
@@ -107,7 +107,7 @@ impl<'q> MessageResponseBuilder<'q> {
     ///
     /// * `queries` - queries (from the Request) to associate with the Response
     /// * `edns` - Optional Edns data to associate with the Response
-    pub fn new(queries: &'q Queries, edns: Option<Edns>) -> Self {
+    pub fn new(queries: &'q Queries, edns: Option<&'q Edns>) -> Self {
         MessageResponseBuilder {
             queries,
             signature: MessageSignature::default(),
@@ -147,7 +147,7 @@ impl<'q> MessageResponseBuilder<'q> {
     }
 
     /// Associate EDNS with the Response
-    pub fn edns(&mut self, edns: Edns) -> &mut Self {
+    pub fn edns(&mut self, edns: &'q Edns) -> &mut Self {
         self.edns = Some(edns);
         self
     }

--- a/tests/integration-tests/src/mock_request_handler.rs
+++ b/tests/integration-tests/src/mock_request_handler.rs
@@ -88,7 +88,7 @@ async fn send_response(
 
     let mut message_response_builder = MessageResponseBuilder::from_message_request(request);
     if let Some(edns) = response.extensions() {
-        message_response_builder.edns(edns.clone());
+        message_response_builder.edns(edns);
     }
     let message_response = message_response_builder.build(
         response_header,

--- a/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
+++ b/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
@@ -220,7 +220,7 @@ where
         let signers = block_on(handler.secure_keys());
         let public_key = signers
             .first()
-            .expect("expected a key in the authority")
+            .expect("expected a key in the zone handler")
             .key()
             .to_public_key()
             .expect("could not convert keypair to public_key");

--- a/tests/integration-tests/tests/integration/sqlite_zone_handler_tests.rs
+++ b/tests/integration-tests/tests/integration/sqlite_zone_handler_tests.rs
@@ -1020,7 +1020,7 @@ async fn test_update_tsig_valid() {
     edns.options_mut().insert(EdnsOption::NSID(
         NSIDPayload::new([0xC0, 0xFF, 0xEE]).unwrap(),
     ));
-    let response = MessageResponseBuilder::new(request.raw_queries(), Some(edns.clone()));
+    let response = MessageResponseBuilder::new(request.raw_queries(), Some(&edns));
     let mut response_header = Header::new(request.id(), MessageType::Response, OpCode::Update);
     response_header.set_response_code(ResponseCode::NoError);
     let mut response = response.build_no_records(response_header);
@@ -1030,7 +1030,7 @@ async fn test_update_tsig_valid() {
     let mut encoder = BinEncoder::with_mode(&mut tbs_response_buf, EncodeMode::Normal);
     let mut response_header = Header::new(request.id(), MessageType::Response, OpCode::Update);
     response_header.set_response_code(ResponseCode::NoError);
-    let tbs_response = MessageResponseBuilder::new(request.raw_queries(), Some(edns))
+    let tbs_response = MessageResponseBuilder::new(request.raw_queries(), Some(&edns))
         .build_no_records(response_header);
     tbs_response.destructive_emit(&mut encoder).unwrap();
 


### PR DESCRIPTION
While I was working on an UPDATE test, I noticed another case where we were failing to send a response in certain error conditions (leading to a test hang). This is related to #2572. I went through `Catalog::handle_request()` and its call tree to send error responses in more cases; we should have complete coverage now. Error responses were primarily missing in `Catalog::update()`, in fall-through code where no zone handler in a chain handled a request, and during response signing where `?` was used to return early. I changed the return type of some functions or methods from a `Result` to a `ResponseInfo`, which helped flush out the latter. I also changed `MessageResponse` so that it only holds a reference to the response's `Edns` struct, not ownership of it, in order to eliminate some unnecessary clones.