### PR TITLE
Recursor: support Happy Eyeballs for lookups

### DIFF
--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -590,6 +590,13 @@ pub struct ResolverOpts {
     pub allow_answers: Vec<IpNet>,
     /// Networks listed here will be removed from any answers returned by an upstream server.
     pub deny_answers: Vec<IpNet>,
+    /// Interleave servers by address family (IPv4/IPv6) after sorting.
+    ///
+    /// When enabled, the server list is reordered so that IPv4 and IPv6 servers alternate. Combined
+    /// with `num_concurrent_reqs >= 2`, this provides Happy Eyeballs-style behavior: both address
+    /// families are tried concurrently, and whichever responds first wins. This is particularly
+    /// useful when one address family is configured but has no actual connectivity.
+    pub happy_eyeballs: bool,
 }
 
 impl ResolverOpts {
@@ -640,6 +647,7 @@ impl Default for ResolverOpts {
             trust_anchor: None,
             allow_answers: vec![],
             deny_answers: vec![],
+            happy_eyeballs: false,
         }
     }
 }
@@ -1119,5 +1127,6 @@ mod tests {
         assert_eq!(code.os_port_selection, json.os_port_selection);
         assert_eq!(code.case_randomization, json.case_randomization);
         assert_eq!(code.trust_anchor, json.trust_anchor);
+        assert_eq!(code.happy_eyeballs, json.happy_eyeballs);
     }
 }

--- a/crates/resolver/src/name_server_pool.rs
+++ b/crates/resolver/src/name_server_pool.rs
@@ -267,6 +267,10 @@ impl<P: ConnectionProvider> PoolState<P> {
             }
         }
 
+        if self.cx.options.happy_eyeballs {
+            servers = interleave_by_address_family(servers);
+        }
+
         // If the name server we're trying is giving us backpressure by returning NetErrorKind::Busy,
         // we will first try the other name servers (as for other error types). However, if the other
         // servers are also busy, we're going to wait for a little while and then retry each server that
@@ -347,8 +351,8 @@ impl<P: ConnectionProvider> PoolState<P> {
                     }
                     // If the server is busy, try it again later if necessary.
                     NetError::Busy => busy.push(server),
