### PR TITLE
net: release connections lock before handshake and use separate per-connection timeout

### DIFF
--- a/crates/net/src/h2.rs
+++ b/crates/net/src/h2.rs
@@ -182,7 +182,7 @@ impl<P: RuntimeProvider> HttpsClientStreamBuilder<P> {
         self.set_headers.replace(headers);
     }
 
-    /// Override the connect timeout (default: 5 seconds).
+    /// Override the connect timeout (default: 2 seconds).
     ///
     /// This controls both the TCP connect and the HTTP/2 handshake timeouts.
     pub fn connect_timeout(mut self, timeout: Duration) -> Self {

--- a/crates/net/src/h2.rs
+++ b/crates/net/src/h2.rs
@@ -15,6 +15,7 @@ use core::str::FromStr;
 use core::task::{Context, Poll};
 use std::io;
 use std::sync::Arc;
+use std::time::Duration;
 
 use bytes::{Buf, Bytes, BytesMut};
 use futures_util::stream::{Stream, StreamExt};
@@ -54,6 +55,7 @@ impl HttpsClientStream {
             client_config,
             bind_addr: None,
             set_headers: None,
+            connect_timeout: CONNECT_TIMEOUT,
         }
     }
 }
@@ -166,6 +168,7 @@ pub struct HttpsClientStreamBuilder<P> {
     client_config: Arc<ClientConfig>,
     bind_addr: Option<SocketAddr>,
     set_headers: Option<Arc<dyn SetHeaders>>,
+    connect_timeout: Duration,
 }
 
 impl<P: RuntimeProvider> HttpsClientStreamBuilder<P> {
@@ -177,6 +180,14 @@ impl<P: RuntimeProvider> HttpsClientStreamBuilder<P> {
     /// Set the [`SetHeaders`] trait object used to inject dynamic headers into the DoH request
     pub fn set_headers(&mut self, headers: Arc<dyn SetHeaders>) {
         self.set_headers.replace(headers);
+    }
+
+    /// Override the connect timeout (default: 5 seconds).
+    ///
+    /// This controls both the TCP connect and the HTTP/2 handshake timeouts.
+    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = timeout;
+        self
     }
 
     /// Creates a new [`DnsExchange`] wrapping the [`HttpsClientStream`] from this builder
@@ -213,6 +224,7 @@ impl<P: RuntimeProvider> HttpsClientStreamBuilder<P> {
             server_name,
             path,
             self.set_headers,
+            self.connect_timeout,
         )
     }
 }
@@ -225,6 +237,7 @@ pub fn connect(
     server_name: Arc<str>,
     query_path: Arc<str>,
     set_headers: Option<Arc<dyn SetHeaders>>,
+    connect_timeout: Duration,
 ) -> impl Future<Output = Result<HttpsClientStream, NetError>> + Send + 'static {
     // ensure the ALPN protocol is set correctly
     if client_config.alpn_protocols.is_empty() {
@@ -252,21 +265,19 @@ pub fn connect(
             }
         };
 
