### PR TITLE
recursor: tidy up builder filters, recursor handle construction

### DIFF
--- a/crates/recursor/src/metrics_tests.rs
+++ b/crates/recursor/src/metrics_tests.rs
@@ -54,6 +54,7 @@ fn test_recursor_metrics() {
         let provider = MockProvider::new(handler);
         runtime.block_on(async {
             let recursor = Recursor::builder_with_provider(provider)
+                .clear_deny_servers() // We use addresses in the default deny filter.
                 .build(&[ROOT_IP.into()])
                 .unwrap();
             for _ in 0..3 {

--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -94,18 +94,41 @@ impl<P: ConnectionProvider> RecursorBuilder<P> {
         self
     }
 
-    /// Add networks that should not be queried during recursive resolution
-    pub fn nameserver_filter<'a>(
-        mut self,
-        allow: impl Iterator<Item = &'a IpNet>,
-        deny: impl Iterator<Item = &'a IpNet>,
-    ) -> Self {
-        for addr in RECOMMENDED_SERVER_FILTERS {
-            self.deny_servers.push(addr);
-        }
-
-        self.allow_servers.extend(allow);
+    /// Skip querying nameservers within the provided networks during recursive resolution.
+    ///
+    /// The provided `deny` networks will be added to any existing networks denied
+    /// by default, or that were added by previous calls to [`Self::deny_servers`].
+    pub fn deny_servers<'a>(mut self, deny: impl Iterator<Item = &'a IpNet>) -> Self {
         self.deny_servers.extend(deny);
+        self
+    }
+
+    /// Allow querying nameservers within the provided networks during recursive resolution.
+    ///
+    /// The provided `allow` networks will be added to any existing networks that were added by
+    /// previous calls to [`Self::allow_servers`].
+    ///
+    /// Allowed networks take precedence over deny networks added with [`Self::deny_servers`].
+    pub fn allow_servers<'a>(mut self, allow: impl Iterator<Item = &'a IpNet>) -> Self {
+        self.allow_servers.extend(allow);
+        self
+    }
+
+    /// Clear the networks that should be allowed to be queried during recursive resolution.
+    ///
+    /// This will remove any allow filter networks previously added by [`Self::allow_servers`],
+    pub fn clear_allow_servers(mut self) -> Self {
+        self.allow_servers.clear();
+        self
+    }
+
+    /// Clear the networks that should not be queried during recursive resolution.
+    ///
+    /// This will remove any deny filter networks previously added by [`Self::deny_servers`],
+    /// as well as the default recommended server filters (internal networks, broadcast addresses,
+    /// etc.).
+    pub fn clear_deny_servers(mut self) -> Self {
+        self.deny_servers.clear();
         self
     }
 
@@ -167,7 +190,7 @@ impl<P: ConnectionProvider> Recursor<P> {
             ns_recursion_limit: Some(24),
             dnssec_policy: DnssecPolicy::SecurityUnaware,
             allow_servers: vec![],
-            deny_servers: vec![],
+            deny_servers: RECOMMENDED_SERVER_FILTERS.to_vec(),
             avoid_local_udp_ports: HashSet::new(),
             ttl_config: TtlConfig::default(),
             case_randomization: false,

--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -33,7 +33,7 @@ use crate::{
     ErrorKind,
     proto::{
         DnsError, NoRecords, ProtoError,
-        dnssec::{DnssecDnsHandle, TrustAnchors},
+        dnssec::DnssecDnsHandle,
         op::{DnsRequestOptions, ResponseCode},
         rr::RecordType,
         xfer::{DnsHandle as _, FirstAnswer as _},
@@ -44,21 +44,21 @@ use crate::{
 /// A `Recursor` builder
 #[derive(Clone)]
 pub struct RecursorBuilder<P: ConnectionProvider> {
-    ns_cache_size: usize,
-    response_cache_size: u64,
+    pub(super) ns_cache_size: usize,
+    pub(super) response_cache_size: u64,
     /// This controls how many nested lookups will be attempted to resolve a CNAME chain. Setting it
     /// to None will disable the recursion limit check, and is not recommended.
-    recursion_limit: Option<u8>,
+    pub(super) recursion_limit: Option<u8>,
     /// This controls how many nested lookups will be attempted when trying to build an NS pool.
     /// Setting it to None will disable the recursion limit check, and is not recommended.
-    ns_recursion_limit: Option<u8>,
-    dnssec_policy: DnssecPolicy,
-    allow_servers: Vec<IpNet>,
-    deny_servers: Vec<IpNet>,
-    avoid_local_udp_ports: HashSet<u16>,
-    ttl_config: TtlConfig,
-    case_randomization: bool,
-    conn_provider: P,
+    pub(super) ns_recursion_limit: Option<u8>,
+    pub(super) dnssec_policy: DnssecPolicy,
+    pub(super) allow_servers: Vec<IpNet>,
+    pub(super) deny_servers: Vec<IpNet>,
+    pub(super) avoid_local_udp_ports: HashSet<u16>,
+    pub(super) ttl_config: TtlConfig,
+    pub(super) case_randomization: bool,
+    pub(super) conn_provider: P,
 }
 
 impl<P: ConnectionProvider> RecursorBuilder<P> {
@@ -167,7 +167,7 @@ impl<P: ConnectionProvider> RecursorBuilder<P> {
 ///
 /// This is the well known root nodes, referred to as hints in RFCs. See the IANA [Root Servers](https://www.iana.org/domains/root/servers) list.
 pub struct Recursor<P: ConnectionProvider> {
-    mode: RecursorMode<P>,
+    pub(super) mode: RecursorMode<P>,
 }
 
 impl Recursor<TokioRuntimeProvider> {
@@ -205,71 +205,13 @@ impl<P: ConnectionProvider> Recursor<P> {
     }
 
     fn build(roots: &[IpAddr], builder: RecursorBuilder<P>) -> Result<Self, Error> {
-        let RecursorBuilder {
-            ns_cache_size,
-            response_cache_size,
-            recursion_limit,
-            ns_recursion_limit,
-            dnssec_policy,
-            allow_servers,
-            deny_servers,
-            avoid_local_udp_ports,
-            ttl_config,
-            case_randomization,
-            conn_provider,
-        } = builder;
-
-        let handle = RecursorDnsHandle::new(
-            roots,
-            ns_cache_size,
-            response_cache_size,
-            recursion_limit,
-            ns_recursion_limit,
-            dnssec_policy.is_security_aware(),
-            allow_servers,
-            deny_servers,
-            Arc::new(avoid_local_udp_ports),
-            ttl_config.clone(),
-            case_randomization,
-            Arc::new(TlsConfig::new()?),
-            conn_provider,
-        );
-
-        let mode = match dnssec_policy {
-            DnssecPolicy::SecurityUnaware => RecursorMode::NonValidating { handle },
-
-            #[cfg(feature = "__dnssec")]
-            DnssecPolicy::ValidationDisabled => RecursorMode::NonValidating { handle },
-
-            #[cfg(feature = "__dnssec")]
-            DnssecPolicy::ValidateWithStaticKey {
-                trust_anchor,
-                nsec3_soft_iteration_limit,
-                nsec3_hard_iteration_limit,
-            } => {
-                let validated_response_cache = ResponseCache::new(response_cache_size, ttl_config);
-                let trust_anchor = match trust_anchor {
-                    Some(anchor) if anchor.is_empty() => {
-                        return Err(Error::from("trust anchor must not be empty"));
-                    }
-                    Some(anchor) => anchor,
-                    None => Arc::new(TrustAnchors::default()),
-                };
-
-                RecursorMode::Validating {
-                    validated_response_cache,
-                    #[cfg(feature = "metrics")]
-                    cache_metrics: handle.cache_metrics().clone(),
-                    handle: DnssecDnsHandle::with_trust_anchor(handle, trust_anchor)
-                        .nsec3_iteration_limits(
-                            nsec3_soft_iteration_limit,
-                            nsec3_hard_iteration_limit,
-                        ),
-                }
-            }
-        };
-
-        Ok(Self { mode })
+        Ok(Self {
+            mode: RecursorDnsHandle::build_recursor_mode(
+                roots,
+                Arc::new(TlsConfig::new()?),
+                builder,
+            )?,
+        })
     }
 
     /// Perform a recursive resolution
@@ -546,7 +488,7 @@ impl<P: ConnectionProvider> Recursor<P> {
     }
 }
 
-enum RecursorMode<P: ConnectionProvider> {
+pub(super) enum RecursorMode<P: ConnectionProvider> {
     NonValidating {
         handle: RecursorDnsHandle<P>,
     },

--- a/crates/server/src/store/recursor.rs
+++ b/crates/server/src/store/recursor.rs
@@ -79,7 +79,8 @@ impl<P: RuntimeProvider> RecursiveZoneHandler<P> {
 
         let recursor = builder
             .dnssec_policy(config.dnssec_policy.load().map_err(|e| e.to_string())?)
-            .nameserver_filter(config.allow_server.iter(), config.deny_server.iter())
+            .deny_servers(config.deny_server.iter())
+            .allow_servers(config.allow_server.iter())
             .recursion_limit(match config.recursion_limit {
                 0 => None,
                 limit => Some(limit),


### PR DESCRIPTION
First, untangle the default recommended filters from the builder method that allows extending the filters with additional IP networks. I bumped into this in the next commit when I was updating a unit test that previously side-stepped the builder that failed when I converted it to use it. The root cause was the surprising way that `RecursorBuilder::nameserver_filter()` applied defaults in addition to the networks the user provides. See the commit message for more detail.

Second, rejig the `RecursorDnsHandle` construction to use the `RecursorBuilder` and return a `RecursorMode`. In practice, 98% of the arguments to `RecursorDnsHandle::new()` were coming directly from the builder, and then a few additional ones were used to build the `RecursorMode`. Instead, pass the whole builder into the `RecursorDnsHandle` and return the `RecursorMode` that wraps the constructed handle. This requires promoting some pieces of `recursor.rs` to `pub(super)`. Alternatively we could consider folding `recursor_dns_handle.rs` into `recursor.rs` since they're so closely intertwined.