### PR TITLE
Add hickory-resolver to workspace

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -95,6 +95,7 @@ hex.workspace = true
 hickory-client.workspace = true
 hickory-proto.workspace = true
 hickory-server = { workspace = true, features = ["toml"] }
+hickory-resolver = { workspace = true, features = ["tokio"] }
 hostname.workspace = true
 metrics = { workspace = true, optional = true }
 metrics-exporter-prometheus = { workspace = true, optional = true }


### PR DESCRIPTION
When I enable prometheus-metrics feature, it comes failed at building
```
CARGO_BUILD_TARGET=aarch64-unknown-linux-musl CARGO_HOME=/root/openwrt-ipq/dl/cargo CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 CARGO_PROFILE_RELEASE_DEBUG=false CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=false CARGO_PROFILE_RELEASE_LTO=true CARGO_PROFILE_RELEASE_OPT_LEVEL=z CARGO_PROFILE_RELEASE_OVERFLOW_CHECKS=true CARGO_PROFILE_RELEASE_PANIC=unwind CARGO_PROFILE_RELEASE_RPATH=false CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-openwrt-linux-musl-gcc RUSTFLAGS="-Ctarget-feature=-crt-static -lssp_nonshared -Clink-arg=-fuse-ld=mold" TARGET_CC=aarch64-openwrt-linux-musl-gcc TARGET_CFLAGS="-O2 -pipe -mcpu=cortex-a53+crc+crypto -fno-caller-saves -fno-plt -fhonour-copts -fmacro-prefix-map=/root/openwrt-ipq/build_dir/target-aarch64_cortex-a53_musl/hickory-dns-c86328365ba9416609e25ee6ffa941d75794c7de=hickory-dns-c86328365ba9416609e25ee6ffa941d75794c7de -ffunction-sections -fdata-sections -flto=auto -fno-fat-lto-objects -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -mno-outline-atomics" CC=/root/openwrt-ipq/staging_dir/host/bin/gcc MAKEFLAGS="--jobserver-auth=fifo:/tmp/GMfifo700959 " cargo install -v --profile release --features "resolver,tls-ring,https-ring,quic-ring,h3-ring,rustls-platform-verifier,prometheus-metrics" --root /root/openwrt-ipq/build_dir/target-aarch64_cortex-a53_musl/hickory-dns-c86328365ba9416609e25ee6ffa941d75794c7de/ipkg-install --path "/root/openwrt-ipq/build_dir/target-aarch64_cortex-a53_musl/hickory-dns-c86328365ba9416609e25ee6ffa941d75794c7de/bin"  --locked --no-default-features
  Installing hickory-dns v0.26.0-alpha.1 (/root/openwrt-ipq/build_dir/target-aarch64_cortex-a53_musl/hickory-dns-c86328365ba9416609e25ee6ffa941d75794c7de/bin)
    Updating crates.io index
error: failed to compile `hickory-dns v0.26.0-alpha.1 (/root/openwrt-ipq/build_dir/target-aarch64_cortex-a53_musl/hickory-dns-c86328365ba9416609e25ee6ffa941d75794c7de/bin)`, intermediate artifacts can be found at `/root/openwrt-ipq/build_dir/target-aarch64_cortex-a53_musl/hickory-dns-c86328365ba9416609e25ee6ffa941d75794c7de/target`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  package `hickory-dns v0.26.0-alpha.1 (/root/openwrt-ipq/build_dir/target-aarch64_cortex-a53_musl/hickory-dns-c86328365ba9416609e25ee6ffa941d75794c7de/bin)` does not have a dependency named `hickory-resolver`
```