### PR TITLE
Limit work expended on name compression

### DIFF
--- a/crates/proto/benches/lib.rs
+++ b/crates/proto/benches/lib.rs
@@ -6,7 +6,8 @@ extern crate test;
 use hickory_proto::op::{
     Header, HeaderCounts, Message, MessageType, Metadata, OpCode, ResponseCode,
 };
-use hickory_proto::rr::{Name, Record, RecordType};
+use hickory_proto::rr::rdata::PTR;
+use hickory_proto::rr::{Name, RData, Record, RecordType};
 use hickory_proto::serialize::binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder};
 
 use test::Bencher;
@@ -91,6 +92,31 @@ fn bench_emit_message_no_reservation(b: &mut Bencher) {
         let mut byte_vec: Vec<u8> = Vec::with_capacity(0);
         let mut encoder = BinEncoder::new(&mut byte_vec);
         message.emit(&mut encoder)
+    })
+}
+
+#[bench]
+fn bench_emit_message_cve_2024_8508(b: &mut Bencher) {
+    let mut message = Message::response(10, OpCode::Update);
+    for i in 0..20 {
+        for j in 0..10 {
+            for k in 0..10 {
+                let record = Record::from_rdata(
+                    Name::parse(&format!("l{i}.l{j}.l{k}.example."), None).unwrap(),
+                    86400,
+                    RData::PTR(PTR(
+                        Name::parse(&format!("l{i}.l{j}.l{k}.test."), None).unwrap()
+                    )),
+                );
+                message.add_answer(record);
+            }
+        }
+    }
+    let mut buffer = Vec::with_capacity(u16::MAX as usize);
+    b.iter(|| {
+        let mut encoder = BinEncoder::new(&mut buffer);
+        message.emit(&mut encoder).unwrap();
+        buffer.clear();
     })
 }
 

--- a/crates/proto/src/rr/domain/name.rs
+++ b/crates/proto/src/rr/domain/name.rs
@@ -1150,7 +1150,8 @@ impl BinEncodable for Name {
         } else {
             self
         };
-        let compression = matches!(encoder.name_encoding(), NameEncoding::Compressed);
+        let compression = matches!(encoder.name_encoding(), NameEncoding::Compressed)
+            && encoder.compressed_name_count < COMPRESSED_NAME_LIMIT;
 
         let buf_len = encoder.len(); // lazily assert the size is less than 255...
         // lookup the label in the BinEncoder
