### PR TITLE
chore: hickory-net does not need once_cell dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,7 +844,6 @@ dependencies = [
  "ipnet",
  "jni",
  "lru-cache",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
  "quinn",

--- a/conformance/Cargo.lock
+++ b/conformance/Cargo.lock
@@ -684,7 +684,6 @@ dependencies = [
  "ipnet",
  "jni",
  "lru-cache",
- "once_cell",
  "parking_lot",
  "rand 0.10.0",
  "ring",

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -71,7 +71,6 @@ http = { workspace = true, optional = true }
 idna.workspace = true
 ipnet.workspace = true
 lru-cache = { workspace = true, optional = true }
-once_cell = { workspace = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true, optional = true }
 quinn = { workspace = true, optional = true, features = ["log", "runtime-tokio"] }


### PR DESCRIPTION
`hickory-proto` may still need `once_cell` since the no_std `critical_section` based impl depends on it and the `std::sync::LazyLock` is unavailable in that case.