### PR TITLE
Remove unnecessary references to other software

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ edition = "2021"
 rust-version = "1.83"
 homepage = "https://hickory-dns.org/"
 repository = "https://github.com/hickory-dns/hickory-dns"
-keywords = ["DNS", "BIND", "dig", "named", "dnssec"]
+keywords = ["dns", "dnssec"]
 categories = ["network-programming"]
 license = "MIT OR Apache-2.0"
 

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -4,13 +4,12 @@ name = "hickory-dns"
 # A short blurb about the package. This is not rendered in any format when
 # uploaded to crates.io (aka this is not markdown)
 description = """
-Hickory DNS is a safe and secure DNS server with DNSSEC support.
- Eventually this could be a replacement for BIND9. The DNSSEC support allows
- for live signing of all records, in it does not currently support
- records signed offline. The server supports dynamic DNS with SIG0 authenticated
- requests. Hickory DNS is based on the Tokio and Futures libraries, which means
- it should be easily integrated into other software that also use those
- libraries.
+Hickory DNS is a safe and secure DNS server with DNSSEC support. The DNSSEC
+support allows for live signing of all records, but it does not currently
+support records signed offline. The server supports dynamic DNS with SIG(0) or
+TSIG authenticated requests. Hickory DNS is based on the Tokio and Futures
+libraries, which means it should be easy to integrate into other software that
+also uses those libraries.
 """
 
 documentation = "https://docs.rs/hickory-dns"

--- a/bin/README.md
+++ b/bin/README.md
@@ -2,12 +2,11 @@
 
 Hickory DNS provides a binary for hosting or forwarding DNS zones.
 
-This a named implementation for DNS zone hosting, stub resolvers, and recursive
-resolvers. It is capable of performing signing all records in the zone for
-server DNSSEC RRSIG records associated with all records in a zone. There is also
-a `hickory-dns` binary that can be generated from the library with `cargo
-install hickory-dns`. Dynamic updates are supported via `SIG0` (an mTLS
-authentication method is under development).
+This is a DNS server implementation for DNS zone hosting, stub resolvers, and
+recursive resolvers. It is capable of signing all records in the zone to serve
+DNSSEC RRSIG records. There is also a `hickory-dns` binary that can be generated
+from the library with `cargo install hickory-dns`. Dynamic updates are supported
+via SIG(0) or TSIG (an mTLS authentication method is under development).
 
 **NOTICE** This project was rebranded from Trust-DNS to Hickory DNS and has been moved to the https://github.com/hickory-dns/hickory-dns organization and repo, this crate/binary has been moved to [hickory-dns](https://crates.io/crates/hickory-dns), from `0.24` and onward, for prior versions see [trust-dns](https://crates.io/crates/trust-dns).
 

--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -5,7 +5,7 @@
 // https://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! Configuration module for the server binary, `named`.
+//! Configuration module for the server binary, `hickory-dns`.
 
 #[cfg(feature = "__dnssec")]
 pub mod dnssec;

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -2,13 +2,12 @@
 name = "hickory-server"
 
 description = """
-Hickory DNS is a safe and secure DNS server with DNSSEC support.
- Eventually this could be a replacement for BIND9. The DNSSEC support allows
- for live signing of all records, in it does not currently support
- records signed offline. The server supports dynamic DNS with SIG0 authenticated
- requests. Hickory DNS is based on the Tokio and Futures libraries, which means
- it should be easily integrated into other software that also use those
- libraries.
+Hickory DNS is a safe and secure DNS server with DNSSEC support. The DNSSEC
+support allows for live signing of all records, but it does not currently
+support records signed offline. The server supports dynamic DNS with SIG(0) or
+TSIG authenticated requests. Hickory DNS is based on the Tokio and Futures
+libraries, which means it should be easy to integrate into other software that
+also uses those libraries.
 """
 
 documentation = "https://docs.rs/hickory-server"

--- a/tests/test-data/test_configs/example.toml
+++ b/tests/test-data/test_configs/example.toml
@@ -1,20 +1,15 @@
 ##
-## This is an example configuration file for the Hickory DNS named server.
+## This is an example configuration file for the Hickory DNS server.
 ##
 ## The format is in TOML: https://github.com/toml-lang/toml which was chosen
-##  as the configuration format for Hickory DNS. While Hickory DNS is intended to
-##  be a drop-in replacement for BIND9, it will not support the named.conf files
-##  directly. At some point, there will be a binary tool for converting the
-##  BIND9 configuration files over to Hickory DNS TOML.
+## as the configuration format for Hickory DNS.
 ##
 ## Many of these options are available as both command line options and
-##  configuration options in these files. In that case, the command line option
-##  will take precedence.
+## configuration options in these files. In that case, the command line option
+## will take precedence.
 ##
 ## Comments with two hash marks, ##, document the config parameter
 ## Comments with one hash mark, #, is an example line and should be the default
-##
-## The root options are similar to the options in 'options { .. }' in named.conf
 
 ## listen_addrs: address on which to listen for incoming connections
 ##  this can be a list of ipv4 or ipv6 addresses


### PR DESCRIPTION
I went through documentation, comments, and crate metadata to remove some unnecessary references to other software, and rephrase some text for clarity.