### PR TITLE
Revert "justfile: keep going across crates even if clippy fails"

### DIFF
--- a/justfile
+++ b/justfile
@@ -92,7 +92,7 @@ build-bench:
 
 [private]
 clippy-inner feature='':
-    cargo ws exec --no-bail cargo {{MSRV}} clippy --locked --all-targets {{feature}} -- -D warnings
+    cargo ws exec cargo {{MSRV}} clippy --locked --all-targets {{feature}} -- -D warnings
 
 # Run clippy on all targets and all sources
 clippy:


### PR DESCRIPTION
This reverts commit e60b16e2c2b8164ae4675f518126a1c8b6ba2c9f.

See https://github.com/hickory-dns/hickory-dns/pull/3257#discussion_r2322015165. Thanks @divergentdave!

Can add this back if/when my fix is merged/released:

- https://github.com/pksunkara/cargo-workspaces/pull/201