### PR TITLE
resolver: add optional metrics feature, opp. enc. probe metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,8 @@ dependencies = [
  "hickory-proto",
  "ipconfig",
  "jni",
+ "metrics",
+ "metrics-util",
  "moka",
  "ndk-context",
  "once_cell",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -38,7 +38,7 @@ recursor = ["hickory-server/recursor"]
 resolver = ["hickory-server/resolver"]
 sqlite = ["hickory-server/sqlite", "dep:rusqlite"]
 prometheus-metrics = ["metrics", "dep:http", "dep:hyper", "dep:hyper-util", "dep:metrics-exporter-prometheus", "dep:tokio-util"]
-metrics = ["hickory-server/metrics", "dep:metrics", "dep:metrics-process"]
+metrics = ["hickory-server/metrics", "hickory-resolver/metrics", "dep:metrics", "dep:metrics-process"]
 
 tls-aws-lc-rs = ["hickory-server/tls-aws-lc-rs", "__tls"]
 https-aws-lc-rs = ["hickory-server/https-aws-lc-rs", "tls-aws-lc-rs", "__https"]

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -55,6 +55,8 @@ system-config = ["dep:ipconfig", "dep:resolv-conf", "dep:jni", "dep:ndk-context"
 
 tokio = ["dep:tokio", "tokio/rt", "hickory-proto/tokio"]
 
+metrics = ["dep:metrics"]
+
 [lib]
 name = "hickory_resolver"
 path = "src/lib.rs"
@@ -65,6 +67,7 @@ cfg-if.workspace = true
 futures-util = { workspace = true, default-features = false, features = [
     "std",
 ] }
+metrics = { workspace = true, optional = true }
 moka = { workspace = true, features = ["sync"] }
 once_cell.workspace = true
 parking_lot.workspace = true
@@ -94,6 +97,7 @@ ndk-context = { workspace = true, optional = true }
 [dev-dependencies]
 futures-executor = { workspace = true, default-features = false, features = ["std"] }
 hickory-proto = { workspace = true, features = ["tokio"] }
+metrics-util = { workspace = true, features = ["debugging"] }
 serde_json = { workspace = true }
 test-support.workspace = true
 tokio = { workspace = true, features = ["macros", "test-util"] }


### PR DESCRIPTION
This branch adds an optional metrics feature to the resolver crate, populating it based on the higher-level hickory-dns binary's metrics flag. 

Additionally, it instruments the behaviour of the opportunistic encryption probing added in https://github.com/hickory-dns/hickory-dns/pull/3276 to expose metrics. It maintains counters for attempts, timeouts, errors, and successes, and a gauge for the current probe budget value. Initially I considered a histogram for the overall per-probe elapsed duration, but there are no other histogram metrics and adding the first one requires addressing some challenges ([see this comment thread](https://github.com/hickory-dns/hickory-dns/pull/3314#discussion_r2437307499)).

Testing is a little bit complicated because of the way probe requests are spawned as anonymous background tasks. In this branch we update the test mocking to run the probe requests synchronously so that we can easily write tests that know when the probe has completed to assert on metric updates that were observed. Similarly, since the metrics crate's `with_local_recorder()` applies only to the current thread, we need to use a `new_current_thread()` tokio `Runtime` to make sure the background task and the test are both using the same `DebuggingRecorder`.