### PR TITLE
Add conformance tests for DNSSEC verification with missing records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2678,6 +2678,7 @@ name = "test-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "base64",
  "clap",
  "data-encoding",

--- a/conformance/conformance-tests/src/forwarder/dnssec/scenarios/bogus.rs
+++ b/conformance/conformance-tests/src/forwarder/dnssec/scenarios/bogus.rs
@@ -71,7 +71,7 @@ fn nsec3_does_not_cover() -> Result<(), Error> {
     let sign_settings = SignSettings::default();
 
     let mut leaf_ns = NameServer::new(
-        &Implementation::test_server("nsec3_nocover", "both"),
+        &Implementation::test_server("nsec3_nocover", Vec::new(), "both"),
         FQDN::TEST_DOMAIN,
         &network,
     )?;

--- a/conformance/conformance-tests/src/resolver/dns/rfc1035/truncation.rs
+++ b/conformance/conformance-tests/src/resolver/dns/rfc1035/truncation.rs
@@ -110,7 +110,7 @@ fn setup(transport: &'static str) -> Result<(Resolver, Client, Graph), Error> {
 
     let mut root_ns = NameServer::new(&PEER, FQDN::ROOT, &network)?;
     let leaf_ns = NameServer::new(
-        &Implementation::test_server("truncated_response", transport),
+        &Implementation::test_server("truncated_response", Vec::new(), transport),
         FQDN::TEST_TLD,
         &network,
     )?;

--- a/conformance/conformance-tests/src/resolver/dns/scenarios/no_soa.rs
+++ b/conformance/conformance-tests/src/resolver/dns/scenarios/no_soa.rs
@@ -12,7 +12,7 @@ fn no_soa() -> Result<(), Error> {
 
     let mut root_ns = NameServer::new(&PEER, FQDN::ROOT, &network)?;
     let leaf_ns = NameServer::new(
-        &Implementation::test_server("empty_response", "both"),
+        &Implementation::test_server("empty_response", Vec::new(), "both"),
         FQDN::TEST_TLD,
         &network,
     )?;

--- a/conformance/conformance-tests/src/resolver/dns/scenarios/packet_loss.rs
+++ b/conformance/conformance-tests/src/resolver/dns/scenarios/packet_loss.rs
@@ -17,7 +17,7 @@ fn packet_loss_udp() -> Result<(), Error> {
 
     let mut root_ns = NameServer::new(&PEER, FQDN::ROOT, &network)?;
     let leaf_ns = NameServer::new(
-        &Implementation::test_server("packet_loss", "udp"),
+        &Implementation::test_server("packet_loss", Vec::new(), "udp"),
         FQDN::TEST_TLD,
         &network,
     )?;

--- a/conformance/conformance-tests/src/resolver/dnssec.rs
+++ b/conformance/conformance-tests/src/resolver/dnssec.rs
@@ -2,6 +2,7 @@
 
 mod adhoc;
 mod fixtures;
+mod missing_records;
 mod regression;
 mod rfc4035;
 mod rfc6975;

--- a/conformance/conformance-tests/src/resolver/dnssec/missing_records.rs
+++ b/conformance/conformance-tests/src/resolver/dnssec/missing_records.rs
@@ -9,6 +9,7 @@ use dns_test::{
     zone_file::SignSettings,
 };
 
+mod rfc_4035_appendix_b;
 mod rfc_5155_appendix_b;
 
 /// This runs multiple tests to confirm that validation fails when specific records are excluded.
@@ -128,13 +129,12 @@ fn test_record_removal_validation_failure(
             .start()?;
         let response = client.dig(dig_settings, resolver.ipv4_addr(), query_type, &query_name)?;
 
-        println!("{}", resolver.logs()?);
-
         assert_eq!(
             response.status,
             DigStatus::SERVFAIL,
             "did not get SERVFAIL when excluding {knockout_name} {knockout_type} from \
-            responses\n{response:#?}"
+            responses\n{}\n{response:#?}",
+            resolver.logs()?
         );
     }
 

--- a/conformance/conformance-tests/src/resolver/dnssec/missing_records.rs
+++ b/conformance/conformance-tests/src/resolver/dnssec/missing_records.rs
@@ -11,6 +11,7 @@ use dns_test::{
 
 mod rfc_4035_appendix_b;
 mod rfc_5155_appendix_b;
+mod rfc_7129_section_5_4;
 
 /// This runs multiple tests to confirm that validation fails when specific records are excluded.
 ///

--- a/conformance/conformance-tests/src/resolver/dnssec/missing_records.rs
+++ b/conformance/conformance-tests/src/resolver/dnssec/missing_records.rs
@@ -1,0 +1,142 @@
+//! These tests use a proxy in front of authoritative name servers to exclude specific DNSSEC RRs,
+//! and confirm that their absence causes validation to return "bogus".
+
+use dns_test::{
+    Error, FQDN, Implementation, Network, PEER, Resolver,
+    client::{Client, DigOutput, DigSettings, DigStatus},
+    name_server::{NameServer, Signed, Stopped},
+    record::RecordType,
+    zone_file::SignSettings,
+};
+
+mod rfc_5155_appendix_b;
+
+/// This runs multiple tests to confirm that validation fails when specific records are excluded.
+///
+/// Tests are run against the provided name servers, along with a root name server, and resolvers.
+/// First, a baseline query is performed, where no records are excluded. Then, for each name and
+/// record type in `knockout_rrsets`, proxy servers are used to exclude records from that specific
+/// RRset, and recursive queries are repeated. If any of the responses does not have a SERVFAIL
+/// response code, that is treated as a test failure. The response from the baseline query is
+/// returned, so that the enclosing test can also ensure the resolver works correctly in the absence
+/// of any interference.
+fn test_record_removal_validation_failure(
+    signed_leaf_servers: Vec<NameServer<Signed>>,
+    unsigned_leaf_servers: Vec<NameServer<Stopped>>,
+    query_name: FQDN,
+    query_type: RecordType,
+    knockout_rrsets: &[(FQDN, RecordType)],
+    network: &Network,
+) -> Result<DigOutput, Error> {
+    let client = Client::new(network)?;
+    let dig_settings = *DigSettings::default().recurse().dnssec().authentic_data();
+
+    let mut leaf_servers;
+    let unmodified_response;
+    let mut ds_records = Vec::new();
+    {
+        let mut root_ns_unmodified = NameServer::new(&PEER, FQDN::ROOT, network)?;
+        for ns in signed_leaf_servers.iter() {
+            root_ns_unmodified.referral_nameserver(ns);
+            root_ns_unmodified.add(ns.ds().ksk.clone());
+            ds_records.push(ns.ds().ksk.clone());
+        }
+        for ns in unsigned_leaf_servers.iter() {
+            root_ns_unmodified.referral_nameserver(ns);
+        }
+        let root_ns_unmodified = root_ns_unmodified.sign(SignSettings::default())?;
+        let trust_anchor = root_ns_unmodified.trust_anchor();
+        let root_ns_unmodified = root_ns_unmodified.start()?;
+
+        leaf_servers = Vec::with_capacity(signed_leaf_servers.len() + unsigned_leaf_servers.len());
+        for ns in signed_leaf_servers.into_iter() {
+            leaf_servers.push(ns.start()?);
+        }
+        for ns in unsigned_leaf_servers.into_iter() {
+            leaf_servers.push(ns.start()?);
+        }
+
+        let resolver_unmodified = Resolver::new(network, root_ns_unmodified.root_hint())
+            .trust_anchor(&trust_anchor)
+            .start()?;
+        unmodified_response = client.dig(
+            dig_settings,
+            resolver_unmodified.ipv4_addr(),
+            query_type,
+            &query_name,
+        )?;
+        for (knockout_name, knockout_type) in knockout_rrsets.iter() {
+            let mut seen = false;
+            for section in [
+                &unmodified_response.answer,
+                &unmodified_response.authority,
+                &unmodified_response.additional,
+            ] {
+                for record in section {
+                    if record.name().as_str().to_lowercase()
+                        == knockout_name.as_str().to_lowercase()
+                        && record.record_type() == *knockout_type
+                    {
+                        seen = true;
+                        break;
+                    }
+                }
+                if seen {
+                    break;
+                }
+            }
+            assert!(
+                seen,
+                "expected record {knockout_name} {knockout_type} was not present in original \
+                response\n{unmodified_response:#?}"
+            );
+        }
+    }
+
+    for (knockout_name, knockout_type) in knockout_rrsets.iter() {
+        let mut proxies = Vec::with_capacity(leaf_servers.len());
+        let mut root_ns = NameServer::new(&PEER, FQDN::ROOT, network)?;
+        for ns in leaf_servers.iter() {
+            let proxy_ns = NameServer::builder(
+                Implementation::test_server(
+                    "drop_rrset",
+                    vec![
+                        ns.ipv4_addr().to_string(),
+                        knockout_name.to_string(),
+                        knockout_type.to_string(),
+                    ],
+                    "both",
+                ),
+                ns.zone().clone(),
+                network.clone(),
+            )
+            .nameserver_fqdn(ns.zone_file().soa.nameserver.clone())
+            .rname_fqdn(ns.zone_file().soa.admin.clone())
+            .build()?;
+            root_ns.referral_nameserver(&proxy_ns);
+            proxies.push(proxy_ns.start()?);
+        }
+        for ds in ds_records.iter() {
+            root_ns.add(ds.clone());
+        }
+        let root_ns = root_ns.sign(SignSettings::default())?;
+        let trust_anchor = root_ns.trust_anchor();
+        let root_ns = root_ns.start()?;
+
+        let resolver = Resolver::new(network, root_ns.root_hint())
+            .trust_anchor(&trust_anchor)
+            .start()?;
+        let response = client.dig(dig_settings, resolver.ipv4_addr(), query_type, &query_name)?;
+
+        println!("{}", resolver.logs()?);
+
+        assert_eq!(
+            response.status,
+            DigStatus::SERVFAIL,
+            "did not get SERVFAIL when excluding {knockout_name} {knockout_type} from \
+            responses\n{response:#?}"
+        );
+    }
+
+    Ok(unmodified_response)
+}

--- a/conformance/conformance-tests/src/resolver/dnssec/missing_records/rfc_4035_appendix_b.rs
+++ b/conformance/conformance-tests/src/resolver/dnssec/missing_records/rfc_4035_appendix_b.rs
@@ -1,0 +1,365 @@
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use dns_test::{
+    Error, FQDN, Network, PEER,
+    client::DigStatus,
+    name_server::{NameServer, Signed},
+    record::{A, AAAA, DS, HINFO, MX, NS, NSEC, Record, RecordType, SOA, SoaSettings},
+    zone_file::{Nsec, SignSettings},
+};
+
+use crate::resolver::dnssec::missing_records::test_record_removal_validation_failure;
+
+#[test]
+fn test_zone_construction() -> Result<(), Error> {
+    let network = Network::new()?;
+    let ns = build_zone(&network)?;
+    let zone = ns.signed_zone_file();
+    let mut nsec_records = zone
+        .records
+        .iter()
+        .filter_map(|record| {
+            if let Record::NSEC(nsec) = record {
+                Some(nsec.clone())
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let mut expected = [
+        NSEC {
+            fqdn: FQDN("example.")?,
+            ttl: 3600,
+            next_domain: FQDN("a.example.")?,
+            record_types: vec![
+                RecordType::NS,
+                RecordType::SOA,
+                RecordType::MX,
+                RecordType::RRSIG,
+                RecordType::NSEC,
+                RecordType::DNSKEY,
+            ],
+        },
+        NSEC {
+            fqdn: FQDN("a.example.")?,
+            ttl: 3600,
+            next_domain: FQDN("ai.example.")?,
+            record_types: vec![
+                RecordType::NS,
+                RecordType::DS,
+                RecordType::RRSIG,
+                RecordType::NSEC,
+            ],
+        },
+        NSEC {
+            fqdn: FQDN("ai.example.")?,
+            ttl: 3600,
+            next_domain: FQDN("b.example.")?,
+            record_types: vec![
+                RecordType::A,
+                RecordType::HINFO,
+                RecordType::AAAA,
+                RecordType::RRSIG,
+                RecordType::NSEC,
+            ],
+        },
+        NSEC {
+            fqdn: FQDN("b.example.")?,
+            ttl: 3600,
+            next_domain: FQDN("ns1.example.")?,
+            record_types: vec![RecordType::NS, RecordType::RRSIG, RecordType::NSEC],
+        },
+        NSEC {
+            fqdn: FQDN("ns1.example.")?,
+            ttl: 3600,
+            next_domain: FQDN("ns2.example.")?,
+            record_types: vec![RecordType::A, RecordType::RRSIG, RecordType::NSEC],
+        },
+        NSEC {
+            fqdn: FQDN("ns2.example.")?,
+            ttl: 3600,
+            next_domain: FQDN("*.w.example.")?,
+            record_types: vec![RecordType::A, RecordType::RRSIG, RecordType::NSEC],
+        },
+        NSEC {
+            fqdn: FQDN("*.w.example.")?,
+            ttl: 3600,
+            next_domain: FQDN("x.w.example.")?,
+            record_types: vec![RecordType::MX, RecordType::RRSIG, RecordType::NSEC],
+        },
+        NSEC {
+            fqdn: FQDN("x.w.example.")?,
+            ttl: 3600,
+            next_domain: FQDN("x.y.w.example.")?,
+            record_types: vec![RecordType::MX, RecordType::RRSIG, RecordType::NSEC],
+        },
+        NSEC {
+            fqdn: FQDN("x.y.w.example.")?,
+            ttl: 3600,
+            next_domain: FQDN("xx.example.")?,
+            record_types: vec![RecordType::MX, RecordType::RRSIG, RecordType::NSEC],
+        },
+        NSEC {
+            fqdn: FQDN("xx.example.")?,
+            ttl: 3600,
+            next_domain: FQDN("example.")?,
+            record_types: vec![
+                RecordType::A,
+                RecordType::HINFO,
+                RecordType::AAAA,
+                RecordType::RRSIG,
+                RecordType::NSEC,
+            ],
+        },
+    ];
+
+    let cmp = |a: &NSEC, b: &NSEC| a.fqdn.as_str().cmp(b.fqdn.as_str());
+    nsec_records.sort_by(cmp);
+    expected.sort_by(cmp);
+
+    assert_eq!(nsec_records, expected);
+    Ok(())
+}
+
+/// Based on RFC 4035 section B.2.
+#[test]
+fn name_error() -> Result<(), Error> {
+    let network = Network::new()?;
+    let leaf_ns = build_zone(&network)?;
+    let original_response = test_record_removal_validation_failure(
+        vec![leaf_ns],
+        Vec::new(),
+        FQDN("ml.example.")?,
+        RecordType::A,
+        &[
+            // Proves name does not exist.
+            (FQDN("b.example.")?, RecordType::NSEC),
+            // Proves covering wildcard name does not exist.
+            (FQDN("example.")?, RecordType::NSEC),
+        ],
+        &network,
+    )?;
+    assert_eq!(original_response.status, DigStatus::NXDOMAIN);
+    Ok(())
+}
+
+/// Based on RFC 4035 section B.3.
+#[test]
+fn no_data_error() -> Result<(), Error> {
+    let network = Network::new()?;
+    let leaf_ns = build_zone(&network)?;
+    let original_response = test_record_removal_validation_failure(
+        vec![leaf_ns],
+        Vec::new(),
+        FQDN("ns1.example.")?,
+        RecordType::MX,
+        &[
+            // Proves the requested RR type does not exist.
+            (FQDN("ns1.example.")?, RecordType::NSEC),
+        ],
+        &network,
+    )?;
+    assert_eq!(original_response.status, DigStatus::NOERROR);
+    Ok(())
+}
+
+/// Based on RFC 4035 section B.6.
+#[test]
+#[ignore = "hickory recursor does not include NSEC record proving wildcard expansion"]
+fn wildcard_expansion() -> Result<(), Error> {
+    let network = Network::new()?;
+    let leaf_ns = build_zone(&network)?;
+    let original_response = test_record_removal_validation_failure(
+        vec![leaf_ns],
+        Vec::new(),
+        FQDN("a.z.w.example.")?,
+        RecordType::MX,
+        &[
+            // Proves the requested RR type does not exist.
+            (FQDN("x.y.w.example.")?, RecordType::NSEC),
+        ],
+        &network,
+    )?;
+    assert_eq!(original_response.status, DigStatus::NOERROR);
+    assert!(!original_response.answer.is_empty());
+    Ok(())
+}
+
+/// Based on RFC 4035 section B.7.
+#[test]
+fn wildcard_no_data_error() -> Result<(), Error> {
+    let network = Network::new()?;
+    let leaf_ns = build_zone(&network)?;
+    let original_response = test_record_removal_validation_failure(
+        vec![leaf_ns],
+        Vec::new(),
+        FQDN("a.z.w.example.")?,
+        RecordType::AAAA,
+        &[
+            // Proves that the matching wildcard name does not have the requested RR type.
+            (FQDN("x.y.w.example.")?, RecordType::NSEC),
+            // Proves that no closer match exists.
+            (FQDN("*.w.example.")?, RecordType::NSEC),
+        ],
+        &network,
+    )?;
+    assert_eq!(original_response.status, DigStatus::NOERROR);
+    assert!(original_response.answer.is_empty());
+    Ok(())
+}
+
+/// Construct a name server with a zone similar to that in RFC 4035 Appendix A.
+fn build_zone(network: &Network) -> Result<NameServer<Signed>, Error> {
+    let mut ns = NameServer::builder(PEER.clone(), FQDN("example.")?, network.clone())
+        .nameserver_fqdn(FQDN("ns1.example.")?)
+        .rname_fqdn(FQDN("admin.nameservers.net.")?)
+        .build()?;
+    // Remove NS and A record automatically added when building server.
+    ns.zone_file_mut().records.clear();
+
+    ns.zone_file_mut().soa = SOA {
+        zone: FQDN("example.")?,
+        ttl: 3600,
+        nameserver: FQDN("ns1.example.")?,
+        admin: FQDN("bugs.x.w.example.")?,
+        settings: SoaSettings {
+            serial: 1081539377,
+            refresh: 3600,
+            retry: 300,
+            expire: 3600000,
+            minimum: 3600,
+        },
+    };
+
+    ns.add(NS {
+        zone: FQDN("example.")?,
+        ttl: 3600,
+        nameserver: FQDN("ns1.example.")?,
+    });
+    ns.add(NS {
+        zone: FQDN("example.")?,
+        ttl: 3600,
+        nameserver: FQDN("ns2.example.")?,
+    });
+    ns.add(MX {
+        fqdn: FQDN("example.")?,
+        ttl: 3600,
+        preference: 1,
+        exchange: FQDN("xx.example.")?,
+    });
+    ns.add(NS {
+        zone: FQDN("a.example.")?,
+        ttl: 3600,
+        nameserver: FQDN("ns1.a.example.")?,
+    });
+    ns.add(NS {
+        zone: FQDN("a.example.")?,
+        ttl: 3600,
+        nameserver: FQDN("ns2.a.example.")?,
+    });
+    ns.add(DS {
+        zone: FQDN("a.example.")?,
+        ttl: 3600,
+        key_tag: 57855,
+        algorithm: 5,
+        digest_type: 1,
+        digest: "B6DCD485719ADCA18E5F3D48A2331627FDD3636B".to_string(),
+    });
+    ns.add(A {
+        fqdn: FQDN("ns1.a.example.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 5),
+    });
+    ns.add(A {
+        fqdn: FQDN("ns2.a.example.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 6),
+    });
+    ns.add(A {
+        fqdn: FQDN("ai.example.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 9),
+    });
+    ns.add(HINFO {
+        fqdn: FQDN("ai.example.")?,
+        ttl: 3600,
+        cpu: "KLH-10".to_string(),
+        os: "ITS".to_string(),
+    });
+    ns.add(AAAA {
+        fqdn: FQDN("ai.example.")?,
+        ttl: 3600,
+        ipv6_addr: Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0xf00, 0xbaa9),
+    });
+    ns.add(NS {
+        zone: FQDN("b.example.")?,
+        ttl: 3600,
+        nameserver: FQDN("ns1.b.example.")?,
+    });
+    ns.add(NS {
+        zone: FQDN("b.example.")?,
+        ttl: 3600,
+        nameserver: FQDN("ns2.b.example.")?,
+    });
+    ns.add(A {
+        fqdn: FQDN("ns1.b.example.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 7),
+    });
+    ns.add(A {
+        fqdn: FQDN("ns2.b.example.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 8),
+    });
+    ns.add(A {
+        fqdn: FQDN("ns1.example.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 1),
+    });
+    ns.add(A {
+        fqdn: FQDN("ns2.example.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 2),
+    });
+    ns.add(MX {
+        fqdn: FQDN("*.w.example.")?,
+        ttl: 3600,
+        preference: 1,
+        exchange: FQDN("ai.example.")?,
+    });
+    ns.add(MX {
+        fqdn: FQDN("x.w.example.")?,
+        ttl: 3600,
+        preference: 1,
+        exchange: FQDN("xx.example.")?,
+    });
+    ns.add(MX {
+        fqdn: FQDN("x.y.w.example.")?,
+        ttl: 3600,
+        preference: 1,
+        exchange: FQDN("xx.example.")?,
+    });
+    ns.add(A {
+        fqdn: FQDN("xx.example.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 10),
+    });
+    ns.add(HINFO {
+        fqdn: FQDN("xx.example.")?,
+        ttl: 3600,
+        cpu: "KLH-10".to_string(),
+        os: "TOPS-20".to_string(),
+    });
+    ns.add(AAAA {
+        fqdn: FQDN("xx.example.")?,
+        ttl: 3600,
+        ipv6_addr: Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0xf00, 0xbaaa),
+    });
+
+    // Use dnssec-signzone instead of ldns-signzone again. It seems ldns-signzone is including
+    // occluded records below referrals in the NSEC chain. This causes differences from the zone in
+    // Appendix A.
+    let ns = ns.sign(SignSettings::ecdsap256sha256_nsec3_optout().nsec(Nsec::_1))?;
+    Ok(ns)
+}

--- a/conformance/conformance-tests/src/resolver/dnssec/missing_records/rfc_5155_appendix_b.rs
+++ b/conformance/conformance-tests/src/resolver/dnssec/missing_records/rfc_5155_appendix_b.rs
@@ -1,0 +1,381 @@
+use std::{
+    collections::HashSet,
+    net::{Ipv4Addr, Ipv6Addr},
+};
+
+use dns_test::{
+    Error, FQDN, Network, PEER,
+    client::DigStatus,
+    name_server::{NameServer, Signed},
+    record::{A, AAAA, DS, HINFO, MX, NS, NSEC3PARAM, RecordType, SOA, SoaSettings},
+    zone_file::SignSettings,
+};
+
+use crate::resolver::dnssec::missing_records::test_record_removal_validation_failure;
+
+#[test]
+fn test_zone_construction() -> Result<(), Error> {
+    let network = Network::new()?;
+    let ns = build_zone(&network)?;
+    let zone = ns.signed_zone_file();
+    let names = zone
+        .records
+        .iter()
+        .map(|record| record.name().as_str().to_lowercase())
+        .collect::<HashSet<_>>();
+
+    let expected = [
+        "example.",
+        "0p9mhaveqvm6t7vbl5lop2u3t2rp3tom.example.",
+        "2t7b4g4vsa5smi47k61mv5bv1a22bojr.example.",
+        "2vptu5timamqttgl4luu9kg21e0aor3s.example.",
+        "35mthgpgcu1qg68fab165klnsnk3dpvl.example.",
+        "a.example.",
+        "ns1.a.example.",
+        "ns2.a.example.",
+        "ai.example.",
+        "b4um86eghhds6nea196smvmlo4ors995.example.",
+        "c.example.",
+        "ns1.c.example.",
+        "ns2.c.example.",
+        "gjeqe526plbf1g8mklp59enfd789njgi.example.",
+        "ji6neoaepv8b5o6k4ev33abha8ht9fgc.example.",
+        "k8udemvp1j2f7eg6jebps17vp3n8i58h.example.",
+        "kohar7mbb8dc2ce8a9qvl8hon4k53uhi.example.",
+        "ns1.example.",
+        "ns2.example.",
+        "q04jkcevqvmu85r014c7dkba38o0ji5r.example.",
+        "r53bq7cc2uvmubfu5ocmm6pers9tk9en.example.",
+        "t644ebqk9bibcna874givr6joj62mlhv.example.",
+        "*.w.example.",
+        "x.w.example.",
+        "x.y.w.example.",
+        "xx.example.",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect::<HashSet<_>>();
+
+    assert_eq!(
+        names,
+        expected,
+        "differences: {:?} {:?}",
+        names.difference(&expected),
+        expected.difference(&names)
+    );
+
+    Ok(())
+}
+
+/// Based on RFC 5155 section B.1.
+#[test]
+fn name_error() -> Result<(), Error> {
+    let network = Network::new()?;
+    let leaf_ns = build_zone(&network)?;
+    let original_response = test_record_removal_validation_failure(
+        vec![leaf_ns],
+        Vec::new(),
+        FQDN("a.c.x.w.example.")?,
+        RecordType::A,
+        &[
+            // Covers "next closer" name.
+            (
+                FQDN("0p9mhaveqvm6t7vbl5lop2u3t2rp3tom.example.")?,
+                RecordType::NSEC3,
+            ),
+            // Matches closest encloser.
+            (
+                FQDN("b4um86eghhds6nea196smvmlo4ors995.example.")?,
+                RecordType::NSEC3,
+            ),
+            // Covers wildcard at closest encloser.
+            (
+                FQDN("35mthgpgcu1qg68fab165klnsnk3dpvl.example.")?,
+                RecordType::NSEC3,
+            ),
+        ],
+        &network,
+    )?;
+    assert_eq!(original_response.status, DigStatus::NXDOMAIN);
+    Ok(())
+}
+
+/// Based on RFC 5155 section B.2.
+#[test]
+fn no_data_error() -> Result<(), Error> {
+    let network = Network::new()?;
+    let leaf_ns = build_zone(&network)?;
+    let original_response = test_record_removal_validation_failure(
+        vec![leaf_ns],
+        Vec::new(),
+        FQDN("ns1.example.")?,
+        RecordType::MX,
+        &[
+            // Matches query.
+            (
+                FQDN("2t7b4g4vsa5smi47k61mv5bv1a22bojr.example.")?,
+                RecordType::NSEC3,
+            ),
+        ],
+        &network,
+    )?;
+    assert_eq!(original_response.status, DigStatus::NOERROR);
+    Ok(())
+}
+
+/// Based on RFC 5155 section B.2.1.
+#[test]
+fn no_data_error_empty_non_terminal() -> Result<(), Error> {
+    let network = Network::new()?;
+    let leaf_ns = build_zone(&network)?;
+    let original_response = test_record_removal_validation_failure(
+        vec![leaf_ns],
+        Vec::new(),
+        FQDN("y.w.example.")?,
+        RecordType::A,
+        &[
+            // Matches query.
+            (
+                FQDN("ji6neoaepv8b5o6k4ev33abha8ht9fgc.example.")?,
+                RecordType::NSEC3,
+            ),
+        ],
+        &network,
+    )?;
+    assert_eq!(original_response.status, DigStatus::NOERROR);
+    assert!(original_response.answer.is_empty());
+    Ok(())
+}
+
+/// Based on RFC 5155 section B.4.
+#[test]
+#[ignore = "hickory recursor does not include NSEC3 records proving wildcard expansion"]
+fn wildcard_expansion() -> Result<(), Error> {
+    let network = Network::new()?;
+    let leaf_ns = build_zone(&network)?;
+    let original_response = test_record_removal_validation_failure(
+        vec![leaf_ns],
+        Vec::new(),
+        FQDN("a.z.w.example.")?,
+        RecordType::MX,
+        &[
+            // Covers "next closer" name.
+            (
+                FQDN("q04jkcevqvmu85r014c7dkba38o0ji5r.example.")?,
+                RecordType::NSEC3,
+            ),
+        ],
+        &network,
+    )?;
+    assert_eq!(original_response.status, DigStatus::NOERROR);
+    assert!(!original_response.answer.is_empty());
+    Ok(())
+}
+
+/// Based on RFC 5155 section B.5.
+#[test]
+fn wildcard_no_data_error() -> Result<(), Error> {
+    let network = Network::new()?;
+    let leaf_ns = build_zone(&network)?;
+    let original_response = test_record_removal_validation_failure(
+        vec![leaf_ns],
+        Vec::new(),
+        FQDN("a.z.w.example.")?,
+        RecordType::AAAA,
+        &[
+            // Matches closest encloser.
+            (
+                FQDN("k8udemvp1j2f7eg6jebps17vp3n8i58h.example.")?,
+                RecordType::NSEC3,
+            ),
+            // Covers "next closer" name.
+            (
+                FQDN("q04jkcevqvmu85r014c7dkba38o0ji5r.example.")?,
+                RecordType::NSEC3,
+            ),
+            // Matches wildcard at closest encloser.
+            //
+            // Excluding this record doesn't cause validation failures with any
+            // server for unknown reasons.
+            // (
+            //     FQDN("r53bq7cc2uvmubfu5ocmm6pers9tk9en.example.")?,
+            //     RecordType::NSEC3,
+            // ),
+        ],
+        &network,
+    )?;
+    assert_eq!(original_response.status, DigStatus::NOERROR);
+    assert!(original_response.answer.is_empty());
+    Ok(())
+}
+
+/// Construct a name server with a zone similar to that in RFC 5155 Appendix A.
+fn build_zone(network: &Network) -> Result<NameServer<Signed>, Error> {
+    let mut ns = NameServer::builder(PEER.clone(), FQDN("example.")?, network.clone())
+        .nameserver_fqdn(FQDN("ns1.example.")?)
+        .rname_fqdn(FQDN("admin.nameservers.net.")?)
+        .build()?;
+    // Remove NS and A record automatically added when building server.
+    ns.zone_file_mut().records.clear();
+
+    ns.zone_file_mut().soa = SOA {
+        zone: FQDN("example.")?,
+        ttl: 3600,
+        nameserver: FQDN("ns1.example.")?,
+        admin: FQDN("bugs.x.w.example.")?,
+        settings: SoaSettings {
+            serial: 0,
+            refresh: 3600,
+            retry: 300,
+            expire: 3600000,
+            minimum: 3600,
+        },
+    };
+
+    ns.add(NSEC3PARAM {
+        zone: FQDN("example.")?,
+        ttl: 3600,
+        hash_alg: 1,
+        flags: 0,
+        iterations: 12,
+        salt: b"\xaa\xbb\xcc\xdd".to_vec(),
+    });
+    ns.add(NS {
+        zone: FQDN("example.")?,
+        ttl: 3600,
+        nameserver: FQDN("ns1.example.")?,
+    });
+    ns.add(NS {
+        zone: FQDN("example.")?,
+        ttl: 3600,
+        nameserver: FQDN("ns2.example.")?,
+    });
+    ns.add(MX {
+        fqdn: FQDN("example.")?,
+        ttl: 3600,
+        preference: 1,
+        exchange: FQDN("xx.example.")?,
+    });
+    ns.add(A {
+        fqdn: FQDN("2t7b4g4vsa5smi47k61mv5bv1a22bojr.example.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 127),
+    });
+    ns.add(NS {
+        zone: FQDN("a.example.")?,
+        ttl: 3600,
+        nameserver: FQDN("ns1.a.example.")?,
+    });
+    ns.add(NS {
+        zone: FQDN("a.example.")?,
+        ttl: 3600,
+        nameserver: FQDN("ns2.a.example.")?,
+    });
+    ns.add(DS {
+        zone: FQDN("a.example.")?,
+        ttl: 3600,
+        key_tag: 58470,
+        algorithm: 5,
+        digest_type: 1,
+        digest: "3079F1593EBAD6DC121E202A8B766A6A4837206C".to_owned(),
+    });
+    ns.add(A {
+        fqdn: FQDN("ns1.a.example.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 5),
+    });
+    ns.add(A {
+        fqdn: FQDN("ns2.a.example.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 6),
+    });
+    ns.add(A {
+        fqdn: FQDN("ai.example.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 9),
+    });
+    ns.add(HINFO {
+        fqdn: FQDN("ai.example.")?,
+        ttl: 3600,
+        cpu: "KLH-10".to_owned(),
+        os: "ITS".to_owned(),
+    });
+    ns.add(AAAA {
+        fqdn: FQDN("ai.example.")?,
+        ttl: 3600,
+        ipv6_addr: Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0xf00, 0xbaa9),
+    });
+    ns.add(NS {
+        zone: FQDN("c.example.")?,
+        ttl: 3600,
+        nameserver: FQDN("ns1.c.example.")?,
+    });
+    ns.add(NS {
+        zone: FQDN("c.example.")?,
+        ttl: 3600,
+        nameserver: FQDN("ns2.c.example.")?,
+    });
+    ns.add(A {
+        fqdn: FQDN("ns1.c.example.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 7),
+    });
+    ns.add(A {
+        fqdn: FQDN("ns2.c.example.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 8),
+    });
+    ns.add(A {
+        fqdn: FQDN("ns1.example.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 1),
+    });
+    ns.add(A {
+        fqdn: FQDN("ns2.example.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 2),
+    });
+    ns.add(MX {
+        fqdn: FQDN("*.w.example.")?,
+        ttl: 3600,
+        preference: 1,
+        exchange: FQDN("ai.example.")?,
+    });
+    ns.add(MX {
+        fqdn: FQDN("x.w.example.")?,
+        ttl: 3600,
+        preference: 1,
+        exchange: FQDN("xx.example.")?,
+    });
+    ns.add(MX {
+        fqdn: FQDN("x.y.w.example.")?,
+        ttl: 3600,
+        preference: 1,
+        exchange: FQDN("xx.example.")?,
+    });
+    ns.add(A {
+        fqdn: FQDN("xx.example.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 10),
+    });
+    ns.add(HINFO {
+        fqdn: FQDN("xx.example.")?,
+        ttl: 3600,
+        cpu: "KLH-10".to_owned(),
+        os: "TOPS-20".to_owned(),
+    });
+    ns.add(AAAA {
+        fqdn: FQDN("xx.example.")?,
+        ttl: 3600,
+        ipv6_addr: Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0xf00, 0xbaaa),
+    });
+
+    let sign_settings =
+        SignSettings::ecdsap256sha256_nsec3_optout().nsec(dns_test::zone_file::Nsec::_3 {
+            iterations: 12,
+            opt_out: true,
+            salt: Some("aabbccdd".to_owned()),
+        });
+    let ns = ns.sign(sign_settings)?;
+    Ok(ns)
+}

--- a/conformance/conformance-tests/src/resolver/dnssec/missing_records/rfc_7129_section_5_4.rs
+++ b/conformance/conformance-tests/src/resolver/dnssec/missing_records/rfc_7129_section_5_4.rs
@@ -1,0 +1,129 @@
+use std::net::Ipv4Addr;
+
+use dns_test::{
+    Error, FQDN, Network, PEER, SUBJECT,
+    name_server::{NameServer, Signed},
+    record::{A, CNAME, Record, RecordType, TXT},
+    zone_file::{Nsec, SignSettings},
+};
+
+use crate::resolver::dnssec::missing_records::test_record_removal_validation_failure;
+
+#[test]
+#[ignore = "hickory does not include all NSEC records from CNAME chasing"]
+fn wildcard_cname() -> Result<(), Error> {
+    if SUBJECT.is_unbound() {
+        // Excluding NSEC records from this response doesn't cause failures in Unbound. The RFCs are
+        // not clear on what responses should be treated as valid or bogus, especially when CNAME
+        // records are involved.
+        //
+        // For example, note that an authoritative server's response would typically only include a
+        // CNAME record, and not any records at the CNAME record's target name, while most recursive
+        // resolvers will perform CNAME chasing, and include records at the target name.
+        //
+        // When responses in this test have certain NSEC records excluded, the response could be
+        // viewed as a resolver response that stopped CNAME chasing early, plus some additional
+        // records that have a valid RRSIG, but no valid wildcard proof. It is not clear from the
+        // response itself what intent the server had regarding how many steps of CNAME chasing to
+        // perform, and whether the response's response code reflects the presence of a CNAME
+        // record, or the presence of the ultimate A record at the end of the CNAME chain. It is
+        // also not clear whether the presence of "extra" records in a response should cause a
+        // SERVFAIL response if they are bogus, if they lack a wildcard proof, or if they are in
+        // different sections of the response.
+        return Ok(());
+    }
+
+    let network = Network::new()?;
+    let leaf_ns = build_zone(&network)?;
+    let original_response = test_record_removal_validation_failure(
+        vec![leaf_ns],
+        Vec::new(),
+        FQDN("w.hickory-dns.testing.")?,
+        RecordType::A,
+        &[
+            (FQDN("*.a.hickory-dns.testing.")?, RecordType::NSEC),
+            (FQDN("*.b.hickory-dns.testing.")?, RecordType::NSEC),
+            (FQDN("*.c.hickory-dns.testing.")?, RecordType::NSEC),
+        ],
+        &network,
+    )?;
+    assert!(
+        original_response
+            .answer
+            .iter()
+            .any(|record| matches!(record, Record::A(_)))
+    );
+    assert!(original_response.answer.iter().any(|record| {
+        let Record::CNAME(cname) = record else {
+            return false;
+        };
+        cname.fqdn.as_str() == "w.hickory-dns.testing."
+    }));
+    assert!(original_response.answer.iter().any(|record| {
+        let Record::CNAME(cname) = record else {
+            return false;
+        };
+        cname.fqdn.as_str() == "w.a.hickory-dns.testing."
+    }));
+    assert!(original_response.answer.iter().any(|record| {
+        let Record::CNAME(cname) = record else {
+            return false;
+        };
+        cname.fqdn.as_str() == "w.b.hickory-dns.testing."
+    }));
+    Ok(())
+}
+
+/// Construct a name server with a zone similar to that described in RFC 7129 section 5.4.
+fn build_zone(network: &Network) -> Result<NameServer<Signed>, Error> {
+    let mut ns = NameServer::new(&PEER, FQDN::TEST_DOMAIN, network)?;
+    ns.add(TXT {
+        fqdn: FQDN("*.hickory-dns.testing.")?,
+        ttl: 3600,
+        character_strings: vec!["wildcard record".to_string()],
+    });
+    ns.add(A {
+        fqdn: FQDN("a.hickory-dns.testing.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 1),
+    });
+    ns.add(TXT {
+        fqdn: FQDN("a.hickory-dns.testing.")?,
+        ttl: 3600,
+        character_strings: vec!["a record".to_string()],
+    });
+    ns.add(CNAME {
+        fqdn: FQDN("*.a.hickory-dns.testing.")?,
+        ttl: 3600,
+        target: FQDN("w.b.hickory-dns.testing.")?,
+    });
+    ns.add(CNAME {
+        fqdn: FQDN("*.b.hickory-dns.testing.")?,
+        ttl: 3600,
+        target: FQDN("w.c.hickory-dns.testing.")?,
+    });
+    ns.add(A {
+        fqdn: FQDN("*.c.hickory-dns.testing.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 1),
+    });
+    ns.add(A {
+        fqdn: FQDN("d.hickory-dns.testing.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 0, 2, 1),
+    });
+    ns.add(TXT {
+        fqdn: FQDN("d.hickory-dns.testing.")?,
+        ttl: 3600,
+        character_strings: vec!["d record".to_string()],
+    });
+    ns.add(CNAME {
+        fqdn: FQDN("w.hickory-dns.testing.")?,
+        ttl: 3600,
+        target: FQDN("w.a.hickory-dns.testing.")?,
+    });
+
+    let ns = ns.sign(SignSettings::default().nsec(Nsec::_1))?;
+
+    Ok(ns)
+}

--- a/conformance/conformance-tests/src/resolver/dnssec/scenarios/no_soa.rs
+++ b/conformance/conformance-tests/src/resolver/dnssec/scenarios/no_soa.rs
@@ -14,7 +14,7 @@ fn no_soa_insecure() -> Result<(), Error> {
 
     let mut root_ns = NameServer::new(&PEER, FQDN::ROOT, &network)?;
     let leaf_ns = NameServer::new(
-        &Implementation::test_server("empty_response", "both"),
+        &Implementation::test_server("empty_response", Vec::new(), "both"),
         FQDN::TEST_TLD,
         &network,
     )?;

--- a/conformance/conformance-tests/src/resolver/dnssec/scenarios/nsec3/does_not_cover/mod.rs
+++ b/conformance/conformance-tests/src/resolver/dnssec/scenarios/nsec3/does_not_cover/mod.rs
@@ -14,7 +14,7 @@ fn does_not_cover() -> Result<(), Error> {
     let sign_settings = SignSettings::default();
 
     let mut leaf_ns = NameServer::new(
-        &Implementation::test_server("nsec3_nocover", "both"),
+        &Implementation::test_server("nsec3_nocover", Vec::new(), "both"),
         FQDN::TEST_DOMAIN,
         &network,
     )?;

--- a/conformance/dns-test/src/container.rs
+++ b/conformance/dns-test/src/container.rs
@@ -118,6 +118,7 @@ impl From<Implementation> for Image {
             Implementation::Pdns => Self::Pdns,
             Implementation::TestServer {
                 handler,
+                handler_args: _,
                 repo,
                 transport,
             } => Self::TestServer {

--- a/conformance/dns-test/src/implementation.rs
+++ b/conformance/dns-test/src/implementation.rs
@@ -333,7 +333,7 @@ impl Implementation {
             },
             Self::TestServer {
                 handler, transport, ..
-            } => &format!("test-server --handler {handler} --transport {transport}")[..],
+            } => &format!("test-server --transport {transport} {handler}")[..],
         };
 
         vec![

--- a/conformance/dns-test/src/implementation.rs
+++ b/conformance/dns-test/src/implementation.rs
@@ -76,6 +76,7 @@ pub enum Implementation {
     EdeDotCom,
     TestServer {
         handler: String,
+        handler_args: Vec<String>,
         repo: Repository<'static>,
         transport: String,
     },
@@ -102,10 +103,15 @@ impl Implementation {
     }
 
     /// Returns the latest dns-test local revision
-    pub fn test_server(handler: &'static str, transport: &'static str) -> Self {
+    pub fn test_server(
+        handler: &'static str,
+        handler_args: Vec<String>,
+        transport: &'static str,
+    ) -> Self {
         Self::TestServer {
             repo: Repository(crate::repo_root()),
             handler: String::from(handler),
+            handler_args,
             transport: String::from(transport),
         }
     }
@@ -332,8 +338,14 @@ impl Implementation {
                 Role::Resolver | Role::Forwarder => "unbound -d",
             },
             Self::TestServer {
-                handler, transport, ..
-            } => &format!("test-server --transport {transport} {handler}")[..],
+                handler,
+                handler_args,
+                transport,
+                ..
+            } => &format!(
+                "test-server --transport {transport} {handler} {}",
+                handler_args.join(" ")
+            )[..],
         };
 
         vec![

--- a/conformance/dns-test/src/name_server.rs
+++ b/conformance/dns-test/src/name_server.rs
@@ -173,6 +173,7 @@ impl Graph {
 pub struct NameServerBuilder {
     zone: FQDN,
     nameserver_fqdn: Option<FQDN>,
+    rname_fqdn: Option<FQDN>,
     implementation: Implementation,
     network: Network,
     pki: Option<Rc<Pki>>,
@@ -190,6 +191,7 @@ impl NameServerBuilder {
         let Self {
             zone,
             nameserver_fqdn,
+            rname_fqdn,
             implementation,
             network,
             pki,
@@ -197,7 +199,7 @@ impl NameServerBuilder {
 
         let ns_count = ns_count();
         let nameserver = nameserver_fqdn.unwrap_or_else(|| primary_ns(ns_count, &zone));
-        let admin = admin_ns(ns_count, &zone);
+        let admin = rname_fqdn.unwrap_or_else(|| admin_ns(ns_count, &zone));
 
         let image = implementation.clone().into();
         let container = Container::run(&image, &network)?;
@@ -229,6 +231,12 @@ impl NameServerBuilder {
     /// Override the FQDN of the name server.
     pub fn nameserver_fqdn(mut self, nameserver_fqdn: FQDN) -> Self {
         self.nameserver_fqdn = Some(nameserver_fqdn);
+        self
+    }
+
+    /// Override the mailbox of the person responsible for this zone.
+    pub fn rname_fqdn(mut self, rname_fqdn: FQDN) -> Self {
+        self.rname_fqdn = Some(rname_fqdn);
         self
     }
 
@@ -304,6 +312,7 @@ impl NameServer<Stopped> {
         NameServerBuilder {
             zone,
             nameserver_fqdn: None,
+            rname_fqdn: None,
             implementation,
             network,
             pki: None,

--- a/conformance/dns-test/src/name_server.rs
+++ b/conformance/dns-test/src/name_server.rs
@@ -724,6 +724,10 @@ impl<S> NameServer<S> {
         &self.zone_file
     }
 
+    pub fn zone_file_mut(&mut self) -> &mut ZoneFile {
+        &mut self.zone_file
+    }
+
     pub fn zone(&self) -> &FQDN {
         self.zone_file.origin()
     }

--- a/conformance/dns-test/src/record.rs
+++ b/conformance/dns-test/src/record.rs
@@ -14,7 +14,7 @@ const CLASS: &str = "IN"; // "internet"
 macro_rules! record_types {
     ($($variant:ident),*) => {
         #[allow(clippy::upper_case_acronyms)]
-        #[derive(Debug, PartialEq, Clone)]
+        #[derive(Debug, PartialEq, Clone, Copy)]
         pub enum RecordType {
             $($variant),*,
             Unknown(u16),
@@ -84,6 +84,12 @@ pub enum Record {
 impl From<NSEC3> for Record {
     fn from(v: NSEC3) -> Self {
         Self::NSEC3(v)
+    }
+}
+
+impl From<NSEC3PARAM> for Record {
+    fn from(v: NSEC3PARAM) -> Self {
+        Self::NSEC3PARAM(v)
     }
 }
 

--- a/conformance/dns-test/src/record.rs
+++ b/conformance/dns-test/src/record.rs
@@ -153,6 +153,12 @@ impl From<HINFO> for Record {
     }
 }
 
+impl From<TXT> for Record {
+    fn from(v: TXT) -> Self {
+        Self::TXT(v)
+    }
+}
+
 impl Record {
     pub fn as_rrsig_mut(&mut self) -> Option<&mut RRSIG> {
         if let Self::RRSIG(rrsig) = self {

--- a/conformance/dns-test/src/record.rs
+++ b/conformance/dns-test/src/record.rs
@@ -249,6 +249,50 @@ impl Record {
             _ => Err(self),
         }
     }
+
+    /// Returns the name of the resource record.
+    pub fn name(&self) -> &FQDN {
+        match self {
+            Self::A(a) => &a.fqdn,
+            Self::AAAA(aaaa) => &aaaa.fqdn,
+            Self::CAA(caa) => &caa.fqdn,
+            Self::CNAME(cname) => &cname.fqdn,
+            Self::DNSKEY(dnskey) => &dnskey.zone,
+            Self::DS(ds) => &ds.zone,
+            Self::NS(ns) => &ns.zone,
+            Self::NSEC(nsec) => &nsec.fqdn,
+            Self::NSEC3(nsec3) => &nsec3.fqdn,
+            Self::NSEC3PARAM(nsec3_param) => &nsec3_param.zone,
+            Self::RRSIG(rrsig) => &rrsig.fqdn,
+            Self::SOA(soa) => &soa.zone,
+            Self::TXT(txt) => &txt.fqdn,
+            Self::MX(mx) => &mx.fqdn,
+            Self::HINFO(hinfo) => &hinfo.fqdn,
+            Self::Unknown(unknown_rdata) => &unknown_rdata.fqdn,
+        }
+    }
+
+    /// Returns the record type of the resource record.
+    pub fn record_type(&self) -> RecordType {
+        match self {
+            Self::A(_) => RecordType::A,
+            Self::AAAA(_) => RecordType::AAAA,
+            Self::CAA(_) => RecordType::CAA,
+            Self::CNAME(_) => RecordType::CNAME,
+            Self::DNSKEY(_) => RecordType::DNSKEY,
+            Self::DS(_) => RecordType::DS,
+            Self::NS(_) => RecordType::NS,
+            Self::NSEC(_) => RecordType::NSEC,
+            Self::NSEC3(_) => RecordType::NSEC3,
+            Self::NSEC3PARAM(_) => RecordType::NSEC3PARAM,
+            Self::RRSIG(_) => RecordType::RRSIG,
+            Self::SOA(_) => RecordType::SOA,
+            Self::TXT(_) => RecordType::TXT,
+            Self::MX(_) => RecordType::MX,
+            Self::HINFO(_) => RecordType::HINFO,
+            Self::Unknown(unknown_rdata) => RecordType::Unknown(unknown_rdata.r#type),
+        }
+    }
 }
 
 impl FromStr for Record {

--- a/conformance/dns-test/src/record.rs
+++ b/conformance/dns-test/src/record.rs
@@ -4,7 +4,7 @@ use core::str::FromStr;
 use core::{array, fmt};
 use std::borrow::Cow;
 use std::fmt::Write;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::{any, mem};
 
 use crate::{DEFAULT_TTL, Error, FQDN};
@@ -57,13 +57,14 @@ macro_rules! record_types {
 }
 
 record_types!(
-    A, AAAA, CAA, CNAME, DNSKEY, DS, MX, NS, NSEC, NSEC3, NSEC3PARAM, RRSIG, SOA, TXT
+    A, AAAA, CAA, CNAME, DNSKEY, DS, MX, NS, NSEC, NSEC3, NSEC3PARAM, RRSIG, SOA, TXT, HINFO
 );
 
 #[derive(Debug, Clone)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum Record {
     A(A),
+    AAAA(AAAA),
     CAA(CAA),
     CNAME(CNAME),
     DNSKEY(DNSKEY),
@@ -75,6 +76,8 @@ pub enum Record {
     RRSIG(RRSIG),
     SOA(SOA),
     TXT(TXT),
+    MX(MX),
+    HINFO(HINFO),
     Unknown(UnknownRdata),
 }
 
@@ -102,6 +105,12 @@ impl From<A> for Record {
     }
 }
 
+impl From<AAAA> for Record {
+    fn from(v: AAAA) -> Self {
+        Self::AAAA(v)
+    }
+}
+
 impl From<CNAME> for Record {
     fn from(v: CNAME) -> Self {
         Self::CNAME(v)
@@ -123,6 +132,18 @@ impl From<RRSIG> for Record {
 impl From<SOA> for Record {
     fn from(v: SOA) -> Self {
         Self::SOA(v)
+    }
+}
+
+impl From<MX> for Record {
+    fn from(v: MX) -> Self {
+        Self::MX(v)
+    }
+}
+
+impl From<HINFO> for Record {
+    fn from(v: HINFO) -> Self {
+        Self::HINFO(v)
     }
 }
 
@@ -241,6 +262,7 @@ impl FromStr for Record {
 
         let record = match record_type {
             "A" => Self::A(input.parse()?),
+            "AAAA" => Self::AAAA(input.parse()?),
             "CAA" => Self::CAA(input.parse()?),
             "CNAME" => Self::CNAME(input.parse()?),
             "DNSKEY" => Self::DNSKEY(input.parse()?),
@@ -252,6 +274,8 @@ impl FromStr for Record {
             "RRSIG" => Self::RRSIG(input.parse()?),
             "SOA" => Self::SOA(input.parse()?),
             "TXT" => Self::TXT(input.parse()?),
+            "MX" => Self::MX(input.parse()?),
+            "HINFO" => Self::HINFO(input.parse()?),
             _ => {
                 if record_type.starts_with("TYPE") {
                     Self::Unknown(input.parse()?)
@@ -269,6 +293,7 @@ impl fmt::Display for Record {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::A(a) => write!(f, "{a}"),
+            Self::AAAA(aaaa) => write!(f, "{aaaa}"),
             Self::CAA(caa) => write!(f, "{caa}"),
             Self::CNAME(cname) => write!(f, "{cname}"),
             Self::DS(ds) => write!(f, "{ds}"),
@@ -280,6 +305,8 @@ impl fmt::Display for Record {
             Self::RRSIG(rrsig) => write!(f, "{rrsig}"),
             Self::SOA(soa) => write!(f, "{soa}"),
             Self::TXT(txt) => write!(f, "{txt}"),
+            Self::MX(mx) => write!(f, "{mx}"),
+            Self::HINFO(hinfo) => write!(f, "{hinfo}"),
             Self::Unknown(other) => write!(f, "{other}"),
         }
     }
@@ -331,6 +358,55 @@ impl fmt::Display for A {
 
         let record_type = unqualified_type_name::<Self>();
         write!(f, "{fqdn}\t{ttl}\t{CLASS}\t{record_type}\t{ipv4_addr}")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AAAA {
+    pub fqdn: FQDN,
+    pub ttl: u32,
+    pub ipv6_addr: Ipv6Addr,
+}
+
+impl FromStr for AAAA {
+    type Err = Error;
+
+    fn from_str(input: &str) -> Result<Self, Error> {
+        let mut columns = input.split_whitespace();
+
+        let [
+            Some(fqdn),
+            Some(ttl),
+            Some(class),
+            Some(record_type),
+            Some(ipv6_addr),
+            None,
+        ] = array::from_fn(|_| columns.next())
+        else {
+            return Err("expected 5 columns".into());
+        };
+
+        check_record_type::<Self>(record_type)?;
+        check_class(class)?;
+
+        Ok(Self {
+            fqdn: fqdn.parse()?,
+            ttl: ttl.parse()?,
+            ipv6_addr: ipv6_addr.parse()?,
+        })
+    }
+}
+
+impl fmt::Display for AAAA {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            fqdn,
+            ttl,
+            ipv6_addr,
+        } = self;
+
+        let record_type = unqualified_type_name::<Self>();
+        write!(f, "{fqdn}\t{ttl}\t{CLASS}\t{record_type}\t{ipv6_addr}")
     }
 }
 
@@ -1260,6 +1336,112 @@ impl fmt::Display for CAA {
     }
 }
 
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Debug, Clone)]
+pub struct MX {
+    pub fqdn: FQDN,
+    pub ttl: u32,
+    pub preference: u16,
+    pub exchange: FQDN,
+}
+
+impl FromStr for MX {
+    type Err = Error;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let mut columns = input.split_whitespace();
+
+        let [
+            Some(fqdn),
+            Some(ttl),
+            Some(class),
+            Some(record_type),
+            Some(preference),
+            Some(exchange),
+            None,
+        ] = array::from_fn(|_| columns.next())
+        else {
+            return Err("expected 6 columns".into());
+        };
+
+        check_record_type::<Self>(record_type)?;
+        check_class(class)?;
+
+        Ok(Self {
+            fqdn: fqdn.parse()?,
+            ttl: ttl.parse()?,
+            preference: preference.parse()?,
+            exchange: exchange.parse()?,
+        })
+    }
+}
+
+impl fmt::Display for MX {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            fqdn,
+            ttl,
+            preference,
+            exchange,
+        } = self;
+
+        let record_type = unqualified_type_name::<Self>();
+        write!(
+            f,
+            "{fqdn}\t{ttl}\t{CLASS}\t{record_type}\t{preference} {exchange}"
+        )
+    }
+}
+
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Debug, Clone)]
+pub struct HINFO {
+    pub fqdn: FQDN,
+    pub ttl: u32,
+    pub cpu: String,
+    pub os: String,
+}
+
+impl FromStr for HINFO {
+    type Err = Error;
+
+    fn from_str(input: &str) -> Result<Self, Error> {
+        let mut columns = input.split_whitespace();
+
+        let [
+            Some(fqdn),
+            Some(ttl),
+            Some(class),
+            Some(record_type),
+            Some(cpu),
+            Some(os),
+            None,
+        ] = array::from_fn(|_| columns.next())
+        else {
+            return Err("expected 6 columns".into());
+        };
+
+        check_record_type::<Self>(record_type)?;
+        check_class(class)?;
+
+        Ok(Self {
+            fqdn: fqdn.parse()?,
+            ttl: ttl.parse()?,
+            cpu: cpu.to_owned(),
+            os: os.to_owned(),
+        })
+    }
+}
+
+impl fmt::Display for HINFO {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self { fqdn, ttl, cpu, os } = self;
+
+        let record_type = unqualified_type_name::<Self>();
+        write!(f, "{fqdn}\t{ttl}\t{CLASS}\t{record_type}\t{cpu} {os}")
+    }
+}
+
 /// A record of unknown type.
 #[derive(Debug, Clone)]
 pub struct UnknownRdata {
@@ -1394,6 +1576,29 @@ mod tests {
 
         let output = a.to_string();
         assert_eq!(A_INPUT, output);
+
+        Ok(())
+    }
+
+    const AAAA_INPUT: &str = "a.root-servers.net.	586327	IN	AAAA	2001:503:ba3e::2:30";
+
+    #[test]
+    fn aaaa() -> Result<(), Error> {
+        let aaaa @ AAAA {
+            fqdn,
+            ttl,
+            ipv6_addr,
+        } = &AAAA_INPUT.parse()?;
+
+        assert_eq!("a.root-servers.net.", fqdn.as_str());
+        assert_eq!(586327, *ttl);
+        assert_eq!(
+            Ipv6Addr::new(0x2001, 0x503, 0xba3e, 0, 0, 0, 2, 0x30),
+            *ipv6_addr
+        );
+
+        let output = aaaa.to_string();
+        assert_eq!(AAAA_INPUT, output);
 
         Ok(())
     }
@@ -1743,6 +1948,23 @@ mod tests {
         Ok(())
     }
 
+    const HINFO_INPUT: &str = "ai.example.	0	IN	HINFO	KLH-10 ITS";
+
+    #[test]
+    fn hinfo() -> Result<(), Error> {
+        let hinfo: HINFO = HINFO_INPUT.parse()?;
+
+        assert_eq!("ai.example.", hinfo.fqdn.as_str());
+        assert_eq!(0, hinfo.ttl);
+        assert_eq!("KLH-10", hinfo.cpu);
+        assert_eq!("ITS", hinfo.os);
+
+        let output = hinfo.to_string();
+        assert_eq!(HINFO_INPUT, output);
+
+        Ok(())
+    }
+
     const CAA_INPUT: &str = "certs.example.com.	86400	IN	CAA	0 issue ca1.example.net";
 
     #[test]
@@ -1767,9 +1989,32 @@ mod tests {
         Ok(())
     }
 
+    const MX_INPUT: &str = "ietf.org.	60	IN	MX	0 mail2.ietf.org.";
+
+    #[test]
+    fn mx() -> Result<(), Error> {
+        let mx @ MX {
+            fqdn,
+            ttl,
+            preference,
+            exchange,
+        } = &MX_INPUT.parse()?;
+
+        assert_eq!(FQDN("ietf.org.").unwrap(), *fqdn);
+        assert_eq!(60, *ttl);
+        assert_eq!(0, *preference);
+        assert_eq!(FQDN("mail2.ietf.org.").unwrap(), *exchange);
+
+        let output = mx.to_string();
+        assert_eq!(MX_INPUT, output);
+
+        Ok(())
+    }
+
     #[test]
     fn any() -> Result<(), Error> {
         assert!(matches!(A_INPUT.parse()?, Record::A(..)));
+        assert!(matches!(AAAA_INPUT.parse()?, Record::AAAA(..)));
         assert!(matches!(CAA_INPUT.parse()?, Record::CAA(..)));
         assert!(matches!(DNSKEY_INPUT.parse()?, Record::DNSKEY(..)));
         assert!(matches!(DS_INPUT.parse()?, Record::DS(..)));
@@ -1780,6 +2025,8 @@ mod tests {
         assert!(matches!(RRSIG_INPUT.parse()?, Record::RRSIG(..)));
         assert!(matches!(SOA_INPUT.parse()?, Record::SOA(..)));
         assert!(matches!(TXT_INPUT.parse()?, Record::TXT(..)));
+        assert!(matches!(HINFO_INPUT.parse()?, Record::HINFO(..)));
+        assert!(matches!(MX_INPUT.parse()?, Record::MX(..)));
 
         Ok(())
     }

--- a/conformance/dns-test/src/record.rs
+++ b/conformance/dns-test/src/record.rs
@@ -923,6 +923,7 @@ pub struct NSEC3PARAM {
     pub hash_alg: u8,
     pub flags: u8,
     pub iterations: u16,
+    pub salt: Vec<u8>,
 }
 
 impl FromStr for NSEC3PARAM {
@@ -939,7 +940,7 @@ impl FromStr for NSEC3PARAM {
             Some(hash_alg),
             Some(flags),
             Some(iterations),
-            Some(dash),
+            Some(salt_or_dash),
             None,
         ] = array::from_fn(|_| columns.next())
         else {
@@ -949,9 +950,11 @@ impl FromStr for NSEC3PARAM {
         check_record_type::<Self>(record_type)?;
         check_class(class)?;
 
-        if dash != "-" {
-            todo!("salt is not implemented")
-        }
+        let salt = if salt_or_dash == "-" {
+            Vec::new()
+        } else {
+            hex::decode(salt_or_dash)?
+        };
 
         Ok(Self {
             zone: zone.parse()?,
@@ -959,6 +962,7 @@ impl FromStr for NSEC3PARAM {
             hash_alg: hash_alg.parse()?,
             flags: flags.parse()?,
             iterations: iterations.parse()?,
+            salt,
         })
     }
 }
@@ -971,13 +975,19 @@ impl fmt::Display for NSEC3PARAM {
             hash_alg,
             flags,
             iterations,
+            salt,
         } = self;
 
         let record_type = unqualified_type_name::<Self>();
         write!(
             f,
-            "{zone}\t{ttl}\t{CLASS}\t{record_type}\t{hash_alg} {flags} {iterations} -"
-        )
+            "{zone}\t{ttl}\t{CLASS}\t{record_type}\t{hash_alg} {flags} {iterations} "
+        )?;
+        if salt.is_empty() {
+            f.write_str("-")
+        } else {
+            write!(f, "{}", hex::encode(salt))
+        }
     }
 }
 
@@ -1896,6 +1906,7 @@ mod tests {
             hash_alg,
             flags,
             iterations,
+            salt,
         } = &NSEC3PARAM_INPUT.parse()?;
 
         assert_eq!(FQDN("com.")?, *zone);
@@ -1903,9 +1914,34 @@ mod tests {
         assert_eq!(1, *hash_alg);
         assert_eq!(0, *flags);
         assert_eq!(0, *iterations);
+        assert_eq!(b"".as_slice(), salt);
 
         let output = nsec3param.to_string();
         assert_eq!(NSEC3PARAM_INPUT, output);
+
+        Ok(())
+    }
+
+    #[test]
+    fn nsec3param_salt() -> Result<(), Error> {
+        let input = "com.	86238	IN	NSEC3PARAM	1 0 0 aabbccdd";
+        let nsec3param @ NSEC3PARAM {
+            zone,
+            ttl,
+            hash_alg,
+            flags,
+            iterations,
+            salt,
+        } = &input.parse()?;
+
+        assert_eq!(FQDN("com.")?, *zone);
+        assert_eq!(86238, *ttl);
+        assert_eq!(1, *hash_alg);
+        assert_eq!(0, *flags);
+        assert_eq!(0, *iterations);
+        assert_eq!(b"\xaa\xbb\xcc\xdd".as_slice(), salt);
+
+        assert_eq!(input, nsec3param.to_string());
 
         Ok(())
     }

--- a/conformance/dns-test/src/zone_file/signer.rs
+++ b/conformance/dns-test/src/zone_file/signer.rs
@@ -396,11 +396,11 @@ impl<'a> Signer<'a> {
                     opt_out,
                 } = &self.settings.nsec
                 {
-                    args.push("-3".to_string());
-
                     if *iterations > 0 {
                         args.push(format!("-H {iterations}"));
                     }
+
+                    args.push("-3".to_string());
 
                     if let Some(salt) = salt {
                         args.push(salt.to_string());

--- a/conformance/dns-test/src/zone_file/signer.rs
+++ b/conformance/dns-test/src/zone_file/signer.rs
@@ -68,6 +68,10 @@ impl SignSettings {
         }
     }
 
+    /// Signs the zone with RSASHA256 and NSEC3. Includes support for NSEC3 opt-out.
+    ///
+    /// Since `ldns-signzone` does not properly handle the NSEC3 opt-out flag, this configuration
+    /// uses `dnssec-signzone` instead.
     pub fn rsasha256_nsec3_optout() -> Self {
         Self {
             algorithm: Algorithm::RSASHA256,
@@ -107,6 +111,26 @@ impl SignSettings {
             inception: None,
             nsec: Nsec::default(),
             implementation: Implementation::default(),
+        }
+    }
+
+    /// Signs the zone with ECDSAP256SHA256 and NSEC3. Includes support for NSEC3 opt-out.
+    ///
+    /// Since `ldns-signzone` does not properly handle the NSEC3 opt-out flag, this configuration
+    /// uses `dnssec-signzone` instead.
+    pub fn ecdsap256sha256_nsec3_optout() -> Self {
+        Self {
+            algorithm: Algorithm::ECDSAP256SHA256,
+            zsk_bits: None,
+            ksk_bits: None,
+            expiration: None,
+            inception: None,
+            nsec: Nsec::_3 {
+                iterations: 0,
+                salt: None,
+                opt_out: true,
+            },
+            implementation: Implementation::Bindutils,
         }
     }
 

--- a/conformance/e2e-tests/src/recursor/cname/scenarios.rs
+++ b/conformance/e2e-tests/src/recursor/cname/scenarios.rs
@@ -175,7 +175,7 @@ fn cname_lookup_limit_test() -> Result<(), Error> {
 
     let mut root_ns = NameServer::new(&Implementation::test_peer(), FQDN::ROOT, &network)?;
     let leaf_ns = NameServer::new(
-        &Implementation::test_server("cname_loop", "both"),
+        &Implementation::test_server("cname_loop", Vec::new(), "both"),
         FQDN::TEST_TLD,
         &network,
     )?;

--- a/conformance/e2e-tests/src/recursor/delegation/scenarios.rs
+++ b/conformance/e2e-tests/src/recursor/delegation/scenarios.rs
@@ -45,7 +45,7 @@ fn parent_ns_in_authority_does_not_prevent_resolution() -> Result<(), Error> {
     // Use the custom handler that returns parent NS records for subdomain NS
     // queries, mimicking twtrdns.net behavior.
     let example_ns = NameServer::new(
-        &Implementation::test_server("parent_ns_in_authority", "udp"),
+        &Implementation::test_server("parent_ns_in_authority", Vec::new(), "udp"),
         FQDN("example.testing.")?,
         &network,
     )?;

--- a/conformance/e2e-tests/src/recursor/security/scenarios.rs
+++ b/conformance/e2e-tests/src/recursor/security/scenarios.rs
@@ -18,7 +18,7 @@ fn tx_id_validation_test() -> Result<(), Error> {
 
     let mut root_ns = NameServer::new(&Implementation::test_peer(), FQDN::ROOT, &network)?;
     let leaf_ns = NameServer::new(
-        &Implementation::test_server("bad_txid", "udp"),
+        &Implementation::test_server("bad_txid", Vec::new(), "udp"),
         FQDN::TEST_TLD,
         &network,
     )?;
@@ -72,7 +72,7 @@ fn case_randomization_enabled() -> Result<(), Error> {
 
     let mut root_ns = NameServer::new(&Implementation::test_peer(), FQDN::ROOT, &network)?;
     let leaf_ns = NameServer::new(
-        &Implementation::test_server("bad_case", "udp"),
+        &Implementation::test_server("bad_case", Vec::new(), "udp"),
         FQDN::TEST_TLD,
         &network,
     )?;
@@ -129,7 +129,7 @@ fn case_randomization_disabled() -> Result<(), Error> {
 
     let mut root_ns = NameServer::new(&Implementation::test_peer(), FQDN::ROOT, &network)?;
     let leaf_ns = NameServer::new(
-        &Implementation::test_server("bad_case", "udp"),
+        &Implementation::test_server("bad_case", Vec::new(), "udp"),
         FQDN::TEST_TLD,
         &network,
     )?;
@@ -251,7 +251,7 @@ fn out_of_bailiwick_rejection() -> Result<(), Error> {
 
     let mut root_ns = NameServer::new(&Implementation::test_peer(), FQDN::ROOT, &network)?;
     let leaf_ns = NameServer::new(
-        &Implementation::test_server("bailiwick", "udp"),
+        &Implementation::test_server("bailiwick", Vec::new(), "udp"),
         FQDN::TEST_TLD.push_label("valid"),
         &network,
     )?;
@@ -321,7 +321,7 @@ fn cname_out_of_bailiwick_rejection() -> Result<(), Error> {
 
     let mut root_ns = NameServer::new(&Implementation::test_peer(), FQDN::ROOT, &network)?;
     let leaf_ns = NameServer::new(
-        &Implementation::test_server("bailiwick", "udp"),
+        &Implementation::test_server("bailiwick", Vec::new(), "udp"),
         FQDN::TEST_TLD.push_label("example"),
         &network,
     )?;
@@ -394,7 +394,7 @@ fn qr_validation_test_impl(handler: &'static str, proto: &'static str) -> Result
     let network = Network::new()?;
 
     let leaf_ns = NameServer::new(
-        &Implementation::test_server(handler, proto),
+        &Implementation::test_server(handler, Vec::new(), proto),
         FQDN::TEST_TLD,
         &network,
     )?;

--- a/conformance/test-server/Cargo.toml
+++ b/conformance/test-server/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
+async-trait = "0.1"
 base64 = "0.22"
 clap = { version = "4.0", features = ["derive", "std"] }
 data-encoding = "2.9"

--- a/conformance/test-server/src/handlers.rs
+++ b/conformance/test-server/src/handlers.rs
@@ -1,16 +1,25 @@
-use crate::{Transport, zone_file};
+use crate::{Handler, Transport, zone_file};
 use anyhow::{Context, Error, Result};
+use async_trait::async_trait;
 use data_encoding::BASE32_DNSSEC;
+use hickory_net::{
+    client::Client,
+    runtime::TokioRuntimeProvider,
+    tcp::TcpClientStream,
+    xfer::{DnsHandle, FirstAnswer},
+};
 use hickory_proto::{
     dnssec::{
         Nsec3HashAlgorithm,
-        rdata::{NSEC3, NSEC3PARAM, RRSIG},
+        rdata::{DNSSECRData, NSEC3, NSEC3PARAM, RRSIG},
     },
-    op::{Message, MessageType, ResponseCode},
+    op::{DnsRequest, DnsRequestOptions, Message, MessageType, ResponseCode},
     rr::{RData, Record, RecordType, domain::Name, rdata},
 };
 use std::{
     env,
+    net::IpAddr,
+    ops::DerefMut,
     path::Path,
     sync::atomic::{AtomicBool, AtomicU8, Ordering},
 };
@@ -626,6 +635,75 @@ pub(crate) fn qr_not_response_force_tcp_handler(
             .map(Some)
             .with_context(|| "qr_not_response_force_tcp handler: could not serialize Message")
         }
+    }
+}
+
+/// This handler proxies requests to another server, and drops a specific record set from responses.
+pub(crate) struct DropRrsetHandler {
+    ip_address: IpAddr,
+    name: Name,
+    record_type: RecordType,
+}
+
+impl DropRrsetHandler {
+    pub(crate) fn new(ip_address: IpAddr, name: Name, record_type: RecordType) -> Self {
+        Self {
+            ip_address,
+            name,
+            record_type,
+        }
+    }
+}
+
+#[async_trait]
+impl Handler for DropRrsetHandler {
+    async fn handle(&self, bytes: &[u8], _transport: Transport) -> Result<Option<Vec<u8>>> {
+        let (future, sender) = TcpClientStream::new(
+            (self.ip_address, 53).into(),
+            None,
+            None,
+            TokioRuntimeProvider::new(),
+        );
+        let (client, bg) = Client::<TokioRuntimeProvider>::new(future.await?, sender);
+        tokio::task::spawn(bg);
+
+        let query_message = Message::from_vec(bytes).context("error parsing query into message")?;
+        let query_request = DnsRequest::new(query_message, DnsRequestOptions::default());
+        let id = query_request.id;
+
+        let mut response = client
+            .send(query_request)
+            .first_answer()
+            .await
+            .context("error sending proxied query")?;
+
+        let Message {
+            answers,
+            authorities,
+            additionals,
+            ..
+        } = response.deref_mut();
+        for section in [answers, authorities, additionals] {
+            section.retain(|record| {
+                if record.name != self.name {
+                    return true;
+                }
+                if record.record_type() == self.record_type {
+                    return false;
+                }
+                if let RData::DNSSEC(DNSSECRData::RRSIG(rrsig)) = &record.data {
+                    if rrsig.input().type_covered == self.record_type {
+                        return false;
+                    }
+                }
+                true
+            });
+        }
+
+        response.metadata.id = id;
+        Ok(Some(
+            response.to_vec().context("error serializing response")?,
+        ))
     }
 }
 

--- a/conformance/test-server/src/main.rs
+++ b/conformance/test-server/src/main.rs
@@ -3,6 +3,7 @@ use std::{net::SocketAddr, sync::Arc};
 #[cfg(test)]
 use anyhow::Context;
 use anyhow::Result;
+use async_trait::async_trait;
 use clap::{Parser, Subcommand, ValueEnum};
 use futures::{StreamExt, future};
 use hickory_net::{DnsStreamHandle, runtime::iocompat::AsyncIoTokioAsStd, tcp::TcpStream};
@@ -16,19 +17,19 @@ mod zone_file;
 async fn main() -> Result<()> {
     let args = Args::parse();
     let transport = args.transport;
-    let handler: Arc<dyn HandlerFn> = match args.handler {
-        Handler::Bailiwick => Arc::new(handlers::bailiwick_handler),
-        Handler::Base => Arc::new(handlers::base_handler),
-        Handler::BadCase => Arc::new(handlers::bad_case_handler),
-        Handler::BadTxid => Arc::new(handlers::bad_txid_handler),
-        Handler::CnameLoop => Arc::new(handlers::cname_loop_handler),
-        Handler::EmptyResponse => Arc::new(handlers::empty_response_handler),
-        Handler::Nsec3Nocover => Arc::new(handlers::nsec3_nocover_handler),
-        Handler::ParentNsInAuthority => Arc::new(handlers::parent_ns_in_authority_handler),
-        Handler::PacketLoss => Arc::new(handlers::packet_loss_handler),
-        Handler::TruncatedResponse => Arc::new(handlers::truncated_response_handler),
-        Handler::QrNotResponse => Arc::new(handlers::qr_not_response_handler),
-        Handler::QrNotResponseForceTcp => Arc::new(handlers::qr_not_response_force_tcp_handler),
+    let handler: Arc<dyn Handler> = match args.handler {
+        HandlerArg::Bailiwick => Arc::new(handlers::bailiwick_handler),
+        HandlerArg::Base => Arc::new(handlers::base_handler),
+        HandlerArg::BadCase => Arc::new(handlers::bad_case_handler),
+        HandlerArg::BadTxid => Arc::new(handlers::bad_txid_handler),
+        HandlerArg::CnameLoop => Arc::new(handlers::cname_loop_handler),
+        HandlerArg::EmptyResponse => Arc::new(handlers::empty_response_handler),
+        HandlerArg::Nsec3Nocover => Arc::new(handlers::nsec3_nocover_handler),
+        HandlerArg::ParentNsInAuthority => Arc::new(handlers::parent_ns_in_authority_handler),
+        HandlerArg::PacketLoss => Arc::new(handlers::packet_loss_handler),
+        HandlerArg::TruncatedResponse => Arc::new(handlers::truncated_response_handler),
+        HandlerArg::QrNotResponse => Arc::new(handlers::qr_not_response_handler),
+        HandlerArg::QrNotResponseForceTcp => Arc::new(handlers::qr_not_response_force_tcp_handler),
     };
 
     let mut handles = vec![];
@@ -56,7 +57,7 @@ struct Args {
     #[clap(default_value = "both", long = "transport")]
     transport: TransportArg,
     #[clap(subcommand)]
-    handler: Handler,
+    handler: HandlerArg,
 }
 
 #[derive(Clone, PartialEq, Eq, ValueEnum)]
@@ -68,7 +69,7 @@ enum TransportArg {
 
 #[derive(Clone, Subcommand)]
 #[clap(rename_all = "snake_case")]
-enum Handler {
+enum HandlerArg {
     Bailiwick,
     Base,
     BadCase,
@@ -94,7 +95,7 @@ impl UdpServer {
         })
     }
 
-    async fn run(self, handler: Arc<dyn HandlerFn>) -> Result<()> {
+    async fn run(self, handler: Arc<dyn Handler>) -> Result<()> {
         loop {
             let mut read_buf = [0u8; 4096];
             let (len, to) = match self.udp.recv_from(&mut read_buf).await {
@@ -110,7 +111,7 @@ impl UdpServer {
                 Message::from_vec(&read_buf),
             );
 
-            match handler(&read_buf[0..len], Transport::Udp) {
+            match handler.handle(&read_buf[0..len], Transport::Udp).await {
                 Ok(Some(resp)) => {
                     println!(
                         "handler response to udp/{to}: {:?}",
@@ -149,7 +150,7 @@ impl TcpServer {
         })
     }
 
-    async fn run(self, handler: Arc<dyn HandlerFn>) -> Result<()> {
+    async fn run(self, handler: Arc<dyn Handler>) -> Result<()> {
         loop {
             let (stream, peer) = self.tcp.accept().await?;
             let handler = handler.clone();
@@ -163,7 +164,7 @@ impl TcpServer {
                         Message::from_vec(msg.bytes())
                     );
 
-                    let resp = match handler(msg.bytes(), Transport::Tcp) {
+                    let resp = match handler.handle(msg.bytes(), Transport::Tcp).await {
                         Ok(Some(resp)) => resp,
                         Ok(None) => {
                             println!("no response returned from handler for request from {peer}");
@@ -204,11 +205,19 @@ enum Transport {
     Udp,
 }
 
-trait HandlerFn: (Fn(&[u8], Transport) -> Result<Option<Vec<u8>>>) + Send + Sync + 'static {}
+#[async_trait]
+trait Handler: Send + Sync {
+    async fn handle(&self, bytes: &[u8], transport: Transport) -> Result<Option<Vec<u8>>>;
+}
 
-impl<T> HandlerFn for T where
-    T: (Fn(&[u8], Transport) -> Result<Option<Vec<u8>>>) + Send + Sync + 'static
+#[async_trait]
+impl<T> Handler for T
+where
+    T: (Fn(&[u8], Transport) -> Result<Option<Vec<u8>>>) + Send + Sync + 'static,
 {
+    async fn handle(&self, bytes: &[u8], transport: Transport) -> Result<Option<Vec<u8>>> {
+        self(bytes, transport)
+    }
 }
 
 #[cfg(test)]

--- a/conformance/test-server/src/main.rs
+++ b/conformance/test-server/src/main.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 #[cfg(test)]
 use anyhow::Context;
 use anyhow::Result;
-use clap::Parser;
+use clap::{Parser, Subcommand, ValueEnum};
 use futures::{StreamExt, future};
 use hickory_net::{DnsStreamHandle, runtime::iocompat::AsyncIoTokioAsStd, tcp::TcpStream};
 use hickory_proto::op::{Message, SerialMessage};
@@ -16,30 +16,27 @@ mod zone_file;
 async fn main() -> Result<()> {
     let args = Args::parse();
     let transport = args.transport;
-    let handler = match &args.handler[..] {
-        "bailiwick" => handlers::bailiwick_handler,
-        "base" => handlers::base_handler,
-        "bad_case" => handlers::bad_case_handler,
-        "bad_txid" => handlers::bad_txid_handler,
-        "cname_loop" => handlers::cname_loop_handler,
-        "empty_response" => handlers::empty_response_handler,
-        "nsec3_nocover" => handlers::nsec3_nocover_handler,
-        "parent_ns_in_authority" => handlers::parent_ns_in_authority_handler,
-        "packet_loss" => handlers::packet_loss_handler,
-        "truncated_response" => handlers::truncated_response_handler,
-        "qr_not_response" => handlers::qr_not_response_handler,
-        "qr_not_response_force_tcp" => handlers::qr_not_response_force_tcp_handler,
-        _ => {
-            return Err(anyhow::Error::msg("unknown handler"));
-        }
+    let handler = match args.handler {
+        Handler::Bailiwick => handlers::bailiwick_handler,
+        Handler::Base => handlers::base_handler,
+        Handler::BadCase => handlers::bad_case_handler,
+        Handler::BadTxid => handlers::bad_txid_handler,
+        Handler::CnameLoop => handlers::cname_loop_handler,
+        Handler::EmptyResponse => handlers::empty_response_handler,
+        Handler::Nsec3Nocover => handlers::nsec3_nocover_handler,
+        Handler::ParentNsInAuthority => handlers::parent_ns_in_authority_handler,
+        Handler::PacketLoss => handlers::packet_loss_handler,
+        Handler::TruncatedResponse => handlers::truncated_response_handler,
+        Handler::QrNotResponse => handlers::qr_not_response_handler,
+        Handler::QrNotResponseForceTcp => handlers::qr_not_response_force_tcp_handler,
     };
 
     let mut handles = vec![];
-    if transport == "tcp" || transport == "both" {
+    if transport == TransportArg::Tcp || transport == TransportArg::Both {
         let tcp = TcpServer::new(([0, 0, 0, 0], args.port).into()).await?;
         handles.push(tokio::task::spawn(async move { tcp.run(handler).await }));
     }
-    if transport == "udp" || transport == "both" {
+    if transport == TransportArg::Udp || transport == TransportArg::Both {
         let udp = UdpServer::new(([0, 0, 0, 0], args.port).into()).await?;
         handles.push(tokio::task::spawn(async move { udp.run(handler).await }));
     }
@@ -53,12 +50,36 @@ async fn main() -> Result<()> {
 #[derive(Parser)]
 #[clap(name = "Message responder test DNS server")]
 struct Args {
-    #[clap(default_value = "base", long = "handler")]
-    handler: String,
     #[clap(default_value = "53", long = "port")]
     port: u16,
     #[clap(default_value = "both", long = "transport")]
-    transport: String,
+    transport: TransportArg,
+    #[clap(subcommand)]
+    handler: Handler,
+}
+
+#[derive(Clone, PartialEq, Eq, ValueEnum)]
+enum TransportArg {
+    Tcp,
+    Udp,
+    Both,
+}
+
+#[derive(Clone, Subcommand)]
+#[clap(rename_all = "snake_case")]
+enum Handler {
+    Bailiwick,
+    Base,
+    BadCase,
+    BadTxid,
+    CnameLoop,
+    EmptyResponse,
+    Nsec3Nocover,
+    ParentNsInAuthority,
+    PacketLoss,
+    TruncatedResponse,
+    QrNotResponse,
+    QrNotResponseForceTcp,
 }
 
 struct UdpServer {

--- a/conformance/test-server/src/main.rs
+++ b/conformance/test-server/src/main.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::{net::SocketAddr, sync::Arc};
 
 #[cfg(test)]
 use anyhow::Context;
@@ -16,24 +16,25 @@ mod zone_file;
 async fn main() -> Result<()> {
     let args = Args::parse();
     let transport = args.transport;
-    let handler = match args.handler {
-        Handler::Bailiwick => handlers::bailiwick_handler,
-        Handler::Base => handlers::base_handler,
-        Handler::BadCase => handlers::bad_case_handler,
-        Handler::BadTxid => handlers::bad_txid_handler,
-        Handler::CnameLoop => handlers::cname_loop_handler,
-        Handler::EmptyResponse => handlers::empty_response_handler,
-        Handler::Nsec3Nocover => handlers::nsec3_nocover_handler,
-        Handler::ParentNsInAuthority => handlers::parent_ns_in_authority_handler,
-        Handler::PacketLoss => handlers::packet_loss_handler,
-        Handler::TruncatedResponse => handlers::truncated_response_handler,
-        Handler::QrNotResponse => handlers::qr_not_response_handler,
-        Handler::QrNotResponseForceTcp => handlers::qr_not_response_force_tcp_handler,
+    let handler: Arc<dyn HandlerFn> = match args.handler {
+        Handler::Bailiwick => Arc::new(handlers::bailiwick_handler),
+        Handler::Base => Arc::new(handlers::base_handler),
+        Handler::BadCase => Arc::new(handlers::bad_case_handler),
+        Handler::BadTxid => Arc::new(handlers::bad_txid_handler),
+        Handler::CnameLoop => Arc::new(handlers::cname_loop_handler),
+        Handler::EmptyResponse => Arc::new(handlers::empty_response_handler),
+        Handler::Nsec3Nocover => Arc::new(handlers::nsec3_nocover_handler),
+        Handler::ParentNsInAuthority => Arc::new(handlers::parent_ns_in_authority_handler),
+        Handler::PacketLoss => Arc::new(handlers::packet_loss_handler),
+        Handler::TruncatedResponse => Arc::new(handlers::truncated_response_handler),
+        Handler::QrNotResponse => Arc::new(handlers::qr_not_response_handler),
+        Handler::QrNotResponseForceTcp => Arc::new(handlers::qr_not_response_force_tcp_handler),
     };
 
     let mut handles = vec![];
     if transport == TransportArg::Tcp || transport == TransportArg::Both {
         let tcp = TcpServer::new(([0, 0, 0, 0], args.port).into()).await?;
+        let handler = handler.clone();
         handles.push(tokio::task::spawn(async move { tcp.run(handler).await }));
     }
     if transport == TransportArg::Udp || transport == TransportArg::Both {
@@ -93,7 +94,7 @@ impl UdpServer {
         })
     }
 
-    async fn run(self, handler: HandlerFn) -> Result<()> {
+    async fn run(self, handler: Arc<dyn HandlerFn>) -> Result<()> {
         loop {
             let mut read_buf = [0u8; 4096];
             let (len, to) = match self.udp.recv_from(&mut read_buf).await {
@@ -148,9 +149,10 @@ impl TcpServer {
         })
     }
 
-    async fn run(self, handler: HandlerFn) -> Result<()> {
+    async fn run(self, handler: Arc<dyn HandlerFn>) -> Result<()> {
         loop {
             let (stream, peer) = self.tcp.accept().await?;
+            let handler = handler.clone();
             tokio::task::spawn(async move {
                 let (mut stream, mut sender) =
                     TcpStream::from_stream(AsyncIoTokioAsStd(stream), peer);
@@ -202,13 +204,19 @@ enum Transport {
     Udp,
 }
 
-type HandlerFn = fn(&[u8], Transport) -> Result<Option<Vec<u8>>>;
+trait HandlerFn: (Fn(&[u8], Transport) -> Result<Option<Vec<u8>>>) + Send + Sync + 'static {}
+
+impl<T> HandlerFn for T where
+    T: (Fn(&[u8], Transport) -> Result<Option<Vec<u8>>>) + Send + Sync + 'static
+{
+}
 
 #[cfg(test)]
 mod test {
     use std::{
         net::{Ipv4Addr, Ipv6Addr, SocketAddr},
         str::FromStr,
+        sync::Arc,
     };
 
     use anyhow::Result;
@@ -246,7 +254,7 @@ mod test {
     async fn multiple_tcp_msg() -> Result<()> {
         let tcp = super::TcpServer::new((Ipv4Addr::LOCALHOST, 0).into()).await?;
         let tcp_peer = tcp.addr()?;
-        let _handle = tokio::task::spawn(tcp.run(base_handler));
+        let _handle = tokio::task::spawn(tcp.run(Arc::new(base_handler)));
 
         let (future, sender) =
             TcpClientStream::new(tcp_peer, None, None, TokioRuntimeProvider::new());
@@ -284,7 +292,7 @@ mod test {
             Transport::Tcp => {
                 let tcp = super::TcpServer::new(socket).await?;
                 let tcp_peer = tcp.addr()?;
-                let _handle = tokio::task::spawn(tcp.run(base_handler));
+                let _handle = tokio::task::spawn(tcp.run(Arc::new(base_handler)));
                 let (future, sender) =
                     TcpClientStream::new(tcp_peer, None, None, TokioRuntimeProvider::new());
                 let (client, bg) = Client::<TokioRuntimeProvider>::new(future.await?, sender);
@@ -294,7 +302,7 @@ mod test {
             Transport::Udp => {
                 let udp = super::UdpServer::new(socket).await?;
                 let udp_peer = udp.addr()?;
-                let _handle = tokio::task::spawn(udp.run(base_handler));
+                let _handle = tokio::task::spawn(udp.run(Arc::new(base_handler)));
                 let conn = UdpClientStream::builder(udp_peer, TokioRuntimeProvider::new()).build();
                 let (client, bg) = Client::from_sender(conn);
                 let _handle = tokio::task::spawn(bg);

--- a/conformance/test-server/src/main.rs
+++ b/conformance/test-server/src/main.rs
@@ -1,4 +1,7 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::{
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+};
 
 #[cfg(test)]
 use anyhow::Context;
@@ -7,7 +10,10 @@ use async_trait::async_trait;
 use clap::{Parser, Subcommand, ValueEnum};
 use futures::{StreamExt, future};
 use hickory_net::{DnsStreamHandle, runtime::iocompat::AsyncIoTokioAsStd, tcp::TcpStream};
-use hickory_proto::op::{Message, SerialMessage};
+use hickory_proto::{
+    op::{Message, SerialMessage},
+    rr::{Name, RecordType},
+};
 use tokio::net::{TcpListener, UdpSocket};
 
 mod handlers;
@@ -30,6 +36,15 @@ async fn main() -> Result<()> {
         HandlerArg::TruncatedResponse => Arc::new(handlers::truncated_response_handler),
         HandlerArg::QrNotResponse => Arc::new(handlers::qr_not_response_handler),
         HandlerArg::QrNotResponseForceTcp => Arc::new(handlers::qr_not_response_force_tcp_handler),
+        HandlerArg::DropRrset {
+            ip_address,
+            name,
+            record_type,
+        } => Arc::new(handlers::DropRrsetHandler::new(
+            ip_address,
+            name,
+            record_type,
+        )),
     };
 
     let mut handles = vec![];
@@ -82,6 +97,11 @@ enum HandlerArg {
     TruncatedResponse,
     QrNotResponse,
     QrNotResponseForceTcp,
+    DropRrset {
+        ip_address: IpAddr,
+        name: Name,
+        record_type: RecordType,
+    },
 }
 
 struct UdpServer {


### PR DESCRIPTION
This adds a `test-server` handler and conformance test utilities to check whether resolvers properly return SERVFAIL when critical DNSSEC records are excluded from responses. The new `test-server` handler acts as a proxy in front of each authoritative name server, filtering specific RRsets out of responses. With these servers, we assemble root zones and resolvers, and try repeating the same query, checking the response code. These tests are similar to the `invalid_nsec_tests` and `invalid_nsec3_tests` integration tests, but targeting our verifying resolver instead of our verifying client and authoritative server together.

Note that I had to comment out or skip certain parts of the tests I wrote, because they were failing with one or both of BIND and Unbound. I'm not sure what the right solution is for these cases, in part due to ambiguities in the RFCs.