### PR TITLE
Prepare 0.26.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,7 +912,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-dns"
-version = "0.26.0-beta.4"
+version = "0.26.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-integration"
-version = "0.26.0-beta.4"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "data-encoding",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-net"
-version = "0.26.0-beta.4"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0-beta.4"
+version = "0.26.0"
 dependencies = [
  "aws-lc-rs",
  "bitflags",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.0-beta.4"
+version = "0.26.0"
 dependencies = [
  "async-recursion",
  "cfg-if",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-server"
-version = "0.26.0-beta.4"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-util"
-version = "0.26.0-beta.4"
+version = "0.26.0"
 dependencies = [
  "clap",
  "console",
@@ -2687,7 +2687,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "test-support"
-version = "0.26.0-beta.4"
+version = "0.26.0"
 dependencies = [
  "bytes",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.26.0-beta.4"
+version = "0.26.0"
 authors = ["The contributors to Hickory DNS"]
 edition = "2021"
 rust-version = "1.88"
@@ -26,10 +26,10 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 # hickory
-hickory-net = { version = "=0.26.0-beta.4", path = "crates/net", default-features = false }
-hickory-resolver = { version = "=0.26.0-beta.4", path = "crates/resolver", default-features = false }
-hickory-server = { version = "=0.26.0-beta.4", path = "crates/server", default-features = false }
-hickory-proto = { version = "=0.26.0-beta.4", path = "crates/proto", default-features = false, features = ["std"] }
+hickory-net = { version = "0.26.0", path = "crates/net", default-features = false }
+hickory-resolver = { version = "0.26.0", path = "crates/resolver", default-features = false }
+hickory-server = { version = "0.26.0", path = "crates/server", default-features = false }
+hickory-proto = { version = "0.26.0", path = "crates/proto", default-features = false, features = ["std"] }
 test-support.path = "tests/test-support"
 
 

--- a/conformance/Cargo.lock
+++ b/conformance/Cargo.lock
@@ -668,7 +668,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-net"
-version = "0.26.0-beta.4"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0-beta.4"
+version = "0.26.0"
 dependencies = [
  "aws-lc-rs",
  "bitflags",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.0-beta.4"
+version = "0.26.0"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "test-support"
-version = "0.26.0-beta.4"
+version = "0.26.0"
 dependencies = [
  "bytes",
  "futures-util",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -243,7 +243,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0-beta.4"
+version = "0.26.0"
 dependencies = [
  "aws-lc-rs",
  "bitflags",


### PR DESCRIPTION
13 months after the release of 0.25.0, we finally have a bigger feature release of Hickory DNS, the suite of DNS libraries and authoritative/recursive name servers written in pure Rust. A lot of work has gone into this release, so we wanted to take a moment to release this before we continue work on deploying the Hickory DNS recursive resolver [at Let's Encrypt](https://github.com/hickory-dns/hickory-dns/issues/2725) (and did you see that Hickory is being used [in some of Google's Pixel devices](https://security.googleblog.com/2026/04/bringing-rust-to-pixel-baseband.html)?). Because of the ongoing work, we expect that 0.27.0 might happen quite a bit sooner than in 13 months from now.

These release notes describe a number of high-level improvements as well as API changes that are likely to break a larger fraction of our downstream users. Feedback (both on these notes and the release itself) is always welcome in our [issue tracker](https://github.com/hickory-dns/hickory-dns/issues) or via our [Discord server](https://discord.gg/89nxE4n).

Most of the following notes are broken up by specific components: the server binary and our library crates. However, for this release we've made several changes to the structure of our crates itself:

- Network protocol support has moved out of the hickory-proto crate, into a new hickory-net crate (#3394); this allows the hickory-proto crate to cleanly focus on message encoding and decoding.
- The hickory-client crate has been subsumed into hickory-net, in the `client` module (#3366). No future releases of the hickory-client crate are expected.
- The hickory-recursor crate has been merged into hickory-resolver (#3370), guarded by a `recursor` feature which must be enabled explicitly. The recursor implementation was already tightly coupled to the resolver internals, so keeping it separate didn't really make sense.

Additionally, substantial cross-crate changes have been made to improve our error handling:

* https://github.com/hickory-dns/hickory-dns/pull/3387
* https://github.com/hickory-dns/hickory-dns/pull/3374
* https://github.com/hickory-dns/hickory-dns/pull/3251
* https://github.com/hickory-dns/hickory-dns/pull/3505
* #2970
* #3000

### hickory-dns (the server binary)

* We've added a number of ways to optimize performance via low-level networking configuration:
  * https://github.com/hickory-dns/hickory-dns/pull/3509
  * https://github.com/hickory-dns/hickory-dns/pull/3507
  * https://github.com/hickory-dns/hickory-dns/pull/3549
  * https://github.com/hickory-dns/hickory-dns/pull/3578
* We further extended and reworked our metrics:
  * #3428 
  * #3421 
  * #3367
* Miscellaneous changes:
  * https://github.com/hickory-dns/hickory-dns/pull/3070
  * https://github.com/hickory-dns/hickory-dns/pull/3184
  * https://github.com/hickory-dns/hickory-dns/pull/3576
  * https://github.com/hickory-dns/hickory-dns/pull/3579
  * https://github.com/hickory-dns/hickory-dns/pull/3585

### hickory-server (the library API)

* The `Authority` trait was renamed to `ZoneHandler` and simplified to better reflect its usage:
  * https://github.com/hickory-dns/hickory-dns/pull/3241
  * https://github.com/hickory-dns/hickory-dns/pull/3250
  * https://github.com/hickory-dns/hickory-dns/pull/3086
  * https://github.com/hickory-dns/hickory-dns/pull/3074
* Miscellaneous changes:
  * https://github.com/hickory-dns/hickory-dns/pull/3035
  * https://github.com/hickory-dns/hickory-dns/pull/3060
  * https://github.com/hickory-dns/hickory-dns/pull/3030

### hickory-resolver

We made many improvements to improve correctness and efficiency of both the recursive resolver and the "stub" resolver. In addition, we want to highlight the following changes:

* We substantially changed the high-level resolver and configuration API:
  * #3019
  * #2968
  * https://github.com/hickory-dns/hickory-dns/pull/3029
  * https://github.com/hickory-dns/hickory-dns/pull/3052
  * https://github.com/hickory-dns/hickory-dns/pull/3059
  * https://github.com/hickory-dns/hickory-dns/pull/3091
  * https://github.com/hickory-dns/hickory-dns/pull/3085
  * https://github.com/hickory-dns/hickory-dns/pull/3027
  * https://github.com/hickory-dns/hickory-dns/pull/3112
  * https://github.com/hickory-dns/hickory-dns/pull/3033
  * https://github.com/hickory-dns/hickory-dns/pull/3281
  * https://github.com/hickory-dns/hickory-dns/pull/3210
* We improved handling of the system default resolution settings:
  * https://github.com/hickory-dns/hickory-dns/pull/3095
  * https://github.com/hickory-dns/hickory-dns/pull/3324
  * https://github.com/hickory-dns/hickory-dns/pull/3278
* We improved the efficiency of the resolver internals:
  * https://github.com/hickory-dns/hickory-dns/pull/3554
* Miscellaneous changes:
  * https://github.com/hickory-dns/hickory-dns/pull/3276
  * https://github.com/hickory-dns/hickory-dns/pull/3449
  * https://github.com/hickory-dns/hickory-dns/pull/3123
  * https://github.com/hickory-dns/hickory-dns/pull/3040

### hickory-net

We made substantial improvements to DNSSEC validation and our handling of potentially spoofing messages.

* Miscellaneous changes:
  * #3499
  * https://github.com/hickory-dns/hickory-dns/pull/3298
  * https://github.com/hickory-dns/hickory-dns/pull/3402

### hickory-proto

* We have made the fields for several core types directly public:
  * https://github.com/hickory-dns/hickory-dns/pull/3511
  * https://github.com/hickory-dns/hickory-dns/pull/3557
  * https://github.com/hickory-dns/hickory-dns/pull/3542
  * https://github.com/hickory-dns/hickory-dns/pull/3106
  * #2986
* We now enable EDNS by default in outgoing messages, increasing the max payload length:
  * https://github.com/hickory-dns/hickory-dns/pull/3498
  * https://github.com/hickory-dns/hickory-dns/pull/3504
* We have removed SIG(0) authentication in favor of the more popular TSIG alternative:
  * https://github.com/hickory-dns/hickory-dns/pull/3437
* Miscellaneous changes:
  * https://github.com/hickory-dns/hickory-dns/pull/3510
  * #3577
  * https://github.com/hickory-dns/hickory-dns/pull/3302
  * https://github.com/hickory-dns/hickory-dns/pull/3347

For more details, review the detailed release notes for our pre-releases:

- [Beta 4](https://github.com/hickory-dns/hickory-dns/releases/tag/v0.26.0-beta.4)
- [Beta 3](https://github.com/hickory-dns/hickory-dns/releases/tag/v0.26.0-beta.3)
- [Beta 2](https://github.com/hickory-dns/hickory-dns/releases/tag/v0.26.0-beta.2)
- [Beta 1](https://github.com/hickory-dns/hickory-dns/releases/tag/v0.26.0-beta.1)
- [Alpha 1](https://github.com/hickory-dns/hickory-dns/releases/tag/v0.26.0-alpha.1)