### PR TITLE
Fix wildcard synthesis

### DIFF
--- a/crates/server/src/store/in_memory/inner.rs
+++ b/crates/server/src/store/in_memory/inner.rs
@@ -194,13 +194,19 @@ impl InnerInMemory {
         }
     }
 
-    pub(super) fn inner_lookup(
+    /// Checks if a name exists in the zone, either because it has records of any type
+    /// or because it is an empty non-terminal (a parent of names that have records).
+    fn name_exists(&self, name: &LowerName) -> bool {
+        self.records.keys().any(|key| name.zone_of(key.name()))
+    }
+
+    /// Looks up records with the exact name, matching the requested type (CNAME, ANAME, etc.).
+    /// Does not perform wildcard synthesis.
+    fn inner_lookup_exact(
         &self,
         name: &LowerName,
         record_type: RecordType,
-        lookup_options: LookupOptions,
     ) -> Option<Arc<RecordSet>> {
-        // this range covers all the records for any of the RecordTypes at a given label.
         let start_range_key = RrKey::new(name.clone(), RecordType::Unknown(u16::MIN));
         let end_range_key = RrKey::new(name.clone(), RecordType::Unknown(u16::MAX));
 
@@ -209,24 +215,40 @@ impl InnerInMemory {
                 && key_type == RecordType::ANAME
         }
 
-        let lookup = self
-            .records
+        self.records
             .range(&start_range_key..&end_range_key)
-            // remember CNAME can be the only record at a particular label
             .find(|(key, _)| {
                 key.record_type == record_type
                     || key.record_type == RecordType::CNAME
                     || aname_covers_type(key.record_type, record_type)
             })
-            .map(|(_key, rr_set)| rr_set);
+            .map(|(_key, rr_set)| rr_set.clone())
+    }
 
-        // TODO: maybe unwrap this recursion.
-        match lookup {
-            None => self.inner_lookup_wildcard(name, record_type, lookup_options),
-            l => l.cloned(),
+    pub(super) fn inner_lookup(
+        &self,
+        name: &LowerName,
+        record_type: RecordType,
+        lookup_options: LookupOptions,
+    ) -> Option<Arc<RecordSet>> {
+        match self.inner_lookup_exact(name, record_type) {
+            Some(rr_set) => Some(rr_set),
+            None => {
+                // RFC 4592 Section 2.2.1: wildcard synthesis only occurs when the
+                // query name does not match any existing owner name in the zone.
+                // A name "exists" if it has records of any type, or is an empty
+                // non-terminal (a parent of names that have records).
+                if self.name_exists(name) {
+                    None
+                } else {
+                    self.inner_lookup_wildcard(name, record_type, lookup_options)
+                }
+            }
         }
     }
 
+    /// RFC 4592 wildcard synthesis: find the closest encloser of the query name
+    /// (the longest existing ancestor), then try the wildcard at that level only.
     fn inner_lookup_wildcard(
         &self,
         name: &LowerName,
@@ -238,55 +260,60 @@ impl InnerInMemory {
             return None;
         }
 
+        // Walk up from the query name to find the closest encloser.
         let mut wildcard = name.clone().into_wildcard();
         loop {
-            let Some(rrset) = self.inner_lookup(&wildcard, record_type, lookup_options) else {
-                let parent = wildcard.base_name();
-                if parent.is_root() {
-                    return None;
-                }
+            let closest_encloser = wildcard.base_name();
 
-                wildcard = parent.into_wildcard();
-                continue;
-            };
-
-            // we need to change the name to the query name in the result set since this was a wildcard
-            let mut new_answer =
-                RecordSet::with_ttl(Name::from(name), rrset.record_type(), rrset.ttl());
-
-            #[allow(clippy::needless_late_init)]
-            let records;
-            #[allow(clippy::needless_late_init)]
-            let _rrsigs: Vec<&Record>;
-            cfg_if! {
-                if #[cfg(feature = "__dnssec")] {
-                    let (records_tmp, rrsigs_tmp) = rrset
-                        .records(lookup_options.dnssec_ok)
-                        .partition(|r| r.record_type() != RecordType::RRSIG);
-                    records = records_tmp;
-                    _rrsigs = rrsigs_tmp;
-                } else {
-                    let (records_tmp, rrsigs_tmp) = (rrset.records_without_rrsigs(), Vec::with_capacity(0));
-                    records = records_tmp;
-                    _rrsigs = rrsigs_tmp;
-                }
-            };
-
-            for record in records {
-                new_answer.add_rdata(record.data().clone());
+            if closest_encloser.is_root() {
+                return None;
             }
 
-            #[cfg(feature = "__dnssec")]
-            for rrsig in _rrsigs {
-                let mut rrsig = rrsig.clone();
-                if *rrsig.name() == *wildcard {
-                    rrsig.set_name(Name::from(name));
-                }
-                new_answer.insert_rrsig(rrsig)
+            if self.name_exists(&closest_encloser) {
+                break;
             }
 
-            return Some(Arc::new(new_answer));
+            wildcard = closest_encloser.into_wildcard();
         }
+
+        let rrset = self.inner_lookup_exact(&wildcard, record_type)?;
+
+        // Synthesize: copy the wildcard records but set the owner name to the query name.
+        let mut new_answer =
+            RecordSet::with_ttl(Name::from(name), rrset.record_type(), rrset.ttl());
+
+        #[allow(clippy::needless_late_init)]
+        let records;
+        #[allow(clippy::needless_late_init)]
+        let _rrsigs: Vec<&Record>;
+        cfg_if! {
+            if #[cfg(feature = "__dnssec")] {
+                let (records_tmp, rrsigs_tmp) = rrset
+                    .records(lookup_options.dnssec_ok)
+                    .partition(|r| r.record_type() != RecordType::RRSIG);
+                records = records_tmp;
+                _rrsigs = rrsigs_tmp;
+            } else {
+                let (records_tmp, rrsigs_tmp) = (rrset.records_without_rrsigs(), Vec::with_capacity(0));
+                records = records_tmp;
+                _rrsigs = rrsigs_tmp;
+            }
+        };
+
+        for record in records {
+            new_answer.add_rdata(record.data().clone());
+        }
+
+        #[cfg(feature = "__dnssec")]
+        for rrsig in _rrsigs {
+            let mut rrsig = rrsig.clone();
+            if *rrsig.name() == *wildcard {
+                rrsig.set_name(Name::from(name));
+            }
+            new_answer.insert_rrsig(rrsig)
+        }
+
+        Some(Arc::new(new_answer))
     }
 
     /// Search for additional records to include in the response

--- a/tests/integration-tests/tests/integration/rfc4592_tests.rs
+++ b/tests/integration-tests/tests/integration/rfc4592_tests.rs
@@ -120,7 +120,6 @@ async fn wildcard_synthesis_3() {
 ///         because host1.example. exists
 /// ```
 #[tokio::test]
-#[ignore = "hickory does not check for blocking names"]
 async fn no_synthesis_1() {
     subscribe();
 
@@ -144,7 +143,6 @@ async fn no_synthesis_1() {
 ///    QNAME=sub.*.example., QTYPE=MX, QCLASS=IN
 ///         because sub.*.example. exists
 /// ```
-#[ignore = "hickory does not check for blocking names"]
 #[tokio::test]
 async fn no_synthesis_2() {
     subscribe();
@@ -227,7 +225,6 @@ async fn no_synthesis_4() {
 ///         because *.example. exists
 /// ```
 #[tokio::test]
-#[ignore = "hickory does not treat wildcards as blocking themselves"]
 async fn no_synthesis_5() {
     subscribe();
 
@@ -242,6 +239,131 @@ async fn no_synthesis_5() {
     print_response(&response);
     assert_eq!(response.response_code(), ResponseCode::NXDomain);
     assert_eq!(response.answers(), []);
+}
+
+/// A CNAME wildcard must not match a name that already exists in the zone,
+/// even if the existing name has a different record type. Per RFC 4592 Section
+/// 2.2.1, the presence of *any* record at a name blocks wildcard synthesis for
+/// all types at that name.
+///
+/// Zone:
+///   server.example.   A     1.2.3.4
+///   catchall.example. A     3.4.5.6
+///   catchall.example. AAAA  ::1
+///   *.example.        CNAME catchall.example.
+///
+/// Query: server.example. AAAA => must be NODATA (the A record blocks the wildcard).
+#[tokio::test]
+async fn wildcard_cname_blocked_by_existing_name() {
+    subscribe();
+
+    let origin = Name::parse("example.", None).unwrap();
+    const SERIAL: u32 = 1;
+    const TTL: u32 = 3600;
+
+    let mut handler = InMemoryZoneHandler::<TokioRuntimeProvider>::empty(
+        origin.clone(),
+        ZoneType::Primary,
+        AxfrPolicy::Deny,
+        #[cfg(feature = "__dnssec")]
+        None,
+    );
+    handler.upsert_mut(
+        Record::from_rdata(
+            origin.clone(),
+            TTL,
+            RData::SOA(SOA::new(
+                Name::parse("mname", Some(&origin)).unwrap(),
+                Name::parse("rname", Some(&origin)).unwrap(),
+                SERIAL,
+                3600,
+                300,
+                3600000,
+                TTL,
+            )),
+        ),
+        SERIAL,
+    );
+    handler.upsert_mut(
+        Record::from_rdata(
+            origin.clone(),
+            TTL,
+            RData::NS(NS(Name::parse("ns.example.com.", None).unwrap())),
+        ),
+        SERIAL,
+    );
+    handler.upsert_mut(
+        Record::from_rdata(
+            Name::parse("server", Some(&origin)).unwrap(),
+            TTL,
+            RData::A(A::new(1, 2, 3, 4)),
+        ),
+        SERIAL,
+    );
+    handler.upsert_mut(
+        Record::from_rdata(
+            Name::parse("catchall", Some(&origin)).unwrap(),
+            TTL,
+            RData::A(A::new(3, 4, 5, 6)),
+        ),
+        SERIAL,
+    );
+    handler.upsert_mut(
+        Record::from_rdata(
+            Name::parse("catchall", Some(&origin)).unwrap(),
+            TTL,
+            RData::AAAA(hickory_proto::rr::rdata::AAAA::new(0, 0, 0, 0, 0, 0, 0, 1)),
+        ),
+        SERIAL,
+    );
+    handler.upsert_mut(
+        Record::from_rdata(
+            Name::parse("*", Some(&origin)).unwrap(),
+            TTL,
+            RData::CNAME(hickory_proto::rr::rdata::CNAME(
+                Name::parse("catchall", Some(&origin)).unwrap(),
+            )),
+        ),
+        SERIAL,
+    );
+
+    let mut catalog = Catalog::new();
+    catalog.upsert(origin.into(), vec![Arc::new(handler)]);
+
+    let udp_socket = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let local_addr = udp_socket.local_addr().unwrap();
+    let mut server = Server::new(catalog);
+    server.register_socket(udp_socket);
+
+    let stream = UdpClientStream::builder(local_addr, TokioRuntimeProvider::new()).build();
+    let (mut client, bg) = Client::<TokioRuntimeProvider>::from_sender(stream);
+    tokio::spawn(bg);
+
+    // server.example. AAAA must return NODATA, not the wildcard CNAME
+    let query_name = Name::parse("server.example.", None).unwrap();
+    let response = client
+        .query(query_name.clone(), DNSClass::IN, RecordType::AAAA)
+        .await
+        .unwrap();
+    print_response(&response);
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+    assert_eq!(response.answers(), []);
+
+    // unknown.example. AAAA should still get the wildcard CNAME
+    let query_name = Name::parse("unknown.example.", None).unwrap();
+    let response = client
+        .query(query_name.clone(), DNSClass::IN, RecordType::AAAA)
+        .await
+        .unwrap();
+    print_response(&response);
+    assert_eq!(response.response_code(), ResponseCode::NoError);
+    assert!(
+        response
+            .answers()
+            .iter()
+            .any(|record| record.record_type() == RecordType::CNAME
+                && record.name() == &query_name)
+    );
 }
 
 /// ```text


### PR DESCRIPTION
According to the RFC 4592 Section 2.2.1, the wildcards should not be expanded if there's any matching name for the query.

For example:

```
server A 1.2.3.4

catchall A    4.5.6.7
catchall AAAA 1::2

* CNAME catchall.yourdomain.net.
```

Before this change, the `AAAA` lookup for `server.yourdomain.net` resulted in it getting resolved to the `catchall` record.

AI disclosure: this code was written by me. AI was used to generate the test case and for basic autocompletion.