### PR TITLE
bin: use SO_REUSEADDR for tcp sockets

### DIFF
--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -655,6 +655,7 @@ fn build_tcp_listener(ip: IpAddr, port: u16) -> Result<TcpListener, Error> {
         s
     };
 
+    sock.set_reuse_address(true)?;
     sock.set_nonblocking(true)?;
 
     let s_addr = SocketAddr::new(ip, port);


### PR DESCRIPTION
Notably this prevents already bound errors when restarting a `hickory-dns` process that binds TCP listeners (e.g. for Prometheus metrics, or DoT) without waiting for the previous socket from the exited process to exit [`TIME_WAIT` state](https://totozhang.github.io/2016-01-31-tcp-timewait-status/).

Other languages (e.g. [Go](https://github.com/golang/go/blob/65f76a20a32fc2a63f22f681591813e568506c9d/src/net/sockopt_linux.go#L26-L29)) set this by default for TCP listeners to allow reuse of recently-used addresses.