### PR TITLE
Change MessageSigner to use 64-bit timestamp

### DIFF
--- a/crates/proto/src/dnssec/signer.rs
+++ b/crates/proto/src/dnssec/signer.rs
@@ -483,7 +483,7 @@ impl MessageSigner for SigSigner {
     fn sign_message(
         &self,
         message: &Message,
-        current_time: u32,
+        current_time: u64,
     ) -> ProtoResult<(MessageSignature, Option<MessageVerifier>)> {
         debug!("signing message: {message:?}");
         let key_tag: u16 = self.calculate_key_tag()?;
@@ -497,7 +497,10 @@ impl MessageSigner for SigSigner {
 
         let num_labels = name.num_labels();
 
-        let expiration_time = current_time + (5 * 60); // +5 minutes in seconds
+        // Truncate the current time to 32 bits. Note that signature inception and expiration times
+        // use serial number arithmetic.
+        let current_time = current_time as u32;
+        let expiration_time = current_time.wrapping_add(5 * 60); // +5 minutes in seconds
         let input = SigInput {
             type_covered: RecordType::ZERO,
             algorithm: self.key.algorithm(),

--- a/crates/proto/src/dnssec/tsig.rs
+++ b/crates/proto/src/dnssec/tsig.rs
@@ -366,10 +366,9 @@ impl MessageSigner for TSigner {
     fn sign_message(
         &self,
         message: &Message,
-        current_time: u32,
+        current_time: u64,
     ) -> ProtoResult<(MessageSignature, Option<MessageVerifier>)> {
         debug!("signing message: {:?}", message);
-        let current_time = current_time as u64;
 
         let pre_tsig = TSIG::stub(message.id(), current_time, self);
         let mut signature = self
@@ -432,7 +431,7 @@ mod tests {
 
         assert_eq!(question.signature(), &MessageSignature::Unsigned);
         question
-            .finalize(&signer, time_begin as u32)
+            .finalize(&signer, time_begin)
             .expect("should have signed");
         assert!(matches!(question.signature(), &MessageSignature::Tsig(_)));
 
@@ -462,7 +461,7 @@ mod tests {
 
         assert_eq!(question.signature(), &MessageSignature::Unsigned);
         question
-            .finalize(&signer, time_begin as u32)
+            .finalize(&signer, time_begin)
             .expect("should have signed");
         assert!(matches!(question.signature(), &MessageSignature::Tsig(_)));
 

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -711,7 +711,7 @@ impl Message {
     pub fn finalize(
         &mut self,
         finalizer: &dyn MessageSigner,
-        inception_time: u32,
+        inception_time: u64,
     ) -> ProtoResult<Option<MessageVerifier>> {
         debug!("finalizing message: {:?}", self);
 
@@ -870,7 +870,7 @@ pub trait MessageSigner: Send + Sync + 'static {
     fn sign_message(
         &self,
         message: &Message,
-        current_time: u32,
+        current_time: u64,
     ) -> ProtoResult<(MessageSignature, Option<MessageVerifier>)>;
 
     /// Return whether the message requires a signature before being sent.

--- a/crates/proto/src/udp/udp_client_stream.rs
+++ b/crates/proto/src/udp/udp_client_stream.rs
@@ -145,8 +145,7 @@ impl<P: RuntimeProvider> DnsRequestSender for UdpClientStream<P> {
 
         let case_randomization = request.options().case_randomization;
 
-        // TODO: truncates u64 to u32, error on overflow?
-        let now = P::Timer::current_time() as u32;
+        let now = P::Timer::current_time();
 
         let mut verifier = None;
         if let Some(signer) = &self.signer {

--- a/crates/proto/src/xfer/dns_multiplexer.rs
+++ b/crates/proto/src/xfer/dns_multiplexer.rs
@@ -279,8 +279,7 @@ where
         let (mut request, _) = request.into_parts();
         request.set_id(query_id);
 
-        // TODO: truncates u64 to u32, error on overflow?
-        let now = S::Time::current_time() as u32;
+        let now = S::Time::current_time();
 
         let mut verifier = None;
         if let Some(signer) = &self.signer {

--- a/tests/integration-tests/tests/integration/sqlite_zone_handler_tests.rs
+++ b/tests/integration-tests/tests/integration/sqlite_zone_handler_tests.rs
@@ -985,7 +985,7 @@ async fn test_update_tsig_valid() {
         .map(|t| t.as_secs())
         .unwrap();
     let (sig, _) = (&signer as &dyn MessageSigner)
-        .sign_message(&message, now as u32)
+        .sign_message(&message, now)
         .unwrap();
     // Save the MAC of the request so we can verify the response.
     let MessageSignature::Tsig(tsig_rr) = sig.clone() else {
@@ -1096,7 +1096,7 @@ async fn test_update_tsig_invalid_unknown_signer() {
         .map(|t| t.as_secs())
         .unwrap();
     let (sig, _) = (&bad_signer as &dyn MessageSigner)
-        .sign_message(&message, now as u32)
+        .sign_message(&message, now)
         .unwrap();
     message.set_signature(sig);
 
@@ -1157,7 +1157,7 @@ async fn test_update_tsig_invalid_sig() {
         .map(|t| t.as_secs())
         .unwrap();
     let (sig, _) = (&bad_signer as &dyn MessageSigner)
-        .sign_message(&message, now as u32)
+        .sign_message(&message, now)
         .unwrap();
     message.set_signature(sig);
 
@@ -1212,7 +1212,7 @@ async fn test_update_tsig_invalid_stale_sig() {
         .unwrap();
     let too_stale = now - (signer.fudge() as u64) - 1;
     let (sig, _) = (&signer as &dyn MessageSigner)
-        .sign_message(&message, too_stale as u32)
+        .sign_message(&message, too_stale)
         .unwrap();
     // Save the MAC of the request so we can verify the response.
     let MessageSignature::Tsig(tsig_rr) = sig.clone() else {
@@ -1703,7 +1703,7 @@ async fn test_axfr_allow_tsig_signed() {
         .unwrap();
 
     let (sig, _) = (&signer as &dyn MessageSigner)
-        .sign_message(&message, now as u32)
+        .sign_message(&message, now)
         .unwrap();
     message.set_signature(sig);
 


### PR DESCRIPTION
This makes the change I described in https://github.com/hickory-dns/hickory-dns/pull/3311#discussion_r2462176455, fixing some TODOs. We should be using a wider type here because TSIG signatures have 48-bit timestamps. Truncation to 32 bits should only be done when signing with SIG(0).