### PR TITLE
conformance: try to avoid flakes by setting a positive min TTL

### DIFF
--- a/conformance/dns-test/src/templates/hickory.resolver.toml.jinja
+++ b/conformance/dns-test/src/templates/hickory.resolver.toml.jinja
@@ -15,3 +15,8 @@ dnssec_policy = "ValidationDisabled"
 {% endif %}
 allow_server = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
 case_randomization = {{ case_randomization }}
+
+# Avoid TTL=0 cache entries that expire on the same Instant they are inserted,
+# which causes flaky cache-hit assertions in conformance tests.
+[zones.stores.cache_policy.default]
+positive_min_ttl = 1


### PR DESCRIPTION
There have been a few test flakes like this:

```
---- resolver::dnssec::rfc4035::section_4::section_4_5::caches_intermediate_records stdout ----

thread 'resolver::dnssec::rfc4035::section_4::section_4_5::caches_intermediate_records' (182445) panicked at conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_5.rs:136:9:
assertion failed: !ns_addrs.contains(&direction.peer_addr())
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    resolver::dnssec::rfc4035::section_4::section_4_5::caches_intermediate_records
```

My hypothesis is that this might be because the test peer could return a DS RRset with TTL=0, triggering another query due to acache miss. Fix it by setting a low positive minimum TTL in the test recursor config.