### PR TITLE
Fix flaky RRSIG TTL test

### DIFF
--- a/bin/tests/integration/named_test_rsa_dnssec.rs
+++ b/bin/tests/integration/named_test_rsa_dnssec.rs
@@ -205,27 +205,26 @@ fn test_rrsig_ttl() {
             // query www.example.com. expected ttl is 86400.
             let query = Query::query("www.example.com.".parse().unwrap(), RecordType::A);
             let response = io_loop
-                .block_on(client.lookup(query, options).try_collect::<Vec<_>>())
-                .unwrap();
-            let answers = response
-                .into_iter()
-                .flat_map(|mut response| response.take_answers())
-                .collect::<Vec<_>>();
+                .block_on(client.lookup(query, options).try_next())
+                .unwrap()
+                .expect("Expected an answer");
 
             // check the ttl of all answers, of which at least one must be of type A and one
             // of type RRSIG
             let expected_ttl = 86400;
-            for answer in &answers {
+            for answer in response.answers() {
                 println!("{answer}");
                 assert_eq!(answer.ttl(), expected_ttl);
             }
             assert!(
-                answers
+                response
+                    .answers()
                     .iter()
                     .any(|answer| answer.record_type() == RecordType::A)
             );
             assert!(
-                answers
+                response
+                    .answers()
                     .iter()
                     .any(|answer| answer.record_type() == RecordType::RRSIG)
             );
@@ -239,27 +238,26 @@ fn test_rrsig_ttl() {
             // query shortlived.example.com. expected ttl is 900.
             let query = Query::query("shortlived.example.com.".parse().unwrap(), RecordType::A);
             let response = io_loop
-                .block_on(client.lookup(query, options).try_collect::<Vec<_>>())
-                .unwrap();
-            let answers = response
-                .into_iter()
-                .flat_map(|mut response| response.take_answers())
-                .collect::<Vec<_>>();
+                .block_on(client.lookup(query, options).try_next())
+                .unwrap()
+                .expect("Expected an answer");
 
             // check the ttl of all answers, of which at least one must be of type A and one
             // of type RRSIG
             let expected_ttl = 900;
-            for answer in &answers {
+            for answer in response.answers() {
                 println!("{answer}");
                 assert_eq!(answer.ttl(), expected_ttl);
             }
             assert!(
-                answers
+                response
+                    .answers()
                     .iter()
                     .any(|answer| answer.record_type() == RecordType::A)
             );
             assert!(
-                answers
+                response
+                    .answers()
                     .iter()
                     .any(|answer| answer.record_type() == RecordType::RRSIG)
             );


### PR DESCRIPTION
It turns out that fetching all DNS responses as part of the test can have one of two outcomes:
 - stall for 10s and then return None
 - fail because the stream closed

This PR changes the test to only fetch the first response. I tested it like 20 times on my local computer and didn't see a single test failure.