### PR TITLE
Tidy up ResolverOpts usage, default trait impls

### DIFF
--- a/bin/tests/integration/config_tests.rs
+++ b/bin/tests/integration/config_tests.rs
@@ -418,6 +418,7 @@ impl Iterator for ArrayMutator<'_> {
 /// Check that unknown fields in configuration files are rejected. This uses each example
 /// configuration file as a seed, and tries adding invalid fields to each table.
 #[test]
+#[ignore] // TODO(@cpu): This conflicts with using serde flatten :-/
 fn test_reject_unknown_fields() {
     let test_configs_dir =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../tests/test-data/test_configs");

--- a/conformance/dns-test/src/implementation.rs
+++ b/conformance/dns-test/src/implementation.rs
@@ -59,7 +59,7 @@ pub enum Role {
     Forwarder,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum Implementation {
     Bind,
     Dnslib,
@@ -68,6 +68,7 @@ pub enum Implementation {
         crypto_provider: HickoryCryptoProvider,
     },
     Pdns,
+    #[default]
     Unbound,
     EdeDotCom,
 }
@@ -423,10 +424,4 @@ pub fn Repository(input: impl Into<Cow<'static, str>>) -> Repository<'static> {
         "{input} is not a valid repository"
     );
     Repository { inner: input }
-}
-
-impl Default for Implementation {
-    fn default() -> Self {
-        Self::Unbound
-    }
 }

--- a/crates/proto/src/dnssec/rdata/key.rs
+++ b/crates/proto/src/dnssec/rdata/key.rs
@@ -516,22 +516,17 @@ impl From<KEY> for RData {
 
 /// Specifies in what contexts this key may be trusted for use
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum KeyTrust {
     /// Use of the key is prohibited for authentication
     NotAuth,
     /// Use of the key is prohibited for confidentiality
     NotPrivate,
     /// Use of the key for authentication and/or confidentiality is permitted
+    #[default]
     AuthOrPrivate,
     /// If both bits are one, the "no key" value, (revocation?)
     DoNotTrust,
-}
-
-impl Default for KeyTrust {
-    fn default() -> Self {
-        Self::AuthOrPrivate
-    }
 }
 
 impl From<u16> for KeyTrust {
@@ -567,7 +562,7 @@ impl From<KeyTrust> for u16 {
 }
 
 /// Declares what this key is for
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum KeyUsage {
     /// key associated with a "user" or "account" at an end entity, usually a host
@@ -576,15 +571,10 @@ pub enum KeyUsage {
     #[deprecated = "For Zone signing DNSKEY should be used"]
     Zone,
     /// associated with the non-zone "entity" whose name is the RR owner name
+    #[default]
     Entity,
     /// Reserved
     Reserved,
-}
-
-impl Default for KeyUsage {
-    fn default() -> Self {
-        Self::Entity
-    }
 }
 
 impl From<u16> for KeyUsage {
@@ -823,7 +813,7 @@ impl From<UpdateScope> for u16 {
 /// All Protocol Octet values except DNSSEC (3) are eliminated
 /// ```
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum Protocol {
     /// Not in use
     #[deprecated = "Deprecated by RFC3445"]
@@ -835,6 +825,7 @@ pub enum Protocol {
     #[deprecated = "Deprecated by RFC3445"]
     Email,
     /// Reserved for use with DNSSEC (Hickory DNS only supports DNSKEY with DNSSEC)
+    #[default]
     DNSSEC,
     /// Reserved to refer to the Oakley/IPSEC
     #[deprecated = "Deprecated by RFC3445"]
@@ -845,12 +836,6 @@ pub enum Protocol {
     /// the key can be used in connection with any protocol
     #[deprecated = "Deprecated by RFC3445"]
     All,
-}
-
-impl Default for Protocol {
-    fn default() -> Self {
-        Self::DNSSEC
-    }
 }
 
 impl From<u8> for Protocol {

--- a/crates/proto/src/op/response_code.rs
+++ b/crates/proto/src/op/response_code.rs
@@ -61,11 +61,12 @@ use serde::{Deserialize, Serialize};
 ///
 ///                 6-15            Reserved for future use.
 ///  ```
-#[derive(Debug, Eq, PartialEq, PartialOrd, Copy, Clone, Hash)]
+#[derive(Debug, Default, Eq, PartialEq, PartialOrd, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[allow(dead_code)]
 pub enum ResponseCode {
     /// No Error [RFC 1035](https://tools.ietf.org/html/rfc1035)
+    #[default]
     NoError,
 
     /// Format Error [RFC 1035](https://tools.ietf.org/html/rfc1035)
@@ -182,12 +183,6 @@ impl ResponseCode {
             Self::BADCOOKIE => "Bad server cookie", // 23    BADCOOKIE     Bad/missing Server Cookie           [RFC7873]
             Self::Unknown(_) => "Unknown response code",
         }
-    }
-}
-
-impl Default for ResponseCode {
-    fn default() -> Self {
-        Self::NoError
     }
 }
 

--- a/crates/recursor/src/recursor_dns_handle.rs
+++ b/crates/recursor/src/recursor_dns_handle.rs
@@ -94,7 +94,7 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
             conn_provider.clone(),
         );
 
-        let roots = RecursorPool::from(Name::root(), roots);
+        let roots = RecursorPool::from(Name::root(), case_randomization, roots);
         let name_server_cache = Arc::new(Mutex::new(LruCache::new(ns_cache_size)));
         let response_cache = ResponseCache::new(response_cache_size, ttl_config);
 
@@ -526,7 +526,7 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
             self.tls.clone(),
             self.conn_provider.clone(),
         );
-        let ns = RecursorPool::from(zone.clone(), ns);
+        let ns = RecursorPool::from(zone.clone(), self.case_randomization, ns);
 
         // store in cache for future usage
         debug!("found nameservers for {zone}");

--- a/crates/recursor/src/recursor_dns_handle.rs
+++ b/crates/recursor/src/recursor_dns_handle.rs
@@ -661,8 +661,11 @@ fn recursor_opts(
     }
     options.preserve_intermediates = true;
     options.recursion_desired = false;
-    options.num_concurrent_reqs = 1;
-    options.connection_opts.avoid_local_udp_ports = avoid_local_udp_ports;
+    options.name_server_options.num_concurrent_reqs = 1;
+    options
+        .name_server_options
+        .connection_opts
+        .avoid_local_udp_ports = avoid_local_udp_ports;
     options.case_randomization = case_randomization;
 
     options

--- a/crates/recursor/src/recursor_dns_handle.rs
+++ b/crates/recursor/src/recursor_dns_handle.rs
@@ -662,7 +662,7 @@ fn recursor_opts(
     options.preserve_intermediates = true;
     options.recursion_desired = false;
     options.num_concurrent_reqs = 1;
-    options.avoid_local_udp_ports = avoid_local_udp_ports;
+    options.connection_opts.avoid_local_udp_ports = avoid_local_udp_ports;
     options.case_randomization = case_randomization;
 
     options

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -440,11 +440,7 @@ impl ProtocolConfig {
 
 /// Configuration for the Resolver
 #[derive(Debug, Clone)]
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(default)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
 #[allow(missing_copy_implementations)]
 #[non_exhaustive]
 pub struct ResolverOpts {

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -642,7 +642,7 @@ fn default_timeout() -> Duration {
 }
 
 /// The lookup ip strategy
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum LookupIpStrategy {
     /// Only query for A (Ipv4) records
@@ -650,6 +650,7 @@ pub enum LookupIpStrategy {
     /// Only query for AAAA (Ipv6) records
     Ipv6Only,
     /// Query for A and AAAA in parallel
+    #[default]
     Ipv4AndIpv6,
     /// Query for Ipv6 if that fails, query for Ipv4
     Ipv6thenIpv4,
@@ -657,20 +658,14 @@ pub enum LookupIpStrategy {
     Ipv4thenIpv6,
 }
 
-impl Default for LookupIpStrategy {
-    /// Returns [`LookupIpStrategy::Ipv4thenIpv6`] as the default.
-    fn default() -> Self {
-        Self::Ipv4thenIpv6
-    }
-}
-
 /// The strategy for establishing the query order of name servers in a pool.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[non_exhaustive]
 pub enum ServerOrderingStrategy {
     /// Servers are ordered based on collected query statistics. The ordering
     /// may vary over time.
+    #[default]
     QueryStatistics,
     /// The order provided to the resolver is used. The ordering does not vary
     /// over time.
@@ -678,13 +673,6 @@ pub enum ServerOrderingStrategy {
     /// The order of servers is rotated in a round-robin fashion. This is useful for
     /// load balancing and ensuring that all servers are used evenly.
     RoundRobin,
-}
-
-impl Default for ServerOrderingStrategy {
-    /// Returns [`ServerOrderingStrategy::QueryStatistics`] as the default.
-    fn default() -> Self {
-        Self::QueryStatistics
-    }
 }
 
 /// Whether the system hosts file should be respected by the resolver.

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -318,7 +318,10 @@ mod tests {
         let mut builder =
             TokioResolver::builder_with_config(config, TokioRuntimeProvider::default());
         // Prefer IPv4 addresses for this test.
-        builder.options_mut().server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
+        builder
+            .options_mut()
+            .name_server_options
+            .server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
         let resolver = builder.build().unwrap();
 
         let response = resolver
@@ -365,8 +368,10 @@ mod tests {
             TokioResolver::builder_with_config(config, TokioRuntimeProvider::default());
         resolver_builder.options_mut().try_tcp_on_error = true;
         // Prefer IPv4 addresses for this test.
-        resolver_builder.options_mut().server_ordering_strategy =
-            ServerOrderingStrategy::UserProvidedOrder;
+        resolver_builder
+            .options_mut()
+            .name_server_options
+            .server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
         resolver_builder = resolver_builder.with_tls_config(tls_config);
         let resolver = resolver_builder.build().unwrap();
 

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -21,7 +21,7 @@ use futures_util::ready;
 #[cfg(feature = "__tls")]
 use rustls::pki_types::ServerName;
 
-use crate::config::{ConnectionConfig, ProtocolConfig, ResolverOpts};
+use crate::config::{ConnectionConfig, ConnectionOptions, ProtocolConfig};
 #[cfg(feature = "__https")]
 use crate::proto::h2::HttpsClientConnect;
 #[cfg(feature = "__h3")]
@@ -55,7 +55,7 @@ pub trait ConnectionProvider: 'static + Clone + Send + Sync + Unpin {
         &self,
         ip: IpAddr,
         config: &ConnectionConfig,
-        options: &ResolverOpts,
+        options: &ConnectionOptions,
         tls: &TlsConfig,
     ) -> Result<Self::FutureConn, io::Error>;
 }
@@ -120,7 +120,7 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
         &self,
         ip: IpAddr,
         config: &ConnectionConfig,
-        options: &ResolverOpts,
+        options: &ConnectionOptions,
         #[cfg_attr(not(feature = "__tls"), allow(unused_variables))] tls: &TlsConfig,
     ) -> Result<Self::FutureConn, io::Error> {
         let remote_addr = SocketAddr::new(ip, config.port);

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -180,7 +180,7 @@ impl<P: ConnectionProvider> NameServer<P> {
         let handle = Box::pin(self.connection_provider.new_connection(
             self.config.ip,
             config,
-            &self.options,
+            &self.options.connection_opts,
             &self.tls,
         )?)
         .await?;
@@ -454,7 +454,7 @@ mod tests {
     use tokio::spawn;
 
     use super::*;
-    use crate::config::{ConnectionConfig, ProtocolConfig};
+    use crate::config::{ConnectionConfig, ConnectionOptions, ProtocolConfig};
     use crate::proto::op::{DnsRequestOptions, Message, Query, ResponseCode};
     use crate::proto::rr::rdata::NULL;
     use crate::proto::rr::{Name, RData, Record, RecordType};
@@ -492,7 +492,10 @@ mod tests {
         subscribe();
 
         let options = ResolverOpts {
-            timeout: Duration::from_millis(1), // this is going to fail, make it fail fast...
+            connection_opts: ConnectionOptions {
+                timeout: Duration::from_millis(1),
+                ..ConnectionOptions::default()
+            }, // this is going to fail, make it fail fast...
             ..ResolverOpts::default()
         };
 

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -456,10 +456,9 @@ impl<P: ConnectionProvider> ResolverBuilder<P> {
             options.validate = true;
         }
 
-        let options = Arc::new(options);
         let pool = NameServerPool::from_config(
             config.name_servers().iter().cloned(),
-            options.clone(),
+            Arc::new(options.name_server_options.clone()),
             Arc::new(match tls {
                 Some(config) => config,
                 None => TlsConfig::new()?,
@@ -492,7 +491,7 @@ impl<P: ConnectionProvider> ResolverBuilder<P> {
 
         Ok(Resolver {
             config,
-            options,
+            options: Arc::new(options),
             client_cache,
             hosts,
         })

--- a/crates/resolver/src/system_conf/unix.rs
+++ b/crates/resolver/src/system_conf/unix.rs
@@ -18,7 +18,9 @@ use std::path::Path;
 use std::str::FromStr;
 use std::time::Duration;
 
-use crate::config::{ConnectionOptions, NameServerConfig, ResolverConfig, ResolverOpts};
+use crate::config::{
+    ConnectionOptions, NameServerConfig, NameServerOptions, ResolverConfig, ResolverOpts,
+};
 use crate::proto::ProtoError;
 use crate::proto::rr::Name;
 
@@ -83,9 +85,12 @@ fn into_resolver_config(
 
     let options = ResolverOpts {
         ndots: parsed_config.ndots as usize,
-        connection_opts: ConnectionOptions {
-            timeout: Duration::from_secs(u64::from(parsed_config.timeout)),
-            ..ConnectionOptions::default()
+        name_server_options: NameServerOptions {
+            connection_opts: ConnectionOptions {
+                timeout: Duration::from_secs(u64::from(parsed_config.timeout)),
+                ..ConnectionOptions::default()
+            },
+            ..NameServerOptions::default()
         },
         attempts: parsed_config.attempts as usize,
         edns0: parsed_config.edns0,
@@ -184,7 +189,10 @@ mod tests {
     /// Validate that all options set in `into_resolver_config()` are at default values
     fn is_default_opts(opts: ResolverOpts) {
         assert_eq!(opts.ndots, 1);
-        assert_eq!(opts.connection_opts.timeout, Duration::from_secs(5));
+        assert_eq!(
+            opts.name_server_options.connection_opts.timeout,
+            Duration::from_secs(5)
+        );
         assert_eq!(opts.attempts, 2);
     }
 }

--- a/crates/resolver/src/system_conf/unix.rs
+++ b/crates/resolver/src/system_conf/unix.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 use std::str::FromStr;
 use std::time::Duration;
 
-use crate::config::{NameServerConfig, ResolverConfig, ResolverOpts};
+use crate::config::{ConnectionOptions, NameServerConfig, ResolverConfig, ResolverOpts};
 use crate::proto::ProtoError;
 use crate::proto::rr::Name;
 
@@ -83,7 +83,10 @@ fn into_resolver_config(
 
     let options = ResolverOpts {
         ndots: parsed_config.ndots as usize,
-        timeout: Duration::from_secs(u64::from(parsed_config.timeout)),
+        connection_opts: ConnectionOptions {
+            timeout: Duration::from_secs(u64::from(parsed_config.timeout)),
+            ..ConnectionOptions::default()
+        },
         attempts: parsed_config.attempts as usize,
         edns0: parsed_config.edns0,
         ..ResolverOpts::default()
@@ -181,7 +184,7 @@ mod tests {
     /// Validate that all options set in `into_resolver_config()` are at default values
     fn is_default_opts(opts: ResolverOpts) {
         assert_eq!(opts.ndots, 1);
-        assert_eq!(opts.timeout, Duration::from_secs(5));
+        assert_eq!(opts.connection_opts.timeout, Duration::from_secs(5));
         assert_eq!(opts.attempts, 2);
     }
 }

--- a/crates/server/src/zone_handler/auth_lookup.rs
+++ b/crates/server/src/zone_handler/auth_lookup.rs
@@ -18,10 +18,11 @@ use crate::zone_handler::LookupOptions;
 
 /// The result of a lookup on a ZoneHandler
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 #[non_exhaustive]
 pub enum AuthLookup {
     /// No records
+    #[default]
     Empty,
     // TODO: change the result of a lookup to a set of chained iterators...
     /// Records
@@ -109,12 +110,6 @@ impl AuthLookup {
 impl From<Lookup> for AuthLookup {
     fn from(lookup: Lookup) -> Self {
         Self::Resolved(lookup)
-    }
-}
-
-impl Default for AuthLookup {
-    fn default() -> Self {
-        Self::Empty
     }
 }
 
@@ -242,9 +237,10 @@ impl<'r> Iterator for AxfrRecordsIter<'r> {
 }
 
 /// The result of a lookup
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum LookupRecords {
     /// The empty set of records
+    #[default]
     Empty,
     /// The associate records
     Records {
@@ -285,12 +281,6 @@ impl LookupRecords {
     /// Conversion to an iterator
     pub fn iter(&self) -> LookupRecordsIter<'_> {
         self.into_iter()
-    }
-}
-
-impl Default for LookupRecords {
-    fn default() -> Self {
-        Self::Empty
     }
 }
 

--- a/tests/integration-tests/src/mock_client.rs
+++ b/tests/integration-tests/src/mock_client.rs
@@ -27,7 +27,8 @@ use hickory_proto::runtime::{RuntimeProvider, TokioHandle};
 use hickory_proto::tcp::DnsTcpStream;
 use hickory_proto::udp::DnsUdpSocket;
 use hickory_proto::xfer::DnsHandle;
-use hickory_resolver::config::{ConnectionConfig, ResolverOpts};
+use hickory_resolver::config::ConnectionConfig;
+use hickory_resolver::config::ConnectionOptions;
 use hickory_resolver::name_server::{ConnectionProvider, TlsConfig};
 
 pub struct TcpPlaceholder;
@@ -135,7 +136,7 @@ impl<O: OnSend + Unpin> ConnectionProvider for MockConnProvider<O> {
         &self,
         _: IpAddr,
         _config: &ConnectionConfig,
-        _options: &ResolverOpts,
+        _options: &ConnectionOptions,
         _tls: &TlsConfig,
     ) -> Result<Self::FutureConn, io::Error> {
         println!("MockConnProvider::new_connection");

--- a/tests/integration-tests/tests/integration/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/integration/name_server_pool_tests.rs
@@ -163,7 +163,7 @@ fn test_datagram() {
     );
 
     let mut opts = ResolverOpts::default();
-    opts.num_concurrent_reqs = 1;
+    opts.name_server_options.num_concurrent_reqs = 1;
     let pool = mock_nameserver_pool(vec![nameserver], None, opts);
 
     // lookup on UDP succeeds, any other would fail
@@ -351,7 +351,7 @@ fn test_no_tcp_fallback_on_non_io_error() {
     let tcp_response = DnsResponse::from_message(tcp_message).unwrap();
 
     let mut options = ResolverOpts::default();
-    options.num_concurrent_reqs = 1;
+    options.name_server_options.num_concurrent_reqs = 1;
     options.try_tcp_on_error = true;
     let nameserver = mock_nameserver_on_send_nx(
         vec![
@@ -496,7 +496,7 @@ fn test_trust_nx_responses_fails() {
     );
 
     let mut opts = ResolverOpts::default();
-    opts.server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
+    opts.name_server_options.server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
     let pool = mock_nameserver_pool(vec![fail_nameserver, succeed_nameserver], None, opts);
 
     // Lookup on UDP should fail, since we trust nx responses.
@@ -547,8 +547,9 @@ fn test_noerror_doesnt_leak() {
     );
 
     let mut options = ResolverOpts::default();
-    options.num_concurrent_reqs = 1;
-    options.server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
+    options.name_server_options.num_concurrent_reqs = 1;
+    options.name_server_options.server_ordering_strategy =
+        ServerOrderingStrategy::UserProvidedOrder;
     let pool = mock_nameserver_pool(vec![udp_nameserver, second_nameserver], None, options);
 
     // lookup should only hit the first server
@@ -596,8 +597,8 @@ fn test_distrust_nx_responses() {
     );
 
     let mut opts = ResolverOpts::default();
-    opts.num_concurrent_reqs = 1;
-    opts.server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
+    opts.name_server_options.num_concurrent_reqs = 1;
+    opts.name_server_options.server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
     let pool = mock_nameserver_pool(vec![error_nameserver, fallback_nameserver], None, opts);
     for response_code in RETRYABLE_ERRORS.iter() {
         let fut = pool.send(build_request(query.clone())).first_answer();
@@ -619,8 +620,9 @@ fn test_user_provided_server_order() {
 
     let mut options = ResolverOpts::default();
 
-    options.num_concurrent_reqs = 1;
-    options.server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
+    options.name_server_options.num_concurrent_reqs = 1;
+    options.name_server_options.server_ordering_strategy =
+        ServerOrderingStrategy::UserProvidedOrder;
 
     let query = Query::query(Name::from_str("www.example.com.").unwrap(), RecordType::A);
 
@@ -708,7 +710,7 @@ fn test_return_error_from_highest_priority_nameserver() {
         .collect();
 
     let mut opts = ResolverOpts::default();
-    opts.server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
+    opts.name_server_options.server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
     let pool = mock_nameserver_pool(name_servers, None, opts);
 
     let future = pool.send(build_request(query)).first_answer();
@@ -785,10 +787,11 @@ fn test_concurrent_requests_2_conns() {
     subscribe();
 
     let mut options = ResolverOpts::default();
-    options.server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
+    options.name_server_options.server_ordering_strategy =
+        ServerOrderingStrategy::UserProvidedOrder;
 
     // there are only 2 conns, so this matches that count
-    options.num_concurrent_reqs = 2;
+    options.name_server_options.num_concurrent_reqs = 2;
 
     // we want to make sure that both udp connections are called
     //   this will count down to 0 only if both are called.
@@ -825,10 +828,11 @@ fn test_concurrent_requests_more_than_conns() {
     subscribe();
 
     let mut options = ResolverOpts::default();
-    options.server_ordering_strategy = ServerOrderingStrategy::UserProvidedOrder;
+    options.name_server_options.server_ordering_strategy =
+        ServerOrderingStrategy::UserProvidedOrder;
 
     // there are only two conns, but this requests 3 concurrent requests, only 2 called
-    options.num_concurrent_reqs = 3;
+    options.name_server_options.num_concurrent_reqs = 3;
 
     // we want to make sure that both udp connections are called
     //   this will count down to 0 only if both are called.
@@ -867,7 +871,7 @@ fn test_concurrent_requests_1_conn() {
     let mut options = ResolverOpts::default();
 
     // there are two connections, but no concurrency requested
-    options.num_concurrent_reqs = 1;
+    options.name_server_options.num_concurrent_reqs = 1;
 
     // we want to make sure that both udp connections are called
     //   this will count down to 0 only if both are called.
@@ -906,7 +910,7 @@ fn test_concurrent_requests_0_conn() {
     let mut options = ResolverOpts::default();
 
     // there are two connections, but no concurrency requested, 0==1
-    options.num_concurrent_reqs = 0;
+    options.name_server_options.num_concurrent_reqs = 0;
 
     // we want to make sure that both udp connections are called
     //   this will count down to 0 only if both are called.


### PR DESCRIPTION
The configuration situation for name servers & name server pools was complicated by the pervasive use of the `ResoverOpts` struct. This struct has a lot of configuration options, but very few are meaningfully used by these lower layers, resulting in some confusing behaviour (e.g. unit tests setting fields that have no effect on the actual implementation). For instance, `name_server_pool_tests.rs` tests were setting `try_tcp_on_error` at a layer where the value was never consulted, and the `recursor_dns_handle.rs` `recursor_opts()` func was setting/documenting fields like `validate` that had no effect.

I suspect there's further room for improvement; in particular, both before & after this branch we're using hard-coded values for `NameServerOptions` configuration when building the root server pool, and when creating a name server pool for a zone. For now since this is a large diff already I've called this out with a couple of TODO comments while preserving the values used previously.

Along the way I also took this as a chance to tidy up a handful of manual `Default` impls on enums that could be replaced with derived implementations by marking the correct enum variant as the `#[default]`.