-                    // If the connection failed, try another one.
-                    NetError::Io(_) | NetError::NoConnections => {}
+                    // If the connection failed or timed out, try another one.
+                    NetError::Io(_) | NetError::NoConnections | NetError::Timeout => {}
                     // If we got an `NXDomain` response from a server whose negative responses we
                     // don't trust, we should try another server.
                     NetError::Dns(DnsError::NoRecordsFound(NoRecords {
@@ -391,6 +395,51 @@ fn most_specific(previous: NetError, current: NetError) -> NetError {
     }
 
     previous
+}
+
+/// Interleave servers by address family so IPv4 and IPv6 servers alternate.
+///
+/// Expects `servers` to already be sorted (e.g., by SRTT). Preserves the relative order within
+/// each family. The family whose first server has the lower SRTT goes first.
+///
+/// Combined with `num_concurrent_reqs >= 2` this gives Happy Eyeballs-style behavior: both
+/// address families are tried concurrently and whichever responds first wins.
+fn interleave_by_address_family<P: ConnectionProvider>(
+    servers: Vec<Arc<NameServer<P>>>,
+) -> Vec<Arc<NameServer<P>>> {
+    let mut v4 = servers.iter().filter(|s| s.ip().is_ipv4());
+    let mut v6 = servers.iter().filter(|s| s.ip().is_ipv6());
+
+    let (Some(first_v4), Some(first_v6)) = (v4.next(), v6.next()) else {
+        return servers;
+    };
+
+    let mut take_v4 = first_v4.decayed_srtt() <= first_v6.decayed_srtt();
+    let mut result = Vec::with_capacity(servers.len());
+
+    let (mut next_v4, mut next_v6) = (Some(first_v4), Some(first_v6));
+    loop {
+        let next = if take_v4 {
+            next_v4.take().or_else(|| next_v6.take())
+        } else {
+            next_v6.take().or_else(|| next_v4.take())
+        };
+
+        let Some(server) = next else { break };
+        result.push(server.clone());
+        take_v4 = !take_v4;
+
+        if next_v4.is_none() {
+            next_v4 = v4.next();
+        }
+        if next_v6.is_none() {
+            next_v6 = v6.next();
+        }
+        if next_v4.is_none() && next_v6.is_none() {
+            break;
+        }
+    }
+    result
 }
 
 /// Context for a [`NameServerPool`]
@@ -1024,5 +1073,58 @@ mod tests {
             name_servers[0].is_connected(),
             "if this is failing then the NameServers aren't being properly shared."
         );
+    }
+
+    #[test]
+    fn test_interleave_by_address_family() {
+        let conn_provider = TokioRuntimeProvider::default();
+        let opts = ResolverOpts::default();
+
+        let make_ns = |ip: IpAddr| -> Arc<NameServer<TokioRuntimeProvider>> {
+            Arc::new(NameServer::new(
+                [],
+                NameServerConfig::udp(ip),
+                &opts,
+                conn_provider.clone(),
+            ))
+        };
+
+        let v4_1: IpAddr = [1, 1, 1, 1].into();
+        let v4_2: IpAddr = [8, 8, 8, 8].into();
+        let v6_1: IpAddr = "2606:4700::1".parse().unwrap();
+        let v6_2: IpAddr = "2001:4860:4860::8888".parse().unwrap();
+
+        // Mixed: should interleave
+        let servers = vec![make_ns(v4_1), make_ns(v4_2), make_ns(v6_1), make_ns(v6_2)];
+        let result = interleave_by_address_family(servers);
+        let ips: Vec<IpAddr> = result.iter().map(|s| s.ip()).collect();
+        // First two should be from different families
+        assert_ne!(ips[0].is_ipv4(), ips[1].is_ipv4());
+        assert_eq!(ips.len(), 4);
+
+        // Only IPv4: no change
+        let servers = vec![make_ns(v4_1), make_ns(v4_2)];
+        let result = interleave_by_address_family(servers);
+        let ips: Vec<IpAddr> = result.iter().map(|s| s.ip()).collect();
+        assert_eq!(ips, vec![v4_1, v4_2]);
+
+        // Only IPv6: no change
+        let servers = vec![make_ns(v6_1), make_ns(v6_2)];
+        let result = interleave_by_address_family(servers);
+        let ips: Vec<IpAddr> = result.iter().map(|s| s.ip()).collect();
+        assert_eq!(ips, vec![v6_1, v6_2]);
+
+        // Empty
+        let servers: Vec<Arc<NameServer<TokioRuntimeProvider>>> = vec![];
+        let result = interleave_by_address_family(servers);
+        assert!(result.is_empty());
+
+        // Unequal counts: 3 v4, 1 v6
+        let v4_3: IpAddr = [9, 9, 9, 9].into();
+        let servers = vec![make_ns(v4_1), make_ns(v4_2), make_ns(v4_3), make_ns(v6_1)];
+        let result = interleave_by_address_family(servers);
+        let ips: Vec<IpAddr> = result.iter().map(|s| s.ip()).collect();
+        assert_ne!(ips[0].is_ipv4(), ips[1].is_ipv4());
+        assert_eq!(ips.len(), 4);
     }
 }

--- a/crates/resolver/src/recursor/handle.rs
+++ b/crates/resolver/src/recursor/handle.rs
@@ -14,7 +14,10 @@ use lru_cache::LruCache;
 use parking_lot::Mutex;
 use tracing::{debug, error, trace, warn};
 
-use super::{DnssecPolicy, RecursorError, RecursorOptions, error::AuthorityData, is_subzone};
+use super::{
+    DnssecPolicy, RecursorError, RecursorIpStrategy, RecursorOptions, error::AuthorityData,
+    is_subzone,
+};
 #[cfg(feature = "metrics")]
 use crate::metrics::recursor::RecursorMetrics;
 #[cfg(feature = "__dnssec")]
