### PR TITLE
Add tests combining NSEC and NSEC3 via CNAME chain

### DIFF
--- a/conformance/conformance-tests/src/resolver/dnssec/scenarios/cname.rs
+++ b/conformance/conformance-tests/src/resolver/dnssec/scenarios/cname.rs
@@ -801,3 +801,194 @@ fn insecure_cname_secure_nodata(sign_settings: SignSettings) -> Result<(), Error
 
     Ok(())
 }
+
+#[test]
+#[ignore = "hickory drops NSEC records associated with the CNAME record"]
+fn secure_cname_nsec_secure_nodata_nsec3() -> Result<(), Error> {
+    secure_cname_secure_nodata(
+        SignSettings::default().nsec(Nsec::_1),
+        SignSettings::default(),
+    )
+}
+
+#[test]
+#[ignore = "hickory returns an error about the name of the SOA record"]
+fn secure_cname_nsec3_secure_nodata_nsec() -> Result<(), Error> {
+    secure_cname_secure_nodata(
+        SignSettings::default(),
+        SignSettings::default().nsec(Nsec::_1),
+    )
+}
+
+/// Combines a CNAME with a wildcard name in one zone pointing to a name in another zone with a no
+/// data response. Proofs of nonexistence will be required from both zones for proper verification.
+fn secure_cname_secure_nodata(
+    alias_sign_settings: SignSettings,
+    target_sign_settings: SignSettings,
+) -> Result<(), Error> {
+    let network = Network::new()?;
+
+    let alias_zone_fqdn = FQDN::TEST_TLD.push_label("alias-zone");
+    let alias_query_name_fqdn = alias_zone_fqdn.push_label("alias-name");
+    let alias_wildcard_name_fqdn = alias_zone_fqdn.push_label("*");
+    let record_name_fqdn = FQDN::TEST_DOMAIN.push_label("record");
+
+    let mut alias_ns = NameServer::new(&PEER, alias_zone_fqdn, &network)?;
+    alias_ns.add(CNAME {
+        fqdn: alias_wildcard_name_fqdn.clone(),
+        ttl: 86400,
+        target: record_name_fqdn.clone(),
+    });
+
+    let mut leaf_ns = NameServer::new(&PEER, FQDN::TEST_DOMAIN, &network)?;
+    leaf_ns.add(A {
+        fqdn: record_name_fqdn,
+        ttl: 86400,
+        ipv4_addr: Ipv4Addr::new(10, 0, 0, 1),
+    });
+
+    let mut tld_ns = NameServer::new(&PEER, FQDN::TEST_TLD, &network)?;
+    tld_ns.referral_nameserver(&alias_ns);
+    tld_ns.referral_nameserver(&leaf_ns);
+
+    let mut root_ns = NameServer::new(&PEER, FQDN::ROOT, &network)?;
+    root_ns.referral_nameserver(&tld_ns);
+
+    let alias_ns = alias_ns.sign(alias_sign_settings)?;
+    tld_ns.add(alias_ns.ds().ksk.clone());
+    let leaf_ns = leaf_ns.sign(target_sign_settings)?;
+    tld_ns.add(leaf_ns.ds().ksk.clone());
+    let tld_ns = tld_ns.sign(SignSettings::default())?;
+    root_ns.add(tld_ns.ds().ksk.clone());
+    let root_ns = root_ns.sign(SignSettings::default())?;
+
+    let _alias_ns = alias_ns.start()?;
+    let _leaf_ns = leaf_ns.start()?;
+    let _tld_ns = tld_ns.start()?;
+    let root_ns = root_ns.start()?;
+
+    let resolver = Resolver::new(&network, root_ns.root_hint())
+        .trust_anchor(root_ns.trust_anchor().unwrap())
+        .start()?;
+    let client = Client::new(&network)?;
+
+    let settings = *DigSettings::default().recurse().dnssec().authentic_data();
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::CAA,
+        &alias_query_name_fqdn,
+    )?;
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert!(
+        output
+            .answer
+            .iter()
+            .any(|record| matches!(record, Record::CNAME(_)))
+    );
+    assert!(
+        !output
+            .answer
+            .iter()
+            .any(|record| matches!(record, Record::CAA(_)))
+    );
+    assert!(!output.authority.is_empty());
+
+    Ok(())
+}
+
+#[test]
+#[ignore = "hickory drops NSEC and NSEC3 records"]
+fn secure_cname_nsec_secure_positive_wildcard_expanded_nsec3() -> Result<(), Error> {
+    secure_cname_secure_positive_wildcard_expanded(
+        SignSettings::default().nsec(Nsec::_1),
+        SignSettings::default(),
+    )
+}
+
+#[test]
+#[ignore = "hickory drops NSEC and NSEC3 records"]
+fn secure_cname_nsec3_secure_positive_wildcard_expanded_nsec() -> Result<(), Error> {
+    secure_cname_secure_positive_wildcard_expanded(
+        SignSettings::default(),
+        SignSettings::default().nsec(Nsec::_1),
+    )
+}
+
+/// Combines a CNAME with a wildcard name in one zone with a target that requires wildcard
+/// expansion. Verification will need to check correct wildcard expansion of both RRsets.
+fn secure_cname_secure_positive_wildcard_expanded(
+    alias_sign_settings: SignSettings,
+    target_sign_settings: SignSettings,
+) -> Result<(), Error> {
+    let network = Network::new()?;
+
+    let alias_zone_fqdn = FQDN::TEST_TLD.push_label("alias-zone");
+    let alias_query_name_fqdn = alias_zone_fqdn.push_label("alias-name");
+    let alias_wildcard_name_fqdn = alias_zone_fqdn.push_label("*");
+    let wildcard_name_fqdn = FQDN::TEST_DOMAIN.push_label("*");
+    let target_name_fqdn = FQDN::TEST_DOMAIN.push_label("record");
+
+    let mut alias_ns = NameServer::new(&PEER, alias_zone_fqdn, &network)?;
+    alias_ns.add(CNAME {
+        fqdn: alias_wildcard_name_fqdn.clone(),
+        ttl: 86400,
+        target: target_name_fqdn,
+    });
+
+    let mut leaf_ns = NameServer::new(&PEER, FQDN::TEST_DOMAIN, &network)?;
+    leaf_ns.add(A {
+        fqdn: wildcard_name_fqdn,
+        ttl: 86400,
+        ipv4_addr: Ipv4Addr::new(10, 0, 0, 1),
+    });
+
+    let mut tld_ns = NameServer::new(&PEER, FQDN::TEST_TLD, &network)?;
+    tld_ns.referral_nameserver(&alias_ns);
+    tld_ns.referral_nameserver(&leaf_ns);
+
+    let mut root_ns = NameServer::new(&PEER, FQDN::ROOT, &network)?;
+    root_ns.referral_nameserver(&tld_ns);
+
+    let alias_ns = alias_ns.sign(alias_sign_settings)?;
+    tld_ns.add(alias_ns.ds().ksk.clone());
+    let leaf_ns = leaf_ns.sign(target_sign_settings)?;
+    tld_ns.add(leaf_ns.ds().ksk.clone());
+    let tld_ns = tld_ns.sign(SignSettings::default())?;
+    root_ns.add(tld_ns.ds().ksk.clone());
+    let root_ns = root_ns.sign(SignSettings::default())?;
+
+    let _alias_ns = alias_ns.start()?;
+    let _leaf_ns = leaf_ns.start()?;
+    let _tld_ns = tld_ns.start()?;
+    let root_ns = root_ns.start()?;
+
+    let resolver = Resolver::new(&network, root_ns.root_hint())
+        .trust_anchor(root_ns.trust_anchor().unwrap())
+        .start()?;
+    let client = Client::new(&network)?;
+
+    let settings = *DigSettings::default().recurse().dnssec().authentic_data();
+    let output = client.dig(
+        settings,
+        resolver.ipv4_addr(),
+        RecordType::A,
+        &alias_query_name_fqdn,
+    )?;
+    assert_eq!(output.status, DigStatus::NOERROR);
+    assert!(
+        output
+            .answer
+            .iter()
+            .any(|record| matches!(record, Record::CNAME(_)))
+    );
+    assert!(
+        output
+            .answer
+            .iter()
+            .any(|record| matches!(record, Record::A(_)))
+    );
+    assert!(!output.authority.is_empty());
+
+    Ok(())
+}


### PR DESCRIPTION
Inspired by RFC 7129 section 5.4, this adds some additional tests that combine wildcard names and CNAME chasing. The responses in these tests should contain both NSEC and NSEC3 records, one type from each zone. This is my motivating example for getting rid of the "response contains both NSEC and NSEC3 records" error condition. However, these tests don't yet trigger that condition, due to other issues. The recursor is not including necessary NSEC/NSEC3 RRs and their RRSIGs from CNAME chasing, and one of the tests triggers an error about an SOA record name not being an ancestor of the query name.