### PR TITLE
ci: update cargo-all-features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,7 +165,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-all-features
-          version: 1.11.0
+          version: 1.12.0
 
       - name: cargo check-all-features
         run: cargo check-all-features --n-chunks 4 --chunk ${{ matrix.chunk }}


### PR DESCRIPTION
Removes warning annotations on the CI jobs telling us there's a new version available:

<img width="1135" height="445" alt="warns" src="https://github.com/user-attachments/assets/f58d01ab-8f95-425f-b869-0b1ff6f8d3c7" />
