### PR TITLE
Build and test hickory-resolver for android

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -287,3 +287,31 @@ jobs:
 
       - name: Build proto crate for aarch64-unknown-none
         run: just proto-aarch64-none
+
+  cross:
+    name: cross-target building
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - aarch64-linux-android
+          - x86_64-linux-android
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: extractions/setup-just@v3
+
+      - name: Install cross
+        run: just init-cross
+
+      - name: Build crates for ${{ matrix.target }}
+        run: just cross-build ${{ matrix.target }}
+
+      - name: Test android implementation
+        run: just cross-test ${{ matrix.target }} hickory-resolver

--- a/justfile
+++ b/justfile
@@ -282,6 +282,14 @@ ede-dot-com-ignored:
 proto-aarch64-none:
     cargo build --package hickory-proto -v --lib --target aarch64-unknown-none --no-default-features --features=no-std-rand
 
+# builds hickory for a target
+cross-build target:
+    cross build --target {{target}}
+
+# tests the resolver for android
+cross-test target package:
+    cross test --target {{target}} --package {{package}}
+
 [private]
 [macos]
 init-openssl:
@@ -344,6 +352,10 @@ init-cargo-workspaces:
 # Install audit tools
 init-audit:
     @cargo audit --version || cargo install cargo-audit
+
+# Install cross compilation tool. c7dee4d is known to work, current release (0.2.5) causes linking problems
+init-cross:
+    cross --version || cargo install cross --rev c7dee4d --git https://github.com/cross-rs/cross
 
 # Install the code coverage components for LLVM
 init-llvm-cov:


### PR DESCRIPTION
This is a PR to add support for building and testing the hickory-resolver for the Android targets.

This currently call `cross` directly but I get the sense that I should create a `just` command instead. Is me assessment correct?
While this won't test the resolver itself (there is no NDK context in a basic test), I can know nothing broke.

I can try to get it to build a proper Android app and test in an emulator if desired.

Thanks!