### PR TITLE
tests: drop nsec3_no_data test

### DIFF
--- a/tests/integration-tests/tests/integration/client_tests.rs
+++ b/tests/integration-tests/tests/integration/client_tests.rs
@@ -403,23 +403,6 @@ async fn test_nsec3_nxdomain() {
     assert_eq!(response.response_code(), ResponseCode::NXDomain);
 }
 
-#[tokio::test]
-#[cfg(feature = "__dnssec")]
-async fn test_nsec3_no_data() {
-    subscribe();
-
-    let name = Name::from_labels(vec!["www", "example", "com"]).unwrap();
-
-    let mut client = tcp_dnssec_client(GOOGLE_V4).await;
-    let response = client
-        .query(name, DNSClass::IN, RecordType::PTR)
-        .await
-        .expect("Query failed");
-
-    // the name "www.example.com" exists but there's no PTR record on it
-    assert_eq!(response.response_code(), ResponseCode::NoError);
-}
-
 #[allow(deprecated)]
 #[cfg(all(feature = "__dnssec", feature = "sqlite"))]
 async fn create_sig0_ready_client(mut catalog: Catalog) -> (Client<TokioRuntimeProvider>, Name) {


### PR DESCRIPTION
As discussed on Discord, this test started (intermittently) failing locally, and @marcus0x62 suggests that the intended coverage is already provided by `resolver::nsec::zone_exist_domain_does_not_nsec3`. Drop it.