### PR TITLE
replace manual Default impl for enums

### DIFF
--- a/conformance/dns-test/src/implementation.rs
+++ b/conformance/dns-test/src/implementation.rs
@@ -59,7 +59,7 @@ pub enum Role {
     Forwarder,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum Implementation {
     Bind,
     Dnslib,
@@ -68,6 +68,7 @@ pub enum Implementation {
         crypto_provider: HickoryCryptoProvider,
     },
     Pdns,
+    #[default]
     Unbound,
     EdeDotCom,
 }
@@ -423,10 +424,4 @@ pub fn Repository(input: impl Into<Cow<'static, str>>) -> Repository<'static> {
         "{input} is not a valid repository"
     );
     Repository { inner: input }
-}
-
-impl Default for Implementation {
-    fn default() -> Self {
-        Self::Unbound
-    }
 }

--- a/crates/proto/src/dnssec/rdata/key.rs
+++ b/crates/proto/src/dnssec/rdata/key.rs
@@ -516,22 +516,17 @@ impl From<KEY> for RData {
 
 /// Specifies in what contexts this key may be trusted for use
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum KeyTrust {
     /// Use of the key is prohibited for authentication
     NotAuth,
     /// Use of the key is prohibited for confidentiality
     NotPrivate,
     /// Use of the key for authentication and/or confidentiality is permitted
+    #[default]
     AuthOrPrivate,
     /// If both bits are one, the "no key" value, (revocation?)
     DoNotTrust,
-}
-
-impl Default for KeyTrust {
-    fn default() -> Self {
-        Self::AuthOrPrivate
-    }
 }
 
 impl From<u16> for KeyTrust {
@@ -567,7 +562,7 @@ impl From<KeyTrust> for u16 {
 }
 
 /// Declares what this key is for
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum KeyUsage {
     /// key associated with a "user" or "account" at an end entity, usually a host
@@ -576,15 +571,10 @@ pub enum KeyUsage {
     #[deprecated = "For Zone signing DNSKEY should be used"]
     Zone,
     /// associated with the non-zone "entity" whose name is the RR owner name
+    #[default]
     Entity,
     /// Reserved
     Reserved,
-}
-
-impl Default for KeyUsage {
-    fn default() -> Self {
-        Self::Entity
-    }
 }
 
 impl From<u16> for KeyUsage {
@@ -823,7 +813,7 @@ impl From<UpdateScope> for u16 {
 /// All Protocol Octet values except DNSSEC (3) are eliminated
 /// ```
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum Protocol {
     /// Not in use
     #[deprecated = "Deprecated by RFC3445"]
@@ -835,6 +825,7 @@ pub enum Protocol {
     #[deprecated = "Deprecated by RFC3445"]
     Email,
     /// Reserved for use with DNSSEC (Hickory DNS only supports DNSKEY with DNSSEC)
+    #[default]
     DNSSEC,
     /// Reserved to refer to the Oakley/IPSEC
     #[deprecated = "Deprecated by RFC3445"]
@@ -845,12 +836,6 @@ pub enum Protocol {
     /// the key can be used in connection with any protocol
     #[deprecated = "Deprecated by RFC3445"]
     All,
-}
-
-impl Default for Protocol {
-    fn default() -> Self {
-        Self::DNSSEC
-    }
 }
 
 impl From<u8> for Protocol {

--- a/crates/proto/src/op/response_code.rs
+++ b/crates/proto/src/op/response_code.rs
@@ -61,11 +61,12 @@ use serde::{Deserialize, Serialize};
 ///
 ///                 6-15            Reserved for future use.
 ///  ```
-#[derive(Debug, Eq, PartialEq, PartialOrd, Copy, Clone, Hash)]
+#[derive(Debug, Default, Eq, PartialEq, PartialOrd, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[allow(dead_code)]
 pub enum ResponseCode {
     /// No Error [RFC 1035](https://tools.ietf.org/html/rfc1035)
+    #[default]
     NoError,
 
     /// Format Error [RFC 1035](https://tools.ietf.org/html/rfc1035)
@@ -182,12 +183,6 @@ impl ResponseCode {
             Self::BADCOOKIE => "Bad server cookie", // 23    BADCOOKIE     Bad/missing Server Cookie           [RFC7873]
             Self::Unknown(_) => "Unknown response code",
         }
-    }
-}
-
-impl Default for ResponseCode {
-    fn default() -> Self {
-        Self::NoError
     }
 }
 

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -607,7 +607,7 @@ fn default_recursion_desired() -> bool {
 }
 
 /// The lookup ip strategy
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum LookupIpStrategy {
     /// Only query for A (Ipv4) records
@@ -615,6 +615,7 @@ pub enum LookupIpStrategy {
     /// Only query for AAAA (Ipv6) records
     Ipv6Only,
     /// Query for A and AAAA in parallel
+    #[default]
     Ipv4AndIpv6,
     /// Query for Ipv6 if that fails, query for Ipv4
     Ipv6thenIpv4,
@@ -622,20 +623,14 @@ pub enum LookupIpStrategy {
     Ipv4thenIpv6,
 }
 
-impl Default for LookupIpStrategy {
-    /// Returns [`LookupIpStrategy::Ipv4thenIpv6`] as the default.
-    fn default() -> Self {
-        Self::Ipv4thenIpv6
-    }
-}
-
 /// The strategy for establishing the query order of name servers in a pool.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[non_exhaustive]
 pub enum ServerOrderingStrategy {
     /// Servers are ordered based on collected query statistics. The ordering
     /// may vary over time.
+    #[default]
     QueryStatistics,
     /// The order provided to the resolver is used. The ordering does not vary
     /// over time.
@@ -643,13 +638,6 @@ pub enum ServerOrderingStrategy {
     /// The order of servers is rotated in a round-robin fashion. This is useful for
     /// load balancing and ensuring that all servers are used evenly.
     RoundRobin,
-}
-
-impl Default for ServerOrderingStrategy {
-    /// Returns [`ServerOrderingStrategy::QueryStatistics`] as the default.
-    fn default() -> Self {
-        Self::QueryStatistics
-    }
 }
 
 /// Whether the system hosts file should be respected by the resolver.

--- a/crates/server/src/zone_handler/auth_lookup.rs
+++ b/crates/server/src/zone_handler/auth_lookup.rs
@@ -18,10 +18,11 @@ use crate::zone_handler::LookupOptions;
 
 /// The result of a lookup on a ZoneHandler
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 #[non_exhaustive]
 pub enum AuthLookup {
     /// No records
+    #[default]
     Empty,
     // TODO: change the result of a lookup to a set of chained iterators...
     /// Records
@@ -109,12 +110,6 @@ impl AuthLookup {
 impl From<Lookup> for AuthLookup {
     fn from(lookup: Lookup) -> Self {
         Self::Resolved(lookup)
-    }
-}
-
-impl Default for AuthLookup {
-    fn default() -> Self {
-        Self::Empty
     }
 }
 
@@ -242,9 +237,10 @@ impl<'r> Iterator for AxfrRecordsIter<'r> {
 }
 
 /// The result of a lookup
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum LookupRecords {
     /// The empty set of records
+    #[default]
     Empty,
     /// The associate records
     Records {
@@ -285,12 +281,6 @@ impl LookupRecords {
     /// Conversion to an iterator
     pub fn iter(&self) -> LookupRecordsIter<'_> {
         self.into_iter()
-    }
-}
-
-impl Default for LookupRecords {
-    fn default() -> Self {
-        Self::Empty
     }
 }
 


### PR DESCRIPTION
Use the `#[default]` syntax on a variant and a derived `Default` instead.