### PR TITLE
Do not resolve private/reserved addresses on public zones

### DIFF
--- a/conformance/dns-test/src/templates/hickory.resolver.toml.jinja
+++ b/conformance/dns-test/src/templates/hickory.resolver.toml.jinja
@@ -13,5 +13,6 @@ dnssec_policy.ValidateWithStaticKey.path = "/etc/trusted-key.key"
 {% else %}
 dnssec_policy = "ValidationDisabled"
 {% endif %}
+allow_answers = ["0.0.0.0/0"]
 allow_server = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
 case_randomization = {{ case_randomization }}

--- a/crates/recursor/src/lib.rs
+++ b/crates/recursor/src/lib.rs
@@ -33,6 +33,8 @@ mod recursor;
 mod recursor_dns_handle;
 pub(crate) mod recursor_pool;
 
+use std::net::IpAddr;
+
 #[cfg(feature = "__dnssec")]
 use std::sync::Arc;
 
@@ -47,8 +49,11 @@ use proto::{
     rr::Record,
 };
 pub use recursor::{Recursor, RecursorBuilder};
+
+use ipnet::{IpNet, Ipv4Net, Ipv6Net};
+use prefix_trie::PrefixSet;
 use resolver::Name;
-use tracing::warn;
+use tracing::{debug, warn};
 
 /// `Recursor`'s DNSSEC policy
 // `Copy` can only be implemented when `dnssec` is disabled we don't want to remove a trait
