### PR TITLE
proto: handle $TTL correctly when parsing zone file

### DIFF
--- a/bin/tests/integration/txt_tests.rs
+++ b/bin/tests/integration/txt_tests.rs
@@ -17,12 +17,13 @@ async fn test_zone() {
     subscribe();
 
     const ZONE: &str = r#"
+$TTL 60
 @   IN  SOA     venera      action\.domains (
                             20     ; SERIAL
                             7200   ; REFRESH
                             600    ; RETRY
                             3600000; EXPIRE
-                            60)    ; MINIMUM
+                            60)    ; Negative response caching TTL
 
         NS      a.isi.edu.
         NS      venera
@@ -109,7 +110,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
     let soa_record = lookup.iter().next().cloned().unwrap();
     assert_eq!(RecordType::SOA, soa_record.record_type());
     assert_eq!(&Name::from_str("isi.edu.").unwrap(), soa_record.name()); // i.e. the origin or domain
-    assert_eq!(3_600_000, soa_record.ttl());
+    assert_eq!(60, soa_record.ttl());
     assert_eq!(DNSClass::IN, soa_record.dns_class());
     if let RData::SOA(soa) = soa_record.data() {
         // this should all be lowercased
@@ -539,12 +540,13 @@ fn test_bad_cname_at_soa() {
     subscribe();
 
     const ZONE: &str = r"
+$TTL 60
 @   IN  SOA     venera      action\.domains (
                             20     ; SERIAL
                             7200   ; REFRESH
                             600    ; RETRY
                             3600000; EXPIRE
-                            60)    ; MINIMUM
+                            60)    ; Negative response caching TTL
 
         CNAME   a
 a       A       127.0.0.1
@@ -576,12 +578,13 @@ fn test_bad_cname_at_a() {
     subscribe();
 
     const ZONE: &str = r"
+$TTL 60
 @   IN  SOA     venera      action\.domains (
                             20     ; SERIAL
                             7200   ; REFRESH
                             600    ; RETRY
                             3600000; EXPIRE
-                            60)    ; MINIMUM
+                            60)    ; Negative response caching TTL
 
 a       CNAME   b
 a       A       127.0.0.1
@@ -614,12 +617,13 @@ fn test_aname_at_soa() {
     subscribe();
 
     const ZONE: &str = r"
+$TTL 60
 @   IN  SOA     venera      action\.domains (
                             20     ; SERIAL
                             7200   ; REFRESH
                             600    ; RETRY
                             3600000; EXPIRE
-                            60)    ; MINIMUM
+                            60)    ; Negative response caching TTL
 
         ANAME   a
 a       A       127.0.0.1

--- a/tests/test-data/test_configs/dnssec/example.com.zone
+++ b/tests/test-data/test_configs/dnssec/example.com.zone
@@ -1,10 +1,11 @@
 ; replace the hickory-dns.org with your own name
+$TTL 86400
 @   IN          SOA     hickory-dns.org. root.hickory-dns.org. (
                                 199609203       ; Serial
                                 28800   ; Refresh
                                 7200    ; Retry
                                 604800  ; Expire
-                                86400)  ; Minimum TTL
+                                86400)  ; Negative response caching TTL
 
                 NS      bbb
 

--- a/tests/test-data/test_configs/example.com.zone
+++ b/tests/test-data/test_configs/example.com.zone
@@ -1,10 +1,11 @@
 ; replace the hickory-dns.org with your own name
+$TTL 24h
 @   IN          SOA     hickory-dns.org. root.hickory-dns.org. (
                                 199609203 ; Serial
                                 8h        ; Refresh
                                 120m      ; Retry
                                 7d        ; Expire
-                                24h)      ; Minimum TTL
+                                24h)      ; Negative response caching TTL
 
                 NS      bbb
 


### PR DESCRIPTION
- The TTL of the last record should only be used when $TTL does not exist.
- The TTL of records should not be derived from the SOA record’s value after RFC 2308, so this is removed as well. ~but so many tests depend on it so it's kept~

Issue
---
Consider the following code

```rust
use hickory_proto::serialize::txt::Parser;

fn main() {
    let zone = r"
$ORIGIN .
$TTL 3600
a 10 IN TXT
b IN TXT
";

    let (_, records) = Parser::new(zone, None, None).parse().unwrap();
    let records = records.into_iter().map(|(_, r)| r.into_iter()).flatten();
    for record in records {
        println!("{}", record);
    }
}
```

expected:
```
a 10 IN TXT
b 3600 IN TXT
```

however, result:
```
a 10 IN TXT
b 10 IN TXT
```