### PR TITLE
proto: decode Edns directly

### DIFF
--- a/bin/tests/integration/server_harness.rs
+++ b/bin/tests/integration/server_harness.rs
@@ -17,10 +17,7 @@ use hickory_net::{NetError, client::ClientHandle, xfer::Protocol};
 #[cfg(feature = "__dnssec")]
 use hickory_net::{client::Client, runtime::TokioRuntimeProvider, xfer::DnsHandle};
 #[cfg(feature = "__dnssec")]
-use hickory_proto::{
-    dnssec::Algorithm,
-    op::{DnsRequest, Edns},
-};
+use hickory_proto::{dnssec::Algorithm, op::DnsRequest};
 use hickory_proto::{
     op::{DnsResponse, ResponseCode},
     rr::{DNSClass, Name, RData, RecordType, rdata::A},
@@ -320,8 +317,8 @@ impl<C: ClientHandle + Unpin> DnsHandle for MutMessageHandle<C> {
 
     fn send(&self, mut request: DnsRequest) -> Self::Response {
         // mutable block
-        let edns = request.edns.get_or_insert_with(Edns::new);
-        edns.set_dnssec_ok(true);
+        let edns = request.edns.get_or_insert_default();
+        edns.flags.dnssec_ok = true;
 
         println!("sending message");
         self.client.send(request)

--- a/crates/net/src/client/mod.rs
+++ b/crates/net/src/client/mod.rs
@@ -34,8 +34,8 @@ use crate::{
     proto::{
         ProtoError,
         op::{
-            DEFAULT_MAX_PAYLOAD_LEN, DnsRequest, DnsRequestOptions, DnsResponse, Edns, Message,
-            OpCode, Query, update_message,
+            DEFAULT_MAX_PAYLOAD_LEN, DnsRequest, DnsRequestOptions, DnsResponse, Message, OpCode,
+            Query, update_message,
         },
         rr::{DNSClass, Name, RData, Record, RecordSet, RecordType, rdata::SOA},
     },
@@ -252,7 +252,7 @@ pub trait ClientHandle: 'static + Clone + DnsHandle + Send {
         if self.is_using_edns() {
             message
                 .edns
-                .get_or_insert_with(Edns::new)
+                .get_or_insert_default()
                 .set_max_payload(DEFAULT_MAX_PAYLOAD_LEN)
                 .set_version(0);
         }

--- a/crates/net/src/client/mod.rs
+++ b/crates/net/src/client/mod.rs
@@ -33,10 +33,7 @@ use crate::{
     error::NetError,
     proto::{
         ProtoError,
-        op::{
-            DEFAULT_MAX_PAYLOAD_LEN, DnsRequest, DnsRequestOptions, DnsResponse, Message, OpCode,
-            Query, update_message,
-        },
+        op::{DnsRequest, DnsRequestOptions, DnsResponse, Message, OpCode, Query, update_message},
         rr::{DNSClass, Name, RData, Record, RecordSet, RecordType, rdata::SOA},
     },
     runtime::RuntimeProvider,
@@ -250,11 +247,7 @@ pub trait ClientHandle: 'static + Clone + DnsHandle + Send {
 
         // Extended dns
         if self.is_using_edns() {
-            message
-                .edns
-                .get_or_insert_default()
-                .set_max_payload(DEFAULT_MAX_PAYLOAD_LEN)
-                .set_version(0);
+            message.edns.get_or_insert_default();
         }
 
         // add the query

--- a/crates/net/src/dnssec/mod.rs
+++ b/crates/net/src/dnssec/mod.rs
@@ -37,9 +37,7 @@ use crate::{
             Proof, TrustAnchors, Verifier,
             rdata::{DNSKEY, DNSSECRData, DS, NSEC, RRSIG},
         },
-        op::{
-            DnsRequest, DnsRequestOptions, DnsResponse, Edns, Message, OpCode, Query, ResponseCode,
-        },
+        op::{DnsRequest, DnsRequestOptions, DnsResponse, Message, OpCode, Query, ResponseCode},
         rr::{Name, RData, Record, RecordRef, RecordSet, RecordSetParts, RecordType, SerialNumber},
     },
     runtime::{RuntimeProvider, Time},
@@ -1052,7 +1050,7 @@ impl<H: DnsHandle> DnsHandle for DnssecDnsHandle<H> {
         };
 
         let handle = self.clone_with_context();
-        request.edns.get_or_insert_with(Edns::new).enable_dnssec();
+        request.edns.get_or_insert_default().enable_dnssec();
 
         request.metadata.authentic_data = true;
         request.metadata.checking_disabled = false;

--- a/crates/net/src/h2.rs
+++ b/crates/net/src/h2.rs
@@ -515,10 +515,7 @@ mod tests {
         let query = Query::new(Name::from_str("www.example.com.").unwrap(), RecordType::A);
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::default();
-        edns.set_version(0);
-        edns.set_max_payload(1232);
-        request.edns = Some(edns);
+        request.edns = Some(Edns::default());
 
         let request = DnsRequest::new(request, DnsRequestOptions::default());
 
@@ -553,10 +550,7 @@ mod tests {
         );
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::default();
-        edns.set_version(0);
-        edns.set_max_payload(1232);
-        request.edns = Some(edns);
+        request.edns = Some(Edns::default());
 
         let request = DnsRequest::new(request, DnsRequestOptions::default());
 
@@ -584,10 +578,7 @@ mod tests {
         let query = Query::new(Name::from_str("www.example.com.").unwrap(), RecordType::A);
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::default();
-        edns.set_version(0);
-        edns.set_max_payload(1232);
-        request.edns = Some(edns);
+        request.edns = Some(Edns::default());
 
         let request = DnsRequest::new(request, DnsRequestOptions::default());
 
@@ -626,10 +617,7 @@ mod tests {
         );
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::default();
-        edns.set_version(0);
-        edns.set_max_payload(1232);
-        request.edns = Some(edns);
+        request.edns = Some(Edns::default());
 
         let request = DnsRequest::new(request, DnsRequestOptions::default());
 
@@ -658,10 +646,7 @@ mod tests {
         let query = Query::new(Name::from_str("www.example.com.").unwrap(), RecordType::A);
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::default();
-        edns.set_version(0);
-        edns.set_max_payload(1232);
-        request.edns = Some(edns);
+        request.edns = Some(Edns::default());
 
         let request = DnsRequest::new(request, DnsRequestOptions::default());
 
@@ -698,10 +683,7 @@ mod tests {
         );
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::default();
-        edns.set_version(0);
-        edns.set_max_payload(1232);
-        request.edns = Some(edns);
+        request.edns = Some(Edns::default());
 
         let request = DnsRequest::new(request, DnsRequestOptions::default());
 

--- a/crates/net/src/h2.rs
+++ b/crates/net/src/h2.rs
@@ -515,7 +515,7 @@ mod tests {
         let query = Query::new(Name::from_str("www.example.com.").unwrap(), RecordType::A);
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::new();
+        let mut edns = Edns::default();
         edns.set_version(0);
         edns.set_max_payload(1232);
         request.edns = Some(edns);
@@ -553,7 +553,7 @@ mod tests {
         );
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::new();
+        let mut edns = Edns::default();
         edns.set_version(0);
         edns.set_max_payload(1232);
         request.edns = Some(edns);
@@ -584,7 +584,7 @@ mod tests {
         let query = Query::new(Name::from_str("www.example.com.").unwrap(), RecordType::A);
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::new();
+        let mut edns = Edns::default();
         edns.set_version(0);
         edns.set_max_payload(1232);
         request.edns = Some(edns);
@@ -626,7 +626,7 @@ mod tests {
         );
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::new();
+        let mut edns = Edns::default();
         edns.set_version(0);
         edns.set_max_payload(1232);
         request.edns = Some(edns);
@@ -658,7 +658,7 @@ mod tests {
         let query = Query::new(Name::from_str("www.example.com.").unwrap(), RecordType::A);
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::new();
+        let mut edns = Edns::default();
         edns.set_version(0);
         edns.set_max_payload(1232);
         request.edns = Some(edns);
@@ -698,7 +698,7 @@ mod tests {
         );
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::new();
+        let mut edns = Edns::default();
         edns.set_version(0);
         edns.set_max_payload(1232);
         request.edns = Some(edns);

--- a/crates/net/src/h3/h3_client_stream.rs
+++ b/crates/net/src/h3/h3_client_stream.rs
@@ -515,7 +515,7 @@ mod tests {
         let query = Query::new(Name::from_str("www.example.com.").unwrap(), RecordType::A);
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::new();
+        let mut edns = Edns::default();
         edns.set_version(0);
         edns.set_max_payload(1232);
         request.edns = Some(edns);
@@ -553,7 +553,7 @@ mod tests {
         );
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::new();
+        let mut edns = Edns::default();
         edns.set_version(0);
         edns.set_max_payload(1232);
         request.edns = Some(edns);
@@ -583,7 +583,7 @@ mod tests {
         let query = Query::new(Name::from_str("www.example.com.").unwrap(), RecordType::A);
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::new();
+        let mut edns = Edns::default();
         edns.set_version(0);
         edns.set_max_payload(1232);
         request.edns = Some(edns);
@@ -625,7 +625,7 @@ mod tests {
         );
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::new();
+        let mut edns = Edns::default();
         edns.set_version(0);
         edns.set_max_payload(1232);
         request.edns = Some(edns);
@@ -655,7 +655,7 @@ mod tests {
         let query = Query::new(Name::from_str("www.example.com.").unwrap(), RecordType::A);
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::new();
+        let mut edns = Edns::default();
         edns.set_version(0);
         edns.set_max_payload(1232);
         request.edns = Some(edns);
@@ -699,7 +699,7 @@ mod tests {
         );
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::new();
+        let mut edns = Edns::default();
         edns.set_version(0);
         edns.set_max_payload(1232);
         request.edns = Some(edns);

--- a/crates/net/src/h3/h3_client_stream.rs
+++ b/crates/net/src/h3/h3_client_stream.rs
@@ -515,10 +515,7 @@ mod tests {
         let query = Query::new(Name::from_str("www.example.com.").unwrap(), RecordType::A);
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::default();
-        edns.set_version(0);
-        edns.set_max_payload(1232);
-        request.edns = Some(edns);
+        request.edns = Some(Edns::default());
 
         let request = DnsRequest::new(request, DnsRequestOptions::default());
 
@@ -553,10 +550,7 @@ mod tests {
         );
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::default();
-        edns.set_version(0);
-        edns.set_max_payload(1232);
-        request.edns = Some(edns);
+        request.edns = Some(Edns::default());
 
         let request = DnsRequest::new(request, DnsRequestOptions::default());
 
@@ -583,10 +577,7 @@ mod tests {
         let query = Query::new(Name::from_str("www.example.com.").unwrap(), RecordType::A);
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::default();
-        edns.set_version(0);
-        edns.set_max_payload(1232);
-        request.edns = Some(edns);
+        request.edns = Some(Edns::default());
 
         let request = DnsRequest::new(request, DnsRequestOptions::default());
 
@@ -625,10 +616,7 @@ mod tests {
         );
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::default();
-        edns.set_version(0);
-        edns.set_max_payload(1232);
-        request.edns = Some(edns);
+        request.edns = Some(Edns::default());
 
         let request = DnsRequest::new(request, DnsRequestOptions::default());
 
@@ -655,10 +643,7 @@ mod tests {
         let query = Query::new(Name::from_str("www.example.com.").unwrap(), RecordType::A);
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::default();
-        edns.set_version(0);
-        edns.set_max_payload(1232);
-        request.edns = Some(edns);
+        request.edns = Some(Edns::default());
 
         let request = DnsRequest::new(request, DnsRequestOptions::default());
 
@@ -699,10 +684,7 @@ mod tests {
         );
         request.add_query(query);
         request.metadata.recursion_desired = true;
-        let mut edns = Edns::default();
-        edns.set_version(0);
-        edns.set_max_payload(1232);
-        request.edns = Some(edns);
+        request.edns = Some(Edns::default());
 
         let request = DnsRequest::new(request, DnsRequestOptions::default());
 

--- a/crates/proto/src/op/dns_request.rs
+++ b/crates/proto/src/op/dns_request.rs
@@ -92,11 +92,9 @@ impl DnsRequest {
         message.metadata.recursion_desired = options.recursion_desired;
 
         if options.use_edns {
-            message
-                .edns
-                .get_or_insert_default()
-                .set_max_payload(options.edns_payload_len)
-                .set_dnssec_ok(options.edns_set_dnssec_ok);
+            let edns = message.edns.get_or_insert_default();
+            edns.udp_payload_size = options.edns_payload_len;
+            edns.flags.dnssec_ok = options.edns_set_dnssec_ok;
         }
 
         Self::new(message, options).with_original_query(original_query)

--- a/crates/proto/src/op/dns_request.rs
+++ b/crates/proto/src/op/dns_request.rs
@@ -12,7 +12,7 @@ use core::ops::{Deref, DerefMut};
 use core::time::Duration;
 
 #[cfg(feature = "std")]
-use super::{DEFAULT_RETRY_FLOOR, Edns};
+use super::DEFAULT_RETRY_FLOOR;
 use super::{Message, Query, edns::DEFAULT_MAX_PAYLOAD_LEN};
 
 /// A set of options for expressing options to how requests should be treated
@@ -94,7 +94,7 @@ impl DnsRequest {
         if options.use_edns {
             message
                 .edns
-                .get_or_insert_with(Edns::new)
+                .get_or_insert_default()
                 .set_max_payload(options.edns_payload_len)
                 .set_dnssec_ok(options.edns_set_dnssec_ok);
         }

--- a/crates/proto/src/op/edns.rs
+++ b/crates/proto/src/op/edns.rs
@@ -19,7 +19,7 @@ use crate::{
     rr::{
         DNSClass, Name, RData, Record, RecordType,
         rdata::{
-            OPT,
+            EdnsOptions,
             opt::{EdnsCode, EdnsOption},
         },
     },
@@ -40,7 +40,7 @@ pub struct Edns {
     // max payload size, minimum of 512, (from RR CLASS)
     max_payload: u16,
 
-    options: OPT,
+    options: EdnsOptions,
 }
 
 impl Default for Edns {
@@ -50,7 +50,7 @@ impl Default for Edns {
             version: 0,
             flags: EdnsFlags::default(),
             max_payload: 512,
-            options: OPT::default(),
+            options: EdnsOptions::default(),
         }
     }
 }
@@ -92,12 +92,12 @@ impl Edns {
     }
 
     /// Returns the options portion of EDNS
-    pub fn options(&self) -> &OPT {
+    pub fn options(&self) -> &EdnsOptions {
         &self.options
     }
 
     /// Returns a mutable options portion of EDNS
-    pub fn options_mut(&mut self) -> &mut OPT {
+    pub fn options_mut(&mut self) -> &mut EdnsOptions {
         &mut self.options
     }
 
@@ -170,7 +170,7 @@ impl<'a> From<&'a Record> for Edns {
         let options = match &value.data {
             RData::Update0(..) | RData::NULL(..) => {
                 // NULL, there was no data in the OPT
-                OPT::default()
+                EdnsOptions::default()
             }
             RData::OPT(option_data) => {
                 option_data.clone() // TODO: Edns should just refer to this, have the same lifetime as the Record

--- a/crates/proto/src/op/edns.rs
+++ b/crates/proto/src/op/edns.rs
@@ -7,6 +7,7 @@
 
 //! Extended DNS options
 
+use alloc::boxed::Box;
 use core::fmt;
 
 #[cfg(feature = "serde")]
@@ -17,13 +18,13 @@ use crate::dnssec::{Algorithm, SupportedAlgorithms};
 use crate::{
     error::*,
     rr::{
-        DNSClass, Name, RData, Record, RecordType,
+        DNSClass, Name, RecordDataDecodable,
         rdata::{
             EdnsOptions,
             opt::{EdnsCode, EdnsOption},
         },
     },
-    serialize::binary::{BinEncodable, BinEncoder},
+    serialize::binary::{BinDecoder, BinEncodable, BinEncoder, DecodeError},
 };
 
 /// Edns implements the higher level concepts for working with extended dns as it is used to create or be
@@ -44,6 +45,29 @@ pub struct Edns {
 }
 
 impl Edns {
+    pub(crate) fn decode(name: Name, decoder: &mut BinDecoder<'_>) -> Result<Self, DecodeError> {
+        if !name.is_root() {
+            return Err(DecodeError::EdnsNameNotRoot(Box::new(name)));
+        }
+
+        let udp_payload_size = decoder.read_u16()?.unverified();
+        let extended_rcode = decoder.read_u8()?.unverified();
+        let version = decoder.read_u8()?.unverified();
+        let flags = EdnsFlags::from(decoder.read_u16()?.unverified());
+
+        // RDLENGTH        an unsigned 16 bit integer that specifies the length in
+        //                octets of the RDATA field.
+        let rd_length = decoder.read_u16()?;
+        let options = EdnsOptions::read_data(decoder, rd_length)?;
+        Ok(Self {
+            udp_payload_size,
+            extended_rcode,
+            version,
+            flags,
+            options,
+        })
+    }
+
     /// Creates a new extended DNS object.
     #[deprecated(since = "0.26.1", note = "use `Edns::default()` instead")]
     pub fn new() -> Self {
@@ -169,64 +193,9 @@ impl Edns {
     }
 }
 
-// FIXME: this should be a TryFrom
-impl<'a> From<&'a Record> for Edns {
-    fn from(value: &'a Record) -> Self {
-        assert!(value.record_type() == RecordType::OPT);
-
-        let extended_rcode = ((value.ttl & 0xFF00_0000u32) >> 24) as u8;
-        let version = ((value.ttl & 0x00FF_0000u32) >> 16) as u8;
-        let flags = EdnsFlags::from((value.ttl & 0x0000_FFFFu32) as u16);
-        let udp_payload_size = u16::from(value.dns_class);
-
-        let options = match &value.data {
-            RData::Update0(..) | RData::NULL(..) => {
-                // NULL, there was no data in the OPT
-                EdnsOptions::default()
-            }
-            RData::OPT(option_data) => {
-                option_data.clone() // TODO: Edns should just refer to this, have the same lifetime as the Record
-            }
-            _ => {
-                // this should be a coding error, as opposed to a parsing error.
-                panic!("rr_type doesn't match the RData: {:?}", value.data) // valid panic, never should happen
-            }
-        };
-
-        Self {
-            udp_payload_size,
-            extended_rcode,
-            version,
-            flags,
-            options,
-        }
-    }
-}
-
-impl<'a> From<&'a Edns> for Record {
-    /// This returns a Resource Record that is formatted for Edns(0).
-    /// Note: the rcode_high value is only part of the rcode, the rest is part of the base
-    fn from(value: &'a Edns) -> Self {
-        // rebuild the TTL field
-        let mut ttl: u32 = u32::from(value.extended_rcode) << 24;
-        ttl |= u32::from(value.version) << 16;
-        ttl |= u32::from(u16::from(value.flags));
-
-        // now for each option, write out the option array
-        //  also, since this is a hash, there is no guarantee that ordering will be preserved from
-        //  the original binary format.
-        // maybe switch to: https://crates.io/crates/linked-hash-map/
-        let mut record = Self::from_rdata(Name::root(), ttl, RData::OPT(value.options.clone()));
-        record.dns_class = DNSClass::for_opt(value.udp_payload_size);
-        record
-    }
-}
-
 impl BinEncodable for Edns {
     fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
-        0u8.emit(encoder)?; // Name::root
-        RecordType::OPT.emit(encoder)?; //self.rr_type.emit(encoder)?;
-        DNSClass::for_opt(self.udp_payload_size).emit(encoder)?; // self.dns_class.emit(encoder)?;
+        DNSClass::for_opt(self.udp_payload_size).emit(encoder)?;
 
         // rebuild the TTL field
         let mut ttl = u32::from(self.extended_rcode) << 24;
@@ -330,8 +299,9 @@ mod tests {
         edns.options
             .insert(EdnsOption::DAU(SupportedAlgorithms::all()));
 
-        let record = Record::from(&edns);
-        let edns_decode = Edns::from(&record);
+        let bytes = edns.to_bytes().expect("failed to encode");
+        let edns_decode =
+            Edns::decode(Name::root(), &mut BinDecoder::new(&bytes)).expect("failed to decode");
 
         assert_eq!(edns.flags.dnssec_ok, edns_decode.flags.dnssec_ok);
         assert_eq!(edns.flags.z, edns_decode.flags.z);

--- a/crates/proto/src/op/edns.rs
+++ b/crates/proto/src/op/edns.rs
@@ -31,15 +31,16 @@ use crate::{
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Edns {
-    // max payload size, minimum of 512, (from RR CLASS)
-    udp_payload_size: u16,
-    // high 8 bits that make up the 12 bit total field when included with the 4bit rcode from the
-    //  header (from TTL)
-    extended_rcode: u8,
-    // Indicates the implementation level of the setter. (from TTL)
-    version: u8,
-    flags: EdnsFlags,
-    options: EdnsOptions,
+    /// Max payload size, minimum of 512, (from RR CLASS)
+    pub udp_payload_size: u16,
+    /// High 8 bits that make up the 12 bit total result code
+    pub extended_rcode: u8,
+    /// Indicates the implementation level of the setter
+    pub version: u8,
+    /// Flags for EDNS (currently only DNSSEC OK)
+    pub flags: EdnsFlags,
+    /// Options for EDNS, these are the variable length portion of the OPT record
+    pub options: EdnsOptions,
 }
 
 impl Edns {

--- a/crates/proto/src/op/edns.rs
+++ b/crates/proto/src/op/edns.rs
@@ -297,7 +297,7 @@ mod tests {
 
     #[test]
     fn test_encode_decode() {
-        let mut edns = Edns::new();
+        let mut edns = Edns::default();
 
         let flags = edns.flags_mut();
         flags.dnssec_ok = true;

--- a/crates/proto/src/op/edns.rs
+++ b/crates/proto/src/op/edns.rs
@@ -45,31 +45,43 @@ pub struct Edns {
 
 impl Edns {
     /// Creates a new extended DNS object.
+    #[deprecated(since = "0.26.1", note = "use `Edns::default()` instead")]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// The high order bytes for the response code in the DNS Message
+    #[deprecated(
+        since = "0.26.1",
+        note = "use the `Ends::extended_rcode` field instead"
+    )]
     pub fn rcode_high(&self) -> u8 {
         self.extended_rcode
     }
 
     /// Returns the EDNS version
+    #[deprecated(since = "0.26.1", note = "use the `Ends::version` field instead")]
     pub fn version(&self) -> u8 {
         self.version
     }
 
     /// Returns the [`EdnsFlags`] portion of EDNS
+    #[deprecated(since = "0.26.1", note = "use the `Ends::flags` field instead")]
     pub fn flags(&self) -> &EdnsFlags {
         &self.flags
     }
 
     /// Returns a mutable reference to the [`EdnsFlags`]
+    #[deprecated(since = "0.26.1", note = "use the `Ends::flags` field instead")]
     pub fn flags_mut(&mut self) -> &mut EdnsFlags {
         &mut self.flags
     }
 
     /// Maximum supported size of the DNS payload
+    #[deprecated(
+        since = "0.26.1",
+        note = "use the `Ends::udp_payload_size` field instead"
+    )]
     pub fn max_payload(&self) -> u16 {
         self.udp_payload_size
     }
@@ -80,22 +92,29 @@ impl Edns {
     }
 
     /// Returns the options portion of EDNS
+    #[deprecated(since = "0.26.1", note = "use the `Ends::options` field instead")]
     pub fn options(&self) -> &EdnsOptions {
         &self.options
     }
 
     /// Returns a mutable options portion of EDNS
+    #[deprecated(since = "0.26.1", note = "use the `Ends::options` field instead")]
     pub fn options_mut(&mut self) -> &mut EdnsOptions {
         &mut self.options
     }
 
     /// Set the high order bits for the result code.
+    #[deprecated(
+        since = "0.26.1",
+        note = "use the `Ends::extended_rcode` field instead"
+    )]
     pub fn set_rcode_high(&mut self, rcode_high: u8) -> &mut Self {
         self.extended_rcode = rcode_high;
         self
     }
 
     /// Set the EDNS version
+    #[deprecated(since = "0.26.1", note = "use the `Ends::version` field instead")]
     pub fn set_version(&mut self, version: u8) -> &mut Self {
         self.version = version;
         self
@@ -104,7 +123,7 @@ impl Edns {
     /// Creates a new extended DNS object prepared for DNSSEC messages.
     #[cfg(feature = "__dnssec")]
     pub fn enable_dnssec(&mut self) {
-        self.set_dnssec_ok(true);
+        self.flags.dnssec_ok = true;
         self.set_default_algorithms();
     }
 
@@ -127,11 +146,12 @@ impl Edns {
 
         let dau = EdnsOption::DAU(algorithms);
 
-        self.options_mut().insert(dau);
+        self.options.insert(dau);
         self
     }
 
     /// Set to true if DNSSEC is supported
+    #[deprecated(since = "0.26.1", note = "use the `Ends::flags` field instead")]
     pub fn set_dnssec_ok(&mut self, dnssec_ok: bool) -> &mut Self {
         self.flags.dnssec_ok = dnssec_ok;
         self
@@ -139,6 +159,10 @@ impl Edns {
 
     /// Set the maximum payload which can be supported
     /// From RFC 6891: `Values lower than 512 MUST be treated as equal to 512`
+    #[deprecated(
+        since = "0.26.1",
+        note = "use the `Ends::udp_payload_size` field instead"
+    )]
     pub fn set_max_payload(&mut self, max_payload: u16) -> &mut Self {
         self.udp_payload_size = max_payload.max(512);
         self
@@ -184,16 +208,16 @@ impl<'a> From<&'a Edns> for Record {
     /// Note: the rcode_high value is only part of the rcode, the rest is part of the base
     fn from(value: &'a Edns) -> Self {
         // rebuild the TTL field
-        let mut ttl: u32 = u32::from(value.rcode_high()) << 24;
-        ttl |= u32::from(value.version()) << 16;
+        let mut ttl: u32 = u32::from(value.extended_rcode) << 24;
+        ttl |= u32::from(value.version) << 16;
         ttl |= u32::from(u16::from(value.flags));
 
         // now for each option, write out the option array
         //  also, since this is a hash, there is no guarantee that ordering will be preserved from
         //  the original binary format.
         // maybe switch to: https://crates.io/crates/linked-hash-map/
-        let mut record = Self::from_rdata(Name::root(), ttl, RData::OPT(value.options().clone()));
-        record.dns_class = DNSClass::for_opt(value.max_payload());
+        let mut record = Self::from_rdata(Name::root(), ttl, RData::OPT(value.options.clone()));
+        record.dns_class = DNSClass::for_opt(value.udp_payload_size);
         record
     }
 }
@@ -202,11 +226,11 @@ impl BinEncodable for Edns {
     fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
         0u8.emit(encoder)?; // Name::root
         RecordType::OPT.emit(encoder)?; //self.rr_type.emit(encoder)?;
-        DNSClass::for_opt(self.max_payload()).emit(encoder)?; // self.dns_class.emit(encoder)?;
+        DNSClass::for_opt(self.udp_payload_size).emit(encoder)?; // self.dns_class.emit(encoder)?;
 
         // rebuild the TTL field
-        let mut ttl = u32::from(self.rcode_high()) << 24;
-        ttl |= u32::from(self.version()) << 16;
+        let mut ttl = u32::from(self.extended_rcode) << 24;
+        ttl |= u32::from(self.version) << 16;
         ttl |= u32::from(u16::from(self.flags));
 
         ttl.emit(encoder)?;
@@ -232,7 +256,7 @@ impl fmt::Display for Edns {
         write!(
             f,
             "version: {version} dnssec_ok: {dnssec_ok} z_flags: {z_flags} max_payload: {max_payload} opts: {opts_len}",
-            opts_len = self.options().as_ref().len()
+            opts_len = self.options.as_ref().len()
         )
     }
 }
@@ -298,30 +322,28 @@ mod tests {
     #[test]
     fn test_encode_decode() {
         let mut edns = Edns::default();
-
-        let flags = edns.flags_mut();
-        flags.dnssec_ok = true;
-        flags.z = 1;
-        edns.set_max_payload(0x8008);
-        edns.set_version(0x40);
-        edns.set_rcode_high(0x01);
-        edns.options_mut()
+        edns.flags.dnssec_ok = true;
+        edns.flags.z = 1;
+        edns.udp_payload_size = 0x8008;
+        edns.version = 0x40;
+        edns.extended_rcode = 0x01;
+        edns.options
             .insert(EdnsOption::DAU(SupportedAlgorithms::all()));
 
         let record = Record::from(&edns);
         let edns_decode = Edns::from(&record);
 
-        assert_eq!(edns.flags().dnssec_ok, edns_decode.flags().dnssec_ok);
-        assert_eq!(edns.flags().z, edns_decode.flags().z);
-        assert_eq!(edns.max_payload(), edns_decode.max_payload());
-        assert_eq!(edns.version(), edns_decode.version());
-        assert_eq!(edns.rcode_high(), edns_decode.rcode_high());
-        assert_eq!(edns.options(), edns_decode.options());
+        assert_eq!(edns.flags.dnssec_ok, edns_decode.flags.dnssec_ok);
+        assert_eq!(edns.flags.z, edns_decode.flags.z);
+        assert_eq!(edns.udp_payload_size, edns_decode.udp_payload_size);
+        assert_eq!(edns.version, edns_decode.version);
+        assert_eq!(edns.extended_rcode, edns_decode.extended_rcode);
+        assert_eq!(edns.options, edns_decode.options);
 
         // re-insert and remove using mut
-        edns.options_mut()
+        edns.options
             .insert(EdnsOption::DAU(SupportedAlgorithms::all()));
-        edns.options_mut().remove(EdnsCode::DAU);
+        edns.options.remove(EdnsCode::DAU);
         assert!(edns.option(EdnsCode::DAU).is_none());
     }
 }

--- a/crates/proto/src/op/edns.rs
+++ b/crates/proto/src/op/edns.rs
@@ -240,7 +240,7 @@ impl fmt::Display for Edns {
 impl Default for Edns {
     fn default() -> Self {
         Self {
-            udp_payload_size: 512,
+            udp_payload_size: DEFAULT_MAX_PAYLOAD_LEN,
             extended_rcode: 0,
             version: 0,
             flags: EdnsFlags::default(),

--- a/crates/proto/src/op/edns.rs
+++ b/crates/proto/src/op/edns.rs
@@ -42,18 +42,6 @@ pub struct Edns {
     options: EdnsOptions,
 }
 
-impl Default for Edns {
-    fn default() -> Self {
-        Self {
-            udp_payload_size: 512,
-            extended_rcode: 0,
-            version: 0,
-            flags: EdnsFlags::default(),
-            options: EdnsOptions::default(),
-        }
-    }
-}
-
 impl Edns {
     /// Creates a new extended DNS object.
     pub fn new() -> Self {
@@ -245,6 +233,18 @@ impl fmt::Display for Edns {
             "version: {version} dnssec_ok: {dnssec_ok} z_flags: {z_flags} max_payload: {max_payload} opts: {opts_len}",
             opts_len = self.options().as_ref().len()
         )
+    }
+}
+
+impl Default for Edns {
+    fn default() -> Self {
+        Self {
+            udp_payload_size: 512,
+            extended_rcode: 0,
+            version: 0,
+            flags: EdnsFlags::default(),
+            options: EdnsOptions::default(),
+        }
     }
 }
 

--- a/crates/proto/src/op/edns.rs
+++ b/crates/proto/src/op/edns.rs
@@ -31,25 +31,24 @@ use crate::{
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Edns {
+    // max payload size, minimum of 512, (from RR CLASS)
+    udp_payload_size: u16,
     // high 8 bits that make up the 12 bit total field when included with the 4bit rcode from the
     //  header (from TTL)
-    rcode_high: u8,
+    extended_rcode: u8,
     // Indicates the implementation level of the setter. (from TTL)
     version: u8,
     flags: EdnsFlags,
-    // max payload size, minimum of 512, (from RR CLASS)
-    max_payload: u16,
-
     options: EdnsOptions,
 }
 
 impl Default for Edns {
     fn default() -> Self {
         Self {
-            rcode_high: 0,
+            udp_payload_size: 512,
+            extended_rcode: 0,
             version: 0,
             flags: EdnsFlags::default(),
-            max_payload: 512,
             options: EdnsOptions::default(),
         }
     }
@@ -63,7 +62,7 @@ impl Edns {
 
     /// The high order bytes for the response code in the DNS Message
     pub fn rcode_high(&self) -> u8 {
-        self.rcode_high
+        self.extended_rcode
     }
 
     /// Returns the EDNS version
@@ -83,7 +82,7 @@ impl Edns {
 
     /// Maximum supported size of the DNS payload
     pub fn max_payload(&self) -> u16 {
-        self.max_payload
+        self.udp_payload_size
     }
 
     /// Returns the Option associated with the code
@@ -103,7 +102,7 @@ impl Edns {
 
     /// Set the high order bits for the result code.
     pub fn set_rcode_high(&mut self, rcode_high: u8) -> &mut Self {
-        self.rcode_high = rcode_high;
+        self.extended_rcode = rcode_high;
         self
     }
 
@@ -152,7 +151,7 @@ impl Edns {
     /// Set the maximum payload which can be supported
     /// From RFC 6891: `Values lower than 512 MUST be treated as equal to 512`
     pub fn set_max_payload(&mut self, max_payload: u16) -> &mut Self {
-        self.max_payload = max_payload.max(512);
+        self.udp_payload_size = max_payload.max(512);
         self
     }
 }
@@ -162,10 +161,10 @@ impl<'a> From<&'a Record> for Edns {
     fn from(value: &'a Record) -> Self {
         assert!(value.record_type() == RecordType::OPT);
 
-        let rcode_high = ((value.ttl & 0xFF00_0000u32) >> 24) as u8;
+        let extended_rcode = ((value.ttl & 0xFF00_0000u32) >> 24) as u8;
         let version = ((value.ttl & 0x00FF_0000u32) >> 16) as u8;
         let flags = EdnsFlags::from((value.ttl & 0x0000_FFFFu32) as u16);
-        let max_payload = u16::from(value.dns_class);
+        let udp_payload_size = u16::from(value.dns_class);
 
         let options = match &value.data {
             RData::Update0(..) | RData::NULL(..) => {
@@ -182,10 +181,10 @@ impl<'a> From<&'a Record> for Edns {
         };
 
         Self {
-            rcode_high,
+            udp_payload_size,
+            extended_rcode,
             version,
             flags,
-            max_payload,
             options,
         }
     }
@@ -239,7 +238,7 @@ impl fmt::Display for Edns {
         let version = self.version;
         let dnssec_ok = self.flags.dnssec_ok;
         let z_flags = self.flags.z;
-        let max_payload = self.max_payload;
+        let max_payload = self.udp_payload_size;
 
         write!(
             f,

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -25,7 +25,7 @@ use crate::rr::{TSigVerifier, TSigner};
 use crate::{
     error::{ProtoError, ProtoResult},
     op::{Edns, Header, HeaderCounts, MessageType, Metadata, OpCode, Query, ResponseCode},
-    rr::{RData, Record, RecordData, RecordType, rdata::TSIG},
+    rr::{RData, Record, RecordData, RecordType, rdata::TSIG, record::RecordKind},
     serialize::binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError},
 };
 
@@ -432,7 +432,20 @@ impl Message {
         let mut sig = None;
 
         for _ in 0..count {
-            let record = Record::read(decoder)?;
+            let record = match RecordKind::read(decoder)? {
+                RecordKind::Record(record) => record,
+                RecordKind::Opt(_) if !is_additional => {
+                    return Err(DecodeError::RecordNotInAdditionalSection(RecordType::OPT));
+                }
+                RecordKind::Opt(new) => match edns.is_some() {
+                    true => return Err(DecodeError::DuplicateEdns),
+                    false => {
+                        edns = Some(new);
+                        continue;
+                    }
+                },
+            };
+
             if op != OpCode::Update
                 && record.record_type() != RecordType::OPT
                 && record.data.is_update()
@@ -478,12 +491,6 @@ impl Message {
                             })
                             .unwrap(/* match arm ensures correct type */),
                     ))
-                }
-                RData::Update0(RecordType::OPT) | RData::OPT(_) => {
-                    if edns.is_some() {
-                        return Err(DecodeError::DuplicateEdns);
-                    }
-                    edns = Some((&record).into());
                 }
                 _ => {
                     records.push(record);
@@ -603,9 +610,13 @@ where
         // need to commit the error code
         edns.extended_rcode = metadata.response_code.high();
 
-        let count = count_was_truncated(encoder.emit_iter([&Record::from(&edns)]))?;
-        additional_count.0 += count.0;
-        additional_count.1 |= count.1;
+        let result = 0u8
+            .emit(encoder) // Name::root
+            .and_then(|_| RecordType::OPT.emit(encoder))
+            .and_then(|_| edns.emit(encoder));
+        let (count, truncated) = count_was_truncated(result.map(|()| 1))?;
+        additional_count.0 += count;
+        additional_count.1 |= truncated;
     } else if metadata.response_code.high() > 0 {
         warn!(
             "response code: {} for request: {} requires EDNS but none available",

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -368,15 +368,20 @@ impl Message {
     ///
     /// the max payload value as it's defined in the EDNS OPT pseudo-RR.
     pub fn max_payload(&self) -> u16 {
-        let max_size = self.edns.as_ref().map_or(512, Edns::max_payload);
-        if max_size < 512 { 512 } else { max_size }
+        match self.edns.as_ref() {
+            Some(edns) => Ord::max(512, edns.udp_payload_size),
+            None => 512,
+        }
     }
 
     /// # Return value
     ///
     /// the version as defined in the EDNS record
     pub fn version(&self) -> u8 {
-        self.edns.as_ref().map_or(0, Edns::version)
+        match self.edns.as_ref() {
+            Some(edns) => edns.version,
+            None => 0,
+        }
     }
 
     /// # Return value
@@ -596,7 +601,7 @@ where
 
     if let Some(mut edns) = edns.cloned() {
         // need to commit the error code
-        edns.set_rcode_high(metadata.response_code.high());
+        edns.extended_rcode = metadata.response_code.high();
 
         let count = count_was_truncated(encoder.emit_iter([&Record::from(&edns)]))?;
         additional_count.0 += count.0;
@@ -692,8 +697,7 @@ impl<'r> BinDecodable<'r> for Message {
 
         // need to grab error code from EDNS (which might have a higher value)
         if let Some(edns) = &edns {
-            let high_response_code = edns.rcode_high();
-            metadata.merge_response_code(high_response_code);
+            metadata.merge_response_code(edns.extended_rcode);
         }
 
         Ok(Self {

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -756,7 +756,7 @@ mod tests {
 
     use crate::rr::rdata::A;
     #[cfg(feature = "std")]
-    use crate::rr::rdata::OPT;
+    use crate::rr::rdata::EdnsOptions;
     #[cfg(feature = "std")]
     use crate::rr::rdata::opt::{ClientSubnet, EdnsCode, EdnsOption};
     #[cfg(feature = "__dnssec")]
@@ -953,7 +953,7 @@ mod tests {
             Record::from_rdata(
                 Name::new(),
                 0,
-                RData::OPT(OPT::new(vec![(
+                RData::OPT(EdnsOptions::new(vec![(
                     EdnsCode::Subnet,
                     EdnsOption::Subnet(ClientSubnet::new(IpAddr::from([127, 0, 0, 1]), 0, 24)),
                 )])),
@@ -1000,7 +1000,7 @@ mod tests {
             Record::from_rdata(
                 Name::new(),
                 0,
-                RData::OPT(OPT::new(vec![(
+                RData::OPT(EdnsOptions::new(vec![(
                     EdnsCode::Subnet,
                     EdnsOption::Subnet(ClientSubnet::new(IpAddr::from([127, 0, 0, 1]), 0, 24)),
                 )])),
@@ -1026,7 +1026,7 @@ mod tests {
         let opt_record = Record::from_rdata(
             Name::new(),
             0,
-            RData::OPT(OPT::new(vec![(
+            RData::OPT(EdnsOptions::new(vec![(
                 EdnsCode::Subnet,
                 EdnsOption::Subnet(ClientSubnet::new(IpAddr::from([127, 0, 0, 1]), 0, 24)),
             )])),
@@ -1053,7 +1053,7 @@ mod tests {
         let opt_record = Record::from_rdata(
             Name::new(),
             0,
-            RData::OPT(OPT::new(vec![(
+            RData::OPT(EdnsOptions::new(vec![(
                 EdnsCode::Subnet,
                 EdnsOption::Subnet(ClientSubnet::new(IpAddr::from([127, 0, 0, 1]), 0, 24)),
             )])),
@@ -1082,7 +1082,7 @@ mod tests {
         let opt_record = Record::from_rdata(
             Name::new(),
             0,
-            RData::OPT(OPT::new(vec![(
+            RData::OPT(EdnsOptions::new(vec![(
                 EdnsCode::Subnet,
                 EdnsOption::Subnet(ClientSubnet::new(IpAddr::from([127, 0, 0, 1]), 0, 24)),
             )])),

--- a/crates/proto/src/op/message_request.rs
+++ b/crates/proto/src/op/message_request.rs
@@ -97,8 +97,7 @@ impl MessageRequest {
 
         // need to grab error code from EDNS (which might have a higher value)
         if let Some(edns) = &edns {
-            let high_response_code = edns.rcode_high();
-            metadata.merge_response_code(high_response_code);
+            metadata.merge_response_code(edns.extended_rcode);
         }
 
         Ok(Self {
@@ -132,15 +131,20 @@ impl MessageRequest {
     ///
     /// the max payload value as it's defined in the EDNS OPT pseudo-RR.
     pub fn max_payload(&self) -> u16 {
-        let max_size = self.edns.as_ref().map_or(512, Edns::max_payload);
-        if max_size < 512 { 512 } else { max_size }
+        match &self.edns {
+            Some(edns) => Ord::max(512, edns.udp_payload_size),
+            None => 512,
+        }
     }
 
     /// # Return value
     ///
     /// the version as defined in the EDNS record
     pub fn version(&self) -> u8 {
-        self.edns.as_ref().map_or(0, Edns::version)
+        match &self.edns {
+            Some(edns) => edns.version,
+            None => 0,
+        }
     }
 }
 

--- a/crates/proto/src/op/update_message.rs
+++ b/crates/proto/src/op/update_message.rs
@@ -9,15 +9,14 @@
 
 use core::fmt::Debug;
 
-use super::{lower_query::LowerQuery, message_request::MessageRequest};
+use crate::{
+    op::{LowerQuery, Message, MessageRequest, Query},
+    rr::{Record, rdata::TSIG},
+};
 #[cfg(any(feature = "std", feature = "no-std-rand"))]
 use crate::{
-    op::{Edns, OpCode, edns::DEFAULT_MAX_PAYLOAD_LEN},
+    op::{OpCode, edns::DEFAULT_MAX_PAYLOAD_LEN},
     rr::{DNSClass, Name, RData, RecordSet, RecordType, rdata::SOA},
-};
-use crate::{
-    op::{Message, Query},
-    rr::{Record, rdata::TSIG},
 };
 
 /// To reduce errors in using the Message struct as an Update, this will do the call throughs
@@ -192,7 +191,7 @@ pub fn create(rrset: RecordSet, zone_origin: Name, use_edns: bool) -> Message {
     if use_edns {
         message
             .edns
-            .get_or_insert_with(Edns::new)
+            .get_or_insert_default()
             .set_max_payload(DEFAULT_MAX_PAYLOAD_LEN)
             .set_version(0);
     }
@@ -263,7 +262,7 @@ pub fn append(rrset: RecordSet, zone_origin: Name, must_exist: bool, use_edns: b
     if use_edns {
         message
             .edns
-            .get_or_insert_with(Edns::new)
+            .get_or_insert_default()
             .set_max_payload(DEFAULT_MAX_PAYLOAD_LEN)
             .set_version(0);
     }
@@ -355,7 +354,7 @@ pub fn compare_and_swap(
     if use_edns {
         message
             .edns
-            .get_or_insert_with(Edns::new)
+            .get_or_insert_default()
             .set_max_payload(DEFAULT_MAX_PAYLOAD_LEN)
             .set_version(0);
     }
@@ -413,7 +412,7 @@ pub fn delete_by_rdata(mut rrset: RecordSet, zone_origin: Name, use_edns: bool) 
     if use_edns {
         message
             .edns
-            .get_or_insert_with(Edns::new)
+            .get_or_insert_default()
             .set_max_payload(DEFAULT_MAX_PAYLOAD_LEN)
             .set_version(0);
     }
@@ -472,7 +471,7 @@ pub fn delete_rrset(mut record: Record, zone_origin: Name, use_edns: bool) -> Me
     if use_edns {
         message
             .edns
-            .get_or_insert_with(Edns::new)
+            .get_or_insert_default()
             .set_max_payload(DEFAULT_MAX_PAYLOAD_LEN)
             .set_version(0);
     }
@@ -540,7 +539,7 @@ pub fn delete_all(
     if use_edns {
         message
             .edns
-            .get_or_insert_with(Edns::new)
+            .get_or_insert_default()
             .set_max_payload(DEFAULT_MAX_PAYLOAD_LEN)
             .set_version(0);
     }
@@ -585,7 +584,7 @@ pub fn zone_transfer(zone_origin: Name, last_soa: Option<SOA>) -> Message {
     {
         message
             .edns
-            .get_or_insert_with(Edns::new)
+            .get_or_insert_default()
             .set_max_payload(DEFAULT_MAX_PAYLOAD_LEN)
             .set_version(0);
     }

--- a/crates/proto/src/op/update_message.rs
+++ b/crates/proto/src/op/update_message.rs
@@ -9,14 +9,14 @@
 
 use core::fmt::Debug;
 
+#[cfg(any(feature = "std", feature = "no-std-rand"))]
+use crate::{
+    op::{Edns, OpCode},
+    rr::{DNSClass, Name, RData, RecordSet, RecordType, rdata::SOA},
+};
 use crate::{
     op::{LowerQuery, Message, MessageRequest, Query},
     rr::{Record, rdata::TSIG},
-};
-#[cfg(any(feature = "std", feature = "no-std-rand"))]
-use crate::{
-    op::{OpCode, edns::DEFAULT_MAX_PAYLOAD_LEN},
-    rr::{DNSClass, Name, RData, RecordSet, RecordType, rdata::SOA},
 };
 
 /// To reduce errors in using the Message struct as an Update, this will do the call throughs
@@ -189,11 +189,7 @@ pub fn create(rrset: RecordSet, zone_origin: Name, use_edns: bool) -> Message {
 
     // Extended dns
     if use_edns {
-        message
-            .edns
-            .get_or_insert_default()
-            .set_max_payload(DEFAULT_MAX_PAYLOAD_LEN)
-            .set_version(0);
+        message.edns.get_or_insert_default();
     }
 
     message
@@ -260,11 +256,7 @@ pub fn append(rrset: RecordSet, zone_origin: Name, must_exist: bool, use_edns: b
 
     // Extended dns
     if use_edns {
-        message
-            .edns
-            .get_or_insert_default()
-            .set_max_payload(DEFAULT_MAX_PAYLOAD_LEN)
-            .set_version(0);
+        message.edns = Some(Edns::default());
     }
 
     message
@@ -352,11 +344,7 @@ pub fn compare_and_swap(
 
     // Extended dns
     if use_edns {
-        message
-            .edns
-            .get_or_insert_default()
-            .set_max_payload(DEFAULT_MAX_PAYLOAD_LEN)
-            .set_version(0);
+        message.edns = Some(Edns::default());
     }
 
     message
@@ -410,11 +398,7 @@ pub fn delete_by_rdata(mut rrset: RecordSet, zone_origin: Name, use_edns: bool) 
 
     // Extended dns
     if use_edns {
-        message
-            .edns
-            .get_or_insert_default()
-            .set_max_payload(DEFAULT_MAX_PAYLOAD_LEN)
-            .set_version(0);
+        message.edns = Some(Edns::default());
     }
 
     message
@@ -469,11 +453,7 @@ pub fn delete_rrset(mut record: Record, zone_origin: Name, use_edns: bool) -> Me
 
     // Extended dns
     if use_edns {
-        message
-            .edns
-            .get_or_insert_default()
-            .set_max_payload(DEFAULT_MAX_PAYLOAD_LEN)
-            .set_version(0);
+        message.edns = Some(Edns::default());
     }
 
     message
@@ -537,11 +517,7 @@ pub fn delete_all(
 
     // Extended dns
     if use_edns {
-        message
-            .edns
-            .get_or_insert_default()
-            .set_max_payload(DEFAULT_MAX_PAYLOAD_LEN)
-            .set_version(0);
+        message.edns = Some(Edns::default());
     }
 
     message
@@ -582,11 +558,7 @@ pub fn zone_transfer(zone_origin: Name, last_soa: Option<SOA>) -> Message {
 
     // Extended dns
     {
-        message
-            .edns
-            .get_or_insert_default()
-            .set_max_payload(DEFAULT_MAX_PAYLOAD_LEN)
-            .set_version(0);
+        message.edns = Some(Edns::default());
     }
 
     message

--- a/crates/proto/src/rr/rdata/mod.rs
+++ b/crates/proto/src/rr/rdata/mod.rs
@@ -44,7 +44,7 @@ pub use self::name::{ANAME, CNAME, NS, PTR};
 pub use self::naptr::NAPTR;
 pub use self::null::NULL;
 pub use self::openpgpkey::OPENPGPKEY;
-pub use self::opt::OPT;
+pub use self::opt::EdnsOptions;
 pub use self::smimea::SMIMEA;
 pub use self::soa::SOA;
 pub use self::srv::SRV;

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -168,7 +168,7 @@ use crate::dnssec::SupportedAlgorithms;
 ///       in a subsequent specification.
 /// ```
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[derive(Default, Debug, Clone, Ord, PartialOrd)]
+#[derive(Default, Debug, Clone)]
 #[non_exhaustive]
 pub struct EdnsOptions {
     /// List of code and record type tuples

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -170,12 +170,12 @@ use crate::dnssec::SupportedAlgorithms;
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Default, Debug, Clone, Ord, PartialOrd)]
 #[non_exhaustive]
-pub struct OPT {
+pub struct EdnsOptions {
     /// List of code and record type tuples
     pub options: Vec<(EdnsCode, EdnsOption)>,
 }
 
-impl OPT {
+impl EdnsOptions {
     /// Creates a new OPT record data.
     ///
     /// # Arguments
@@ -215,7 +215,7 @@ impl OPT {
     }
 }
 
-impl PartialEq for OPT {
+impl PartialEq for EdnsOptions {
     fn eq(&self, other: &Self) -> bool {
         let matching_elements_count = self
             .options
@@ -227,9 +227,9 @@ impl PartialEq for OPT {
     }
 }
 
-impl Eq for OPT {}
+impl Eq for EdnsOptions {}
 
-impl Hash for OPT {
+impl Hash for EdnsOptions {
     fn hash<H: Hasher>(&self, state: &mut H) {
         let mut sorted = self.options.clone();
         sorted.sort();
@@ -237,19 +237,19 @@ impl Hash for OPT {
     }
 }
 
-impl AsMut<Vec<(EdnsCode, EdnsOption)>> for OPT {
+impl AsMut<Vec<(EdnsCode, EdnsOption)>> for EdnsOptions {
     fn as_mut(&mut self) -> &mut Vec<(EdnsCode, EdnsOption)> {
         &mut self.options
     }
 }
 
-impl AsRef<[(EdnsCode, EdnsOption)]> for OPT {
+impl AsRef<[(EdnsCode, EdnsOption)]> for EdnsOptions {
     fn as_ref(&self) -> &[(EdnsCode, EdnsOption)] {
         &self.options
     }
 }
 
-impl BinEncodable for OPT {
+impl BinEncodable for EdnsOptions {
     fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
         let mut encoder = encoder.with_rdata_behavior(RDataEncoding::Other);
         for (edns_code, edns_option) in self.as_ref().iter() {
@@ -261,7 +261,7 @@ impl BinEncodable for OPT {
     }
 }
 
-impl<'r> RecordDataDecodable<'r> for OPT {
+impl<'r> RecordDataDecodable<'r> for EdnsOptions {
     fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError> {
         let mut state: OptReadState = OptReadState::ReadCode;
         let mut options: Vec<(EdnsCode, EdnsOption)> = Vec::new();
@@ -337,7 +337,7 @@ impl<'r> RecordDataDecodable<'r> for OPT {
     }
 }
 
-impl RecordData for OPT {
+impl RecordData for EdnsOptions {
     fn try_borrow(data: &RData) -> Option<&Self> {
         match data {
             RData::OPT(csync) => Some(csync),
@@ -354,7 +354,7 @@ impl RecordData for OPT {
     }
 }
 
-impl fmt::Display for OPT {
+impl fmt::Display for EdnsOptions {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         fmt::Debug::fmt(self, f)
     }
@@ -859,7 +859,7 @@ mod tests {
     #[test]
     #[cfg(feature = "__dnssec")]
     fn test() {
-        let mut rdata = OPT::default();
+        let mut rdata = EdnsOptions::default();
         rdata.insert(EdnsOption::DAU(SupportedAlgorithms::all()));
 
         let mut bytes = Vec::new();
@@ -872,7 +872,7 @@ mod tests {
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
         let restrict = Restrict::new(bytes.len() as u16);
-        let read_rdata = OPT::read_data(&mut decoder, restrict).expect("Decoding error");
+        let read_rdata = EdnsOptions::read_data(&mut decoder, restrict).expect("Decoding error");
         assert_eq!(rdata, read_rdata);
     }
 
@@ -884,7 +884,7 @@ mod tests {
         ];
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(&bytes);
-        let read_rdata = OPT::read_data(&mut decoder, Restrict::new(bytes.len() as u16));
+        let read_rdata = EdnsOptions::read_data(&mut decoder, Restrict::new(bytes.len() as u16));
         assert!(
             read_rdata.is_ok(),
             "error decoding: {:?}",
@@ -903,7 +903,7 @@ mod tests {
             ),
             (EdnsCode::Keepalive, EdnsOption::Unknown(11, vec![])),
         ];
-        let options = OPT::new(options);
+        let options = EdnsOptions::new(options);
         assert_eq!(opt, options);
     }
 
@@ -915,7 +915,7 @@ mod tests {
         ];
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(&bytes);
-        let read_rdata = OPT::read_data(&mut decoder, Restrict::new(bytes.len() as u16));
+        let read_rdata = EdnsOptions::read_data(&mut decoder, Restrict::new(bytes.len() as u16));
         assert!(
             read_rdata.is_ok(),
             "error decoding: {:?}",
@@ -939,7 +939,7 @@ mod tests {
                 ),
             ),
         ];
-        let options = OPT::new(options);
+        let options = EdnsOptions::new(options);
         assert_eq!(opt, options);
     }
 
@@ -982,7 +982,7 @@ mod tests {
 
     #[test]
     fn test_eq_and_hash() {
-        let options_1 = OPT::new(vec![
+        let options_1 = EdnsOptions::new(vec![
             (
                 EdnsCode::Unknown(15u16),
                 EdnsOption::Unknown(15u16, vec![0x00, 0x06]),
@@ -999,7 +999,7 @@ mod tests {
             ),
         ]);
 
-        let options_2 = OPT::new(vec![
+        let options_2 = EdnsOptions::new(vec![
             (
                 EdnsCode::Unknown(15u16),
                 EdnsOption::Unknown(
@@ -1017,7 +1017,7 @@ mod tests {
         ]);
 
         // Leading byte changed in the vec
-        let options_3 = OPT::new(vec![
+        let options_3 = EdnsOptions::new(vec![
             (
                 EdnsCode::Unknown(15u16),
                 EdnsOption::Unknown(

--- a/crates/proto/src/rr/record.rs
+++ b/crates/proto/src/rr/record.rs
@@ -19,6 +19,7 @@ use crate::dnssec::{Proof, Proven};
 use crate::rr::rdata::A;
 use crate::{
     error::ProtoResult,
+    op::Edns,
     rr::{Name, RData, RecordData, RecordType, dns_class::DNSClass},
     serialize::binary::{
         BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, Restrict,
@@ -239,64 +240,20 @@ impl<R: RecordData> Record<R> {
     }
 }
 
-impl<R: RecordData> BinEncodable for Record<R> {
-    fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
-        self.name.emit(encoder)?;
-        self.record_type().emit(encoder)?;
-
-        #[cfg(not(feature = "mdns"))]
-        self.dns_class.emit(encoder)?;
-
-        #[cfg(feature = "mdns")]
-        {
-            if self.mdns_cache_flush {
-                (u16::from(self.dns_class) | MDNS_ENABLE_CACHE_FLUSH).emit(encoder)?;
-            } else {
-                self.dns_class.emit(encoder)?;
-            }
-        }
-
-        self.ttl.emit(encoder)?;
-
-        // place the RData length
-        let place = encoder.place::<u16>()?;
-
-        // write the RData
-        //   the None case is handled below by writing `0` for the length of the RData
-        //   this is in turn read as `None` during the `read` operation.
-        if !self.data.is_update() {
-            self.data.emit(encoder)?;
-        }
-
-        // get the length written
-        let len = encoder.len_since_place(&place);
-        assert!(len <= u16::MAX as usize);
-
-        // replace the location with the length
-        place.replace(encoder, len as u16)?;
-        Ok(())
-    }
-}
-
-impl<'r> BinDecodable<'r> for Record<RData> {
-    /// parse a resource record line example:
-    ///  WARNING: the record_bytes is 100% consumed and destroyed in this parsing process
-    fn read(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
-        // NAME            an owner name, i.e., the name of the node to which this
-        //                 resource record pertains.
-        let name_labels: Name = Name::read(decoder)?;
-
-        // TYPE            two octets containing one of the RR TYPE codes.
-        let record_type: RecordType = RecordType::read(decoder)?;
-
+impl Record<RData> {
+    fn decode(
+        name: Name,
+        record_type: RecordType,
+        decoder: &mut BinDecoder<'_>,
+    ) -> Result<Self, DecodeError> {
         #[cfg(feature = "mdns")]
         let mut mdns_cache_flush = false;
 
         // CLASS           two octets containing one of the RR CLASS codes.
         let class: DNSClass = if record_type == RecordType::OPT {
             // verify that the OPT record is Root
-            if !name_labels.is_root() {
-                return Err(DecodeError::EdnsNameNotRoot(Box::new(name_labels)));
+            if !name.is_root() {
+                return Err(DecodeError::EdnsNameNotRoot(Box::new(name)));
             }
 
             //  DNS Class is overloaded for OPT records in EDNS - RFC 6891
@@ -345,7 +302,7 @@ impl<'r> BinDecodable<'r> for Record<RData> {
 
         // this is to handle updates, RFC 2136, which uses 0 to indicate certain aspects of pre-requisites.
         // Null represents any data. The caller should validate whether this is allowed.
-        let rdata = if rd_length == 0 {
+        let data = if rd_length == 0 {
             RData::Update0(record_type)
         } else {
             // RDATA           a variable length string of octets that describes the
@@ -357,15 +314,62 @@ impl<'r> BinDecodable<'r> for Record<RData> {
         };
 
         Ok(Self {
-            name: name_labels,
+            name,
             dns_class: class,
             ttl,
-            data: rdata,
+            data,
             #[cfg(feature = "mdns")]
             mdns_cache_flush,
             #[cfg(feature = "__dnssec")]
             proof: Proof::default(),
         })
+    }
+}
+
+impl BinDecodable<'_> for Record<RData> {
+    fn read(decoder: &mut BinDecoder<'_>) -> Result<Self, DecodeError> {
+        let name = Name::read(decoder)?;
+        let record_type = RecordType::read(decoder)?;
+        Self::decode(name, record_type, decoder)
+    }
+}
+
+impl<R: RecordData> BinEncodable for Record<R> {
+    fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
+        self.name.emit(encoder)?;
+        self.record_type().emit(encoder)?;
+
+        #[cfg(not(feature = "mdns"))]
+        self.dns_class.emit(encoder)?;
+
+        #[cfg(feature = "mdns")]
+        {
+            if self.mdns_cache_flush {
+                (u16::from(self.dns_class) | MDNS_ENABLE_CACHE_FLUSH).emit(encoder)?;
+            } else {
+                self.dns_class.emit(encoder)?;
+            }
+        }
+
+        self.ttl.emit(encoder)?;
+
+        // place the RData length
+        let place = encoder.place::<u16>()?;
+
+        // write the RData
+        //   the None case is handled below by writing `0` for the length of the RData
+        //   this is in turn read as `None` during the `read` operation.
+        if !self.data.is_update() {
+            self.data.emit(encoder)?;
+        }
+
+        // get the length written
+        let len = encoder.len_since_place(&place);
+        assert!(len <= u16::MAX as usize);
+
+        // replace the location with the length
+        place.replace(encoder, len as u16)?;
+        Ok(())
     }
 }
 
@@ -538,6 +542,29 @@ impl PartialOrd<Self> for Record {
     }
 }
 
+#[expect(clippy::large_enum_variant)]
+#[derive(Debug, PartialEq)]
+pub(crate) enum RecordKind {
+    Record(Record<RData>),
+    Opt(Edns),
+}
+
+impl<'r> BinDecodable<'r> for RecordKind {
+    /// parse a resource record line example:
+    ///  WARNING: the record_bytes is 100% consumed and destroyed in this parsing process
+    fn read(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
+        // NAME            an owner name, i.e., the name of the node to which this
+        //                 resource record pertains.
+        let name = Name::read(decoder)?;
+
+        // TYPE            two octets containing one of the RR TYPE codes.
+        Ok(match RecordType::read(decoder)? {
+            RecordType::OPT => Self::Opt(Edns::decode(name, decoder)?),
+            record_type => Self::Record(Record::decode(name, record_type, decoder)?),
+        })
+    }
+}
+
 #[cfg(feature = "__dnssec")]
 impl From<Record> for Proven<Record> {
     fn from(record: Record) -> Self {
@@ -698,9 +725,9 @@ mod tests {
 
         let mut decoder = BinDecoder::new(&vec_bytes);
 
-        let got = Record::read(&mut decoder).unwrap();
+        let got = RecordKind::read(&mut decoder).unwrap();
 
-        assert_eq!(got, record);
+        assert_eq!(got, RecordKind::Record(record));
     }
 
     #[test]
@@ -758,7 +785,9 @@ mod tests {
 
         let mut decoder = BinDecoder::new(&vec_bytes);
 
-        let got = Record::<RData>::read(&mut decoder).unwrap();
+        let RecordKind::Record(got) = RecordKind::read(&mut decoder).unwrap() else {
+            panic!("expected a RecordKind::Record");
+        };
 
         assert_eq!(got.dns_class, DNSClass::IN);
         assert!(got.mdns_cache_flush);

--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -25,8 +25,8 @@ use crate::{
     rr::{
         Name, RecordData, RecordDataDecodable,
         rdata::{
-            A, AAAA, ANAME, CAA, CERT, CNAME, CSYNC, HINFO, HTTPS, MX, NAPTR, NS, NULL, OPENPGPKEY,
-            OPT, PTR, SMIMEA, SOA, SRV, SSHFP, SVCB, TLSA, TSIG, TXT,
+            A, AAAA, ANAME, CAA, CERT, CNAME, CSYNC, EdnsOptions, HINFO, HTTPS, MX, NAPTR, NS,
+            NULL, OPENPGPKEY, PTR, SMIMEA, SOA, SRV, SSHFP, SVCB, TLSA, TSIG, TXT,
         },
         record_type::RecordType,
     },
@@ -474,7 +474,7 @@ pub enum RData {
     ///        /                                                               /
     ///        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
     /// ```
-    OPT(OPT),
+    OPT(EdnsOptions),
 
     /// ```text
     /// 3.3.12. PTR RDATA format
@@ -968,7 +968,7 @@ impl RData {
             }
             RecordType::OPT => {
                 trace!("reading OPT");
-                OPT::read_data(decoder, length).map(Self::OPT)
+                EdnsOptions::read_data(decoder, length).map(Self::OPT)
             }
             RecordType::PTR => {
                 trace!("reading PTR");

--- a/crates/resolver/src/name_server_pool.rs
+++ b/crates/resolver/src/name_server_pool.rs
@@ -933,7 +933,7 @@ impl CacheKey {
         let dnssec_ok;
         let client_subnet;
         if let Some(edns) = &request.edns {
-            dnssec_ok = edns.flags().dnssec_ok;
+            dnssec_ok = edns.flags.dnssec_ok;
             if let Some(EdnsOption::Subnet(subnet)) = edns.option(EdnsCode::Subnet) {
                 client_subnet = Some(*subnet);
             } else {

--- a/crates/server/src/server/mod.rs
+++ b/crates/server/src/server/mod.rs
@@ -810,7 +810,7 @@ impl<T: RequestHandler> ServerContext<T> {
             .message
             .edns
             .as_ref()
-            .is_some_and(|edns| edns.flags().dnssec_ok);
+            .is_some_and(|edns| edns.flags.dnssec_ok);
 
         debug!(
             "request:{id} src:{proto}://{addr}#{port} type:{message_type} dnssec:{is_dnssec} {op} qflags:{qflags}",

--- a/crates/server/src/zone_handler/catalog.rs
+++ b/crates/server/src/zone_handler/catalog.rs
@@ -78,15 +78,14 @@ impl RequestHandler for Catalog {
             // check our version against the request
             // TODO: what version are we?
             let our_version = 0;
-            resp_edns.set_dnssec_ok(true);
-            resp_edns.set_max_payload(req_edns.max_payload().max(512));
-            resp_edns.set_version(our_version);
+            resp_edns.flags.dnssec_ok = true;
+            resp_edns.udp_payload_size = Ord::max(512, req_edns.udp_payload_size);
+            resp_edns.version = our_version;
 
-            if req_edns.version() > our_version {
+            if req_edns.version > our_version {
                 warn!(
                     "request edns version greater than {}: {}",
-                    our_version,
-                    req_edns.version()
+                    our_version, req_edns.version
                 );
                 return send_error_response(
                     request,
@@ -107,9 +106,7 @@ impl RequestHandler for Catalog {
                     if !request_option.is_empty() {
                         warn!("ignoring non-empty EDNS NSID request payload")
                     }
-                    resp_edns
-                        .options_mut()
-                        .insert(EdnsOption::NSID(payload.clone()));
+                    resp_edns.options.insert(EdnsOption::NSID(payload.clone()));
                 }
                 // NSID was requested, but we don't have a payload configured.
                 (Some(_), None) => {
@@ -742,7 +739,7 @@ async fn send_error_response(
     if response_code.high() != 0 {
         if let Some(edns) = response_edns {
             new_edns = edns.clone();
-            new_edns.set_rcode_high(response_code.high());
+            new_edns.extended_rcode = response_code.high();
             response_edns = Some(&new_edns);
         }
     }

--- a/crates/server/src/zone_handler/catalog.rs
+++ b/crates/server/src/zone_handler/catalog.rs
@@ -73,7 +73,7 @@ impl RequestHandler for Catalog {
 
         // check if it's edns
         let response_edns = if let Some(req_edns) = request.edns.as_ref() {
-            resp_edns = Edns::new();
+            resp_edns = Edns::default();
 
             // check our version against the request
             // TODO: what version are we?

--- a/crates/server/src/zone_handler/message_response.rs
+++ b/crates/server/src/zone_handler/message_response.rs
@@ -88,7 +88,7 @@ where
         let mut encoder = BinEncoder::new(&mut bytes);
         encoder.set_max_size(match protocol {
             Protocol::Udp => match &self.edns {
-                Some(edns) => edns.max_payload(),
+                Some(edns) => edns.udp_payload_size,
                 // No EDNS, use the recommended max from RFC 6891
                 None => MAX_RECEIVE_BUFFER_SIZE as u16,
             },

--- a/crates/server/src/zone_handler/mod.rs
+++ b/crates/server/src/zone_handler/mod.rs
@@ -530,7 +530,7 @@ impl LookupOptions {
         let mut new = Self::default();
         #[cfg(feature = "__dnssec")]
         if let Some(edns) = edns {
-            new.dnssec_ok = edns.flags().dnssec_ok;
+            new.dnssec_ok = edns.flags.dnssec_ok;
         }
         new
     }

--- a/tests/integration-tests/tests/integration/catalog_tests.rs
+++ b/tests/integration-tests/tests/integration/catalog_tests.rs
@@ -719,7 +719,7 @@ fn test_nsid_request(origin: LowerName, request_nsid: bool) -> Request {
     query.set_name(origin.into());
     query.set_query_type(RecordType::A);
 
-    let mut question_edns = Edns::new();
+    let mut question_edns = Edns::default();
     if request_nsid {
         question_edns
             .options_mut()
@@ -1035,7 +1035,7 @@ mod dnssec {
     async fn run_query(catalog: &Catalog, query: Query) -> Message {
         let mut question = Message::query();
         question.add_query(query);
-        question.edns.get_or_insert_with(Edns::new).enable_dnssec();
+        question.edns.get_or_insert_default().enable_dnssec();
 
         let question_bytes = question.to_bytes().unwrap();
         let question_req =

--- a/tests/integration-tests/tests/integration/catalog_tests.rs
+++ b/tests/integration-tests/tests/integration/catalog_tests.rs
@@ -722,7 +722,7 @@ fn test_nsid_request(origin: LowerName, request_nsid: bool) -> Request {
     let mut question_edns = Edns::default();
     if request_nsid {
         question_edns
-            .options_mut()
+            .options
             .insert(EdnsOption::NSID(NSIDPayload::new([]).unwrap()));
     }
 

--- a/tests/integration-tests/tests/integration/client_future_tests.rs
+++ b/tests/integration-tests/tests/integration/client_future_tests.rs
@@ -180,7 +180,7 @@ async fn test_query_edns(client: &mut Client<TokioRuntimeProvider>) {
 
     let mut edns = Edns::default();
     // garbage subnet value, but lets check
-    edns.options_mut()
+    edns.options
         .insert(EdnsOption::Subnet("1.2.0.0/16".parse().unwrap()));
     msg.edns = Some(edns);
 

--- a/tests/integration-tests/tests/integration/client_future_tests.rs
+++ b/tests/integration-tests/tests/integration/client_future_tests.rs
@@ -168,10 +168,6 @@ async fn test_query(client: &mut Client<TokioRuntimeProvider>) {
 
 async fn test_query_edns(client: &mut Client<TokioRuntimeProvider>) {
     let name = Name::from_ascii("WWW.example.com.").unwrap();
-    let mut edns = Edns::default();
-    // garbage subnet value, but lets check
-    edns.options_mut()
-        .insert(EdnsOption::Subnet("1.2.0.0/16".parse().unwrap()));
 
     // TODO: write builder
     let mut msg = Message::query();
@@ -182,7 +178,10 @@ async fn test_query_edns(client: &mut Client<TokioRuntimeProvider>) {
         query
     });
 
-    edns.set_max_payload(1232).set_version(0);
+    let mut edns = Edns::default();
+    // garbage subnet value, but lets check
+    edns.options_mut()
+        .insert(EdnsOption::Subnet("1.2.0.0/16".parse().unwrap()));
     msg.edns = Some(edns);
 
     let response = client

--- a/tests/integration-tests/tests/integration/client_future_tests.rs
+++ b/tests/integration-tests/tests/integration/client_future_tests.rs
@@ -168,7 +168,7 @@ async fn test_query(client: &mut Client<TokioRuntimeProvider>) {
 
 async fn test_query_edns(client: &mut Client<TokioRuntimeProvider>) {
     let name = Name::from_ascii("WWW.example.com.").unwrap();
-    let mut edns = Edns::new();
+    let mut edns = Edns::default();
     // garbage subnet value, but lets check
     edns.options_mut()
         .insert(EdnsOption::Subnet("1.2.0.0/16".parse().unwrap()));

--- a/tests/integration-tests/tests/integration/client_tests.rs
+++ b/tests/integration-tests/tests/integration/client_tests.rs
@@ -147,7 +147,7 @@ async fn test_query(mut client: Client<TokioRuntimeProvider>) {
 
 async fn test_query_edns(client: Client<TokioRuntimeProvider>) {
     let name = Name::from_ascii("WWW.example.com.").unwrap();
-    let mut edns = Edns::new();
+    let mut edns = Edns::default();
     // garbage subnet value, but lets check
     edns.options_mut()
         .insert(EdnsOption::Subnet("1.2.0.0/16".parse().unwrap()));

--- a/tests/integration-tests/tests/integration/client_tests.rs
+++ b/tests/integration-tests/tests/integration/client_tests.rs
@@ -147,10 +147,6 @@ async fn test_query(mut client: Client<TokioRuntimeProvider>) {
 
 async fn test_query_edns(client: Client<TokioRuntimeProvider>) {
     let name = Name::from_ascii("WWW.example.com.").unwrap();
-    let mut edns = Edns::default();
-    // garbage subnet value, but lets check
-    edns.options_mut()
-        .insert(EdnsOption::Subnet("1.2.0.0/16".parse().unwrap()));
 
     // TODO: write builder
     let mut msg = Message::query();
@@ -161,7 +157,10 @@ async fn test_query_edns(client: Client<TokioRuntimeProvider>) {
         query
     });
 
-    edns.set_max_payload(1232).set_version(0);
+    let mut edns = Edns::default();
+    // garbage subnet value, but lets check
+    edns.options_mut()
+        .insert(EdnsOption::Subnet("1.2.0.0/16".parse().unwrap()));
     msg.edns = Some(edns);
 
     let response = client

--- a/tests/integration-tests/tests/integration/client_tests.rs
+++ b/tests/integration-tests/tests/integration/client_tests.rs
@@ -159,7 +159,7 @@ async fn test_query_edns(client: Client<TokioRuntimeProvider>) {
 
     let mut edns = Edns::default();
     // garbage subnet value, but lets check
-    edns.options_mut()
+    edns.options
         .insert(EdnsOption::Subnet("1.2.0.0/16".parse().unwrap()));
     msg.edns = Some(edns);
 
@@ -232,7 +232,7 @@ async fn test_secure_query_example(mut client: DnssecClient) {
             .edns
             .as_ref()
             .expect("edns not here")
-            .flags()
+            .flags
             .dnssec_ok
     );
 

--- a/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
+++ b/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
@@ -56,7 +56,7 @@ where
             .edns
             .as_ref()
             .expect("edns not here")
-            .flags()
+            .flags
             .dnssec_ok
     );
 

--- a/tests/integration-tests/tests/integration/server_future_tests.rs
+++ b/tests/integration-tests/tests/integration/server_future_tests.rs
@@ -31,7 +31,7 @@ use hickory_net::tls::{default_provider, tls_client_connect_with_bind_addr};
 use hickory_net::udp::UdpClientStream;
 use hickory_net::xfer::{DnsHandle, DnsMultiplexer};
 use hickory_proto::op::{DnsRequest, Message, OpCode, Query, ResponseCode};
-use hickory_proto::rr::rdata::{A, OPT};
+use hickory_proto::rr::rdata::{A, EdnsOptions};
 use hickory_proto::rr::{DNSClass, Name, RData, Record, RecordType};
 use hickory_server::Server;
 use hickory_server::zone_handler::{Catalog, ZoneHandler};
@@ -407,12 +407,12 @@ async fn edns_multiple_opt_rr() {
     message.add_additional(Record::from_rdata(
         Name::root(),
         0,
-        RData::OPT(OPT::new(vec![])),
+        RData::OPT(EdnsOptions::new(vec![])),
     ));
     message.add_additional(Record::from_rdata(
         Name::root(),
         0,
-        RData::OPT(OPT::new(vec![])),
+        RData::OPT(EdnsOptions::new(vec![])),
     ));
     let message_bytes = message.to_vec().unwrap();
 

--- a/tests/integration-tests/tests/integration/sqlite_zone_handler_tests.rs
+++ b/tests/integration-tests/tests/integration/sqlite_zone_handler_tests.rs
@@ -851,7 +851,7 @@ async fn test_update_tsig_valid() {
     // SqliteZoneHandler and so have to do this ourselves. Provide a response EDNS
     // with an option to ensure the response signature handles this correctly.
     let mut edns = Edns::default();
-    edns.options_mut().insert(EdnsOption::NSID(
+    edns.options.insert(EdnsOption::NSID(
         NSIDPayload::new([0xC0, 0xFF, 0xEE]).unwrap(),
     ));
     let response = MessageResponseBuilder::new(&request.queries, Some(&edns));

--- a/tests/integration-tests/tests/integration/sqlite_zone_handler_tests.rs
+++ b/tests/integration-tests/tests/integration/sqlite_zone_handler_tests.rs
@@ -850,7 +850,7 @@ async fn test_update_tsig_valid() {
     // The catalog handles this in normal operation, but we're testing at the level of the
     // SqliteZoneHandler and so have to do this ourselves. Provide a response EDNS
     // with an option to ensure the response signature handles this correctly.
-    let mut edns = Edns::new();
+    let mut edns = Edns::default();
     edns.options_mut().insert(EdnsOption::NSID(
         NSIDPayload::new([0xC0, 0xFF, 0xEE]).unwrap(),
     ));

--- a/tests/integration-tests/tests/integration/truncation_tests.rs
+++ b/tests/integration-tests/tests/integration/truncation_tests.rs
@@ -48,10 +48,9 @@ async fn test_truncation() {
         query
     });
     msg.metadata.recursion_desired = true;
-    msg.edns = Some({
-        let mut edns = Edns::default();
-        edns.set_max_payload(max_payload).set_version(0);
-        edns
+    msg.edns = Some(Edns {
+        udp_payload_size: max_payload,
+        ..Edns::default()
     });
 
     let result = client

--- a/tests/integration-tests/tests/integration/truncation_tests.rs
+++ b/tests/integration-tests/tests/integration/truncation_tests.rs
@@ -49,7 +49,7 @@ async fn test_truncation() {
     });
     msg.metadata.recursion_desired = true;
     msg.edns = Some({
-        let mut edns = Edns::new();
+        let mut edns = Edns::default();
         edns.set_max_payload(max_payload).set_version(0);
         edns
     });


### PR DESCRIPTION
I'm still trying to introduce a bit more type safety in the lower levels of the stack. As part of that, I wanted to introduce a `Ttl` newtype -- but that ran into trouble with how we deal with `Edns`, which previously had a `From<&Record> for Edns` impl (and vice versa) with a note that it should probably be fallible instead.

This instead introduces a `RecordKind` intermediate enum that abstracts over `Record` and `Edns`, and limits `Record` to only decoding "real" record types. In the process, I've also introduced changes along the lines of other recent PRs where we make the fields public (deprecating instead of removing getters/setters), and fixing more code paths that didn't set the right defaults yet.

I think it might make sense to backport some of these to a 0.26.x release branch, so I've tried to cut up the commits such that cherry-picking some of them might make sense.