### PR TITLE
proto: extend Spawn trait to remove hardcoded tokio::spawn calls

### DIFF
--- a/bin/tests/integration/named_https_tests.rs
+++ b/bin/tests/integration/named_https_tests.rs
@@ -71,7 +71,7 @@ fn test_example_https_toml_startup() {
 
         // ipv4 should succeed
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
 
         query_a(&mut io_loop, &mut client);
 

--- a/bin/tests/integration/named_quic_tests.rs
+++ b/bin/tests/integration/named_quic_tests.rs
@@ -61,7 +61,7 @@ fn test_example_quic_toml_startup() {
 
         // ipv4 should succeed
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
 
         query_a(&mut io_loop, &mut client);
 

--- a/bin/tests/integration/named_rustls_tests.rs
+++ b/bin/tests/integration/named_rustls_tests.rs
@@ -69,7 +69,7 @@ fn test_example_tls_toml_startup() {
             let client = Client::<TokioRuntimeProvider>::new(stream, sender, None);
 
             let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-            hickory_proto::runtime::spawn_bg(&io_loop, bg);
+            io_loop.spawn(bg);
 
             // ipv4 should succeed
             query_a(&mut io_loop, &mut client);
@@ -84,7 +84,7 @@ fn test_example_tls_toml_startup() {
             let client = Client::<TokioRuntimeProvider>::new(stream, sender, None);
 
             let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-            hickory_proto::runtime::spawn_bg(&io_loop, bg);
+            io_loop.spawn(bg);
 
             // ipv6 should succeed
             query_a(&mut io_loop, &mut client);

--- a/bin/tests/integration/named_test_rsa_dnssec.rs
+++ b/bin/tests/integration/named_test_rsa_dnssec.rs
@@ -67,14 +67,14 @@ fn generic_test(config_toml: &str, key_path: &str, algorithm: Algorithm) {
         // verify all records are present
         let client = standard_tcp_conn(tcp_port.expect("no tcp port"), provider.clone());
         let (client, bg) = io_loop.block_on(client);
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
         query_all_dnssec(&mut io_loop, client, algorithm);
 
         // test that request with Dnssec client is successful, i.e. validates chain
         let trust_anchor = trust_anchor(&server_path.join(key_path), algorithm);
         let client = standard_tcp_conn(tcp_port.expect("no tcp port"), provider);
         let (client, bg) = io_loop.block_on(client);
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
         let mut client = DnssecDnsHandle::with_trust_anchor(client, trust_anchor);
 
         query_a(&mut io_loop, &mut client);
@@ -200,7 +200,7 @@ fn test_rrsig_ttl() {
         {
             let client = standard_tcp_conn(tcp_port.expect("no tcp port"), provider.clone());
             let (client, bg) = io_loop.block_on(client);
-            hickory_proto::runtime::spawn_bg(&io_loop, bg);
+            io_loop.spawn(bg);
 
             // query www.example.com. expected ttl is 86400.
             let query = Query::query("www.example.com.".parse().unwrap(), RecordType::A);
@@ -234,7 +234,7 @@ fn test_rrsig_ttl() {
         {
             let client = standard_tcp_conn(tcp_port.expect("no tcp port"), provider.clone());
             let (client, bg) = io_loop.block_on(client);
-            hickory_proto::runtime::spawn_bg(&io_loop, bg);
+            io_loop.spawn(bg);
 
             // query shortlived.example.com. expected ttl is 900.
             let query = Query::query("shortlived.example.com.".parse().unwrap(), RecordType::A);

--- a/bin/tests/integration/named_tests.rs
+++ b/bin/tests/integration/named_tests.rs
@@ -34,7 +34,7 @@ fn test_example_toml_startup() {
         let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
 
         query_a(&mut io_loop, &mut client);
 
@@ -44,7 +44,7 @@ fn test_example_toml_startup() {
         let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
 
         query_a(&mut io_loop, &mut client);
     })
@@ -62,7 +62,7 @@ fn test_ipv4_only_toml_startup() {
         let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
 
         // ipv4 should succeed
         query_a(&mut io_loop, &mut client);
@@ -73,7 +73,7 @@ fn test_ipv4_only_toml_startup() {
 
         assert!(io_loop.block_on(client).is_err());
         //let (client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        //hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        //io_loop.spawn(bg);
 
         // ipv6 should fail
         // FIXME: probably need to send something for proper test... maybe use JoinHandle in tokio 0.2
@@ -122,7 +122,7 @@ fn test_ipv4_and_ipv6_toml_startup() {
         let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
         // ipv4 should succeed
         query_a(&mut io_loop, &mut client);
 
@@ -131,7 +131,7 @@ fn test_ipv4_and_ipv6_toml_startup() {
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
         let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
 
         // ipv6 should succeed
         query_a(&mut io_loop, &mut client);
@@ -149,7 +149,7 @@ fn test_nodata_where_name_exists() {
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
         let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
 
         let msg = io_loop
             .block_on(client.query(
@@ -174,7 +174,7 @@ fn test_nxdomain_where_no_name_exists() {
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
         let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
 
         let msg = io_loop
             .block_on(client.query(
@@ -200,7 +200,7 @@ fn test_server_continues_on_bad_data_udp() {
         let stream = UdpClientStream::builder(addr, provider.clone()).build();
         let client = Client::<TokioRuntimeProvider>::connect(stream);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
 
         query_a(&mut io_loop, &mut client);
 
@@ -218,7 +218,7 @@ fn test_server_continues_on_bad_data_udp() {
         let client = Client::<TokioRuntimeProvider>::connect(stream);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
 
         query_a(&mut io_loop, &mut client);
     })
@@ -236,7 +236,7 @@ fn test_server_continues_on_bad_data_tcp() {
         let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
 
         query_a(&mut io_loop, &mut client);
 
@@ -252,7 +252,7 @@ fn test_server_continues_on_bad_data_tcp() {
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
         let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
 
         query_a(&mut io_loop, &mut client);
     })
@@ -274,7 +274,7 @@ fn test_forward() {
         let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
 
         let response = query_message(
             &mut io_loop,
@@ -297,7 +297,7 @@ fn test_forward() {
         let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
 
         let response = query_message(
             &mut io_loop,
@@ -328,7 +328,7 @@ fn test_allow_networks_toml_startup() {
         let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
         // ipv4 should succeed
         query_a(&mut io_loop, &mut client);
 
@@ -337,7 +337,7 @@ fn test_allow_networks_toml_startup() {
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
         let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
 
         // ipv6 should succeed
         query_a(&mut io_loop, &mut client);
@@ -356,7 +356,7 @@ fn test_deny_networks_toml_startup() {
         let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
         // ipv4 should be refused
         query_a_refused(&mut io_loop, &mut client);
 
@@ -365,7 +365,7 @@ fn test_deny_networks_toml_startup() {
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
         let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
 
         // ipv6 should be refused
         query_a_refused(&mut io_loop, &mut client);
@@ -384,7 +384,7 @@ fn test_deny_allow_networks_toml_startup() {
         let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
 
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
         // ipv4 should succeed
         query_a(&mut io_loop, &mut client);
 
@@ -393,7 +393,7 @@ fn test_deny_allow_networks_toml_startup() {
         let (stream, sender) = TcpClientStream::new(addr, None, None, provider.clone());
         let client = Client::<TokioRuntimeProvider>::new(Box::new(stream), sender, None);
         let (mut client, bg) = io_loop.block_on(client).expect("client failed to connect");
-        hickory_proto::runtime::spawn_bg(&io_loop, bg);
+        io_loop.spawn(bg);
 
         // ipv6 should be refused
         query_a_refused(&mut io_loop, &mut client);

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -71,7 +71,7 @@ pub enum Connecting<P: RuntimeProvider> {
         >,
     ),
     #[cfg(all(feature = "__https", feature = "tokio"))]
-    Https(DnsExchangeConnect<HttpsClientConnect<P::Tcp>, HttpsClientStream, P>),
+    Https(DnsExchangeConnect<HttpsClientConnect<P>, HttpsClientStream, P>),
     #[cfg(all(feature = "__quic", feature = "tokio"))]
     Quic(DnsExchangeConnect<QuicClientConnect, QuicClientStream, P>),
     #[cfg(all(feature = "__h3", feature = "tokio"))]

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -184,6 +184,7 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
                     remote_addr,
                     server_name.clone(),
                     path.clone(),
+                    self.clone(),
                 )))
             }
             #[cfg(feature = "__quic")]
@@ -218,7 +219,7 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
                 });
 
                 Connecting::H3(DnsExchange::connect(
-                    H3ClientStream::builder()
+                    H3ClientStream::builder(self.clone())
                         .crypto_config(cx.tls.config.clone())
                         .disable_grease(*disable_grease)
                         .build_with_future(


### PR DESCRIPTION
Part of #3304, aiming to make `proto` less `tokio` dependent.

Removed the uses of `tokio::spawn` by adding a plain `spawn` method to the runtime `Spawn` trait.

The naming might be slightly confusing now between `spawn` and `spawn_bg`. Added a comment to explain the difference in behavior, but maybe renaming `spawn_bg` would be the best option? Or changing `spawn` to `spawn_detached` instead?

Also removed the freestanding `hickory_proto::runtime::spawn_bg` method. Seemed redundant, unless I'm missing something.