@@ -53,6 +56,7 @@ pub(crate) struct RecursorDnsHandle<P: ConnectionProvider> {
     connection_cache: Arc<Mutex<LruCache<IpAddr, Arc<NameServer<P>>>>>,
     request_options: DnsRequestOptions,
     ttl_config: TtlConfig,
+    ip_strategy: RecursorIpStrategy,
 }
 
 impl<P: ConnectionProvider> RecursorDnsHandle<P> {
@@ -65,11 +69,6 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
         conn_provider: P,
     ) -> Result<Self, RecursorError> {
         assert!(!roots.is_empty(), "roots must not be empty");
-        let servers = roots
-            .iter()
-            .copied()
-            .map(|ip| name_server_config(ip, &options.opportunistic_encryption))
-            .collect::<Vec<_>>();
 
         let RecursorOptions {
             ns_cache_size,
@@ -84,7 +83,20 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
             cache_policy,
             case_randomization,
             opportunistic_encryption,
+            ip_strategy,
         } = options;
+
+        let servers = roots
+            .iter()
+            .copied()
+            .filter(|ip| ip_strategy.is_allowed(*ip))
+            .map(|ip| name_server_config(ip, &opportunistic_encryption))
+            .collect::<Vec<_>>();
+
+        assert!(
+            !servers.is_empty(),
+            "no root servers remaining after applying ip_strategy filter"
+        );
 
         let avoid_local_udp_ports = Arc::new(avoid_local_udp_ports);
 
@@ -146,6 +158,7 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
             connection_cache: Arc::new(Mutex::new(LruCache::new(ns_cache_size))),
             request_options,
             ttl_config: cache_policy.clone(),
+            ip_strategy,
         })
     }
 
@@ -586,7 +599,12 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
                     ns_pool_ttl = zns.ttl();
                 }
 