@@ -82,6 +87,79 @@ pub enum DnssecPolicy {
 impl DnssecPolicy {
     pub(crate) fn is_security_aware(&self) -> bool {
         !matches!(self, Self::SecurityUnaware)
+    }
+}
+
+/// An IPv4/IPv6 access control set.  This mainly hides the complexity of supporting v4 and v6
+/// addresses concurrently in a given set.  The AccessControlSet differs from a typical Access
+/// Control List in that there is no order.  The access semantics are:
+///
+/// +-----------------------+----------------------+----------+
+/// | Present in allow list | Present in deny list |  Result  |
+/// +-----------------------+----------------------+----------+
+/// |                  true |                false |  allowed |
+/// |                  true |                 true |  allowed |
+/// |                 false |                false |  allowed |
+/// |                 false |                 true |   denied |
+/// +-----------------------+----------------------+----------+
+#[derive(Clone)]
+pub(crate) struct AccessControlSet {
+    v4_allow: PrefixSet<Ipv4Net>,
+    v4_deny: PrefixSet<Ipv4Net>,
+    v6_allow: PrefixSet<Ipv6Net>,
+    v6_deny: PrefixSet<Ipv6Net>,
+}
+
+impl AccessControlSet {
+    pub(crate) fn new(name: &'static str, allow: &[IpNet], deny: &[IpNet]) -> Self {
+        let mut v4_allow = PrefixSet::new();
+        let mut v4_deny = PrefixSet::new();
+        let mut v6_allow = PrefixSet::new();
+        let mut v6_deny = PrefixSet::new();
+
+        for network in allow {
+            debug!("adding {network} to the {name} list");
+            match network {
+                IpNet::V4(network) => {
+                    v4_allow.insert(*network);
+                }
+                IpNet::V6(network) => {
+                    v6_allow.insert(*network);
+                }
+            }
+        }
+
+        for network in deny {
+            debug!("adding {network} to the {name} list");
+            match network {
+                IpNet::V4(network) => {
+                    v4_deny.insert(*network);
+                }
+                IpNet::V6(network) => {
+                    v6_deny.insert(*network);
+                }
+            }
+        }
+
+        Self {
+            v4_allow,
+            v4_deny,
+            v6_allow,
+            v6_deny,
+        }
+    }
+
+    pub(crate) fn denied(&self, ip: IpAddr) -> bool {
+        match ip {
+            IpAddr::V4(ip) => {
+                self.v4_allow.get_spm(&ip.into()).is_none()
+                    && self.v4_deny.get_spm(&ip.into()).is_some()
+            }
+            IpAddr::V6(ip) => {
+                self.v6_allow.get_spm(&ip.into()).is_none()
+                    && self.v6_deny.get_spm(&ip.into()).is_some()
+            }
+        }
     }
 }
 

--- a/crates/recursor/src/recursor.rs
+++ b/crates/recursor/src/recursor.rs
@@ -53,6 +53,8 @@ pub struct RecursorBuilder<P: ConnectionProvider> {
     /// Setting it to None will disable the recursion limit check, and is not recommended.
     pub(super) ns_recursion_limit: Option<u8>,
     pub(super) dnssec_policy: DnssecPolicy,
+    pub(super) allow_answers: Vec<IpNet>,
+    pub(super) deny_answers: Vec<IpNet>,
     pub(super) allow_servers: Vec<IpNet>,
     pub(super) deny_servers: Vec<IpNet>,
     pub(super) avoid_local_udp_ports: HashSet<u16>,
@@ -91,6 +93,44 @@ impl<P: ConnectionProvider> RecursorBuilder<P> {
     /// Sets the DNSSEC policy
     pub fn dnssec_policy(mut self, dnssec_policy: DnssecPolicy) -> Self {
         self.dnssec_policy = dnssec_policy;
+        self
+    }
+
+    /// Allow listed addresses in responses during recursive resolution.
+    ///
+    /// The provided `allow` networks will be added to any existing networks that were added by
+    /// previous calls to [`Self::allow_answers`].
+    ///
+    /// Allowed networks take precedence over deny networks added with [`Self::deny_answers`].
+    pub fn allow_answers<'a>(mut self, allow: impl Iterator<Item = &'a IpNet>) -> Self {
+        self.allow_answers.extend(allow);
+        self
+    }
+
+    /// Deny listed addresses in responses during recursive resolution.
+    ///
+    /// The provided `deny` networks will be added to any existing networks denied
+    /// by default, or that were added by previous calls to [`Self::deny_answers`].
+    pub fn deny_answers<'a>(mut self, deny: impl Iterator<Item = &'a IpNet>) -> Self {
+        self.deny_answers.extend(deny);
+        self
+    }
+
+    /// Clear the networks that should be allowed as answers during recursive resolution.
+    ///
+    /// This will remove any allow filter networks previously added by [`Self::allow_answers`],
+    pub fn clear_allow_answerss(mut self) -> Self {
+        self.allow_answers.clear();
+        self
+    }
+
+    /// Clear the networks that should not be allowed as answers during recursive resolution.
+    ///
+    /// This will remove any deny filter networks previously added by [`Self::deny_answers`],
+    /// as well as the default recommended server filters (internal networks, broadcast addresses,
+    /// etc.)
+    pub fn clear_deny_answers(mut self) -> Self {
+        self.deny_answers.clear();
         self
     }
 
@@ -189,6 +229,8 @@ impl<P: ConnectionProvider> Recursor<P> {
             recursion_limit: Some(24),
             ns_recursion_limit: Some(24),
             dnssec_policy: DnssecPolicy::SecurityUnaware,
+            allow_answers: vec![],
+            deny_answers: RECOMMENDED_SERVER_FILTERS.to_vec(),
             allow_servers: vec![],
             deny_servers: RECOMMENDED_SERVER_FILTERS.to_vec(),
             avoid_local_udp_ports: HashSet::new(),

--- a/crates/recursor/src/recursor_dns_handle.rs
+++ b/crates/recursor/src/recursor_dns_handle.rs
@@ -11,18 +11,16 @@ use std::{
 use async_recursion::async_recursion;
 use futures_util::{StreamExt, stream::FuturesUnordered};
 use hickory_resolver::name_server::TlsConfig;
-use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use lru_cache::LruCache;
 #[cfg(feature = "metrics")]
 use metrics::{Counter, Unit, counter, describe_counter};
 use parking_lot::Mutex;
-use prefix_trie::PrefixSet;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, trace, warn};
 
 #[cfg(feature = "__dnssec")]
 use crate::proto::dnssec::{DnssecDnsHandle, TrustAnchors};
 use crate::{
-    DnssecPolicy, Error, ErrorKind, RecursorBuilder,
+    AccessControlSet, DnssecPolicy, Error, ErrorKind, RecursorBuilder,
     proto::{
         op::{Message, Query},
         rr::{
@@ -51,10 +49,7 @@ pub(crate) struct RecursorDnsHandle<P: ConnectionProvider> {
     recursion_limit: Option<u8>,
     ns_recursion_limit: Option<u8>,
     security_aware: bool,
-    deny_server_v4: PrefixSet<Ipv4Net>,
-    deny_server_v6: PrefixSet<Ipv6Net>,
-    allow_server_v4: PrefixSet<Ipv4Net>,
-    allow_server_v6: PrefixSet<Ipv6Net>,
+    name_server_filter: AccessControlSet,
     avoid_local_udp_ports: Arc<HashSet<u16>>,
     case_randomization: bool,
     tls: Arc<TlsConfig>,
@@ -106,35 +101,8 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
         let name_server_cache = Arc::new(Mutex::new(LruCache::new(ns_cache_size)));
         let response_cache = ResponseCache::new(response_cache_size, ttl_config.clone());
 
-        let mut deny_server_v4 = PrefixSet::new();
-        let mut deny_server_v6 = PrefixSet::new();
-
-        for network in deny_servers {
-            info!("adding {network} to the do not query list");
-            match network {
-                IpNet::V4(network) => {
-                    deny_server_v4.insert(network);
-                }
-                IpNet::V6(network) => {
-                    deny_server_v6.insert(network);
-                }
-            }
-        }
-
-        let mut allow_server_v4 = PrefixSet::new();
-        let mut allow_server_v6 = PrefixSet::new();
-
-        for network in allow_servers {
-            info!("adding {network} to the do not query override list");
-            match network {
-                IpNet::V4(network) => {
-                    allow_server_v4.insert(network);
-                }
-                IpNet::V6(network) => {
-                    allow_server_v6.insert(network);
-                }
-            }
-        }
+        let name_server_filter =
+            AccessControlSet::new("name_server_filter", &allow_servers, &deny_servers);
 
         let handle = Self {
             roots,
@@ -145,10 +113,7 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
             recursion_limit,
             ns_recursion_limit,
             security_aware: dnssec_policy.is_security_aware(),
-            deny_server_v4,
-            deny_server_v6,
-            allow_server_v4,
-            allow_server_v6,
+            name_server_filter,
             avoid_local_udp_ports,
             case_randomization,
             tls,
@@ -589,28 +554,13 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
                 RData::AAAA(AAAA(ipv6)) => (*ipv6).into(),
                 _ => continue,
             };
-            if self.matches_nameserver_filter(ip) {
+            if self.name_server_filter.denied(ip) {
                 debug!(name = %record.name(), %ip, "ignoring address due to do_not_query");
                 continue;
             }
             let ns_glue_ips = glue_map.entry(record.name().clone()).or_default();
             if !ns_glue_ips.contains(&ip) {
                 ns_glue_ips.push(ip);
-            }
-        }
-    }
-
-    /// Check if an IP address matches any networks listed in the configuration that should not be
-    /// sent recursive queries.
-    fn matches_nameserver_filter(&self, ip: IpAddr) -> bool {
-        match ip {
-            IpAddr::V4(ip) => {
-                self.allow_server_v4.get_spm(&ip.into()).is_none()
-                    && self.deny_server_v4.get_spm(&ip.into()).is_some()
-            }
-            IpAddr::V6(ip) => {
-                self.allow_server_v6.get_spm(&ip.into()).is_none()
-                    && self.deny_server_v6.get_spm(&ip.into()).is_some()
             }
         }
     }
@@ -668,7 +618,7 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
                         .filter_map(|answer| {
                             let ip = answer.data().ip_addr()?;
 
-                            if self.matches_nameserver_filter(ip) {
+                            if self.name_server_filter.denied(ip) {
                                 debug!(%ip, "append_ips_from_lookup: ignoring address due to do_not_query");
                                 None
                             } else {
@@ -781,11 +731,11 @@ mod tests {
             [192, 168, 1, 254],
             [172, 17, 0, 1],
         ] {
-            assert!(handle.matches_nameserver_filter(IpAddr::from(addr)));
+            assert!(handle.name_server_filter.denied(IpAddr::from(addr)));
         }
 
         for addr in [[128, 0, 0, 0], [192, 168, 2, 0], [192, 168, 0, 1]] {
-            assert!(!handle.matches_nameserver_filter(IpAddr::from(addr)));
+            assert!(!handle.name_server_filter.denied(IpAddr::from(addr)));
         }
     }
 }

--- a/crates/recursor/src/recursor_dns_handle.rs
+++ b/crates/recursor/src/recursor_dns_handle.rs
@@ -15,7 +15,7 @@ use lru_cache::LruCache;
 #[cfg(feature = "metrics")]
 use metrics::{Counter, Unit, counter, describe_counter};
 use parking_lot::Mutex;
-use tracing::{debug, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 #[cfg(feature = "__dnssec")]
 use crate::proto::dnssec::{DnssecDnsHandle, TrustAnchors};
@@ -49,6 +49,7 @@ pub(crate) struct RecursorDnsHandle<P: ConnectionProvider> {
     recursion_limit: Option<u8>,
     ns_recursion_limit: Option<u8>,
     security_aware: bool,
+    answer_filter: AccessControlSet,
     name_server_filter: AccessControlSet,
     avoid_local_udp_ports: Arc<HashSet<u16>>,
     case_randomization: bool,
@@ -75,6 +76,8 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
             recursion_limit,
             ns_recursion_limit,
             dnssec_policy,
+            allow_answers,
+            deny_answers,
             allow_servers,
             deny_servers,
             avoid_local_udp_ports,
@@ -101,6 +104,8 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
         let name_server_cache = Arc::new(Mutex::new(LruCache::new(ns_cache_size)));
         let response_cache = ResponseCache::new(response_cache_size, ttl_config.clone());
 
+        let answer_filter = AccessControlSet::new("answer_filter", &allow_answers, &deny_answers);
+
         let name_server_filter =
             AccessControlSet::new("name_server_filter", &allow_servers, &deny_servers);
 
@@ -113,6 +118,7 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
             recursion_limit,
             ns_recursion_limit,
             security_aware: dnssec_policy.is_security_aware(),
+            answer_filter,
             name_server_filter,
             avoid_local_udp_ports,
             case_randomization,
@@ -386,7 +392,31 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
         // TODO: should we change DnsHandle to always be a single response? And build a totally custom handler for other situations?
         // TODO: check if data is "authentic"
         match response_future.await {
-            Ok(r) => {
+            Ok(mut r) => {
+                let answer_filter = |record: &Record| {
+                    let ip = match record.data() {
+                        RData::A(A(ipv4)) => (*ipv4).into(),
+                        RData::AAAA(AAAA(ipv6)) => (*ipv6).into(),
+                        _ => return true,
+                    };
+
+                    if self.answer_filter.denied(ip) {
+                        error!(
+                            query = %query,
+                            ip = %ip,
+                            "removing ip from response: answer filter matched"
+                        );
+
+                        false
+                    } else {
+                        true
+                    }
+                };
+
+                // authority filtering is handled by the name_server_filter logic/AccessControlSet
+                r.additionals_mut().retain(answer_filter);
+                r.answers_mut().retain(answer_filter);
+
                 let message = r.into_message();
                 self.response_cache.insert(query, Ok(message.clone()), now);
                 Ok(message)

--- a/crates/server/src/store/recursor.rs
+++ b/crates/server/src/store/recursor.rs
@@ -79,6 +79,8 @@ impl<P: RuntimeProvider> RecursiveZoneHandler<P> {
 
         let recursor = builder
             .dnssec_policy(config.dnssec_policy.load().map_err(|e| e.to_string())?)
+            .allow_answers(config.allow_answers.iter())
+            .deny_answers(config.deny_answers.iter())
             .deny_servers(config.deny_server.iter())
             .allow_servers(config.allow_server.iter())
             .recursion_limit(match config.recursion_limit {
@@ -233,6 +235,14 @@ pub struct RecursiveConfig {
     /// DNSSEC policy
     #[serde(default)]
     pub dnssec_policy: DnssecPolicyConfig,
+
+    /// Networks that will be queried during resolution
+    #[serde(default)]
+    pub allow_answers: Vec<IpNet>,
+
+    /// Networks that will not be queried during resolution
+    #[serde(default)]
+    pub deny_answers: Vec<IpNet>,
 
     /// Networks that will be queried during resolution
     #[serde(default)]


### PR DESCRIPTION
This PR introduces response address filtering (#347) for the recursor.  The main intended use case is to filter out answers in public zones that contain private or reserved addresses.  The configuration logic is identical to the previous referral filtering:

* There is a default list of reserved/private IP addresses.
* Users can disable response filtering entirely by setting deny_answers = []
* Users can add provide a custom set of addresses to deny by setting deny_answers as appropriate (e.g., deny_answers = ["192.168.0.0/16", "172.16.0.0/12", "10.0.0.0/8"]
* Users can override one or more deny list entries by configured allow_answers. (e.g., allow_answers = ["192.168.1.1/32"]

TODO:
[ ] Handle NXDomain cases
[ ] Documentation for new config flags
[ ] Unit test for AccessControlSet
[ ] Conformance tests for new filtering logic
[ ] move recursor bailiwick filtering over/combine with answer filtering
