### PR TITLE
resolver: fix err propagation from NS hostname resolution

### DIFF
--- a/conformance/conformance-tests/src/resolver/dns/regression.rs
+++ b/conformance/conformance-tests/src/resolver/dns/regression.rs
@@ -1,5 +1,5 @@
 use dns_test::{
-    Error, FQDN, Network, PEER, Resolver,
+    Error, FQDN, Network, PEER, Resolver, SUBJECT,
     client::{Client, DigSettings},
     name_server::{Graph, NameServer, Sign},
     record::{Record, RecordType},
@@ -32,6 +32,57 @@ fn ns_query() -> Result<(), Error> {
         matches!(output.answer[0], Record::NS(_)),
         "{:?}",
         output.answer[0]
+    );
+
+    Ok(())
+}
+
+/// NS hostname resolution producing only NXDOMAIN should return SERVFAIL
+///
+/// This test reproduces issue https://github.com/hickory-dns/hickory-dns/issues/3503:
+/// a zone with only out-of-bailiwick NS hostnames that all produce NXDOMAIN.
+/// In this case the resolver should return SERVFAIL (not NXDOMAIN).
+///
+/// An NXDOMAIN for the NS hostname does not prove that the queried domain
+/// doesn't exist, it only means the resolver cannot reach the authoritative
+/// server.
+#[test]
+fn unresolvable_ns_returns_servfail() -> Result<(), Error> {
+    let network = Network::new()?;
+
+    // Delegate to an out-of-bailiwick NS in a TLD that doesn't exist at the root.
+    // No glue is provided, forcing the resolver to look up the NS hostname.
+    let mut tld_ns = NameServer::new(&PEER, FQDN::TEST_TLD, &network)?;
+    tld_ns.add(Record::ns(
+        FQDN("example.testing.")?,
+        FQDN("ns.nonexistent.")?,
+    ));
+
+    // Root only knows about `testing.` so queries for `nonexistent.` will return NXDOMAIN.
+    let mut root_ns = NameServer::new(&PEER, FQDN::ROOT, &network)?;
+    root_ns.referral(
+        FQDN::TEST_TLD,
+        FQDN("primary.tld-server.testing.")?,
+        tld_ns.ipv4_addr(),
+    );
+
+    let resolver = Resolver::new(&network, root_ns.root_hint()).start_with_subject(&SUBJECT)?;
+
+    let _root_ns = root_ns.start()?;
+    let _tld_ns = tld_ns.start()?;
+
+    let res = Client::new(resolver.network())?.dig(
+        *DigSettings::default().recurse(),
+        resolver.ipv4_addr(),
+        RecordType::A,
+        &FQDN("www.example.testing.")?,
+    )?;
+
+    assert_eq!(res.answer.len(), 0);
+    assert!(
+        res.status.is_servfail(),
+        "expected SERVFAIL, got {:?};",
+        res.status
     );
 
     Ok(())

--- a/crates/resolver/src/recursor/handle.rs
+++ b/crates/resolver/src/recursor/handle.rs
@@ -739,10 +739,20 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
             // To avoid incrementing the depth counter for each nameserver, we'll use the passed in
             // depth as a fixed base for the nameserver lookups
             let nameserver_pool = if !is_subzone(zone, &record_name) {
-                self.ns_pool_for_name(record_name.clone(), request_time, depth)
-                    .await?
-                    .1 // discard the depth part of the tuple
-                    .with_zone(zone.clone())
+                match self
+                    .ns_pool_for_name(record_name.clone(), request_time, depth)
+                    .await
+                {
+                    Ok((_, pool)) => pool.with_zone(zone.clone()),
+                    // The NS hostname could not be resolved. This doesn't mean the
+                    // original queried domain doesn't exist, only that this nameserver
+                    // is unreachable. Skip it and try others. If they all fail, the
+                    // empty pool will result in SERVFAIL.
+                    Err(error) => {
+                        debug!(?record_name, ?error, "nameserver hostname lookup failure");
+                        continue;
+                    }
+                }
             } else {
                 nameserver_pool.clone()
             };


### PR DESCRIPTION
When resolving an out-of-bailiwick NS hostname (e.g., looking up the address of `ns.example.net` to serve zone `foo.com`), an error response (e.g. `NXDOMAIN`) for the NS hostname was incorrectly propagated as a `NXDOMAIN` result for the original query. An error resolving a nameserver's hostname does not prove the queried domain doesn't exist, only that this nameserver is unreachable. Skip such nameservers and try others, eventually returning `SERVFAIL` if none are reachable.

I verified before the fix was implemented that the proposed integration test failed, seeing an `NXDOMAIN` result instead of the asserted `SERVFAIL`.

Resolves https://github.com/hickory-dns/hickory-dns/issues/3503