### PR TITLE
resolver: shuffle name server list at pool startup

### DIFF
--- a/crates/resolver/src/name_server_pool.rs
+++ b/crates/resolver/src/name_server_pool.rs
@@ -23,6 +23,7 @@ use futures_util::{
     future::{BoxFuture, Shared},
 };
 use parking_lot::Mutex;
+use rand::seq::SliceRandom as _;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
@@ -85,7 +86,15 @@ impl<P: ConnectionProvider> NameServerPool<P> {
     }
 
     #[doc(hidden)]
-    pub fn from_nameservers(servers: Vec<Arc<NameServer<P>>>, cx: Arc<PoolContext>) -> Self {
+    pub fn from_nameservers(mut servers: Vec<Arc<NameServer<P>>>, cx: Arc<PoolContext>) -> Self {
+        // Shuffle so that the cold-start phase (before SRTT measurements
+        // differentiate servers) distributes queries across all providers
+        // rather than always hitting the first few in config order.
+        // Only applies to QueryStatistics ordering — UserProvidedOrder and
+        // RoundRobin manage their own sequencing and must not be shuffled.
+        if cx.options.server_ordering_strategy == ServerOrderingStrategy::QueryStatistics {
+            servers.shuffle(&mut rand::rng());
+        }
         Self {
             state: Arc::new(PoolState {
                 servers,


### PR DESCRIPTION
Before any SRTT measurements are taken, all servers have a near-zero initial SRTT (1-31 µs). The sort_by(decayed_srtt) in try_send therefore preserves insertion order, meaning the first few servers in the config file are always queried first during the cold-start phase.

On a deployment with many upstream servers this causes the same small set of providers (whichever appear first in the config) to absorb all cold-start traffic while the rest sit idle.

Shuffling the list once at construction distributes cold-start queries randomly across all configured servers. Once SRTTs are measured the sort takes over and routes subsequent queries to the fastest servers as before.