### PR TITLE
Conformance tests: Defer printing output when command fails

### DIFF
--- a/conformance/dns-test/src/container.rs
+++ b/conformance/dns-test/src/container.rs
@@ -328,9 +328,11 @@ impl Container {
         if status.success() {
             Ok(stdout)
         } else {
-            eprintln!("STDOUT:\n{stdout}\nSTDERR:\n{stderr}");
-
-            Err(format!("[{}] `{command_and_args:?}` failed", self.inner.name).into())
+            Err(format!(
+                "[{}] `{command_and_args:?}` failed\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}",
+                self.inner.name
+            )
+            .into())
         }
     }
 


### PR DESCRIPTION
This replaces an `eprintln!()` in `Container::stdout()` when an executed command fails. The output of the failed command is instead returned via `Result::Err`. The `Container::wait()` method may cause some spurious command failures while it is polling to check log files, in case it tries to run `cat` before log files have been created. With this change, the `cat` error messages get swallowed when the error is swallowed in the polling loop, instead of showing up in test output.