### PR TITLE
Fix docs.rs doc build

### DIFF
--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -1,7 +1,7 @@
 //! Networking library for Hickory DNS
 
 #![warn(clippy::dbg_macro, clippy::print_stdout, missing_docs)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use hickory_proto as proto;
 

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -14,7 +14,7 @@
     clippy::std_instead_of_alloc,
     missing_docs
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Hickory DNS Protocol library
 

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -174,7 +174,7 @@
 //! added to the `Resolver` and used for any lookups performed in the `.local.` zone.
 
 #![warn(clippy::dbg_macro, clippy::print_stdout, missing_docs)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use hickory_net as net;
 pub use hickory_proto as proto;

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -15,7 +15,7 @@
  */
 
 #![warn(clippy::dbg_macro, clippy::print_stdout, missing_docs)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Hickory DNS is intended to be a fully compliant domain name server and client library.
 //!


### PR DESCRIPTION
The doc_auto_cfg feature no longer exists, it got rolled into doc_cfg. This causes the docs.rs build to fail (see https://docs.rs/crate/hickory-resolver/0.26.0-beta.1)