### PR TITLE
chore: Bump verison to beta.4 and ensure pinned verison deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,7 +912,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-dns"
-version = "0.26.0-beta.3"
+version = "0.26.0-beta.4"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-integration"
-version = "0.26.0-beta.3"
+version = "0.26.0-beta.4"
 dependencies = [
  "async-trait",
  "data-encoding",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-net"
-version = "0.26.0-beta.3"
+version = "0.26.0-beta.4"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0-beta.3"
+version = "0.26.0-beta.4"
 dependencies = [
  "aws-lc-rs",
  "bitflags",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.0-beta.3"
+version = "0.26.0-beta.4"
 dependencies = [
  "async-recursion",
  "cfg-if",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-server"
-version = "0.26.0-beta.3"
+version = "0.26.0-beta.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-util"
-version = "0.26.0-beta.3"
+version = "0.26.0-beta.4"
 dependencies = [
  "clap",
  "console",
@@ -2686,7 +2686,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "test-support"
-version = "0.26.0-beta.3"
+version = "0.26.0-beta.4"
 dependencies = [
  "bytes",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.26.0-beta.3"
+version = "0.26.0-beta.4"
 authors = ["The contributors to Hickory DNS"]
 edition = "2021"
 rust-version = "1.88"
@@ -26,10 +26,10 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 # hickory
-hickory-net = { version = "0.26.0-alpha.1", path = "crates/net", default-features = false }
-hickory-resolver = { version = "0.26.0-alpha.1", path = "crates/resolver", default-features = false }
-hickory-server = { version = "0.26.0-alpha.1", path = "crates/server", default-features = false }
-hickory-proto = { version = "0.26.0-alpha.1", path = "crates/proto", default-features = false, features = ["std"] }
+hickory-net = { version = "=0.26.0-beta.4", path = "crates/net", default-features = false }
+hickory-resolver = { version = "=0.26.0-beta.4", path = "crates/resolver", default-features = false }
+hickory-server = { version = "=0.26.0-beta.4", path = "crates/server", default-features = false }
+hickory-proto = { version = "=0.26.0-beta.4", path = "crates/proto", default-features = false, features = ["std"] }
 test-support.path = "tests/test-support"
 
 

--- a/conformance/Cargo.lock
+++ b/conformance/Cargo.lock
@@ -668,7 +668,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-net"
-version = "0.26.0-beta.3"
+version = "0.26.0-beta.4"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0-beta.3"
+version = "0.26.0-beta.4"
 dependencies = [
  "aws-lc-rs",
  "bitflags",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.0-beta.3"
+version = "0.26.0-beta.4"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "test-support"
-version = "0.26.0-beta.3"
+version = "0.26.0-beta.4"
 dependencies = [
  "bytes",
  "futures-util",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -243,7 +243,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0-beta.3"
+version = "0.26.0-beta.4"
 dependencies = [
  "aws-lc-rs",
  "bitflags",


### PR DESCRIPTION
Inter-workspace crate dependencies need to use exact verison bounds (`=0.26.0-beta.4` instead of `0.26.0-beta.4`).
Otherwise, a previous beta release will quickly be broken by a newer beta release, as e.g. depending on hickory-resolver 0.26.0-beta.3 can make cargo's version resolver pick hickory-proto `0.26.0-beta.4`.
(This exact example will actually still continue to be the case, but this PR will make breaking beta.5 releases work well.)

