### PR TITLE
justfile: improve clippy target

### DIFF
--- a/justfile
+++ b/justfile
@@ -96,9 +96,9 @@ clippy-inner feature='':
 
 # Run clippy on all targets and all sources
 clippy:
+    just clippy-inner --all-features
     just clippy-inner --no-default-features
     just clippy-inner
-    just clippy-inner --all-features
     cargo clippy --manifest-path fuzz/Cargo.toml --locked --all-targets -- -D warnings
 
 # Check the format of all the Rust code with rustfmt

--- a/justfile
+++ b/justfile
@@ -92,7 +92,7 @@ build-bench:
 
 [private]
 clippy-inner feature='':
-    cargo ws exec cargo {{MSRV}} clippy --locked --all-targets {{feature}} -- -D warnings
+    cargo ws exec --no-bail cargo {{MSRV}} clippy --locked --all-targets {{feature}} -- -D warnings
 
 # Run clippy on all targets and all sources
 clippy:


### PR DESCRIPTION
The way `justfile clippy` is used in the CI cleanliness job led to progress disclosure, where partial lint denials would lead to the job ending while after pushing a fix another issue would be found. It seems that `cargo ws exec` stops after the first failure, which is suboptimal for this use case.

Also, the `--all-features` variant is most likely to find issues, so run it first.