### PR TITLE
resolver: add cache metrics

### DIFF
--- a/bin/src/prometheus_server.rs
+++ b/bin/src/prometheus_server.rs
@@ -14,7 +14,14 @@ use tracing::{debug, error};
 #[cfg(any(feature = "__tls", feature = "__quic"))]
 use hickory_resolver::metrics::opportunistic_encryption::PROBE_DURATION_SECONDS;
 #[cfg(feature = "recursor")]
-use hickory_resolver::metrics::recursor::{CACHE_HIT_DURATION, CACHE_MISS_DURATION};
+use hickory_resolver::metrics::recursor::{
+    CACHE_HIT_DURATION as RECURSOR_CACHE_HIT_DURATION,
+    CACHE_MISS_DURATION as RECURSOR_CACHE_MISS_DURATION,
+};
+use hickory_resolver::metrics::{
+    CACHE_HIT_DURATION as RESOLVER_CACHE_HIT_DURATION,
+    CACHE_MISS_DURATION as RESOLVER_CACHE_MISS_DURATION,
+};
 
 /// An HTTP server that responds to Prometheus scrape requests.
 pub(crate) struct PrometheusServer {
@@ -132,16 +139,17 @@ fn configure_buckets(mut builder: PrometheusBuilder) -> PrometheusBuilder {
 const HISTOGRAMS: &[(&str, &[f64])] = &[
     #[cfg(any(feature = "__tls", feature = "__quic"))]
     (PROBE_DURATION_SECONDS, INTERNET_LATENCY_BUCKETS),
+    (RESOLVER_CACHE_MISS_DURATION, INTERNET_LATENCY_BUCKETS),
+    (RESOLVER_CACHE_HIT_DURATION, INTERNAL_LATENCY_BUCKETS),
     #[cfg(feature = "recursor")]
-    (CACHE_MISS_DURATION, INTERNET_LATENCY_BUCKETS),
+    (RECURSOR_CACHE_MISS_DURATION, INTERNET_LATENCY_BUCKETS),
     #[cfg(feature = "recursor")]
-    (CACHE_HIT_DURATION, INTERNAL_LATENCY_BUCKETS),
+    (RECURSOR_CACHE_HIT_DURATION, INTERNAL_LATENCY_BUCKETS),
 ];
 
 /// Histogram buckets for operations that traverse the internet to remote systems.
 ///
 /// The values used are matched to the Go client defaults.
-#[cfg(any(feature = "recursor", feature = "__tls", feature = "__quic"))]
 const INTERNET_LATENCY_BUCKETS: &[f64] = &[
     0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
 ];
@@ -149,7 +157,6 @@ const INTERNET_LATENCY_BUCKETS: &[f64] = &[
 /// Histogram buckets for internal operations that don't depend on remote systems.
 ///
 /// The values used are a range of buckets between 100μs and 100ms.
-#[cfg(feature = "recursor")]
 const INTERNAL_LATENCY_BUCKETS: &[f64] = &[
     0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1,
 ];

--- a/crates/resolver/src/cache.rs
+++ b/crates/resolver/src/cache.rs
@@ -101,7 +101,7 @@ impl ResponseCache {
     }
 
     /// Returns the approximate number of entries in the cache.
-    #[cfg(all(feature = "metrics", feature = "recursor"))]
+    #[cfg(feature = "metrics")]
     pub(crate) fn entry_count(&self) -> u64 {
         #[cfg(test)]
         {

--- a/crates/resolver/src/caching_client.rs
+++ b/crates/resolver/src/caching_client.rs
@@ -70,6 +70,8 @@ where
     cache: ResponseCache,
     client: C,
     preserve_intermediates: bool,
+    #[cfg(feature = "metrics")]
+    cache_metrics: crate::metrics::CacheMetrics,
 }
 
 impl<C> CachingClient<C>
@@ -94,6 +96,8 @@ where
             cache,
             client,
             preserve_intermediates,
+            #[cfg(feature = "metrics")]
+            cache_metrics: crate::metrics::CacheMetrics::default(),
         }
     }
 
@@ -161,9 +165,27 @@ where
 
         let is_dnssec = client.client.is_verifying_dnssec();
 
+        #[cfg(feature = "metrics")]
+        let request_start = Instant::now();
+
         if let Some(cached_lookup) = client.lookup_from_cache(&query) {
+            #[cfg(feature = "metrics")]
+            {
+                client.cache_metrics.cache_hit.increment(1);
+                client
+                    .cache_metrics
+                    .cache_hit_duration
+                    .record(request_start.elapsed());
+                client
+                    .cache_metrics
+                    .cache_size
+                    .set(client.cache.entry_count() as f64);
+            }
             return cached_lookup;
         };
+
+        #[cfg(feature = "metrics")]
+        client.cache_metrics.cache_miss.increment(1);
 
         let response_message = client
             .client
@@ -184,14 +206,24 @@ where
         let records = match response_message {
             Ok(response_message) => {
                 // allow the handle_noerror function to deal with any error codes
-                let records = Self::handle_noerror(
+                let records = match Self::handle_noerror(
                     &mut client,
                     options,
                     &query,
                     response_message,
                     preserved_records,
                     depth,
-                )?;
+                ) {
+                    Ok(records) => records,
+                    Err(err) => {
+                        #[cfg(feature = "metrics")]
+                        client
+                            .cache_metrics
+                            .cache_miss_duration
+                            .record(request_start.elapsed());
+                        return Err(err);
+                    }
+                };
 
                 Ok(records)
             }
@@ -202,18 +234,33 @@ where
                 }
                 Err(no_records.into())
             }
-            Err(err) => return Err(err),
+            Err(err) => {
+                #[cfg(feature = "metrics")]
+                client
+                    .cache_metrics
+                    .cache_miss_duration
+                    .record(request_start.elapsed());
+                return Err(err);
+            }
         };
 
         // after the request, evaluate if we have additional queries to perform
