### PR TITLE
Add handling for the case where a name exists under a delegation to other nameservers.

### DIFF
--- a/crates/server/src/store/in_memory/inner.rs
+++ b/crates/server/src/store/in_memory/inner.rs
@@ -200,6 +200,31 @@ impl InnerInMemory {
         record_type: RecordType,
         lookup_options: LookupOptions,
     ) -> Option<Arc<RecordSet>> {
+        // Check for delegation
+        let mut search_name = name.clone();
+        while !search_name.is_root() {
+            let ns_key = RrKey::new(search_name.clone(), RecordType::NS);
+            let soa_key = RrKey::new(search_name.clone(), RecordType::SOA);
+
+            let ns_rrset = self.records.get(&ns_key);
+            let has_soa = self.records.contains_key(&soa_key);
+            let ds_exact = record_type == RecordType::DS && search_name == *name;
+
+            match (ns_rrset, has_soa) {
+                // Request is for a DS record and we're at the delegation point.
+                // Don't return a referral, DS record resides in the parent zone.
+                (Some(_), false) if ds_exact => {}
+                // Return a delegation point: NS exists without SOA.
+                (Some(ns), false) => return Some(ns.clone()),
+                // Zone apex: NS with SOA - we're at the top of the zone
+                (Some(_), true) => break,
+                // No NS, keep walking up.
+                (None, _) => {}
+            }
+
+            search_name = search_name.base_name();
+        }
+
         // this range covers all the records for any of the RecordTypes at a given label.
         let start_range_key = RrKey::new(name.clone(), RecordType::Unknown(u16::MIN));
         let end_range_key = RrKey::new(name.clone(), RecordType::Unknown(u16::MAX));
@@ -867,4 +892,69 @@ fn finish_nsec_record(
 ) -> Record {
     let rdata = NSEC::new_cover_self(next_name.clone(), mem::take(record_type_set));
     Record::from_rdata(name.clone(), ttl, RData::DNSSEC(DNSSECRData::NSEC(rdata)))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use crate::proto::rr::{Name, Record, rdata::NS};
+
+    #[test]
+    fn test_inner_lookup_delegation() {
+        let origin = Name::from_str("example.com.").unwrap();
+        let sub = Name::from_str("sub.example.com.").unwrap();
+        let ns_name = Name::from_str("ns.example.com.").unwrap();
+        let mut inner = InnerInMemory::default();
+
+        // Add SOA for example.com
+        let soa = Record::from_rdata(
+            origin.clone(),
+            3600,
+            RData::SOA(SOA::new(
+                ns_name.clone(),
+                Name::from_str("hostmaster.example.com.").unwrap(),
+                1,
+                3600,
+                3600,
+                3600,
+                3600,
+            )),
+        );
+        inner.upsert(soa, 1, DNSClass::IN);
+
+        // Add NS delegation for sub.example.com
+        let ns = Record::from_rdata(sub.clone(), 3600, RData::NS(NS(ns_name.clone())));
+        inner.upsert(ns, 1, DNSClass::IN);
+
+        // Lookup A record in sub.example.com (should return referral)
+        let query_name = Name::from_str("www.sub.example.com.").unwrap();
+        let result =
+            inner.inner_lookup(&query_name.into(), RecordType::A, LookupOptions::default());
+
+        assert!(result.is_some());
+        let rrset = result.unwrap();
+        assert_eq!(rrset.record_type(), RecordType::NS);
+        assert_eq!(rrset.name(), &sub);
+
+        // Lookup DS record at delegation point (should NOT return referral)
+        let result = inner.inner_lookup(
+            &sub.clone().into(),
+            RecordType::DS,
+            LookupOptions::default(),
+        );
+        assert!(result.is_none());
+
+        // Lookup NS record at delegation point (should return NS record)
+        let result = inner.inner_lookup(
+            &sub.clone().into(),
+            RecordType::NS,
+            LookupOptions::default(),
+        );
+        assert!(result.is_some());
+        let rrset = result.unwrap();
+        assert_eq!(rrset.record_type(), RecordType::NS);
+        assert_eq!(rrset.name(), &sub);
+    }
 }

--- a/crates/server/src/zone_handler/catalog.rs
+++ b/crates/server/src/zone_handler/catalog.rs
@@ -1002,22 +1002,27 @@ async fn build_authoritative_response(
     };
 
     // everything is done, construct a Message with all sections.
-    let (answers, additionals) = match answers {
-        Some(mut answers) => match answers.take_additionals() {
-            Some(additionals) => (
-                answers,
-                AuthLookup::Records {
-                    answers: additionals,
-                    additionals: None,
-                },
-            ),
-            None => (answers, AuthLookup::default()),
-        },
-        None => (AuthLookup::default(), AuthLookup::default()),
-    };
-
     message.set_header(response_header);
-    message.answers_mut().extend(answers.iter().cloned());
+
+    if let Some(mut lookup_records) = answers {
+        if let Some(adds) = lookup_records.take_additionals() {
+            message.additionals_mut().extend(adds.iter().cloned());
+        }
+
+        let is_referral = lookup_records.iter().next().is_some_and(|r| {
+            r.record_type() == RecordType::NS
+                && query.query_type() != RecordType::NS
+                && query.query_type() != RecordType::ANY
+        });
+
+        if is_referral {
+            message
+                .authorities_mut()
+                .extend(lookup_records.iter().cloned());
+        } else {
+            message.answers_mut().extend(lookup_records.iter().cloned());
+        }
+    }
 
     if let Some(ns_records) = ns {
         message.authorities_mut().extend(ns_records.iter().cloned());
@@ -1028,10 +1033,6 @@ async fn build_authoritative_response(
             .authorities_mut()
             .extend(soa_records.iter().cloned());
     }
-
-    message
-        .additionals_mut()
-        .extend(additionals.iter().cloned());
 
     message
 }
@@ -1263,7 +1264,11 @@ async fn build_forwarded_response(
 
 #[cfg(all(test, feature = "resolver"))]
 mod tests {
+    use std::{net::Ipv4Addr, str::FromStr};
+
     use super::*;
+    use crate::net::runtime::TokioRuntimeProvider;
+    use crate::proto::rr::rdata::NS;
     use crate::proto::{
         op::{MessageType, OpCode, Query},
         rr::{
@@ -1272,7 +1277,8 @@ mod tests {
         },
     };
     use crate::resolver::lookup::Lookup;
-    use std::{net::Ipv4Addr, str::FromStr};
+    use crate::store::in_memory::InMemoryZoneHandler;
+    use crate::zone_handler::AxfrPolicy;
 
     #[tokio::test]
     async fn test_build_forwarded_response_preserves_sections() {
@@ -1344,5 +1350,48 @@ mod tests {
             "Additionals section should not be empty, got {} records",
             additionals_count
         );
+    }
+
+    #[tokio::test]
+    async fn test_build_authoritative_response_referral() {
+        let origin = Name::from_str("example.com.").unwrap();
+        let sub = Name::from_str("sub.example.com.").unwrap();
+        let ns_name = Name::from_str("ns.example.com.").unwrap();
+
+        let ns_record = Record::from_rdata(sub.clone(), 3600, RData::NS(NS(ns_name)));
+        let record_set = RecordSet::from(ns_record);
+
+        let auth_lookup = AuthLookup::Records {
+            answers: LookupRecords::new(LookupOptions::default(), Arc::new(record_set)),
+            additionals: None,
+        };
+
+        let handler = InMemoryZoneHandler::<TokioRuntimeProvider>::empty(
+            origin.clone(),
+            ZoneType::Primary,
+            AxfrPolicy::Deny,
+            #[cfg(feature = "__dnssec")]
+            None,
+        );
+
+        let header = Header::new(0, MessageType::Query, OpCode::Query);
+        let query = LowerQuery::from(Query::query(
+            Name::from_str("www.sub.example.com.").unwrap(),
+            RecordType::A,
+        ));
+
+        let message = build_authoritative_response(
+            Ok(auth_lookup),
+            &handler,
+            &header,
+            LookupOptions::default(),
+            0,
+            &query,
+        )
+        .await;
+
+        assert!(message.answers().is_empty());
+        assert!(!message.authorities().is_empty());
+        assert_eq!(message.authorities()[0].record_type(), RecordType::NS);
     }
 }

--- a/tests/integration-tests/tests/integration/rfc4592_tests.rs
+++ b/tests/integration-tests/tests/integration/rfc4592_tests.rs
@@ -193,7 +193,6 @@ async fn no_synthesis_3() {
 ///    QNAME=host.subdel.example., QTYPE=A, QCLASS=IN
 ///         because subdel.example. exists (and is a zone cut)
 /// ```
-#[ignore = "hickory does not send referrals for names below delegation points (issue #2810)"]
 #[tokio::test]
 async fn no_synthesis_4() {
     subscribe();


### PR DESCRIPTION
This change adds handling for the case where a name exists under a delegation to other nameservers.

If NS records exist that point a subdomain elsewhere, these are returned in the AUTHORITATIVE section of the DNS response.

I have added unit tests to prevent regressions and enabled an existsing test that was previously ignored due to the broken behaviour.

This might only be a partial fix to #2810 as I have not looked at other stores than the in-memory one.

Both Rust and the hickory-dns codebase are new to me. Please let me know if something is done the wrong way.