### PR TITLE
Bump version to 0.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,7 +912,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-dns"
-version = "0.26.0"
+version = "0.27.0-alpha.1"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-integration"
-version = "0.26.0"
+version = "0.27.0-alpha.1"
 dependencies = [
  "async-trait",
  "data-encoding",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-net"
-version = "0.26.0"
+version = "0.27.0-alpha.1"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0"
+version = "0.27.0-alpha.1"
 dependencies = [
  "aws-lc-rs",
  "bitflags",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.0"
+version = "0.27.0-alpha.1"
 dependencies = [
  "async-recursion",
  "cfg-if",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-server"
-version = "0.26.0"
+version = "0.27.0-alpha.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-util"
-version = "0.26.0"
+version = "0.27.0-alpha.1"
 dependencies = [
  "clap",
  "console",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "test-support"
-version = "0.26.0"
+version = "0.27.0-alpha.1"
 dependencies = [
  "bytes",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.26.0"
+version = "0.27.0-alpha.1"
 authors = ["The contributors to Hickory DNS"]
 edition = "2021"
 rust-version = "1.88"
@@ -27,10 +27,10 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 # hickory
-hickory-net = { version = "0.26.0", path = "crates/net", default-features = false }
-hickory-resolver = { version = "0.26.0", path = "crates/resolver", default-features = false }
-hickory-server = { version = "0.26.0", path = "crates/server", default-features = false }
-hickory-proto = { version = "0.26.0", path = "crates/proto", default-features = false, features = ["std"] }
+hickory-net = { version = "=0.27.0-alpha.1", path = "crates/net", default-features = false }
+hickory-resolver = { version = "=0.27.0-alpha.1", path = "crates/resolver", default-features = false }
+hickory-server = { version = "=0.27.0-alpha.1", path = "crates/server", default-features = false }
+hickory-proto = { version = "=0.27.0-alpha.1", path = "crates/proto", default-features = false, features = ["std"] }
 test-support.path = "tests/test-support"
 
 

--- a/conformance/Cargo.lock
+++ b/conformance/Cargo.lock
@@ -526,7 +526,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-net"
-version = "0.26.0"
+version = "0.27.0-alpha.1"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0"
+version = "0.27.0-alpha.1"
 dependencies = [
  "bitflags",
  "data-encoding",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.0"
+version = "0.27.0-alpha.1"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "test-support"
-version = "0.26.0"
+version = "0.27.0-alpha.1"
 dependencies = [
  "bytes",
  "futures-util",

--- a/conformance/test-server/Cargo.toml
+++ b/conformance/test-server/Cargo.toml
@@ -9,7 +9,7 @@ base64 = "0.22"
 clap = { version = "4.0", features = ["derive", "std"] }
 data-encoding = "2.9"
 futures = { version = "0.3", default-features = false }
-hickory-proto = { version = "0.26.0-alpha.1", path = "../../crates/proto", default-features = false, features = ["std"] }
-hickory-net = { version = "0.26.0-alpha.1", path = "../../crates/net", default-features = false, features = ["dnssec-aws-lc-rs", "tokio"] }
+hickory-proto = { version = "=0.27.0-alpha.1", path = "../../crates/proto", default-features = false, features = ["std"] }
+hickory-net = { version = "=0.27.0-alpha.1", path = "../../crates/net", default-features = false, features = ["dnssec-aws-lc-rs", "tokio"] }
 tokio = { version = "1.21", features = ["macros", "net", "io-util", "rt-multi-thread"] }
 time = { version = "0.3", features = ["formatting", "macros", "parsing"] }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -243,7 +243,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0"
+version = "0.27.0-alpha.1"
 dependencies = [
  "aws-lc-rs",
  "bitflags",


### PR DESCRIPTION
We've merged some solidly incompatible changes, so let's proactively bump the versions.

I've also pushed a `release/0.26` branch, currently pointing at 14cc3c817e2eec14ed2ff625ee03eee2877874b1, which I think is the last semver-compatible commit from `main`.