### PR TITLE
bin: allow configuring UDP socket buffer sizes

### DIFF
--- a/bin/src/config/mod.rs
+++ b/bin/src/config/mod.rs
@@ -160,6 +160,34 @@ pub(crate) struct Config {
     /// Networks allowed to access the server
     #[serde(default)]
     pub(crate) allow_networks: Vec<IpNet>,
+    /// UDP socket configuration options.
+    #[serde(default)]
+    pub(crate) udp_socket: UdpSocketConfig,
+}
+
+/// Configuration options for UDP sockets.
+///
+/// These settings control the kernel buffer sizes for UDP sockets used by the DNS server.
+/// Under high query load, increasing buffer sizes can help prevent packet loss when the
+/// application cannot process incoming packets fast enough.
+///
+/// Note: The kernel may cap the actual buffer size based on system limits
+/// (e.g., `net.core.rmem_max` on Linux). Check logs at startup to see the actual
+/// buffer size that was configured.
+#[derive(Debug, Default, Clone, Copy, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct UdpSocketConfig {
+    /// UDP socket receive buffer size in bytes.
+    ///
+    /// Controls the kernel buffer for incoming UDP packets. If not specified, the operating
+    /// system default is used. Larger values help absorb traffic bursts without dropping
+    /// packets.
+    pub(crate) recv_buffer_size: Option<usize>,
+    /// UDP socket send buffer size in bytes.
+    ///
+    /// Controls the kernel buffer for outgoing UDP packets. If not specified, the operating
+    /// system default is used. Larger values help when the server is sending many responses.
+    pub(crate) send_buffer_size: Option<usize>,
 }
 
 impl Config {

--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -31,7 +31,7 @@ use hickory_server::server::default_tls_server_config;
 use hickory_server::{server::Server, zone_handler::Catalog};
 
 mod config;
-use config::Config;
+use config::{Config, UdpSocketConfig};
 
 #[cfg(feature = "__dnssec")]
 pub mod dnssec;
@@ -288,6 +288,7 @@ impl DnsServer {
             http_endpoint,
             deny_networks,
             allow_networks,
+            udp_socket: udp_socket_config,
         } = config;
 
         #[cfg(unix)]
@@ -359,6 +360,7 @@ impl DnsServer {
                 .transpose()?,
             #[cfg(any(feature = "__tls", feature = "__https", feature = "__quic"))]
             ssl_keylog_enabled,
+            udp_socket_config,
         };
 
         let listen_port = port.unwrap_or(listen_port);
@@ -467,6 +469,7 @@ struct ServerSetup<'a> {
     cert_resolver: Option<Arc<dyn ResolvesServerCert>>,
     #[cfg(any(feature = "__tls", feature = "__https", feature = "__quic"))]
     ssl_keylog_enabled: bool,
+    udp_socket_config: UdpSocketConfig,
 }
 
 impl ServerSetup<'_> {
@@ -474,7 +477,7 @@ impl ServerSetup<'_> {
         for addr in &self.listen_addrs {
             info!("binding UDP to {addr:?}");
 
-            let udp_socket = build_udp_socket(*addr, port)
+            let udp_socket = build_udp_socket(*addr, port, self.udp_socket_config)
                 .map_err(|err| format!("failed to bind to UDP socket address {addr:?}: {err}"))?;
 
             info!(
@@ -602,7 +605,7 @@ impl ServerSetup<'_> {
         for addr in &self.listen_addrs {
             info!("Binding QUIC to {addr:?}");
 
-            let quic_listener = build_udp_socket(*addr, port)
+            let quic_listener = build_udp_socket(*addr, port, self.udp_socket_config)
                 .map_err(|err| format!("failed to bind to QUIC socket address {addr:?}: {err}"))?;
 
             info!(
@@ -668,7 +671,11 @@ fn build_tcp_listener(ip: IpAddr, port: u16) -> Result<TcpListener, Error> {
 }
 
 /// Build a UdpSocket for a given IP, port pair; IPv6 sockets will not accept v4 connections
-fn build_udp_socket(ip: IpAddr, port: u16) -> Result<UdpSocket, Error> {
+fn build_udp_socket(
+    ip: IpAddr,
+    port: u16,
+    socket_config: UdpSocketConfig,
+) -> Result<UdpSocket, Error> {
     let sock = if ip.is_ipv4() {
         Socket::new(Domain::IPV4, Type::DGRAM, None)?
     } else {
@@ -678,6 +685,22 @@ fn build_udp_socket(ip: IpAddr, port: u16) -> Result<UdpSocket, Error> {
     };
 
     sock.set_nonblocking(true)?;
+
+    if let Some(size) = socket_config.recv_buffer_size {
+        sock.set_recv_buffer_size(size)?;
+    }
+    if let Some(size) = socket_config.send_buffer_size {
+        sock.set_send_buffer_size(size)?;
+    }
+    if socket_config.recv_buffer_size.is_some() || socket_config.send_buffer_size.is_some() {
+        info!(
+            "UDP socket buffer sizes: recv={} send={} (requested recv={:?} send={:?})",
+            sock.recv_buffer_size().unwrap_or(0),
+            sock.send_buffer_size().unwrap_or(0),
+            socket_config.recv_buffer_size,
+            socket_config.send_buffer_size,
+        );
+    }
 
     let s_addr = SocketAddr::new(ip, port);
     sock.bind(&s_addr.into())?;

--- a/tests/test-data/test_configs/example_recursor.toml
+++ b/tests/test-data/test_configs/example_recursor.toml
@@ -1,3 +1,12 @@
+## UDP socket buffer configuration
+## Under high query load, increasing buffer sizes can help prevent packet loss.
+## If not specified, the operating system defaults are used.
+## Note: The kernel may cap the actual buffer size based on system limits
+## (e.g., net.core.rmem_max and net.core.wmem_max on Linux).
+# [udp_socket]
+# recv_buffer_size = 4194304  # 4MB
+# send_buffer_size = 4194304  # 4MB
+
 ## Default zones, these should be present on all nameservers, except in rare
 ##  configuration cases
 [[zones]]


### PR DESCRIPTION
For high-volume deployments it's often necessary to tweak the kernel UDP send and receive buffer sizes to allow the kernel to buffer more data for the server to read when ready. This helps to avoid dropping packets/producing timeouts during spikes in load.

This commit adds a `UdpSocketConfig` structure for optionally setting the `recv_buffer_size` and `send_buffer_size` of UDP sockets bound by the `hickory-dns` server. These are roughly comparable to unbound's [`so-rcvbuf`](https://unbound.docs.nlnetlabs.nl/en/latest/manpages/unbound.conf.html#unbound-conf-so-rcvbuf) and [`so-sndbuf`](https://unbound.docs.nlnetlabs.nl/en/latest/manpages/unbound.conf.html#unbound-conf-so-sndbuf) settings. In both cases we default to the status quo: whatever the kernel's default is. Unbound does the same for the `so-rcvbuf`, but defaults `so-sndbuf` to 4M. For simplicity sake I left both at the kernel default. 