### PR TITLE
resolver: introduce PoolContext

### DIFF
--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -206,11 +206,7 @@ impl<P: ConnectionProvider> Recursor<P> {
 
     fn build(roots: &[IpAddr], builder: RecursorBuilder<P>) -> Result<Self, Error> {
         Ok(Self {
-            mode: RecursorDnsHandle::build_recursor_mode(
-                roots,
-                Arc::new(TlsConfig::new()?),
-                builder,
-            )?,
+            mode: RecursorDnsHandle::build_recursor_mode(roots, TlsConfig::new()?, builder)?,
         })
     }
 

--- a/crates/recursor/src/recursor_dns_handle.rs
+++ b/crates/recursor/src/recursor_dns_handle.rs
@@ -62,7 +62,7 @@ pub(crate) struct RecursorDnsHandle<P: ConnectionProvider> {
 impl<P: ConnectionProvider> RecursorDnsHandle<P> {
     pub(super) fn build_recursor_mode(
         roots: &[IpAddr],
-        tls: Arc<TlsConfig>,
+        tls: TlsConfig,
         builder: RecursorBuilder<P>,
     ) -> Result<RecursorMode<P>, Error> {
         assert!(!roots.is_empty(), "roots must not be empty");
@@ -92,6 +92,7 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
             "Using cache sizes {}/{}",
             ns_cache_size, response_cache_size
         );
+        let tls = Arc::new(tls);
         let roots = NameServerPool::from_config(
             servers,
             Arc::new(recursor_opts(

--- a/crates/recursor/src/recursor_pool.rs
+++ b/crates/recursor/src/recursor_pool.rs
@@ -47,7 +47,7 @@ impl Future for SharedLookup {
 #[derive(Clone)]
 pub(crate) struct RecursorPool<P: ConnectionProvider> {
     zone: Name,
-    pub(super) ns: NameServerPool<P>,
+    ns: NameServerPool<P>,
     active_requests: Arc<Mutex<HashMap<Query, SharedLookup>>>,
     #[cfg(feature = "metrics")]
     outgoing_query_counter: Counter,
@@ -85,7 +85,7 @@ impl<P: ConnectionProvider> RecursorPool<P> {
         let ns = self.ns.clone();
 
         let query_cpy = query.clone();
-        let case_randomization = self.ns.options().case_randomization;
+        let case_randomization = self.ns.context().options.case_randomization;
 
         // block concurrent requests
         let lookup = self

--- a/crates/recursor/src/recursor_pool.rs
+++ b/crates/recursor/src/recursor_pool.rs
@@ -47,7 +47,7 @@ impl Future for SharedLookup {
 #[derive(Clone)]
 pub(crate) struct RecursorPool<P: ConnectionProvider> {
     zone: Name,
-    ns: NameServerPool<P>,
+    pub(super) ns: NameServerPool<P>,
     active_requests: Arc<Mutex<HashMap<Query, SharedLookup>>>,
     #[cfg(feature = "metrics")]
     outgoing_query_counter: Counter,

--- a/crates/resolver/src/name_server/mod.rs
+++ b/crates/resolver/src/name_server/mod.rs
@@ -13,4 +13,4 @@ pub use connection_provider::{ConnectionProvider, TlsConfig};
 mod name_server;
 pub use name_server::NameServer;
 mod name_server_pool;
-pub use name_server_pool::NameServerPool;
+pub use name_server_pool::{NameServerPool, PoolContext};

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -69,7 +69,7 @@ impl<P: ConnectionProvider> NameServerPool<P> {
     }
 
     /// Returns the pool's options.
-    pub fn options(&self) -> &ResolverOpts {
+    pub fn options(&self) -> &Arc<ResolverOpts> {
         &self.state.options
     }
 }

--- a/tests/integration-tests/src/mock_client.rs
+++ b/tests/integration-tests/src/mock_client.rs
@@ -27,8 +27,8 @@ use hickory_proto::runtime::{RuntimeProvider, TokioHandle};
 use hickory_proto::tcp::DnsTcpStream;
 use hickory_proto::udp::DnsUdpSocket;
 use hickory_proto::xfer::DnsHandle;
-use hickory_resolver::config::{ConnectionConfig, ResolverOpts};
-use hickory_resolver::name_server::{ConnectionProvider, TlsConfig};
+use hickory_resolver::config::ConnectionConfig;
+use hickory_resolver::name_server::{ConnectionProvider, PoolContext};
 
 pub struct TcpPlaceholder;
 
@@ -135,8 +135,7 @@ impl<O: OnSend + Unpin> ConnectionProvider for MockConnProvider<O> {
         &self,
         _: IpAddr,
         _config: &ConnectionConfig,
-        _options: &ResolverOpts,
-        _tls: &TlsConfig,
+        _cx: &PoolContext,
     ) -> Result<Self::FutureConn, io::Error> {
         println!("MockConnProvider::new_connection");
         Ok(Box::pin(future::ok(MockClientHandle::mock_on_send(

--- a/tests/integration-tests/tests/integration/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/integration/name_server_pool_tests.rs
@@ -110,13 +110,7 @@ fn mock_nameserver_on_send_nx<O: OnSend + Unpin>(
     }
 
     let config = NameServerConfig::new(ip, trust_negative_responses, configs);
-    Arc::new(NameServer::new(
-        conns,
-        config,
-        Arc::new(options),
-        Arc::new(TlsConfig::new().unwrap()),
-        conn_provider,
-    ))
+    Arc::new(NameServer::new(conns, config, &options, conn_provider))
 }
 
 #[cfg(test)]
@@ -134,7 +128,11 @@ fn mock_nameserver_pool_on_send<O: OnSend + Unpin>(
     _mdns: Option<MockedNameServer<O>>,
     options: ResolverOpts,
 ) -> MockedNameServerPool<O> {
-    NameServerPool::from_nameservers(servers, Arc::new(options))
+    NameServerPool::from_nameservers(
+        servers,
+        Arc::new(options),
+        Arc::new(TlsConfig::new().unwrap()),
+    )
 }
 
 #[test]

--- a/tests/integration-tests/tests/integration/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/integration/name_server_pool_tests.rs
@@ -19,7 +19,7 @@ use hickory_proto::{DnsError, NoRecords, ProtoError, ProtoErrorKind};
 use hickory_resolver::config::{
     ConnectionConfig, NameServerConfig, ProtocolConfig, ResolverOpts, ServerOrderingStrategy,
 };
-use hickory_resolver::name_server::{NameServer, NameServerPool, TlsConfig};
+use hickory_resolver::name_server::{NameServer, NameServerPool, PoolContext, TlsConfig};
 use test_support::subscribe;
 
 const DEFAULT_SERVER_ADDR: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
@@ -130,8 +130,7 @@ fn mock_nameserver_pool_on_send<O: OnSend + Unpin>(
 ) -> MockedNameServerPool<O> {
     NameServerPool::from_nameservers(
         servers,
-        Arc::new(options),
-        Arc::new(TlsConfig::new().unwrap()),
+        Arc::new(PoolContext::new(options, TlsConfig::new().unwrap())),
     )
 }
 


### PR DESCRIPTION
I think this can accomodate further additional state that needs to be shared across multiple name server pools.