### PR TITLE
net: stop ignoring response decoding failures for UDP requests

### DIFF
--- a/crates/net/src/udp/udp_client_stream.rs
+++ b/crates/net/src/udp/udp_client_stream.rs
@@ -243,14 +243,7 @@ impl<P: RuntimeProvider> Request for UdpRequest<P> {
                 continue;
             }
 
-            let mut response = match DnsResponse::from_buffer(response_buffer) {
-                Ok(response) => response,
-                Err(e) => {
-                    // on errors deserializing, continue
-                    warn!("dropped malformed message waiting for id: {msg_id} err: {e}");
-                    continue;
-                }
-            };
+            let mut response = DnsResponse::from_buffer(response_buffer)?;
 
             // Validate the message id in the response matches the value chosen for the query.
             if msg_id != response.id() {


### PR DESCRIPTION
I don't think ignoring these here is helpful -- better to yield them to the caller which can try other things.

Addresses issue reported privately by @qifan-sailboat.