### PR TITLE
net: don't error on UDP responses with the wrong ID

### DIFF
--- a/crates/net/src/error.rs
+++ b/crates/net/src/error.rs
@@ -30,11 +30,6 @@ use crate::proto::serialize::binary::DecodeError;
 #[non_exhaustive]
 #[derive(Error, Clone, Debug)]
 pub enum NetError {
-    /// A UDP response was received with an incorrect transaction id, likely indicating a
-    /// cache-poisoning attempt.
-    #[error("bad transaction id received")]
-    BadTransactionId,
-
     /// The underlying resource is too busy
     ///
     /// This is a signal that an internal resource is too busy. The intended action should be tried

--- a/crates/net/src/udp/tests.rs
+++ b/crates/net/src/udp/tests.rs
@@ -152,8 +152,9 @@ pub(super) async fn udp_client_stream_bad_id_test(
             }
         },
         |response| {
-            // The test should pass when we see a bad transaction ID response error.
-            matches!(response, Err(NetError::BadTransactionId))
+            // The test should pass when we see a timeout after waiting for a response
+            // with a correct transaction ID
+            matches!(response, Err(NetError::Timeout))
         },
     )
     .await;

--- a/crates/net/src/udp/udp_client_stream.rs
+++ b/crates/net/src/udp/udp_client_stream.rs
@@ -254,7 +254,8 @@ impl<P: RuntimeProvider> Request for UdpRequest<P> {
                     response.id()
                 );
 
-                return Err(NetError::BadTransactionId);
+                // await an answer with the correct message id
+                continue;
             }
 
             // Validate the returned query name.


### PR DESCRIPTION
These could be spoofed; we should wait for the real response, instead.