### PR TITLE
server: add default implementation for ZoneHandler::metrics_label

### DIFF
--- a/crates/server/src/zone_handler/mod.rs
+++ b/crates/server/src/zone_handler/mod.rs
@@ -197,7 +197,9 @@ pub trait ZoneHandler: Send + Sync {
 
     /// Returns the zone handler metrics label.
     #[cfg(feature = "metrics")]
-    fn metrics_label(&self) -> &'static str;
+    fn metrics_label(&self) -> &'static str {
+        ""
+    }
 }
 
 /// Extension to ZoneHandler to allow for DNSSEC features


### PR DESCRIPTION
The `prometheus-metrics` feature made metrics_label a required method - add a default empty-string implementation to avoid a compile error:

```
   Compiling hickory-dns v0.26.0 (/build/source/bin)
   Compiling hickory-integration v0.26.0 (/build/source/tests/integration-tests)
error[E0046]: not all trait items implemented, missing: `metrics_label`
   --> tests/integration-tests/tests/integration/chained_zone_handler_tests.rs:176:1
    |
176 | impl ZoneHandler for TestZoneHandler {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `metrics_label` in implementation
    |
    = help: implement the missing item: `fn metrics_label(&self) -> &'static str { todo!() }`

For more information about this error, try `rustc --explain E0046`.
```