@@ -1173,6 +1174,7 @@ impl BinEncodable for Name {
         // now search for other labels already stored matching from the beginning label, strip then to the end
         //   if it's not found, then store this as a new label
         if compression {
+            encoder.compressed_name_count += 1;
             for label_idx in &labels_written {
                 match encoder.get_label_pointer(*label_idx, last_index) {
                     Some(loc) if loc & 0xC000 == 0 => {
@@ -1214,6 +1216,12 @@ impl BinEncodable for Name {
         Ok(())
     }
 }
+
+/// Maximum number of names for which name compression will be attempted per message.
+///
+/// This limit matches that from Unbound, see
+/// <https://nlnetlabs.nl/downloads/unbound/patch_CVE-2024-8508.diff>.
+const COMPRESSED_NAME_LIMIT: usize = 120;
 
 impl<'r> BinDecodable<'r> for Name {
     /// parses the chain of labels

--- a/crates/proto/src/rr/domain/name.rs
+++ b/crates/proto/src/rr/domain/name.rs
@@ -1172,26 +1172,32 @@ impl BinEncodable for Name {
         let last_index = encoder.offset();
         // now search for other labels already stored matching from the beginning label, strip then to the end
         //   if it's not found, then store this as a new label
-        for label_idx in &labels_written {
-            match encoder.get_label_pointer(*label_idx, last_index) {
-                // if writing canonical and already found, continue
-                Some(_) if !compression => continue,
-                Some(loc) if compression && loc & 0xC000 == 0 => {
-                    // reset back to the beginning of this label, and then write the pointer...
-                    encoder.set_offset(*label_idx);
-                    encoder.trim();
+        if compression {
+            for label_idx in &labels_written {
+                match encoder.get_label_pointer(*label_idx, last_index) {
+                    Some(loc) if loc & 0xC000 == 0 => {
+                        // reset back to the beginning of this label, and then write the pointer...
+                        encoder.set_offset(*label_idx);
+                        encoder.trim();
 
-                    // write out the pointer marker
-                    //  or'd with the location which is less than 2^14
-                    encoder.emit_u16(0xC000u16 | loc)?;
+                        // write out the pointer marker
+                        //  or'd with the location which is less than 2^14
+                        encoder.emit_u16(0xC000u16 | loc)?;
 
-                    // we found a pointer don't write more, break
-                    return Ok(());
+                        // we found a pointer don't write more, break
+                        return Ok(());
+                    }
+                    _ => {
+                        // no existing label exists, store this new one.
+                        encoder.store_label_pointer(*label_idx, last_index);
+                    }
                 }
-                _ => {
-                    // no existing label exists, store this new one.
-                    encoder.store_label_pointer(*label_idx, last_index);
-                }
+            }
+        } else {
+            // Compression is disabled for either this name or the entire message. Just attempt to
+            // store the label pointers, in case they'll be used by an eligible RData type later.
+            for label_idx in &labels_written {
+                encoder.store_label_pointer(*label_idx, last_index);
             }
         }
 

--- a/crates/proto/src/serialize/binary/encoder.rs
+++ b/crates/proto/src/serialize/binary/encoder.rs
@@ -101,6 +101,8 @@ pub struct BinEncoder<'a> {
     canonical_form: bool,
     /// How names should be encoded.
     name_encoding: NameEncoding,
+    /// Number of names encoded with compression enabled.
+    pub(crate) compressed_name_count: usize,
 }
 
 impl<'a> BinEncoder<'a> {
@@ -131,6 +133,7 @@ impl<'a> BinEncoder<'a> {
             name_pointers: Vec::new(),
             canonical_form: false,
             name_encoding: NameEncoding::Compressed,
+            compressed_name_count: 0,
         }
     }
 

--- a/crates/proto/src/serialize/binary/encoder.rs
+++ b/crates/proto/src/serialize/binary/encoder.rs
@@ -267,7 +267,7 @@ impl<'a> BinEncoder<'a> {
         assert!(start <= (u16::MAX as usize));
         assert!(end <= (u16::MAX as usize));
         assert!(start <= end);
-        if self.offset < 0x3FFF_usize {
+        if self.offset < 0x3FFF_usize && self.name_pointers.len() < COMPRESSION_CANDIDATE_LIMIT {
             self.name_pointers
                 .push((start, self.slice_of(start, end).to_vec())); // the next char will be at the len() location
         }
@@ -454,6 +454,13 @@ impl<'a> BinEncoder<'a> {
         }
     }
 }
+
+/// Maximum number of label pointers we will store for later use in name compression.
+///
+/// This is chosen to be a power of two, so that we use the full capacity of the backing vector.
+/// With the current limits, name compression searches make up a small portion of the time it takes
+/// to encode pathologically large messages.
+const COMPRESSION_CANDIDATE_LIMIT: usize = 64;
 
 /// Selects how names should be encoded.
 #[derive(Clone, Copy)]


### PR DESCRIPTION
This makes a few related changes to limit the amount of work we do when trying to compress names during message encoding. Previously, message encoding was O(n^2) in the number of labels across all names, and this both caps the quadratic behavior and makes other improvements. The number of pointers to labels that we store is capped, the number of names per message that we try to compress is capped, and we no longer perform a search for a pointer to a previous label if we are not performing name compression.

I added a benchmark for encoding a crafted message containing 8000 labels across 4000 names. These changes reduced the time required to encode this message from 17ms to 0.7ms.

See https://www.nlnetlabs.nl/downloads/unbound/CVE-2024-8508.txt for reference.