### PR TITLE
Move test-server to main workspace, fix Dockerfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2686,6 +2686,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "test-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "clap",
+ "data-encoding",
+ "futures",
+ "hickory-net",
+ "hickory-proto",
+ "time",
+ "tokio",
+]
+
+[[package]]
 name = "test-support"
 version = "0.26.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "util",
     "tests/integration-tests",
     "tests/test-support",
+    "conformance/test-server",
 ]
 exclude = ["fuzz"]
 

--- a/conformance/Cargo.lock
+++ b/conformance/Cargo.lock
@@ -24,56 +24,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,29 +86,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
-dependencies = [
- "aws-lc-sys",
- "untrusted 0.7.1",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.39.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,8 +125,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -225,61 +150,6 @@ dependencies = [
  "cpufeatures",
  "rand_core 0.10.1",
 ]
-
-[[package]]
-name = "clap"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -437,12 +307,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "e2e-tests"
 version = "0.0.0"
 dependencies = [
@@ -511,12 +375,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -671,7 +529,6 @@ name = "hickory-net"
 version = "0.26.0"
 dependencies = [
  "async-trait",
- "aws-lc-rs",
  "bitflags",
  "cfg-if",
  "data-encoding",
@@ -699,7 +556,6 @@ dependencies = [
 name = "hickory-proto"
 version = "0.26.0"
 dependencies = [
- "aws-lc-rs",
  "bitflags",
  "data-encoding",
  "idna",
@@ -867,12 +723,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,16 +775,6 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn",
-]
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
 ]
 
 [[package]]
@@ -1190,12 +1030,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
 name = "ordered-float"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,7 +1279,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -1625,12 +1459,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,21 +1497,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "test-server"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "base64",
- "clap",
- "data-encoding",
- "futures",
- "hickory-net",
- "hickory-proto",
- "time",
- "tokio",
 ]
 
 [[package]]
@@ -1861,12 +1674,6 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -1888,12 +1695,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
-members = ["compatibility-tests", "conformance-tests", "dns-test", "e2e-tests", "ede-dot-com", "test-server"]
+members = ["compatibility-tests", "conformance-tests", "dns-test", "e2e-tests", "ede-dot-com"]
+exclude = ["test-server"]
 resolver = "2"
 
 [workspace.lints.rust]

--- a/conformance/dns-test/src/docker/test-server.Dockerfile
+++ b/conformance/dns-test/src/docker/test-server.Dockerfile
@@ -3,6 +3,7 @@ ENV CARGO_INCREMENTAL=0
 ENV CARGO_PROFILE_DEV_DEBUG=0
 ENV CARGO_PROFILE_DEV_STRIP=true
 RUN cargo install cargo-chef --version 0.1.71 --profile dev
+WORKDIR /usr/src/hickory
 
 # `dns-test` will invoke `docker build` from a temporary directory that contains
 # a clone of the hickory repository. `./src` here refers to that clone; not to
@@ -10,12 +11,10 @@ RUN cargo install cargo-chef --version 0.1.71 --profile dev
 
 FROM chef AS planner
 COPY ./src /usr/src/hickory
-WORKDIR /usr/src/hickory/conformance
 RUN cargo chef prepare
 
 FROM chef AS builder
-COPY --from=planner /usr/src/hickory /usr/src/hickory
-WORKDIR /usr/src/hickory/conformance
+COPY --from=planner /usr/src/hickory/recipe.json /usr/src/hickory/recipe.json
 RUN cargo chef cook -p test-server
 COPY ./src /usr/src/hickory
 RUN cargo build -p test-server
@@ -26,5 +25,5 @@ RUN apt-get update && \
     ldnsutils \
     bind9-utils \
     tshark
-COPY --from=builder /usr/src/hickory/conformance/target/debug/test-server /usr/bin/test-server
+COPY --from=builder /usr/src/hickory/target/debug/test-server /usr/bin/test-server
 ENV RUST_LOG=debug

--- a/justfile
+++ b/justfile
@@ -32,34 +32,34 @@ std: (default "--no-default-features" "--ignore=\\{hickory-proto\\}")
     cargo {{MSRV}} test --locked --package hickory-proto --no-default-features --features="std"
 
 # Check, build, and test all crates with tls-aws-lc-rs enabled
-tls-aws-lc-rs: (default "--features=tls-aws-lc-rs" "--ignore=\\{hickory-proto,test-support\\}")
+tls-aws-lc-rs: (default "--features=tls-aws-lc-rs" "--ignore=\\{hickory-proto,test-support,test-server\\}")
 
 # Check, build, and test all crates with https-aws-lc-rs enabled
-https-aws-lc-rs: (default "--features=https-aws-lc-rs" "--ignore=\\{hickory-proto,test-support\\}")
+https-aws-lc-rs: (default "--features=https-aws-lc-rs" "--ignore=\\{hickory-proto,test-support,test-server\\}")
 
 # Check, build, and test all crates with quic-aws-lc-rs enabled
-quic-aws-lc-rs: (default "--features=quic-aws-lc-rs" "--ignore=\\{hickory-proto,test-support\\}")
+quic-aws-lc-rs: (default "--features=quic-aws-lc-rs" "--ignore=\\{hickory-proto,test-support,test-server\\}")
 
 # Check, build, and test all crates with h3-aws-lc-rs enabled
-h3-aws-lc-rs: (default "--features=h3-aws-lc-rs" "--ignore=\\{hickory-proto,hickory-dns,hickory-client,test-support\\}")
+h3-aws-lc-rs: (default "--features=h3-aws-lc-rs" "--ignore=\\{hickory-proto,hickory-dns,hickory-client,test-support,test-server\\}")
 
 # Check, build, and test all crates with tls-ring enabled
-tls-ring: (default "--features=tls-ring" "--ignore=\\{hickory-proto,test-support\\}")
+tls-ring: (default "--features=tls-ring" "--ignore=\\{hickory-proto,test-support,test-server\\}")
 
 # Check, build, and test all crates with https-ring enabled
-https-ring: (default "--features=https-ring" "--ignore=\\{hickory-proto,test-support\\}")
+https-ring: (default "--features=https-ring" "--ignore=\\{hickory-proto,test-support,test-server\\}")
 
 # Check, build, and test all crates with quic-ring enabled
-quic-ring: (default "--features=quic-ring" "--ignore=\\{hickory-proto,test-support\\}")
+quic-ring: (default "--features=quic-ring" "--ignore=\\{hickory-proto,test-support,test-server\\}")
 
 # Check, build, and test all crates with h3-ring enabled
-h3-ring: (default "--features=h3-ring" "--ignore=\\{hickory-proto,hickory-dns,hickory-client,test-support\\}")
+h3-ring: (default "--features=h3-ring" "--ignore=\\{hickory-proto,hickory-dns,hickory-client,test-support,test-server\\}")
 
 # Check, build, and test all crates with dnssec-aws-lc-rs enabled
-dnssec-aws-lc-rs: (default "--features=dnssec-aws-lc-rs" "--ignore=\\{test-support\\}")
+dnssec-aws-lc-rs: (default "--features=dnssec-aws-lc-rs" "--ignore=\\{test-support,test-server\\}")
 
 # Check, build, and test all crates with dnssec-ring enabled
-dnssec-ring: (default "--features=dnssec-ring" "--ignore=\\{test-support\\}")
+dnssec-ring: (default "--features=dnssec-ring" "--ignore=\\{test-support,test-server\\}")
 
 # Run check on all projects in the workspace
 check feature='' ignore='':
@@ -75,7 +75,7 @@ test feature='' ignore='':
     cargo ws exec {{ignore}} cargo {{MSRV}} test --locked --all-targets {{feature}}
 
 doc feature='':
-    cargo ws exec --ignore=hickory-dns cargo {{MSRV}} test --locked --doc {{feature}}
+    cargo ws exec "--ignore={hickory-dns,test-server}" cargo {{MSRV}} test --locked --doc {{feature}}
 
 test-docs:
     RUSTDOCFLAGS="-Dwarnings" cargo ws exec cargo doc --locked --all-features --no-deps --document-private-items


### PR DESCRIPTION
I noticed that whenever I changed conformance test code, the `test-server` container was rebuilt, including all its dependencies. This PR addresses that by first moving `test-server` from the conformance Cargo workspace to the root Cargo workspace (while still leaving the directory in the same place) and changing the Dockerfile so that we copy only the `recipe.json` file before running `cargo chef cook`. This ensures we only need to rebuild dependencies when manifest files change, not test source code. I had to move the crate to the root workspace for this to work, since `cargo chef prepare` inside the conformance workspace does not rehydrate hickory-proto and hickory-net manifests, but we need those to build the test server.