### PR TITLE
Remove AuthLookup::SOA

### DIFF
--- a/crates/server/src/zone_handler/auth_lookup.rs
+++ b/crates/server/src/zone_handler/auth_lookup.rs
@@ -34,8 +34,6 @@ pub enum AuthLookup {
     /// Records resulting from a resolver lookup
     #[cfg(feature = "resolver")]
     Resolved(Lookup),
-    /// `SOA` is used to store the SOA RR, to be included in the Additional section of a response.
-    SOA(LookupRecords),
     /// A response message
     Response(Message),
 }
@@ -128,9 +126,7 @@ impl<'a> IntoIterator for &'a AuthLookup {
         match self {
             AuthLookup::Empty => AuthLookupIter::Empty,
             // TODO: what about the additionals? is IntoIterator a bad idea?
-            AuthLookup::Records { answers: r, .. } | AuthLookup::SOA(r) => {
-                AuthLookupIter::Records(r.into_iter())
-            }
+            AuthLookup::Records { answers: r, .. } => AuthLookupIter::Records(r.into_iter()),
             #[cfg(feature = "resolver")]
             AuthLookup::Resolved(lookup) => AuthLookupIter::Resolved(lookup.record_iter()),
             AuthLookup::Response(message) => AuthLookupIter::Response(message.answers().iter()),

--- a/crates/server/src/zone_handler/catalog.rs
+++ b/crates/server/src/zone_handler/catalog.rs
@@ -960,7 +960,10 @@ async fn build_forwarded_response(
                 let record_set = Arc::new(RecordSet::from(soa));
                 let records = LookupRecords::new(LookupOptions::default(), record_set);
 
-                (Answer::NoRecords(AuthLookup::SOA(records)), authorities)
+                (
+                    Answer::NoRecords(AuthLookup::answers(records, None)),
+                    authorities,
+                )
             } else {
                 (Answer::Normal(AuthLookup::default()), authorities)
             }
@@ -985,7 +988,7 @@ async fn build_forwarded_response(
                 let records = LookupRecords::new(LookupOptions::default(), record_set);
 
                 (
-                    Answer::NoRecords(AuthLookup::SOA(records)),
+                    Answer::NoRecords(AuthLookup::answers(records, None)),
                     AuthLookup::default(),
                 )
             } else {


### PR DESCRIPTION
This removes another variant from `AuthLookup`. The `SOA` variant is now functionally equivalent to `Records`, so we can remove it.