### PR TITLE
don't use two packets to send request over TCP

### DIFF
--- a/crates/proto/src/runtime.rs
+++ b/crates/proto/src/runtime.rs
@@ -35,7 +35,7 @@ pub fn spawn_bg<F: Future<Output = R> + Send + 'static, R: Send + 'static>(
 pub mod iocompat {
     use core::pin::Pin;
     use core::task::{Context, Poll};
-    use std::io;
+    use std::io::{self, IoSlice};
 
     use futures_io::{AsyncRead, AsyncWrite};
     use tokio::io::{AsyncRead as TokioAsyncRead, AsyncWrite as TokioAsyncWrite, ReadBuf};
@@ -64,6 +64,13 @@ pub mod iocompat {
             buf: &[u8],
         ) -> Poll<io::Result<usize>> {
             Pin::new(&mut self.0).poll_write(cx, buf)
+        }
+        fn poll_write_vectored(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            bufs: &[IoSlice<'_>],
+        ) -> Poll<io::Result<usize>> {
+            Pin::new(&mut self.0).poll_write_vectored(cx, bufs)
         }
         fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
             Pin::new(&mut self.0).poll_flush(cx)

--- a/crates/proto/src/tcp/tcp_stream.rs
+++ b/crates/proto/src/tcp/tcp_stream.rs
@@ -15,7 +15,7 @@ use core::time::Duration;
 use std::io;
 use std::net::SocketAddr;
 
-use futures_io::{AsyncRead, AsyncWrite};
+use futures_io::{AsyncRead, AsyncWrite, IoSlice};
 use futures_util::stream::Stream;
 use futures_util::{self, future::Future, ready};
 use tracing::{debug, trace};
@@ -195,8 +195,11 @@ impl<S: DnsTcpStream> Stream for TcpStream<S> {
             if send_state.is_some() {
                 // sending...
                 match send_state {
-                    Some(WriteTcpState::LenBytes { pos, length, .. }) => {
-                        let wrote = ready!(socket.as_mut().poll_write(cx, &length[*pos..]))?;
+                    Some(WriteTcpState::LenBytes { pos, length, bytes }) => {
+                        let wrote = ready!(socket.as_mut().poll_write_vectored(
+                            cx,
+                            &[IoSlice::new(&length[*pos..]), IoSlice::new(bytes)]
+                        ))?;
                         *pos += wrote;
                     }
                     Some(WriteTcpState::Bytes { pos, bytes }) => {
@@ -217,8 +220,13 @@ impl<S: DnsTcpStream> Stream for TcpStream<S> {
                     Some(WriteTcpState::LenBytes { pos, length, bytes }) => {
                         if pos < length.len() {
                             *send_state = Some(WriteTcpState::LenBytes { pos, length, bytes });
+                        } else if pos < length.len() + bytes.len() {
+                            *send_state = Some(WriteTcpState::Bytes {
+                                pos: pos - length.len(),
+                                bytes,
+                            });
                         } else {
-                            *send_state = Some(WriteTcpState::Bytes { pos: 0, bytes });
+                            *send_state = Some(WriteTcpState::Flushing);
                         }
                     }
                     Some(WriteTcpState::Bytes { pos, bytes }) => {


### PR DESCRIPTION
The TCP socket is in NODELAY mode, so the OS sends a new packet for
every write().   TcpStream first write()'s the length (2 bytes) and then
the packet, resulting in extraneous packets on the wire.

~~minimal POC fix:  this leaves the WriteTcpState::LenBytes enum value
unused, it should be deleted.   Also, there's likely a way to avoid
copying the bytes into a second buffer.~~