### PR TITLE
resolver: replace ipconfig with direct windows-sys bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "serde",
- "socket2 0.6.1",
+ "socket2",
  "test-support",
  "thiserror 2.0.17",
  "time",
@@ -829,7 +829,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
- "socket2 0.6.1",
+ "socket2",
  "test-support",
  "thiserror 2.0.17",
  "time",
@@ -878,7 +878,6 @@ dependencies = [
  "futures-util",
  "hickory-net",
  "hickory-proto",
- "ipconfig",
  "ipnet",
  "jni",
  "lru-cache",
@@ -904,6 +903,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "webpki-roots",
+ "windows-registry",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1054,7 +1055,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1194,18 +1195,6 @@ checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "ipconfig"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
-dependencies = [
- "socket2 0.5.10",
- "widestring",
- "windows-sys 0.48.0",
- "winreg",
 ]
 
 [[package]]
@@ -1755,7 +1744,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -1793,7 +1782,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2252,16 +2241,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
@@ -2476,7 +2455,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2842,12 +2821,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2869,7 +2842,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2962,6 +2935,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2986,15 +2970,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3037,21 +3012,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3104,12 +3064,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3128,12 +3082,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3149,12 +3097,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3188,12 +3130,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3209,12 +3145,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3236,12 +3166,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3260,12 +3184,6 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
@@ -3281,16 +3199,6 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,6 @@ data-encoding = { version = "2.2.0", default-features = false }
 hex = "0.4"
 hostname = "0.4"
 idna = { version = "1.0.3", default-features = false, features = ["alloc", "compiled_data"] }
-ipconfig = "0.3.0"
 ipnet = { version = "2.3.0", default-features = false }
 jni = "0.21.1"
 js-sys = "0.3.44"
@@ -118,6 +117,8 @@ tinyvec = "1.1.1"
 toml = "0.9"
 url = { version = "2.5.4", default-features = false }
 wasm-bindgen-crate = { version = "0.2.58", package = "wasm-bindgen" }
+windows-registry = "0.6.1"
+windows-sys = "0.61"
 
 [patch.crates-io]
 # tokio = { path = "../tokio/tokio" }

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -47,7 +47,7 @@ __dnssec = []
 recursor = ["dep:async-recursion", "dep:lru-cache", "hickory-proto/text-parsing"]
 
 serde = ["dep:serde", "hickory-proto/serde"]
-system-config = ["dep:ipconfig", "dep:resolv-conf", "dep:jni", "dep:ndk-context", "dep:system-configuration"]
+system-config = ["dep:windows-sys", "dep:windows-registry", "dep:resolv-conf", "dep:jni", "dep:ndk-context", "dep:system-configuration"]
 
 toml = ["dep:toml"]
 
@@ -86,7 +86,8 @@ hickory-proto = { workspace = true, features = ["access-control"] }
 webpki-roots = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
-ipconfig = { workspace = true, optional = true }
+windows-sys = { workspace = true, optional = true, features = ["Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis"] }
+windows-registry = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = { workspace = true, optional = true }

--- a/crates/resolver/src/system_conf/windows.rs
+++ b/crates/resolver/src/system_conf/windows.rs
@@ -8,50 +8,119 @@
 //! System configuration loading for windows
 
 use std::net::{IpAddr, Ipv6Addr};
+use std::os::raw::c_ulong;
+use std::ptr;
 use std::str::FromStr;
 
-use ipconfig::computer::{get_domain, get_search_list};
-use ipconfig::get_adapters;
+use windows_registry::LOCAL_MACHINE;
+use windows_sys::Win32::Foundation::{
+    ERROR_BUFFER_OVERFLOW, ERROR_INVALID_PARAMETER, ERROR_NO_DATA, ERROR_NOT_ENOUGH_MEMORY,
+    ERROR_SUCCESS,
+};
+use windows_sys::Win32::NetworkManagement::IpHelper::{
+    GAA_FLAG_INCLUDE_GATEWAYS, GAA_FLAG_INCLUDE_PREFIX, GetAdaptersAddresses,
+    IP_ADAPTER_ADDRESSES_LH,
+};
+use windows_sys::Win32::Networking::WinSock::{
+    AF_INET, AF_INET6, AF_UNSPEC, SOCKADDR, SOCKADDR_IN, SOCKADDR_IN6, SOCKET_ADDRESS,
+};
 
 use crate::config::{NameServerConfig, ResolverConfig, ResolverOpts};
 use crate::proto::ProtoError;
 use crate::proto::rr::Name;
 
 pub fn read_system_conf() -> Result<(ResolverConfig, ResolverOpts), ProtoError> {
-    let adapters = get_adapters().map_err(|e| format!("ipconfig::get_adapters() failed: {e}"))?;
+    // Preallocate 16K per Microsoft recommendation, see Remarks section
+    // https://docs.microsoft.com/en-us/windows/desktop/api/iphlpapi/nf-iphlpapi-getadaptersaddresses
+    let mut buf_len = 16 * 1024u32;
 
-    let servers = adapters
-        .iter()
-        // Only take interfaces whose OperStatus is Up
-        .filter(|adapter| adapter.oper_status() == ipconfig::OperStatus::IfOperStatusUp)
-        .flat_map(|adapter| adapter.dns_servers());
+    let mut buffer = vec![0u8; buf_len as usize];
+    let result = unsafe {
+        GetAdaptersAddresses(
+            AF_UNSPEC as u32,
+            GAA_FLAG_INCLUDE_GATEWAYS | GAA_FLAG_INCLUDE_PREFIX,
+            ptr::null_mut(), // Reserved, must be null
+            buffer.as_mut_ptr() as *mut IP_ADAPTER_ADDRESSES_LH,
+            &mut buf_len as *mut c_ulong,
+        )
+    };
 
-    let mut name_servers = vec![];
-    for &ip in servers {
-        if let IpAddr::V6(ip) = ip {
-            if FORBIDDEN_ADDRS.contains(&ip) {
-                continue;
-            }
-        }
+    let name_servers = match result {
+        ERROR_SUCCESS => name_servers(buffer.as_mut_ptr() as *mut IP_ADAPTER_ADDRESSES_LH)?,
+        ERROR_NO_DATA => vec![],
+        ERROR_BUFFER_OVERFLOW => return Err("GetAdaptersAddresses: buffer overflow".into()),
+        ERROR_INVALID_PARAMETER => return Err("GetAdaptersAddresses: invalid parameter".into()),
+        ERROR_NOT_ENOUGH_MEMORY => return Err("GetAdaptersAddresses: not enough memory".into()),
+        _ => return Err(format!("GetAdaptersAddresses: error {result}").into()),
+    };
 
-        name_servers.push(NameServerConfig::udp_and_tcp(ip));
-    }
+    let search_list = match LOCAL_MACHINE.get_string(SEARCH_LIST_PATH) {
+        Ok(list) => list
+            .split(',')
+            .map(|x| Name::from_str(x.trim()))
+            .collect::<Result<Vec<_>, _>>()?,
+        Err(err) => return Err(format!("failed to read search list from registry: {err}").into()),
+    };
 
-    let search_list = get_search_list()
-        .map_err(|e| format!("ipconfig::get_search_list() failed: {e}"))?
-        .iter()
-        .map(|x| Name::from_str(x))
-        .collect::<Result<Vec<_>, _>>()?;
-
-    let domain = match get_domain().map_err(|e| format!("ipconfig::get_domain() failed: {e}"))? {
-        Some(domain) => Name::from_str(&domain)?,
-        None => Name::root(),
+    let domain = match LOCAL_MACHINE.get_string(DOMAIN_PATH) {
+        Ok(domain) if !domain.is_empty() => Name::from_str(&domain)?,
+        Ok(_) => Name::root(),
+        Err(err) => return Err(format!("failed to read domain from registry: {err}").into()),
     };
 
     Ok((
         ResolverConfig::from_parts(Some(domain), search_list, name_servers),
         ResolverOpts::default(),
     ))
+}
+
+fn name_servers(
+    mut next_adapter: *mut IP_ADAPTER_ADDRESSES_LH,
+) -> Result<Vec<NameServerConfig>, ProtoError> {
+    let mut name_servers = Vec::new();
+    while let Some(adapter) = unsafe { next_adapter.as_mut() } {
+        if adapter.OperStatus != IF_OPER_STATUS_UP {
+            next_adapter = adapter.Next;
+            continue;
+        }
+
+        let mut next_server = adapter.FirstDnsServerAddress;
+        while let Some(dns_server) = unsafe { next_server.as_mut() } {
+            let ip = socket_address_to_ip_addr(&dns_server.Address)?;
+            if let IpAddr::V6(ip) = ip {
+                if FORBIDDEN_ADDRS.contains(&ip) {
+                    continue;
+                }
+            }
+
+            name_servers.push(NameServerConfig::udp_and_tcp(ip));
+            next_server = dns_server.Next;
+        }
+
+        next_adapter = adapter.Next;
+    }
+
+    Ok(name_servers)
+}
+
+/// Convert a Windows SOCKET_ADDRESS to an IpAddr
+fn socket_address_to_ip_addr(socket_addr: &SOCKET_ADDRESS) -> Result<IpAddr, ProtoError> {
+    let sock_addr = socket_addr.lpSockaddr as *const SOCKADDR;
+    let family = unsafe { *sock_addr }.sa_family;
+
+    match family {
+        AF_INET => {
+            let sock_addr_in = sock_addr as *const SOCKADDR_IN;
+            let bytes = unsafe { (*sock_addr_in).sin_addr.S_un.S_addr }.to_ne_bytes();
+            Ok(IpAddr::from(bytes))
+        }
+        AF_INET6 => {
+            let sock_addr_in6 = sock_addr as *const SOCKADDR_IN6;
+            let bytes = unsafe { (*sock_addr_in6).sin6_addr.u.Byte };
+            Ok(IpAddr::from(bytes))
+        }
+        _ => Err(format!("unsupported address family: {family}").into()),
+    }
 }
 
 // https://datatracker.ietf.org/doc/html/draft-ietf-ipv6-dns-discovery-07
@@ -61,3 +130,7 @@ const FORBIDDEN_ADDRS: [Ipv6Addr; 3] = [
     Ipv6Addr::new(0xfec0, 0, 0, 0xffff, 0, 0, 0, 2), // fec0:0:0:ffff::2
     Ipv6Addr::new(0xfec0, 0, 0, 0xffff, 0, 0, 0, 3), // fec0:0:0:ffff::3
 ];
+
+const SEARCH_LIST_PATH: &str = r"SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\SearchList";
+const DOMAIN_PATH: &str = r"SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Domain";
+const IF_OPER_STATUS_UP: i32 = 1;


### PR DESCRIPTION
This replaces the resolver's dependency on the ipconfig crate with inlined bindings, which I've written by looking at the code from ipconfig and modernizing it/simplifying it just for our needs. The ipconfig crate:

- Hasn't released in 2.5 years
- As a result of that, depends on old (large) Windows dependencies
- Has a maintainer who is unresponsive in the repo and via private email

This has some `unsafe` code but (a) there's not a lot, and (b) I think it's mostly not that scary.