### PR TITLE
remove explicit recursion_limit crate attributes

### DIFF
--- a/bin/src/hickory-dns.rs
+++ b/bin/src/hickory-dns.rs
@@ -27,8 +27,6 @@
 //!       -V, --version            Print version
 //! ```
 
-#![recursion_limit = "128"]
-
 #[cfg(any(feature = "__tls", feature = "__https", feature = "__quic"))]
 use std::sync::Arc;
 #[cfg(feature = "metrics")]

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -29,7 +29,6 @@
     clippy::upper_case_acronyms, // can be removed on a major release boundary
     clippy::bool_to_int_with_if,
 )]
-#![recursion_limit = "2048"]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 //! Hickory DNS Protocol library

--- a/crates/recursor/src/lib.rs
+++ b/crates/recursor/src/lib.rs
@@ -23,7 +23,6 @@
     clippy::single_component_path_imports,
     clippy::upper_case_acronyms, // can be removed on a major release boundary
 )]
-#![recursion_limit = "2048"]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod error;

--- a/crates/resolver/examples/custom_provider.rs
+++ b/crates/resolver/examples/custom_provider.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "128"]
-
 #[cfg(all(
     any(feature = "webpki-roots", feature = "rustls-platform-verifier"),
     feature = "__https"

--- a/crates/resolver/examples/flush_cache.rs
+++ b/crates/resolver/examples/flush_cache.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "128"]
-
 use std::sync::Arc;
 
 #[tokio::main]

--- a/crates/resolver/examples/global_resolver.rs
+++ b/crates/resolver/examples/global_resolver.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "128"]
-
 use std::{fmt::Display, future::pending, io, net::SocketAddr};
 
 use once_cell::sync::Lazy;

--- a/crates/resolver/examples/multithreaded_runtime.rs
+++ b/crates/resolver/examples/multithreaded_runtime.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "128"]
-
 //! This example shows how to create a resolver that uses the tokio multithreaded runtime. This is how
 //! you might integrate the resolver into a more complex application.
 

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -187,7 +187,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![recursion_limit = "128"]
 #![allow(clippy::needless_doctest_main, clippy::single_component_path_imports)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -32,7 +32,6 @@
     clippy::single_component_path_imports,
     clippy::upper_case_acronyms, // can be removed on a major release boundary
 )]
-#![recursion_limit = "2048"]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 //! Hickory DNS is intended to be a fully compliant domain name server and client library.


### PR DESCRIPTION
For the cases where the [`recursion_limit` attribute](https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute) was set to 128, it was a no-op: that's the default in rustc. For the cases where it was increased to 2048, AFAICT it's unnecessary. This is a limit on **compile-time** recursion for operations like macro expansion or auto-dereference and this project doesn't need excessive budget for either.

I noticed this reviewing https://github.com/hickory-dns/hickory-dns/pull/3370 while pondering whether the `resolver` crate's `recursion_limit` being increased as a result of merging the `recursor` crate in was meaningful. It looks like the `resolver` crate gained the `128` setting in 0c34c6b667bcac65eed58fc87d87f5a48526ee7d without any particular call-out, and for `recursor` in 5b929d71d7c58707a5ab1bbf75a19c07c8601e08 along with the initial impl, again without any call-out. Perhaps it was initially mistaken as a runtime control on recursion/stack depth and then cargo-culted into other places?