-                for record_type in [RecordType::A, RecordType::AAAA] {
+                let glue_record_types: &[RecordType] = match self.ip_strategy {
+                    RecursorIpStrategy::Ipv4Only => &[RecordType::A],
+                    RecursorIpStrategy::Ipv6Only => &[RecordType::AAAA],
+                    RecursorIpStrategy::Ipv4AndIpv6 => &[RecordType::A, RecordType::AAAA],
+                };
+                for &record_type in glue_record_types {
                     if let Some(Ok(response)) = self
                         .response_cache
                         .get(&Query::query(ns_data.0.clone(), record_type), request_time)
@@ -699,6 +717,10 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
                 RData::AAAA(AAAA(ipv6)) => (*ipv6).into(),
                 _ => continue,
             };
+            if !self.ip_strategy.is_allowed(ip) {
+                debug!(name = %record.name(), %ip, "ignoring address due to ip_strategy");
+                continue;
+            }
             if self.name_server_filter.denied(ip) {
                 debug!(name = %record.name(), %ip, "ignoring address due to do_not_query");
                 continue;
@@ -747,8 +769,14 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
 
         let mut futures = FuturesUnordered::new();
 
+        let record_types: &[RecordType] = match self.ip_strategy {
+            RecursorIpStrategy::Ipv4Only => &[RecordType::A],
+            RecursorIpStrategy::Ipv6Only => &[RecordType::AAAA],
+            RecursorIpStrategy::Ipv4AndIpv6 => &[RecordType::A, RecordType::AAAA],
+        };
+
         for (pool, query) in pool_queries.iter() {
-            for rec_type in [RecordType::A, RecordType::AAAA] {
+            for &rec_type in record_types {
                 futures.push(Box::pin(
                     pool.lookup(Query::query(query.clone(), rec_type), self.request_options)
                         .into_future()
@@ -763,13 +791,17 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
             match next {
                 Some(Ok(mut response)) => {
                     debug!("append_ips_from_lookup: A or AAAA response: {response:?}");
+                    let ip_strategy = self.ip_strategy;
                     config.extend(response
                         .take_answers()
                         .into_iter()
                         .filter_map(|answer| {
                             let ip = answer.data().ip_addr()?;
 
-                            if self.name_server_filter.denied(ip) {
+                            if !ip_strategy.is_allowed(ip) {
+                                debug!(%ip, "append_ips_from_lookup: ignoring address due to ip_strategy");
+                                None
+                            } else if self.name_server_filter.denied(ip) {
                                 debug!(%ip, "append_ips_from_lookup: ignoring address due to do_not_query");
                                 None
                             } else {
@@ -863,9 +895,10 @@ fn recursor_opts(
         validate: false, // we'll need to do any dnssec validation differently in a recursor (top-down rather than bottom-up)
         preserve_intermediates: true,
         recursion_desired: false,
-        num_concurrent_reqs: 1,
+        num_concurrent_reqs: 2,
         avoid_local_udp_ports,
         case_randomization,
+        happy_eyeballs: true,
         ..ResolverOpts::default()
     }
 }

--- a/crates/resolver/src/recursor/mod.rs
+++ b/crates/resolver/src/recursor/mod.rs
@@ -623,6 +623,14 @@ pub struct RecursorOptions {
     /// Configure RFC 9539 opportunistic encryption.
     #[cfg_attr(feature = "serde", serde(default))]
     pub opportunistic_encryption: OpportunisticEncryption,
+
+    /// Which address families to use when connecting to name servers during recursive resolution.
+    ///
+    /// When set to `Ipv4Only`, only IPv4 name server addresses will be used. This is useful on
+    /// systems where IPv6 is configured but has no actual connectivity, as it avoids timeouts
+    /// waiting for unreachable IPv6 name servers.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub ip_strategy: RecursorIpStrategy,
 }
 
 impl Default for RecursorOptions {
@@ -640,6 +648,7 @@ impl Default for RecursorOptions {
             cache_policy: TtlConfig::default(),
             case_randomization: false,
             opportunistic_encryption: OpportunisticEncryption::default(),
+            ip_strategy: RecursorIpStrategy::default(),
         }
     }
 }
@@ -667,6 +676,30 @@ fn ns_recursion_limit_default() -> u8 {
 #[cfg(feature = "serde")]
 fn deny_server_default() -> Vec<IpNet> {
     RECOMMENDED_SERVER_FILTERS.to_vec()
+}
+
+/// Controls which address families the recursor uses when connecting to name servers.
+#[cfg_attr(feature = "serde", derive(Deserialize))]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]
+pub enum RecursorIpStrategy {
+    /// Use both IPv4 and IPv6 name server addresses
+    #[default]
+    Ipv4AndIpv6,
+    /// Only use IPv4 name server addresses
+    Ipv4Only,
+    /// Only use IPv6 name server addresses
+    Ipv6Only,
+}
+
+impl RecursorIpStrategy {
+    /// Returns true if the given IP address is allowed by this strategy.
+    pub fn is_allowed(&self, ip: IpAddr) -> bool {
+        match self {
+            Self::Ipv4AndIpv6 => true,
+            Self::Ipv4Only => ip.is_ipv4(),
+            Self::Ipv6Only => ip.is_ipv6(),
+        }
+    }
 }
 
 /// `Recursor`'s DNSSEC policy


### PR DESCRIPTION
Before this change, the recursor would fail if the server has a broken IPv6 connectivity for a couple of reasons.

1. The timeout error from the servers was treated as a non-recoverable error. So a failed IPv6 lookup would immediately disqualify the name server.
2. Even after adding a timeout to recoverable error, a cascade of lookups needed to validate a DNSSEC name could easily take ~20 seconds for a typical name, resulting in app-level timeouts.

This commit adds an option to restrict connectivity to IPv4/IPv6/both, and it also adds an option (default) to run V4 and V6 queries in parallel.

AI disclosure: the code was written manually by me, AI was used for basic full-line completions, and to generate the tests.