### PR TITLE
Refactor InMemoryZoneHandler into reusable pieces

### DIFF
--- a/crates/server/src/store/in_memory/mod.rs
+++ b/crates/server/src/store/in_memory/mod.rs
@@ -43,6 +43,7 @@ use crate::{
         serialize::txt::Parser,
     },
     server::{Request, RequestInfo},
+    store::StoreBackendExt,
     zone_handler::{
         AuthLookup, AxfrPolicy, AxfrRecords, LookupControlFlow, LookupError, LookupOptions,
         LookupRecords, ZoneHandler, ZoneTransfer, ZoneType,


### PR DESCRIPTION
This PR is an incremental approach to the first couple commits from #3228. It introduces the `StoreBackend` trait and implements it on `InnerInMemory`. The next steps are to move methods from `InnerInMemory` to the extension trait `StoreBackendExt`, so that they can be reused with zones stored in a file or a database, then turn `InMemoryZoneHandler` into a generic authoritative zone handler. Lastly, items can be renamed, and modules can be rearranged. So far I have moved just one method into `StoreBackendExt`, while keeping it in place textually. I'm posting this as a draft for early feedback on the approach.

Part of #3169.