### PR TITLE
Remove tracing-subscriber deps. from hickory-proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tracing",
- "tracing-subscriber",
  "url",
  "wasm-bindgen",
  "webpki-roots",

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -35,9 +35,6 @@ std = [
     "rand/thread_rng",
     "ring?/std",
     "thiserror/std",
-    "tracing-subscriber/env-filter",
-    "tracing-subscriber/fmt",
-    "tracing-subscriber/std",
     "tracing/std",
     "url/std",
 ]
@@ -128,7 +125,6 @@ webpki-roots = { workspace = true, optional = true }
 futures-executor = { workspace = true, default-features = false, features = ["std"] }
 test-support.workspace = true
 tokio = { workspace = true, features = ["rt", "time", "macros"] }
-tracing-subscriber.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
It appears to be entirely unused in the `hickory-proto` crate.