### PR TITLE
fix(server): use dep:rusqlite to suppress implicit rusqlite feature

### DIFF
--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -27,7 +27,7 @@ license.workspace = true
 # Recursive Resolution is Experimental!
 recursor = ["hickory-resolver/recursor"]
 resolver = ["dep:hickory-resolver"]
-sqlite = ["rusqlite"]
+sqlite = ["dep:rusqlite"]
 blocklist = ["resolver"]
 toml = ["dep:toml", "hickory-resolver?/toml"]
 metrics = ["hickory-resolver?/metrics", "dep:metrics"]


### PR DESCRIPTION
hickory-server's sqlite feature enabled rusqlite without the dep: prefix, which created an implicit rusqlite feature. cargo-auditable would see the resulting --cfg 'feature="rusqlite"' and attempt to pass rusqlite as a feature to the root hickory-dns package, which uses dep:rusqlite and has no such implicit feature, causing cargo metadata to fail.

No code uses cfg(feature = "rusqlite") in either crate; all gating is done on cfg(feature = "sqlite"), so this is a no-op change in behaviour.