### PR TITLE
feat(proto): Add support for dynamic headers in DoH request

### DIFF
--- a/crates/proto/src/h2/mod.rs
+++ b/crates/proto/src/h2/mod.rs
@@ -13,5 +13,6 @@ pub mod h2_server;
 pub use crate::http::error::{Error as HttpsError, Result as HttpsResult};
 
 pub use self::h2_client_stream::{
-    HttpsClientConnect, HttpsClientResponse, HttpsClientStream, HttpsClientStreamBuilder,
+    AddHeaders, HttpsClientConnect, HttpsClientResponse, HttpsClientStream,
+    HttpsClientStreamBuilder,
 };

--- a/crates/resolver/src/connection_provider.rs
+++ b/crates/resolver/src/connection_provider.rs
@@ -272,7 +272,7 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
 pub struct TlsConfig {
     /// The TLS configuration to use for secure connections.
     #[cfg(feature = "__tls")]
-    pub(crate) config: rustls::ClientConfig,
+    pub config: rustls::ClientConfig,
 }
 
 impl TlsConfig {


### PR DESCRIPTION
Draft implementation of https://github.com/hickory-dns/hickory-dns/issues/3346

This PR adds the ability to add dynamic headers to a DoH request, implemented via a trait to allow callers to provide a custom implementation. This has just been added to the builder type for the `HttpsClientConnect` type for simplicity and small API surface changes.

I opted to use a `HashMap<String,String>` instead of a `HeaderMap` to avoid re-exporting the `http::HeaderMap` type but can definitely change if that's fine to re-use.

- [x] Add unit tests
- [x] Polish and add more in-depth documentation