### PR TITLE
Remove cfg guard on ZoneHandler::metrics_label()

### DIFF
--- a/crates/server/src/store/blocklist.rs
+++ b/crates/server/src/store/blocklist.rs
@@ -468,7 +468,6 @@ impl ZoneHandler for BlocklistZoneHandler {
         None
     }
 
-    #[cfg(feature = "metrics")]
     fn metrics_label(&self) -> &'static str {
         "blocklist"
     }

--- a/crates/server/src/store/file.rs
+++ b/crates/server/src/store/file.rs
@@ -225,7 +225,6 @@ impl ZoneHandler for FileZoneHandler {
         self.in_memory.nx_proof_kind()
     }
 
-    #[cfg(feature = "metrics")]
     fn metrics_label(&self) -> &'static str {
         "file"
     }

--- a/crates/server/src/store/forwarder.rs
+++ b/crates/server/src/store/forwarder.rs
@@ -282,7 +282,6 @@ impl<P: ConnectionProvider> ZoneHandler for ForwardZoneHandler<P> {
         None
     }
 
-    #[cfg(feature = "metrics")]
     fn metrics_label(&self) -> &'static str {
         "forwarder"
     }

--- a/crates/server/src/store/in_memory/mod.rs
+++ b/crates/server/src/store/in_memory/mod.rs
@@ -644,7 +644,6 @@ impl<P: RuntimeProvider + Send + Sync> ZoneHandler for InMemoryZoneHandler<P> {
         self.nx_proof_kind.as_ref()
     }
 
-    #[cfg(feature = "metrics")]
     fn metrics_label(&self) -> &'static str {
         "in-memory"
     }

--- a/crates/server/src/store/recursor.rs
+++ b/crates/server/src/store/recursor.rs
@@ -160,7 +160,6 @@ impl<P: RuntimeProvider> ZoneHandler for RecursiveZoneHandler<P> {
         None
     }
 
-    #[cfg(feature = "metrics")]
     fn metrics_label(&self) -> &'static str {
         "recursive"
     }

--- a/crates/server/src/store/sqlite/mod.rs
+++ b/crates/server/src/store/sqlite/mod.rs
@@ -1164,7 +1164,6 @@ impl<P: RuntimeProvider + Send + Sync> ZoneHandler for SqliteZoneHandler<P> {
         self.in_memory.nx_proof_kind()
     }
 
-    #[cfg(feature = "metrics")]
     fn metrics_label(&self) -> &'static str {
         "sqlite"
     }

--- a/crates/server/src/zone_handler/mod.rs
+++ b/crates/server/src/zone_handler/mod.rs
@@ -206,7 +206,6 @@ pub trait ZoneHandler: Send + Sync {
     fn nx_proof_kind(&self) -> Option<&NxProofKind>;
 
     /// Returns the zone handler metrics label.
-    #[cfg(feature = "metrics")]
     fn metrics_label(&self) -> &'static str;
 }
 

--- a/tests/integration-tests/tests/integration/chained_zone_handler_tests.rs
+++ b/tests/integration-tests/tests/integration/chained_zone_handler_tests.rs
@@ -254,7 +254,6 @@ impl ZoneHandler for TestZoneHandler {
         (res, None)
     }
 
-    #[cfg(feature = "metrics")]
     fn metrics_label(&self) -> &'static str {
         "test"
     }


### PR DESCRIPTION
This makes `ZoneHandler::metrics_label()` always part of the trait, regardless of Cargo feature flags, per the discussion at https://github.com/hickory-dns/hickory-dns/pull/3599#issuecomment-4282605867.