-        match records {
+        let result = match records {
             Ok(Records::CnameChain { next: future, .. }) => match future.await {
                 Ok(lookup) => client.cname(lookup, query),
                 Err(e) => client.cache(query, Err(e)),
             },
             Ok(Records::Exists { message, min_ttl }) => client.cache(query, Ok((message, min_ttl))),
             Err(e) => client.cache(query, Err(e)),
-        }
+        };
+
+        #[cfg(feature = "metrics")]
+        client
+            .cache_metrics
+            .cache_miss_duration
+            .record(request_start.elapsed());
+
+        result
     }
 
     /// Check if this query is already cached
@@ -467,7 +514,7 @@ where
         result: Result<(Message, u32), NetError>,
     ) -> Result<Lookup, NetError> {
         let now = Instant::now();
-        match result {
+        let result = match result {
             Ok((message, min_ttl)) => {
                 let valid_until = now + Duration::from_secs(min_ttl.into());
                 let lookup = Lookup::new(message.clone(), valid_until);
@@ -478,7 +525,12 @@ where
                 self.cache.insert(query, Err(err.clone()), now);
                 Err(err)
             }
-        }
+        };
+        #[cfg(feature = "metrics")]
+        self.cache_metrics
+            .cache_size
+            .set(self.cache.entry_count() as f64);
+        result
     }
 
     /// Flushes/Removes all entries from the cache

--- a/crates/resolver/src/metrics.rs
+++ b/crates/resolver/src/metrics.rs
@@ -7,8 +7,12 @@
 
 //! Metrics related to resolver and recursive resolver operations
 
+use metrics::{
+    Counter, Gauge, Histogram, Unit, counter, describe_counter, describe_gauge, describe_histogram,
+    gauge, histogram,
+};
+
 use hickory_net::xfer::Protocol;
-use metrics::{Counter, Unit, counter, describe_counter};
 
 #[derive(Clone, Default)]
 pub(crate) struct ResolverMetrics {
@@ -77,8 +81,71 @@ impl Default for ProtocolMetrics {
     }
 }
 
+/// Metrics for the resolver's response cache.
+#[derive(Clone, Debug)]
+pub(crate) struct CacheMetrics {
+    pub(crate) cache_hit: Counter,
+    pub(crate) cache_miss: Counter,
+    pub(crate) cache_hit_duration: Histogram,
+    pub(crate) cache_miss_duration: Histogram,
+    pub(crate) cache_size: Gauge,
+}
+
+impl Default for CacheMetrics {
+    fn default() -> Self {
+        describe_counter!(
+            CACHE_HIT_TOTAL,
+            Unit::Count,
+            "Number of resolver requests answered from the cache."
+        );
+        describe_counter!(
+            CACHE_MISS_TOTAL,
+            Unit::Count,
+            "Number of resolver requests that could not be answered from the cache."
+        );
+        describe_histogram!(
+            CACHE_HIT_DURATION,
+            Unit::Seconds,
+            "Duration of resolver lookups answered from the cache."
+        );
+        describe_histogram!(
+            CACHE_MISS_DURATION,
+            Unit::Seconds,
+            "Duration of resolver lookups that could not be answered from the cache."
+        );
+        describe_gauge!(
+            RESPONSE_CACHE_SIZE,
+            Unit::Count,
+            "Number of entries in the resolver response cache."
+        );
+
+        Self {
+            cache_hit: counter!(CACHE_HIT_TOTAL),
+            cache_miss: counter!(CACHE_MISS_TOTAL),
+            cache_hit_duration: histogram!(CACHE_HIT_DURATION),
+            cache_miss_duration: histogram!(CACHE_MISS_DURATION),
+            cache_size: gauge!(RESPONSE_CACHE_SIZE),
+        }
+    }
+}
+
 /// Number of outgoing resolver queries by transport protocol.
 pub const OUTGOING_QUERIES_TOTAL: &str = "hickory_resolver_outgoing_queries_total";
+
+/// Number of resolver requests answered from the cache.
+pub const CACHE_HIT_TOTAL: &str = "hickory_resolver_cache_hit_total";
+
+/// Number of resolver requests that could not be answered from the cache.
+pub const CACHE_MISS_TOTAL: &str = "hickory_resolver_cache_miss_total";
+
+/// Duration of resolver lookups answered from the cache.
+pub const CACHE_HIT_DURATION: &str = "hickory_resolver_cache_hit_duration_seconds";
+
+/// Duration of resolver lookups that could not be answered from the cache.
+pub const CACHE_MISS_DURATION: &str = "hickory_resolver_cache_miss_duration_seconds";
+
+/// Number of entries in the resolver response cache.
+pub const RESPONSE_CACHE_SIZE: &str = "hickory_resolver_response_cache_size";
 
 /// Metrics for the optional recursive resolver feature
 #[cfg(feature = "recursor")]


### PR DESCRIPTION
We're evaluating switching to Hickory DNS at @turbopuffer and wanted this sort of visibility into the stub client. We haven't actually tested this yet (will go out to staging later this week), but I wanted to put this up for early review for a vibe check. Is this something y'all would be amenable to upstreaming? 

cc @cpu since you seem to be hacking on metrics lately!

----

Add cache metrics to the stub resolver's CachingClient, gated behind the existing `metrics` feature flag:

- hickory_resolver_cache_hit_total
- hickory_resolver_cache_miss_total
- hickory_resolver_cache_hit_duration_milliseconds
- hickory_resolver_cache_miss_duration_seconds
- hickory_resolver_response_cache_size