### PR TITLE
Add client allow-listing

### DIFF
--- a/bin/src/config/mod.rs
+++ b/bin/src/config/mod.rs
@@ -228,6 +228,12 @@ where
 pub(crate) struct ZoneConfig {
     /// name of the zone
     pub zone: String, // TODO: make Domain::Name decodable
+    /// Networks denied from querying this zone
+    #[serde(default)]
+    pub deny_clients: Vec<IpNet>,
+    /// Networks allowed to query this zone
+    #[serde(default)]
+    pub allow_clients: Vec<IpNet>,
     /// type of the zone
     #[serde(flatten)]
     pub zone_type_config: ZoneTypeConfig,

--- a/bin/src/config/tests.rs
+++ b/bin/src/config/tests.rs
@@ -235,6 +235,7 @@ define_test_config!(ipv4_only);
 define_test_config!(ipv6_only);
 #[cfg(feature = "resolver")]
 define_test_config!(example_forwarder);
+define_test_config!(example_client_acl);
 
 /// Iterator that yields modified TOML tables with an extra field added, and recurses down the
 /// table's values.
@@ -498,6 +499,37 @@ fn test_reject_unknown_fields() {
             }
         }
     }
+}
+
+#[test]
+fn test_parse_client_acl() {
+    let config = Config::from_toml(
+        r#"
+[[zones]]
+zone = "example.com"
+zone_type = "Primary"
+allow_clients = ["192.168.0.0/16", "10.0.0.0/8"]
+deny_clients = ["192.168.1.0/24"]
+file = "example.com.zone"
+
+[[zones]]
+zone = "other.com"
+zone_type = "Primary"
+file = "example.com.zone"
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(config.zones[0].allow_clients.len(), 2);
+    assert_eq!(
+        config.zones[0].allow_clients[0],
+        "192.168.0.0/16".parse::<ipnet::IpNet>().unwrap()
+    );
+    assert_eq!(config.zones[0].deny_clients.len(), 1);
+
+    // Zone without client ACL should have empty lists
+    assert!(config.zones[1].allow_clients.is_empty());
+    assert!(config.zones[1].deny_clients.is_empty());
 }
 
 fn server_zone(config: &Config, index: usize) -> &ServerZoneConfig {

--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -315,8 +315,16 @@ impl DnsServer {
             #[cfg(feature = "metrics")]
             config_metrics.increment_zone_metrics(&zone);
 
+            let deny_clients = zone.deny_clients.clone();
+            let allow_clients = zone.allow_clients.clone();
+
             match zone.load(&zone_dir).await {
-                Ok(handlers) => catalog.upsert(zone_name.into(), handlers),
+                Ok(handlers) => catalog.upsert_with_client_policy(
+                    zone_name.into(),
+                    handlers,
+                    deny_clients,
+                    allow_clients,
+                ),
                 Err(err) => return Err(format!("could not load zone {zone_name}: {err}")),
             }
         }

--- a/crates/server/src/zone_handler/catalog.rs
+++ b/crates/server/src/zone_handler/catalog.rs
@@ -10,6 +10,7 @@
 //  then, if requested, do a recursive lookup... i.e. the catalog would only point to files.
 use std::{collections::HashMap, iter, sync::Arc};
 
+use ipnet::IpNet;
 use tracing::{debug, error, info, trace, warn};
 
 #[cfg(feature = "metrics")]
@@ -25,6 +26,7 @@ use crate::{
     zone_handler::Nsec3QueryInfo,
 };
 use crate::{
+    access::AccessControl,
     net::runtime::Time,
     proto::{
         op::{Edns, Header, LowerQuery, Message, MessageType, OpCode, ResponseCode},
@@ -45,11 +47,16 @@ use crate::{
     resolver::recursor,
 };
 
+struct ZoneEntry {
+    handlers: Vec<Arc<dyn ZoneHandler>>,
+    client_acl: AccessControl,
+}
+
 /// Set of zones and zone handlers available to this server.
 #[derive(Default)]
 pub struct Catalog {
     nsid_payload: Option<NSIDPayload>,
-    handlers: HashMap<LowerName, Vec<Arc<dyn ZoneHandler>>>,
+    zones: HashMap<LowerName, ZoneEntry>,
     #[cfg(feature = "metrics")]
     metrics: CatalogMetrics,
 }
@@ -169,7 +176,7 @@ impl Catalog {
     /// Constructs a new Catalog
     pub fn new() -> Self {
         Self {
-            handlers: HashMap::new(),
+            zones: HashMap::new(),
             nsid_payload: None,
             #[cfg(feature = "metrics")]
             metrics: CatalogMetrics::default(),
@@ -183,19 +190,46 @@ impl Catalog {
     /// * `name` - zone name, e.g. example.com.
     /// * `handlers` - a vec of zone handler objects
     pub fn upsert(&mut self, name: LowerName, handlers: Vec<Arc<dyn ZoneHandler>>) {
+        self.upsert_with_client_policy(name, handlers, [], []);
+    }
+
+    /// Insert or update the provided zone handlers with per-zone client access control.
+    ///
+    /// The `denied_clients` and `allowed_clients` parameters control which client IP addresses
+    /// are permitted to query this zone. The semantics match the server-level access control:
+    /// - If only `allowed_clients` is specified, only those networks may query the zone.
+    /// - If only `denied_clients` is specified, those networks are blocked.
+    /// - If both are specified, `denied_clients` takes precedence, but `allowed_clients`
+    ///   can override denials with more specific prefixes.
+    /// - If neither is specified, all clients are allowed.
+    pub fn upsert_with_client_policy(
+        &mut self,
+        name: LowerName,
+        handlers: Vec<Arc<dyn ZoneHandler>>,
+        denied_clients: impl IntoIterator<Item = IpNet>,
+        allowed_clients: impl IntoIterator<Item = IpNet>,
+    ) {
         #[cfg(feature = "metrics")]
         for handler in handlers.iter() {
             self.metrics.add_handler(handler.as_ref())
         }
 
-        self.handlers.insert(name, handlers);
+        let mut client_acl = AccessControl::default();
+        client_acl.insert_deny(denied_clients);
+        client_acl.insert_allow(allowed_clients);
+
+        self.zones.insert(name, ZoneEntry {
+            handlers,
+            client_acl,
+        });
     }
 
     /// Remove a zone from the catalog
     pub fn remove(&mut self, name: &LowerName) -> Option<Vec<Arc<dyn ZoneHandler>>> {
         // NOTE: metrics are not removed to avoid dropping counters that are potentially still
         // being used by other zone handlers having the same labels
-        self.handlers.remove(name)
+
+        self.zones.remove(name).map(|entry| entry.handlers)
     }
 
     /// Set a specified name server identifier (NSID) in responses
@@ -303,7 +337,22 @@ impl Catalog {
         }
 
         // verify the zone type and number of zones in request, then find the zone to update
-        if let Some(handlers) = self.find(request_info.query.name()) {
+        if let Some(entry) = self.find_entry(request_info.query.name()) {
+            if !entry.client_acl.allow(update.src().ip()) {
+                debug!(
+                    src = %update.src(),
+                    query = %request_info.query,
+                    "client denied by zone client access policy",
+                );
+                return send_error_response(
+                    update,
+                    ResponseCode::Refused,
+                    response_edns,
+                    response_handle,
+                )
+                .await;
+            }
+            let handlers = &entry.handlers;
             #[allow(clippy::never_loop)]
             for handler in handlers {
                 #[cfg_attr(not(feature = "__dnssec"), expect(unused))]
@@ -394,7 +443,7 @@ impl Catalog {
     /// If you do not know the exact domain name to use or you actually
     /// want to use the zone handler it contains, use `find` instead.
     pub fn contains(&self, name: &LowerName) -> bool {
-        self.handlers.contains_key(name)
+        self.zones.contains_key(name)
     }
 
     /// Given the requested query, lookup and return any matching results.
@@ -421,9 +470,9 @@ impl Catalog {
             )
             .await;
         };
-        let handlers = self.find(request_info.query.name());
+        let entry = self.find_entry(request_info.query.name());
 
-        let Some(handlers) = handlers else {
+        let Some(entry) = entry else {
             // There are no zone handlers registered that can handle the request
             return send_error_response(
                 request,
@@ -434,6 +483,22 @@ impl Catalog {
             .await;
         };
 
+        if !entry.client_acl.allow(request.src().ip()) {
+            debug!(
+                src = %request.src(),
+                query = %request_info.query,
+                "client denied by zone client access policy",
+            );
+            return send_error_response(
+                request,
+                ResponseCode::Refused,
+                response_edns,
+                response_handle,
+            )
+            .await;
+        }
+
+        let handlers = &entry.handlers;
         if request_info.query.query_type() == RecordType::AXFR {
             zone_transfer(
                 request_info,
@@ -460,11 +525,15 @@ impl Catalog {
 
     /// Recursively searches the catalog for a matching zone handler
     pub fn find(&self, name: &LowerName) -> Option<&Vec<Arc<dyn ZoneHandler + 'static>>> {
+        self.find_entry(name).map(|entry| &entry.handlers)
+    }
+
+    fn find_entry(&self, name: &LowerName) -> Option<&ZoneEntry> {
         debug!("searching zone handlers for: {name}");
-        self.handlers.get(name).or_else(|| {
+        self.zones.get(name).or_else(|| {
             if !name.is_root() {
                 let name = name.base_name();
-                self.find(&name)
+                self.find_entry(&name)
             } else {
                 None
             }

--- a/tests/integration-tests/tests/integration/catalog_tests.rs
+++ b/tests/integration-tests/tests/integration/catalog_tests.rs
@@ -1,4 +1,4 @@
-use std::{net::Ipv4Addr, str::FromStr, sync::Arc};
+use std::{net::Ipv4Addr, net::SocketAddr, str::FromStr, sync::Arc};
 
 use hickory_net::{
     runtime::{Time, TokioTime},
@@ -1205,5 +1205,192 @@ mod dnssec {
             assert_eq!(nsec3param.iterations(), 0);
             assert!(nsec3param.salt().is_empty());
         }
+    }
+}
+
+#[tokio::test]
+async fn test_catalog_client_acl_allow() {
+    subscribe();
+
+    let example = create_example();
+    let origin = example.origin().clone();
+
+    let mut catalog = Catalog::new();
+    catalog.upsert_with_client_policy(
+        origin.clone(),
+        vec![Arc::new(example)],
+        [],
+        ["192.168.0.0/16".parse().unwrap()],
+    );
+
+    let mut question = Message::query();
+    let mut query = Query::new();
+    query.set_name(origin.clone().into());
+    question.add_query(query);
+    let question_bytes = question.to_bytes().unwrap();
+
+    // Client from allowed network should succeed
+    let question_req = Request::from_bytes(
+        question_bytes.clone(),
+        SocketAddr::from(([192, 168, 1, 10], 5553)),
+        Protocol::Udp,
+    )
+    .unwrap();
+
+    let response_handler = TestResponseHandler::new();
+    catalog
+        .lookup(
+            &question_req,
+            None,
+            TokioTime::current_time(),
+            response_handler.clone(),
+        )
+        .await;
+    let result = response_handler.into_message().await;
+    assert_eq!(result.response_code(), ResponseCode::NoError);
+
+    // Client from disallowed network should be refused
+    let question_req = Request::from_bytes(
+        question_bytes,
+        SocketAddr::from(([10, 0, 0, 1], 5553)),
+        Protocol::Udp,
+    )
+    .unwrap();
+
+    let response_handler = TestResponseHandler::new();
+    catalog
+        .lookup(
+            &question_req,
+            None,
+            TokioTime::current_time(),
+            response_handler.clone(),
+        )
+        .await;
+    let result = response_handler.into_message().await;
+    assert_eq!(result.response_code(), ResponseCode::Refused);
+}
+
+#[tokio::test]
+async fn test_catalog_client_acl_deny_with_override() {
+    subscribe();
+
+    let example = create_example();
+    let origin = example.origin().clone();
+
+    let mut catalog = Catalog::new();
+    catalog.upsert_with_client_policy(
+        origin.clone(),
+        vec![Arc::new(example)],
+        ["192.168.0.0/16".parse().unwrap()],
+        ["192.168.1.0/24".parse().unwrap()],
+    );
+
+    let mut question = Message::query();
+    let mut query = Query::new();
+    query.set_name(origin.clone().into());
+    question.add_query(query);
+    let question_bytes = question.to_bytes().unwrap();
+
+    // Client from allowed subnet (overrides deny) should succeed
+    let question_req = Request::from_bytes(
+        question_bytes.clone(),
+        SocketAddr::from(([192, 168, 1, 10], 5553)),
+        Protocol::Udp,
+    )
+    .unwrap();
+
+    let response_handler = TestResponseHandler::new();
+    catalog
+        .lookup(
+            &question_req,
+            None,
+            TokioTime::current_time(),
+            response_handler.clone(),
+        )
+        .await;
+    let result = response_handler.into_message().await;
+    assert_eq!(result.response_code(), ResponseCode::NoError);
+
+    // Client from denied network (not in allow override) should be refused
+    let question_req = Request::from_bytes(
+        question_bytes.clone(),
+        SocketAddr::from(([192, 168, 2, 10], 5553)),
+        Protocol::Udp,
+    )
+    .unwrap();
+
+    let response_handler = TestResponseHandler::new();
+    catalog
+        .lookup(
+            &question_req,
+            None,
+            TokioTime::current_time(),
+            response_handler.clone(),
+        )
+        .await;
+    let result = response_handler.into_message().await;
+    assert_eq!(result.response_code(), ResponseCode::Refused);
+
+    // Client from outside the denied network should succeed
+    let question_req = Request::from_bytes(
+        question_bytes,
+        SocketAddr::from(([10, 0, 0, 1], 5553)),
+        Protocol::Udp,
+    )
+    .unwrap();
+
+    let response_handler = TestResponseHandler::new();
+    catalog
+        .lookup(
+            &question_req,
+            None,
+            TokioTime::current_time(),
+            response_handler.clone(),
+        )
+        .await;
+    let result = response_handler.into_message().await;
+    assert_eq!(result.response_code(), ResponseCode::NoError);
+}
+
+#[tokio::test]
+async fn test_catalog_no_client_acl_allows_all() {
+    subscribe();
+
+    let example = create_example();
+    let origin = example.origin().clone();
+
+    let mut catalog = Catalog::new();
+    catalog.upsert(origin.clone(), vec![Arc::new(example)]);
+
+    let mut question = Message::query();
+    let mut query = Query::new();
+    query.set_name(origin.clone().into());
+    question.add_query(query);
+    let question_bytes = question.to_bytes().unwrap();
+
+    // Any client should succeed when no ACL is configured
+    for addr in [
+        SocketAddr::from(([192, 168, 1, 1], 5553)),
+        SocketAddr::from(([10, 0, 0, 1], 5553)),
+        SocketAddr::from(([1, 2, 3, 4], 5553)),
+    ] {
+        let question_req =
+            Request::from_bytes(question_bytes.clone(), addr, Protocol::Udp).unwrap();
+
+        let response_handler = TestResponseHandler::new();
+        catalog
+            .lookup(
+                &question_req,
+                None,
+                TokioTime::current_time(),
+                response_handler.clone(),
+            )
+            .await;
+        let result = response_handler.into_message().await;
+        assert_eq!(
+            result.response_code(),
+            ResponseCode::NoError,
+            "client {addr} should be allowed"
+        );
     }
 }

--- a/tests/test-data/test_configs/example_client_acl.toml
+++ b/tests/test-data/test_configs/example_client_acl.toml
@@ -1,0 +1,23 @@
+listen_addrs_ipv4 = ["0.0.0.0"]
+listen_addrs_ipv6 = ["::0"]
+
+## A zone available to all clients (authoritative, no client restrictions)
+[[zones]]
+zone = "example.com"
+zone_type = "Primary"
+file = "example.com.zone"
+
+## A zone restricted to LAN clients only
+[[zones]]
+zone = "internal.example.com"
+zone_type = "Primary"
+allow_clients = ["192.168.0.0/16", "10.0.0.0/8", "fd00::/8"]
+file = "example.com.zone"
+
+## A zone with deny + allow override
+[[zones]]
+zone = "restricted.example.com"
+zone_type = "Primary"
+deny_clients = ["192.168.0.0/16"]
+allow_clients = ["192.168.1.0/24"]
+file = "example.com.zone"

--- a/tests/test-data/test_configs/example_recursor.toml
+++ b/tests/test-data/test_configs/example_recursor.toml
@@ -35,6 +35,35 @@ zone = "."
 ## zone_type: Primary, Secondary, External
 zone_type = "External"
 
+## allow_clients: restrict which client networks may query this zone. When set, only
+## clients from the listed networks are allowed; all others receive REFUSED. This is
+## particularly useful for recursive/forwarding zones to prevent open resolver abuse.
+##
+##    10.0.0.0/8         RFC 1918 private space
+##    172.16.0.0/12      RFC 1918 private space
+##    192.168.0.0/16     RFC 1918 private space
+##    100.64.0.0/10      RFC 6598 Carrier-Grade NAT
+##    127.0.0.0/8        Loopback
+##    169.254.0.0/16     RFC 3927 Link-local
+##    fc00::/7           RFC 4193 Unique Local Addresses
+##    fe80::/10          RFC 4291 Link-local
+##    ::1/128            v6 loopback
+allow_clients = [
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+    "100.64.0.0/10",
+    "127.0.0.0/8",
+    "169.254.0.0/16",
+    "fc00::/7",
+    "fe80::/10",
+    "::1/128",
+]
+
+## deny_clients: deny specific client networks from querying this zone. Can be combined
+## with allow_clients to create exceptions — a more specific allow entry overrides a deny.
+#deny_clients = []
+
 [zones.stores]
 type = "recursor"
 roots = "default/root.zone"


### PR DESCRIPTION
Hickory supports limiting _servers_ using the classic ACL approach of allow/deny lists. However, it does not allow limiting _clients_.

This is extremely important for servers that work both as recursive resolvers and authoritative servers, otherwise open recursive resolvers get abused by all kinds of bots trying to work around geoblocks.

AI disclosure: the code was written by me (a human). AI was used for basic autocomplete.