### PR TITLE
Add into functions for rdata types that store certificate data

### DIFF
--- a/crates/proto/src/rr/rdata/cert.rs
+++ b/crates/proto/src/rr/rdata/cert.rs
@@ -440,8 +440,13 @@ impl CERT {
     }
 
     /// Returns the CERT record data
-    pub fn cert_data(&self) -> Vec<u8> {
-        self.cert_data.clone()
+    pub fn cert_data(&self) -> &[u8] {
+        &self.cert_data
+    }
+
+    /// Returns the CERT record data
+    pub fn into_cert_data(self) -> Vec<u8> {
+        self.cert_data
     }
 
     /// Returns the CERT (Base64)

--- a/crates/proto/src/rr/rdata/openpgpkey.rs
+++ b/crates/proto/src/rr/rdata/openpgpkey.rs
@@ -47,6 +47,12 @@ impl OPENPGPKEY {
     pub fn public_key(&self) -> &[u8] {
         &self.public_key
     }
+
+    /// The public key. This should be an OpenPGP Transferable Public Key,
+    /// but this is not guaranteed.
+    pub fn into_public_key(self) -> Vec<u8> {
+        self.public_key
+    }
 }
 
 impl BinEncodable for OPENPGPKEY {

--- a/crates/proto/src/rr/rdata/smimea.rs
+++ b/crates/proto/src/rr/rdata/smimea.rs
@@ -49,6 +49,11 @@ impl SMIMEA {
     ) -> Self {
         Self(TLSA::new(cert_usage, selector, matching, cert_data))
     }
+
+    /// Binary data for validating the cert, see other members to understand the format
+    pub fn into_cert_data(self) -> Vec<u8> {
+        self.0.into_cert_data()
+    }
 }
 
 /// This implementation allows calling the associated functions of [TLSA] on [SMIMEA].

--- a/crates/proto/src/rr/rdata/sshfp.rs
+++ b/crates/proto/src/rr/rdata/sshfp.rs
@@ -103,6 +103,11 @@ impl SSHFP {
     pub fn fingerprint(&self) -> &[u8] {
         &self.fingerprint
     }
+
+    /// The fingerprint of the public key.
+    pub fn into_fingerprint(self) -> Vec<u8> {
+        self.fingerprint
+    }
 }
 
 /// ```text

--- a/crates/proto/src/rr/rdata/tlsa.rs
+++ b/crates/proto/src/rr/rdata/tlsa.rs
@@ -370,9 +370,14 @@ impl TLSA {
         self.matching
     }
 
-    /// Binary data for validating the cert, see other members to understand format
+    /// Binary data for validating the cert, see other members to understand the format
     pub fn cert_data(&self) -> &[u8] {
         &self.cert_data
+    }
+
+    /// Binary data for validating the cert, see other members to understand the format
+    pub fn into_cert_data(self) -> Vec<u8> {
+        self.cert_data
     }
 }
 


### PR DESCRIPTION
This allows accessing the raw certificate data stored in CERT, OPENPGPKEY, SMIMEA, SSHFP and TLSA records without the need to clone the data.

Note that this is a breaking change because I removed the forced clone from the CERT data type. I can revert that change to convert this into a non-breaking change if desired.