-        let tcp = tcp.await?;
-        let future = timeout(
-            CONNECT_TIMEOUT,
-            TlsConnector::from(client_config).connect(tls_server_name, AsyncIoStdAsTokio(tcp)),
-        );
+        let (h2, driver) = timeout(connect_timeout, async {
+            let tcp = tcp.await?;
+            let tls = TlsConnector::from(client_config)
+                .connect(tls_server_name, AsyncIoStdAsTokio(tcp))
+                .await
+                .map_err(NetError::from)?;
 
-        let tls = match future.await {
-            Ok(Ok(tls)) => tls,
-            Ok(Err(err)) => return Err(NetError::from(err)),
-            Err(_) => return Err(NetError::Timeout),
-        };
-
-        let mut handshake = h2::client::Builder::new();
-        handshake.enable_push(false);
-        let (h2, driver) = handshake.handshake(tls).await?;
+            let mut handshake = h2::client::Builder::new();
+            handshake.enable_push(false);
+            handshake.handshake(tls).await.map_err(NetError::from)
+        })
+        .await
+        .map_err(|_| NetError::Timeout)??;
 
         debug!("h2 connection established to: {name_server}");
         tokio::spawn(async {

--- a/crates/net/src/h3/h3_client_stream.rs
+++ b/crates/net/src/h3/h3_client_stream.rs
@@ -327,7 +327,7 @@ impl H3ClientStreamBuilder {
         self
     }
 
-    /// Override the connect timeout (default: 5 seconds).
+    /// Override the connect timeout (default: 2 seconds).
     ///
     /// This controls the QUIC connect and the HTTP/3 handshake timeouts.
     pub fn connect_timeout(mut self, timeout: Duration) -> Self {

--- a/crates/net/src/h3/h3_client_stream.rs
+++ b/crates/net/src/h3/h3_client_stream.rs
@@ -12,6 +12,7 @@ use core::pin::Pin;
 use core::str::FromStr;
 use core::task::{Context, Poll};
 use std::sync::Arc;
+use std::time::Duration;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use futures_util::stream::Stream;
@@ -20,6 +21,7 @@ use h3_quinn::OpenStreams;
 use http::header::{self, CONTENT_LENGTH};
 use quinn::{Endpoint, EndpointConfig, TransportConfig};
 use tokio::sync::mpsc;
+use tokio::time::timeout;
 use tracing::{debug, warn};
 
 use crate::error::NetError;
@@ -30,7 +32,7 @@ use crate::quic::connect_quic;
 use crate::runtime::{RuntimeProvider, Spawn};
 use crate::tls::client_config;
 use crate::udp::UdpSocket;
-use crate::xfer::{DnsExchange, DnsRequestSender, DnsResponseStream};
+use crate::xfer::{CONNECT_TIMEOUT, DnsExchange, DnsRequestSender, DnsResponseStream};
 
 use super::ALPN_H3;
 
@@ -55,6 +57,7 @@ impl H3ClientStream {
             bind_addr: None,
             set_headers: None,
             disable_grease: false,
+            connect_timeout: CONNECT_TIMEOUT,
         }
     }
 
@@ -297,6 +300,7 @@ pub struct H3ClientStreamBuilder {
     bind_addr: Option<SocketAddr>,
     set_headers: Option<Arc<dyn SetHeaders>>,
     disable_grease: bool,
+    connect_timeout: Duration,
 }
 
 impl H3ClientStreamBuilder {
@@ -320,6 +324,14 @@ impl H3ClientStreamBuilder {
     /// Sets whether to disable GREASE
     pub fn disable_grease(mut self, disable_grease: bool) -> Self {
         self.disable_grease = disable_grease;
+        self
+    }
+
+    /// Override the connect timeout (default: 5 seconds).
+    ///
+    /// This controls the QUIC connect and the HTTP/3 handshake timeouts.
+    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = timeout;
         self
     }
 
@@ -414,25 +426,34 @@ impl H3ClientStreamBuilder {
         server_name: Arc<str>,
         path: Arc<str>,
     ) -> Result<H3ClientStream, NetError> {
-        let quic_connection = connect_quic(
-            name_server,
-            server_name.clone(),
-            ALPN_H3,
-            match self.crypto_config {
-                Some(crypto_config) => crypto_config,
-                None => client_config()?,
-            },
-            self.transport_config,
-            endpoint,
+        let quic_connection = timeout(
+            self.connect_timeout,
+            connect_quic(
+                name_server,
+                server_name.clone(),
+                ALPN_H3,
+                match self.crypto_config {
+                    Some(crypto_config) => crypto_config,
+                    None => client_config()?,
+                },
+                self.transport_config,
+                endpoint,
+            ),
         )
-        .await?;
+        .await
+        .map_err(|_| NetError::Timeout)??;
 
         let h3_connection = h3_quinn::Connection::new(quic_connection);
-        let (mut driver, send_request) = h3::client::builder()
-            .send_grease(!self.disable_grease)
-            .build(h3_connection)
-            .await
-            .map_err(|e| ProtoError::from(format!("h3 connection failed: {e}")))?;
+        let mut builder = h3::client::builder();
+        builder.send_grease(!self.disable_grease);
+        let future = builder.build(h3_connection);
+        let (mut driver, send_request) = match timeout(self.connect_timeout, future).await {
+            Ok(Ok(conn)) => conn,
+            Ok(Err(e)) => {
+                return Err(ProtoError::from(format!("h3 connection failed: {e}")).into());
+            }
+            Err(_) => return Err(NetError::Timeout),
+        };
 
         let (shutdown_tx, mut shutdown_rx) = mpsc::channel::<()>(1);
 

--- a/crates/net/src/quic/quic_client_stream.rs
+++ b/crates/net/src/quic/quic_client_stream.rs
@@ -14,6 +14,7 @@ use core::{
 };
 use std::io;
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures_util::stream::Stream;
 use quinn::{
@@ -199,6 +200,7 @@ pub struct QuicClientStreamBuilder {
     crypto_config: Option<rustls::ClientConfig>,
     transport_config: Arc<TransportConfig>,
     bind_addr: Option<SocketAddr>,
+    connect_timeout: Duration,
 }
 
 impl QuicClientStreamBuilder {
@@ -211,6 +213,12 @@ impl QuicClientStreamBuilder {
     /// Sets the address to connect from.
     pub fn bind_addr(mut self, bind_addr: SocketAddr) -> Self {
         self.bind_addr = Some(bind_addr);
+        self
+    }
+
+    /// Override the connect timeout (default: 5 seconds).
+    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = timeout;
         self
     }
 
@@ -306,15 +314,19 @@ impl QuicClientStreamBuilder {
             })?
         };
 
-        let quic_connection = connect_quic(
-            name_server,
-            server_name.clone(),
-            quic_stream::DOQ_ALPN,
-            crypto_config,
-            self.transport_config,
-            endpoint,
+        let quic_connection = timeout(
+            self.connect_timeout,
+            connect_quic(
+                name_server,
+                server_name.clone(),
+                quic_stream::DOQ_ALPN,
+                crypto_config,
+                self.transport_config,
+                endpoint,
+            ),
         )
-        .await?;
+        .await
+        .map_err(|_| NetError::Timeout)??;
 
         Ok(QuicClientStream {
             quic_connection,
@@ -349,22 +361,11 @@ pub(crate) async fn connect_quic(
     Ok(if early_data_enabled {
         match connecting.into_0rtt() {
             Ok((new_connection, _)) => new_connection,
-            Err(connecting) => connect_with_timeout(connecting).await?,
+            Err(connecting) => connecting.await?,
         }
     } else {
-        connect_with_timeout(connecting).await?
+        connecting.await?
     })
-}
-
-async fn connect_with_timeout(connecting: quinn::Connecting) -> Result<Connection, io::Error> {
-    match timeout(CONNECT_TIMEOUT, connecting).await {
-        Ok(Ok(connection)) => Ok(connection),
-        Ok(Err(e)) => Err(e.into()),
-        Err(_) => Err(io::Error::new(
-            io::ErrorKind::TimedOut,
-            format!("QUIC handshake timed out after {CONNECT_TIMEOUT:?}",),
-        )),
-    }
 }
 
 impl Default for QuicClientStreamBuilder {
@@ -377,6 +378,7 @@ impl Default for QuicClientStreamBuilder {
             crypto_config: None,
             transport_config: Arc::new(transport_config),
             bind_addr: None,
+            connect_timeout: CONNECT_TIMEOUT,
         }
     }
 }

--- a/crates/net/src/quic/quic_client_stream.rs
+++ b/crates/net/src/quic/quic_client_stream.rs
@@ -216,7 +216,7 @@ impl QuicClientStreamBuilder {
         self
     }
 
-    /// Override the connect timeout (default: 5 seconds).
+    /// Override the connect timeout (default: 2 seconds).
     pub fn connect_timeout(mut self, timeout: Duration) -> Self {
         self.connect_timeout = timeout;
         self

--- a/crates/net/src/tcp/tcp_client_stream.rs
+++ b/crates/net/src/tcp/tcp_client_stream.rs
@@ -43,22 +43,25 @@ impl<S: DnsTcpStream> TcpClientStream<S> {
     ///
     /// * `remote_addr` - Address of the remote nameserver
     /// * `bind_addr` - Optional local address to bind to
-    /// * `timeout` - Timeout for requests
+    /// * `connect_timeout` - Timeout for establishing the TCP connection
+    /// * `request_timeout` - Timeout for individual DNS requests
     /// * `max_active_requests` - Optional limit on concurrent in-flight requests.
     ///   If `None`, uses the default (32).
     /// * `provider` - Runtime provider for spawning background tasks
     pub async fn exchange<P: RuntimeProvider<Tcp = S>>(
         remote_addr: SocketAddr,
         bind_addr: Option<SocketAddr>,
-        timeout: Duration,
+        connect_timeout: Duration,
+        request_timeout: Duration,
         max_active_requests: Option<usize>,
         provider: P,
     ) -> Result<DnsExchange<P>, NetError> {
         let mut handle = provider.create_handle();
-        let (future, sender) = Self::new(remote_addr, bind_addr, Some(timeout), provider);
+        let (future, sender) = Self::new(remote_addr, bind_addr, Some(connect_timeout), provider);
 
         // TODO: need config for Signer...
-        let mut multiplexer = DnsMultiplexer::new(future.await?, sender).with_timeout(timeout);
+        let mut multiplexer =
+            DnsMultiplexer::new(future.await?, sender).with_timeout(request_timeout);
         if let Some(max) = max_active_requests {
             multiplexer = multiplexer.with_max_active_requests(max);
         }

--- a/crates/net/src/tls.rs
+++ b/crates/net/src/tls.rs
@@ -45,6 +45,7 @@ pub type TlsClientStream<S> =
 /// * `server_name` - TLS server name for certificate validation
 /// * `config` - TLS client configuration
 /// * `timeout` - Timeout for requests
+/// * `connect_timeout` - Timeout for the TCP connect step
 /// * `max_active_requests` - Optional limit on concurrent in-flight requests.
 ///   If `None`, uses the default (32).
 /// * `provider` - Runtime provider for spawning background tasks
@@ -53,6 +54,7 @@ pub async fn tls_exchange<P: RuntimeProvider<Tcp = S>, S: DnsTcpStream>(
     server_name: ServerName<'static>,
     mut config: ClientConfig,
     timeout: Duration,
+    connect_timeout: Duration,
     max_active_requests: Option<usize>,
     provider: P,
 ) -> Result<DnsExchange<P>, NetError> {
@@ -60,7 +62,7 @@ pub async fn tls_exchange<P: RuntimeProvider<Tcp = S>, S: DnsTcpStream>(
     config.enable_sni = false;
 
     let stream = provider
-        .connect_tcp(remote_addr, None, Some(timeout))
+        .connect_tcp(remote_addr, None, Some(connect_timeout))
         .await?;
     let (future, sender) = tls_client_connect_with_future(
         stream,

--- a/crates/net/src/tls.rs
+++ b/crates/net/src/tls.rs
@@ -59,7 +59,9 @@ pub async fn tls_exchange<P: RuntimeProvider<Tcp = S>, S: DnsTcpStream>(
     // The port (853) of DOT is for dns dedicated, SNI is unnecessary. (ISP block by the SNI name)
     config.enable_sni = false;
 
-    let stream = provider.connect_tcp(remote_addr, None, None).await?;
+    let stream = provider
+        .connect_tcp(remote_addr, None, Some(timeout))
+        .await?;
     let (future, sender) = tls_client_connect_with_future(
         stream,
         remote_addr,

--- a/crates/net/src/xfer/mod.rs
+++ b/crates/net/src/xfer/mod.rs
@@ -464,8 +464,9 @@ impl Display for Protocol {
     }
 }
 
+/// Default per-connection timeout for TCP/TLS/QUIC connect attempts.
 #[allow(unused)] // May be unused depending on features
-pub(crate) const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Default buffer size for outbound DNS message streams.
 ///

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -39,7 +39,7 @@ use tracing::{debug, info};
 use crate::name_server_pool::NameServerTransportState;
 #[cfg(any(feature = "__https", feature = "__h3"))]
 use crate::net::http::DEFAULT_DNS_QUERY_PATH;
-use crate::net::xfer::Protocol;
+use crate::net::xfer::{CONNECT_TIMEOUT, Protocol};
 use crate::proto::access_control::{AccessControlSet, AccessControlSetBuilder};
 use crate::proto::op::DEFAULT_MAX_PAYLOAD_LEN;
 use crate::proto::rr::Name;
@@ -606,6 +606,16 @@ pub struct ResolverOpts {
     /// See [DnsRequestOptions::edns_payload_len][crate::proto::op::DnsRequestOptions::edns_payload_len].
     #[cfg_attr(feature = "serde", serde(default = "default_edns_payload_len"))]
     pub edns_payload_len: u16,
+    /// Per-connection timeout for TCP/TLS/QUIC connect attempts.
+    ///
+    /// This controls how long a single connection attempt (TCP SYN + TLS/QUIC handshake) is
+    /// allowed to take before being abandoned, allowing the pool to move on to the next server.
+    /// Defaults to 2s.
+    #[cfg_attr(
+        feature = "serde",
+        serde(default = "default_connect_timeout", with = "duration")
+    )]
+    pub connect_timeout: Duration,
 }
 
 impl ResolverOpts {
@@ -655,6 +665,7 @@ impl Default for ResolverOpts {
             allow_answers: vec![],
             deny_answers: vec![],
             edns_payload_len: default_edns_payload_len(),
+            connect_timeout: default_connect_timeout(),
         }
     }
 }
@@ -665,6 +676,10 @@ fn default_ndots() -> usize {
 
 fn default_timeout() -> Duration {
     Duration::from_secs(5)
+}
+
+fn default_connect_timeout() -> Duration {
+    CONNECT_TIMEOUT
 }
 
 fn default_attempts() -> usize {
@@ -1142,5 +1157,6 @@ mod tests {
         assert_eq!(code.os_port_selection, json.os_port_selection);
         assert_eq!(code.case_randomization, json.case_randomization);
         assert_eq!(code.trust_anchor, json.trust_anchor);
+        assert_eq!(code.connect_timeout, json.connect_timeout);
     }
 }

--- a/crates/resolver/src/connection_provider.rs
+++ b/crates/resolver/src/connection_provider.rs
@@ -140,6 +140,7 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
                 Ok(Box::pin(
                     QuicClientStream::builder()
                         .crypto_config(cx.tls.clone())
+                        .connect_timeout(cx.options.timeout)
                         .exchange(
                             binder.bind_quic(bind_addr, remote_addr)?,
                             remote_addr,
@@ -166,6 +167,7 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
                     H3ClientStream::builder()
                         .crypto_config(cx.tls.clone())
                         .disable_grease(*disable_grease)
+                        .connect_timeout(cx.options.timeout)
                         .exchange(
                             binder.bind_quic(bind_addr, remote_addr)?,
                             remote_addr,

--- a/crates/resolver/src/connection_provider.rs
+++ b/crates/resolver/src/connection_provider.rs
@@ -101,6 +101,7 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
             (ProtocolConfig::Tcp, _) => Ok(Box::pin(TcpClientStream::exchange(
                 remote_addr,
                 config.bind_addr,
+                cx.options.connect_timeout,
                 cx.options.timeout,
                 Some(cx.options.max_active_requests),
                 self.clone(),
@@ -119,6 +120,7 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
                     server_name,
                     cx.tls.clone(),
                     cx.options.timeout,
+                    cx.options.connect_timeout,
                     Some(cx.options.max_active_requests),
                     self.clone(),
                 )))
@@ -126,7 +128,7 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
             #[cfg(feature = "__https")]
             (ProtocolConfig::Https { server_name, path }, _) => Ok(Box::pin(
                 HttpsClientStream::builder(Arc::new(cx.tls.clone()), self.clone())
-                    .connect_timeout(cx.options.timeout)
+                    .connect_timeout(cx.options.connect_timeout)
                     .exchange(remote_addr, server_name.clone(), path.clone()),
             )),
 
@@ -140,7 +142,7 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
                 Ok(Box::pin(
                     QuicClientStream::builder()
                         .crypto_config(cx.tls.clone())
-                        .connect_timeout(cx.options.timeout)
+                        .connect_timeout(cx.options.connect_timeout)
                         .exchange(
                             binder.bind_quic(bind_addr, remote_addr)?,
                             remote_addr,
@@ -167,7 +169,7 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
                     H3ClientStream::builder()
                         .crypto_config(cx.tls.clone())
                         .disable_grease(*disable_grease)
-                        .connect_timeout(cx.options.timeout)
+                        .connect_timeout(cx.options.connect_timeout)
                         .exchange(
                             binder.bind_quic(bind_addr, remote_addr)?,
                             remote_addr,

--- a/crates/resolver/src/connection_provider.rs
+++ b/crates/resolver/src/connection_provider.rs
@@ -125,11 +125,9 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
             }
             #[cfg(feature = "__https")]
             (ProtocolConfig::Https { server_name, path }, _) => Ok(Box::pin(
-                HttpsClientStream::builder(Arc::new(cx.tls.clone()), self.clone()).exchange(
-                    remote_addr,
-                    server_name.clone(),
-                    path.clone(),
-                ),
+                HttpsClientStream::builder(Arc::new(cx.tls.clone()), self.clone())
+                    .connect_timeout(cx.options.timeout)
+                    .exchange(remote_addr, server_name.clone(), path.clone()),
             )),
 
             #[cfg(feature = "__quic")]

--- a/crates/resolver/src/name_server.rs
+++ b/crates/resolver/src/name_server.rs
@@ -208,17 +208,22 @@ impl<P: ConnectionProvider> NameServer<P> {
         policy: ConnectionPolicy,
         cx: &Arc<PoolContext>,
     ) -> Result<(P::Conn, Arc<ConnectionMeta>, Protocol), NetError> {
-        let mut connections = self.connections.lock().await;
-        connections.retain(|conn| matches!(conn.meta.status(), Status::Init | Status::Established));
-        if let Some(conn) = policy.select_connection(
-            self.config.ip,
-            &*cx.transport_state().await,
-            &cx.opportunistic_encryption,
-            &connections,
-        ) {
-            return Ok((conn.handle.clone(), conn.meta.clone(), conn.protocol));
+        // Check for an existing usable connection (short lock)
+        {
+            let mut connections = self.connections.lock().await;
+            connections
+                .retain(|conn| matches!(conn.meta.status(), Status::Init | Status::Established));
+            if let Some(conn) = policy.select_connection(
+                self.config.ip,
+                &*cx.transport_state().await,
+                &cx.opportunistic_encryption,
+                &connections,
+            ) {
+                return Ok((conn.handle.clone(), conn.meta.clone(), conn.protocol));
+            }
         }
 
+        // Select connection config and update transport state (no lock)
         debug!(config = ?self.config, "connecting");
         let config = policy
             .select_connection_config(
@@ -238,6 +243,7 @@ impl<P: ConnectionProvider> NameServer<P> {
             self.consider_probe_encrypted_transport(&policy, cx).await;
         }
 
+        // Establish connection
         let handle = Box::pin(self.connection_provider.new_connection(
             self.config.ip,
             config,
@@ -251,10 +257,10 @@ impl<P: ConnectionProvider> NameServer<P> {
                 .complete_connection(self.config.ip, protocol);
         }
 
-        // establish a new connection
+        // Store the new connection (with lock)
         let state = ConnectionState::new(handle.clone(), protocol);
         let meta = state.meta.clone();
-        connections.push(state);
+        self.connections.lock().await.push(state);
         Ok((handle, meta, protocol))
     }
 

--- a/crates/resolver/src/name_server_pool.rs
+++ b/crates/resolver/src/name_server_pool.rs
@@ -1428,6 +1428,154 @@ mod tests {
         }
     }
 
+    /// Regression test: when the top-ranked servers are unreachable and block for the
+    /// connect timeout duration, the pool must still have enough deadline budget remaining
+    /// to try additional servers.
+    ///
+    /// With `connect_timeout` defaulting to 2s, a batch of slow-to-fail servers consumes
+    /// at most 2s of the 5s deadline, leaving 3s for the remaining servers.
+    #[tokio::test]
+    async fn test_connect_timeout_leaves_budget_for_remaining_servers() {
+        subscribe();
+
+        let slow_ip_1 = IpAddr::from([10, 0, 0, 1]);
+        let slow_ip_2 = IpAddr::from([10, 0, 0, 2]);
+        let good_ip = IpAddr::from([10, 0, 0, 3]);
+        let query_name = Name::from_str("example.com.").unwrap();
+
+        let responses = vec![MockRecord::a(good_ip, &query_name, good_ip)];
+        let handler = MockNetworkHandler::new(responses);
+        let mock_provider = MockProvider::new(handler);
+
+        // The slow IPs will delay for 1.5s before returning TimedOut.
+        // With num_concurrent_reqs=2, both slow servers are tried in the first batch.
+        // With connect_timeout = 2s (default) and pool deadline = 5s,
+        // the slow servers consume ~1.5s, leaving ~3.5s for the good server.
+        let provider = SlowTimeoutProvider::new(
+            mock_provider,
+            vec![slow_ip_1, slow_ip_2],
+            Duration::from_millis(1500),
+        );
+
+        let opts = ResolverOpts {
+            num_concurrent_reqs: 2,
+            server_ordering_strategy: ServerOrderingStrategy::UserProvidedOrder,
+            ..ResolverOpts::default()
+        };
+
+        let pool = NameServerPool::from_nameservers(
+            vec![
+                Arc::new(NameServer::new(
+                    [].into_iter(),
+                    NameServerConfig::udp(slow_ip_1),
+                    &opts,
+                    provider.clone(),
+                )),
+                Arc::new(NameServer::new(
+                    [].into_iter(),
+                    NameServerConfig::udp(slow_ip_2),
+                    &opts,
+                    provider.clone(),
+                )),
+                Arc::new(NameServer::new(
+                    [].into_iter(),
+                    NameServerConfig::udp(good_ip),
+                    &opts,
+                    provider.clone(),
+                )),
+            ],
+            Arc::new(PoolContext::new(opts, TlsConfig::new().unwrap())),
+        );
+
+        let start = Instant::now();
+        let response = pool
+            .lookup(
+                Query::query(query_name.clone(), RecordType::A),
+                DnsRequestOptions::default(),
+            )
+            .first_answer()
+            .await
+            .expect("pool should fall through slow servers and reach the good server");
+
+        let elapsed = start.elapsed();
+
+        assert!(
+            !response.answers.is_empty(),
+            "expected A record in response"
+        );
+
+        // The lookup should complete well within the 5s deadline.
+        // It should take ~1.5s (slow batch) + a small amount for the good server.
+        assert!(
+            elapsed < Duration::from_secs(4),
+            "lookup took {elapsed:?}, which suggests the pool didn't fall through in time"
+        );
+    }
+
+    /// A [`RuntimeProvider`] wrapper where specified IPs delay for a configured duration
+    /// before returning `io::ErrorKind::TimedOut`. This simulates a SYN-drop scenario
+    /// where the TCP connect blocks until the connect timeout fires.
+    #[derive(Clone)]
+    struct SlowTimeoutProvider {
+        inner: MockProvider,
+        slow_ips: Arc<HashSet<IpAddr>>,
+        delay: Duration,
+    }
+
+    impl SlowTimeoutProvider {
+        fn new(inner: MockProvider, slow_ips: Vec<IpAddr>, delay: Duration) -> Self {
+            Self {
+                inner,
+                slow_ips: Arc::new(slow_ips.into_iter().collect()),
+                delay,
+            }
+        }
+    }
+
+    impl RuntimeProvider for SlowTimeoutProvider {
+        type Handle = TokioHandle;
+        type Timer = TokioTime;
+        type Udp = MockUdpSocket;
+        type Tcp = MockTcpStream;
+
+        fn create_handle(&self) -> Self::Handle {
+            self.inner.create_handle()
+        }
+
+        fn connect_tcp(
+            &self,
+            server_addr: SocketAddr,
+            bind_addr: Option<SocketAddr>,
+            timeout: Option<Duration>,
+        ) -> Pin<Box<dyn Future<Output = Result<Self::Tcp, io::Error>> + Send>> {
+            if self.slow_ips.contains(&server_addr.ip()) {
+                let delay = self.delay;
+                Box::pin(async move {
+                    tokio::time::sleep(delay).await;
+                    Err(io::Error::from(io::ErrorKind::TimedOut))
+                })
+            } else {
+                self.inner.connect_tcp(server_addr, bind_addr, timeout)
+            }
+        }
+
+        fn bind_udp(
+            &self,
+            local_addr: SocketAddr,
+            server_addr: SocketAddr,
+        ) -> Pin<Box<dyn Future<Output = Result<Self::Udp, io::Error>> + Send>> {
+            if self.slow_ips.contains(&server_addr.ip()) {
+                let delay = self.delay;
+                Box::pin(async move {
+                    tokio::time::sleep(delay).await;
+                    Err(io::Error::from(io::ErrorKind::TimedOut))
+                })
+            } else {
+                self.inner.bind_udp(local_addr, server_addr)
+            }
+        }
+    }
+
     /// Regression test: `sort_servers_by_query_statistics` must not panic when
     /// SRTT values are concurrently modified.
     ///


### PR DESCRIPTION
This has two fixes for pool behavior when top-ranked encrypted upstreams are unreachable:

1. Release the `connections` mutex before the TCP/TLS handshake -  before the guard was held across the handshake, so when a parallel server won the race the losing connect future lingered until the guard was dropped. Restructured so cancellation drops promptly via `Drop`.

2. Split per-connection timeout from the pool deadline - `ResolverOpts::timeout` was being used for both, so a pair of unresponsive upstreams consumed the entire 5s budget and the pool never fell through to the remaining servers (observed as indefinite SERVFAIL). Added `ResolverOpts::connect_timeout` (with a default of 2s), threaded through all the connection options. Regression test added in `name_server_pool::tests::test_connect_timeout_leaves_budget_for_remaining_servers`.