### PR TITLE
ci: cargo-all-features 1.10 -> 1.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,7 +165,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-all-features
-          version: 1.10.0
+          version: 1.11.0
 
       - name: cargo check-all-features
         run: cargo check-all-features --n-chunks 4 --chunk ${{ matrix.chunk }}


### PR DESCRIPTION
Fixes some warning annotations [I spotted in CI](https://github.com/hickory-dns/hickory-dns/actions/runs/18022306127):

> cargo-all-features (4)
> New version for cargo-all-features available: 1.11.0