### PR TITLE
Drop explicit library target declarations

### DIFF
--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -72,10 +72,6 @@ wasm-bindgen = ["dep:wasm-bindgen-crate", "dep:js-sys"]
 
 access-control  = ["std", "dep:prefix-trie"]
 
-[lib]
-name = "hickory_proto"
-path = "src/lib.rs"
-
 [dependencies]
 async-trait.workspace = true
 aws-lc-rs = { workspace = true, optional = true }

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -55,10 +55,6 @@ tokio = ["dep:tokio", "tokio/rt", "hickory-proto/tokio"]
 
 metrics = ["dep:metrics"]
 
-[lib]
-name = "hickory_resolver"
-path = "src/lib.rs"
-
 [dependencies]
 async-recursion = { workspace = true, optional = true }
 cfg-if.workspace = true

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -94,10 +94,6 @@ rustls-platform-verifier = ["hickory-resolver?/rustls-platform-verifier"]
 
 testing = []
 
-[lib]
-name = "hickory_server"
-path = "src/lib.rs"
-
 [dependencies]
 async-trait.workspace = true
 toml = { workspace = true, optional = true }

--- a/tests/compatibility-tests/Cargo.toml
+++ b/tests/compatibility-tests/Cargo.toml
@@ -23,10 +23,6 @@ default = ["none"]
 none = []
 bind = []
 
-[lib]
-name = "hickory_compatibility"
-path = "src/lib.rs"
-
 [dependencies]
 data-encoding = { workspace = true, features = ["alloc"] }
 rand = { workspace = true, features = ["std", "thread_rng"] }

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -18,10 +18,6 @@ keywords.workspace = true
 categories.workspace = true
 license.workspace = true
 
-[lib]
-name = "hickory_integration"
-path = "src/lib.rs"
-
 [features]
 dnssec-aws-lc-rs = [
     "hickory-resolver/dnssec-aws-lc-rs",


### PR DESCRIPTION
These are unnecessary, and the duplicated name cost me a lot of time yesterday trying to debug why Cargo saw duplicate crate names.