### PR TITLE
bin: drop server before trying to do cleanup

### DIFF
--- a/bin/tests/integration/named_metrics_tests.rs
+++ b/bin/tests/integration/named_metrics_tests.rs
@@ -595,6 +595,7 @@ async fn test_updates() {
     );
 
     // Clean up database.
+    drop(server);
     let server_path = env::var("TDNS_WORKSPACE_ROOT").unwrap_or_else(|_| "..".to_owned());
     let server_path = Path::new(&server_path);
     let database =


### PR DESCRIPTION
`test_updates` has been failing (intermittently?), presumably since

- #3411 

which has this test trying to clean up before the test server is actually gone (still in scope):

```
thread 'named_metrics_tests::test_updates' (1264) panicked at bin\tests\integration\named_metrics_tests.rs:602:32:
failed to cleanup after test: Os { code: 32, kind: Uncategorized, message: "The process cannot access the file because it is being used by another process." }
```