### PR TITLE
recursor: add criterion benchmarks for cold and warm resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +40,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -188,6 +203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +267,33 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -373,6 +421,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +468,16 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -401,6 +495,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "data-encoding"
@@ -465,7 +565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -708,6 +808,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,6 +1001,7 @@ version = "0.26.0-beta.1"
 dependencies = [
  "async-recursion",
  "cfg-if",
+ "criterion",
  "futures-executor",
  "futures-util",
  "hickory-net",
@@ -1069,7 +1181,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1636,6 +1748,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1648,6 +1766,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1696,6 +1824,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1829,7 +1985,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1867,7 +2023,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -1955,6 +2111,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2104,7 +2280,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2163,7 +2339,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2567,6 +2743,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3039,7 +3225,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,9 @@ http = "1.1"
 # no_std
 critical-section = { version = "1.1.1" }
 
+# benchmarks
+criterion = { version = "0.8.2", features = ["async_tokio"] }
+
 # others
 bitflags = "2.4.1"
 bytes = "1"

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -96,6 +96,7 @@ ndk-context = { workspace = true, optional = true }
 system-configuration = { workspace = true, optional = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 futures-executor = { workspace = true, default-features = false, features = ["std"] }
 hickory-proto = { workspace = true }
 metrics-util = { workspace = true, features = ["debugging"] }
@@ -110,6 +111,11 @@ all-features = true
 default-target = "x86_64-unknown-linux-gnu"
 targets = ["x86_64-apple-darwin", "x86_64-pc-windows-msvc"]
 rustdoc-args = ["--cfg", "docsrs"]
+
+[[bench]]
+name = "recursor"
+harness = false
+required-features = ["recursor", "tokio"]
 
 [[example]]
 name = "custom_provider"

--- a/crates/resolver/benches/recursor.rs
+++ b/crates/resolver/benches/recursor.rs
@@ -1,0 +1,131 @@
+// Benchmarks for the recursive resolver.
+//
+// Run with:
+//
+//   cargo bench -p hickory-resolver --features recursor --bench recursor
+//
+// Each benchmark creates a small in-process mock DNS hierarchy using
+// `test_support::MockProvider`, so no real network access is required.
+
+use std::{
+    hint::black_box,
+    net::{IpAddr, Ipv4Addr},
+    sync::Arc,
+    time::Instant,
+};
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use hickory_resolver::{
+    proto::{
+        op::Query,
+        rr::{Name, RecordType},
+    },
+    recursor::{Recursor, RecursorOptions},
+};
+use test_support::{MockNetworkHandler, MockProvider, MockRecord, MockResponseSection};
+use tokio::runtime::Runtime;
+
+/// Cold-cache resolution: a fresh `Recursor` with empty NS and response caches
+/// is created for every iteration. Measures the full cost of zone-cut discovery
+/// plus the final answer lookup.
+fn bench_cold_resolve(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    c.bench_function("recursor/cold_resolve", |b| {
+        b.to_async(&rt).iter_batched(
+            make_recursor,
+            |(recursor, query_name)| async move {
+                black_box(
+                    recursor
+                        .resolve(
+                            Query::query(query_name, RecordType::A),
+                            Instant::now(),
+                            false,
+                        )
+                        .await
+                        .unwrap(),
+                )
+            },
+            BatchSize::PerIteration,
+        );
+    });
+}
+
+/// Warm-cache resolution: a single `Recursor` is shared across all iterations.
+/// Criterion's warmup phase populates the caches; subsequent iterations measure
+/// pure cache-hit latency. This is the theoretical lower bound for a cached name.
+fn bench_warm_resolve(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    let (recursor, query_name) = make_recursor();
+    let recursor = Arc::new(recursor);
+
+    c.bench_function("recursor/warm_resolve", |b| {
+        b.to_async(&rt).iter(|| {
+            let recursor = recursor.clone();
+            let query_name = query_name.clone();
+            async move {
+                black_box(
+                    recursor
+                        .resolve(
+                            Query::query(query_name, RecordType::A),
+                            Instant::now(),
+                            false,
+                        )
+                        .await
+                        .unwrap(),
+                )
+            }
+        });
+    });
+}
+
+criterion_group!(benches, bench_cold_resolve, bench_warm_resolve);
+criterion_main!(benches);
+
+/// Build a two-level mock DNS hierarchy and return a `Recursor` with its query name:
+///
+///   . (ROOT_IP)
+///   └── testing.       (TLD_IP)
+///       └── hickory-dns.testing.  (LEAF_IP)
+///           └── host.hickory-dns.testing.  A -> LEAF_IP
+fn make_recursor() -> (Recursor<MockProvider>, Name) {
+    let query_name = Name::from_ascii("host.hickory-dns.testing.").unwrap();
+    let tld_zone = Name::from_ascii("testing.").unwrap();
+    let tld_ns = Name::from_ascii("testing.testing.").unwrap();
+    let leaf_zone = Name::from_ascii("hickory-dns.testing.").unwrap();
+    let leaf_ns = Name::from_ascii("ns.hickory-dns.testing.").unwrap();
+
+    let provider = MockProvider::new(MockNetworkHandler::new(vec![
+        // Root → TLD delegation
+        MockRecord::ns(ROOT_IP, &tld_zone, &tld_ns),
+        MockRecord::a(ROOT_IP, &tld_ns, TLD_IP)
+            .with_query_name(&tld_zone)
+            .with_query_type(RecordType::NS)
+            .with_section(MockResponseSection::Additional),
+        // TLD → leaf delegation
+        MockRecord::ns(TLD_IP, &leaf_zone, &leaf_ns),
+        MockRecord::a(TLD_IP, &leaf_ns, LEAF_IP)
+            .with_query_name(&leaf_zone)
+            .with_query_type(RecordType::NS)
+            .with_section(MockResponseSection::Additional),
+        // Leaf answer
+        MockRecord::a(LEAF_IP, &query_name, LEAF_IP),
+    ]));
+
+    let recursor = Recursor::with_options(
+        &[ROOT_IP],
+        RecursorOptions {
+            deny_server: Vec::new(),
+            ..RecursorOptions::default()
+        },
+        provider,
+    )
+    .unwrap();
+
+    (recursor, query_name)
+}
+
+const ROOT_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+const TLD_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
+const LEAF_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 0, 3, 1));


### PR DESCRIPTION
Adds a `benches/recursor.rs` benchmark using criterion 0.8.2 that measures recursive resolver performance against an in-process mock DNS hierarchy (no real network required):

- `recursor/cold_resolve`: fresh Recursor per iteration, measures full zone-cut discovery + answer lookup from an empty cache.
- `recursor/warm_resolve`: shared Recursor across iterations, measures pure cache-hit latency as a lower-bound baseline.

Run with:
  cargo bench -p hickory-resolver --features recursor --bench recursor

Related: #3435