### PR TITLE
resolver: abstract NS conn/conn config policy

### DIFF
--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -18,7 +18,7 @@ use parking_lot::Mutex as SyncMutex;
 use tokio::time::{Duration, Instant};
 use tracing::debug;
 
-use crate::config::{NameServerConfig, ProtocolConfig, ResolverOpts, ServerOrderingStrategy};
+use crate::config::{ConnectionConfig, NameServerConfig, ResolverOpts, ServerOrderingStrategy};
 use crate::name_server::connection_provider::{ConnectionProvider, TlsConfig};
 use crate::proto::{
     DnsError, NoRecords, ProtoError, ProtoErrorKind,
@@ -75,9 +75,9 @@ impl<P: ConnectionProvider> NameServer<P> {
     pub(super) async fn send(
         self: Arc<Self>,
         request: DnsRequest,
-        skip_udp: bool,
+        policy: ConnectionPolicy,
     ) -> Result<DnsResponse, ProtoError> {
-        let (handle, meta) = self.connected_mut_client(skip_udp).await?;
+        let (handle, meta) = self.connected_mut_client(policy).await?;
         let now = Instant::now();
         let response = handle.send(request).first_answer().await;
         let rtt = now.elapsed();
@@ -151,30 +151,17 @@ impl<P: ConnectionProvider> NameServer<P> {
     /// If the connection is in a failed state, then this will establish a new connection
     async fn connected_mut_client(
         &self,
-        skip_udp: bool,
+        policy: ConnectionPolicy,
     ) -> Result<(P::Conn, Arc<ConnectionMeta>), ProtoError> {
         let mut connections = self.connections.lock().await;
         connections.retain(|conn| matches!(conn.meta.status(), Status::Init | Status::Established));
-        if !connections.is_empty() {
-            connections.sort_by(|a, b| match (a.protocol, b.protocol) {
-                (ap, bp) if ap == bp => a.meta.srtt.current().total_cmp(&b.meta.srtt.current()),
-                (Protocol::Udp, _) => cmp::Ordering::Less,
-                (_, Protocol::Udp) => cmp::Ordering::Greater,
-                (_, _) => a.meta.srtt.current().total_cmp(&b.meta.srtt.current()),
-            });
-
-            let conn = connections.first().unwrap(); // safe to unwrap because we only get here if `connections` is not empty
-            if !(skip_udp && conn.protocol == Protocol::Udp) {
-                return Ok((conn.handle.clone(), conn.meta.clone()));
-            }
+        if let Some(conn) = policy.select_connection(&connections) {
+            return Ok((conn.handle.clone(), conn.meta.clone()));
         }
 
         debug!(config = ?self.config, "connecting");
-        let config = self
-            .config
-            .connections
-            .iter()
-            .find(|conn| !(matches!(conn.protocol, ProtocolConfig::Udp) && skip_udp))
+        let config = policy
+            .select_connection_config(&self.config.connections)
             .ok_or_else(|| ProtoError::from(ProtoErrorKind::NoConnections))?;
 
         let handle = Box::pin(self.connection_provider.new_connection(
@@ -442,6 +429,62 @@ impl From<u8> for Status {
     }
 }
 
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
+pub(crate) struct ConnectionPolicy {
+    pub(crate) disable_udp: bool,
+}
+
+impl ConnectionPolicy {
+    /// Checks if the given server has any protocols compatible with current policy.
+    pub(crate) fn allows_server<P: ConnectionProvider>(&self, server: &NameServer<P>) -> bool {
+        server.protocols().any(|p| self.allows_protocol(p))
+    }
+
+    /// Select the best pre-existing connection to use.
+    ///
+    /// This choice is made based on protocol policy, and the SRTT performance metrics.
+    fn select_connection<'a, P: ConnectionProvider>(
+        &self,
+        connections: &'a [ConnectionState<P>],
+    ) -> Option<&'a ConnectionState<P>> {
+        connections
+            .iter()
+            .filter(|conn| self.allows_protocol(conn.protocol))
+            .min_by(|a, b| self.compare_connections(a, b))
+    }
+
+    /// Select the best connection configuration to use for a new connection.
+    ///
+    /// This choice is made based on protocol policy.
+    fn select_connection_config<'a>(
+        &self,
+        connection_configs: &'a [ConnectionConfig],
+    ) -> Option<&'a ConnectionConfig> {
+        connection_configs
+            .iter()
+            .find(|c| self.allows_protocol(c.protocol.to_protocol()))
+    }
+
+    /// Checks if the given protocol is allowed by current policy.
+    fn allows_protocol(&self, protocol: Protocol) -> bool {
+        !(self.disable_udp && protocol == Protocol::Udp)
+    }
+
+    /// Compare two connections according to policy and performance.
+    fn compare_connections<P: ConnectionProvider>(
+        &self,
+        a: &ConnectionState<P>,
+        b: &ConnectionState<P>,
+    ) -> cmp::Ordering {
+        match (a.protocol, b.protocol) {
+            (ap, bp) if ap == bp => a.meta.srtt.current().total_cmp(&b.meta.srtt.current()),
+            (Protocol::Udp, _) => cmp::Ordering::Less,
+            (_, Protocol::Udp) => cmp::Ordering::Greater,
+            _ => a.meta.srtt.current().total_cmp(&b.meta.srtt.current()),
+        }
+    }
+}
+
 #[cfg(all(test, feature = "tokio"))]
 mod tests {
     use std::cmp;
@@ -480,7 +523,7 @@ mod tests {
                     Query::query(name.clone(), RecordType::A),
                     DnsRequestOptions::default(),
                 ),
-                false,
+                ConnectionPolicy::default(),
             )
             .await
             .expect("query failed");
@@ -513,7 +556,7 @@ mod tests {
                         Query::query(name.clone(), RecordType::A),
                         DnsRequestOptions::default(),
                     ),
-                    false
+                    ConnectionPolicy::default(),
                 )
                 .await
                 .is_err()
@@ -579,7 +622,7 @@ mod tests {
                     Query::query(name.clone(), RecordType::NULL),
                     request_options,
                 ),
-                false,
+                ConnectionPolicy::default(),
             )
             .await
             .unwrap();

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -20,10 +20,10 @@ use tracing::debug;
 
 use crate::config::{NameServerConfig, ResolverOpts, ServerOrderingStrategy};
 use crate::name_server::connection_provider::{ConnectionProvider, TlsConfig};
-use crate::name_server::name_server::NameServer;
+use crate::name_server::name_server::{ConnectionPolicy, NameServer};
 use crate::proto::op::{DnsRequest, DnsResponse, ResponseCode};
 use crate::proto::runtime::{RuntimeProvider, Time};
-use crate::proto::xfer::{DnsHandle, Protocol};
+use crate::proto::xfer::DnsHandle;
 use crate::proto::{DnsError, NoRecords, ProtoError, ProtoErrorKind};
 
 /// Abstract interface for mocking purpose
@@ -138,7 +138,7 @@ impl<P: ConnectionProvider> PoolState<P> {
         let mut backoff = Duration::from_millis(20);
         let mut busy = SmallVec::<[Arc<NameServer<P>>; 2]>::new();
         let mut err = ProtoError::from(ProtoErrorKind::NoConnections);
-        let mut skip_udp = false;
+        let mut policy = ConnectionPolicy::default();
 
         loop {
             // construct the parallel requests, 2 is the default
@@ -147,7 +147,7 @@ impl<P: ConnectionProvider> PoolState<P> {
                 && par_servers.len() < Ord::max(self.options.num_concurrent_reqs, 1)
             {
                 if let Some(server) = servers.pop_front() {
-                    if !(skip_udp && server.protocols().all(|p| p == Protocol::Udp)) {
+                    if policy.allows_server(&server) {
                         par_servers.push(server);
                     }
                 }
@@ -159,10 +159,7 @@ impl<P: ConnectionProvider> PoolState<P> {
                     backoff,
                 )
                 .await;
-                    servers
-                        .extend(busy.drain(..).filter(|ns| {
-                            !(skip_udp && ns.protocols().all(|p| p == Protocol::Udp))
-                        }));
+                    servers.extend(busy.drain(..).filter(|ns| policy.allows_server(ns)));
                     backoff *= 2;
                     continue;
                 }
@@ -172,7 +169,7 @@ impl<P: ConnectionProvider> PoolState<P> {
             let mut requests = par_servers
                 .into_iter()
                 .map(|server| {
-                    let future = server.clone().send(request.clone(), skip_udp);
+                    let future = server.clone().send(request.clone(), policy);
                     async { (server, future.await) }
                 })
                 .collect::<FuturesUnordered<_>>();
@@ -181,7 +178,7 @@ impl<P: ConnectionProvider> PoolState<P> {
                 let e = match result {
                     Ok(response) if response.truncated() => {
                         debug!("truncated response received, retrying over TCP");
-                        skip_udp = true;
+                        policy.disable_udp = true;
                         err = ProtoError::from("received truncated response");
                         servers.push_front(server);
                         continue;
@@ -195,7 +192,7 @@ impl<P: ConnectionProvider> PoolState<P> {
                     // request to try and avoid further spoofing.
                     ProtoErrorKind::QueryCaseMismatch => {
                         servers.push_front(server);
-                        skip_udp = true;
+                        policy.disable_udp = true;
                         continue;
                     }
                     // If the server is busy, try it again later if necessary.


### PR DESCRIPTION
Update the name server pool and name server logic for selecting existing connections, as well as connection configs, to use a more robust encapsulation that can be extended further as more logic is required (e.g. to consider opportunistic encryption).

Extracted from https://github.com/hickory-dns/hickory-dns/pull/3276, but moved into `name_server.rs` and introduced in one commit instead of more gradually and renamed to `ConnectionPolicy`.