### PR TITLE
Fix units of cache hit duration histogram

### DIFF
--- a/crates/resolver/src/metrics.rs
+++ b/crates/resolver/src/metrics.rs
@@ -136,7 +136,7 @@ pub mod recursor {
             let cache_hit_duration = histogram!(CACHE_HIT_DURATION);
             describe_histogram!(
                 CACHE_HIT_DURATION,
-                Unit::Milliseconds,
+                Unit::Seconds,
                 "Duration of recursive resolution for queries that are answered from cache."
             );
             let cache_miss_duration = histogram!(CACHE_MISS_DURATION);
@@ -309,7 +309,7 @@ pub mod recursor {
     pub const OUTGOING_QUERIES_TOTAL: &str = "hickory_recursor_outgoing_queries_total";
 
     /// Duration of recursive resolution for queries that are answered from cache.
-    pub const CACHE_HIT_DURATION: &str = "hickory_recursor_cache_hit_duration_milliseconds";
+    pub const CACHE_HIT_DURATION: &str = "hickory_recursor_cache_hit_duration_seconds";
 
     /// Duration of recursive resolution for queries that are not answered from cache.
     pub const CACHE_MISS_DURATION: &str = "hickory_recursor_cache_miss_duration_seconds";

--- a/crates/resolver/src/recursor/tests.rs
+++ b/crates/resolver/src/recursor/tests.rs
@@ -875,13 +875,7 @@ mod metrics {
             assert_counter_eq(&map, OUTGOING_QUERIES_TOTAL, vec![], 3);
             assert_counter_eq(&map, CACHE_HIT_TOTAL, vec![], 2);
             assert_counter_eq(&map, CACHE_MISS_TOTAL, vec![], 1);
-            assert_histogram_sample_count_eq(
-                &map,
-                CACHE_HIT_DURATION,
-                vec![],
-                2,
-                Unit::Milliseconds,
-            );
+            assert_histogram_sample_count_eq(&map, CACHE_HIT_DURATION, vec![], 2, Unit::Seconds);
             assert_histogram_sample_count_eq(&map, CACHE_MISS_DURATION, vec![], 1, Unit::Seconds);
 
             assert_gauge_eq(&map, RESPONSE_CACHE_SIZE, vec![], 3);
@@ -895,13 +889,7 @@ mod metrics {
             assert_counter_eq(&map, OUTGOING_QUERIES_TOTAL, vec![], 4);
             assert_counter_eq(&map, CACHE_HIT_TOTAL, vec![], 5);
             assert_counter_eq(&map, CACHE_MISS_TOTAL, vec![], 2);
-            assert_histogram_sample_count_eq(
-                &map,
-                CACHE_HIT_DURATION,
-                vec![],
-                3,
-                Unit::Milliseconds,
-            );
+            assert_histogram_sample_count_eq(&map, CACHE_HIT_DURATION, vec![], 3, Unit::Seconds);
             assert_histogram_sample_count_eq(&map, CACHE_MISS_DURATION, vec![], 1, Unit::Seconds);
 
             // When validating DNSSEC, we should also see DNSSEC-specific metrics.


### PR DESCRIPTION
This fixes a metrics units issue, as noted in https://github.com/hickory-dns/hickory-dns/pull/3522#discussion_r2976315525