### PR TITLE
Prune unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,6 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1139,7 +1138,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2708,7 +2706,6 @@ dependencies = [
  "futures-util",
  "hickory-net",
  "hickory-proto",
- "hickory-resolver",
  "metrics",
  "metrics-util",
  "tokio",

--- a/conformance/Cargo.lock
+++ b/conformance/Cargo.lock
@@ -107,12 +107,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,15 +190,6 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "crossbeam-epoch"
@@ -320,12 +305,6 @@ version = "0.0.0"
 dependencies = [
  "dns-test",
 ]
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -562,7 +541,6 @@ dependencies = [
  "ipnet",
  "jni",
  "once_cell",
- "prefix-trie",
  "rand 0.10.1",
  "ring",
  "rustls-pki-types",
@@ -571,25 +549,6 @@ dependencies = [
  "tinyvec",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.27.0-alpha.1"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-net",
- "hickory-proto",
- "ipnet",
- "moka",
- "once_cell",
- "parking_lot",
- "rand 0.10.1",
- "smallvec",
- "thiserror",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -718,9 +677,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "itoa"
@@ -775,16 +731,6 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn",
-]
-
-[[package]]
-name = "js-sys"
-version = "0.3.95"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
-dependencies = [
- "once_cell",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -920,23 +866,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "moka"
-version = "0.12.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-epoch",
- "crossbeam-utils",
- "equivalent",
- "parking_lot",
- "portable-atomic",
- "smallvec",
- "tagptr",
- "uuid",
 ]
 
 [[package]]
@@ -1111,17 +1040,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prefix-trie"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
-dependencies = [
- "either",
- "ipnet",
- "num-traits",
 ]
 
 [[package]]
@@ -1324,12 +1242,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,12 +1393,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tagptr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,7 +1413,6 @@ dependencies = [
  "futures-util",
  "hickory-net",
  "hickory-proto",
- "hickory-resolver",
  "metrics",
  "metrics-util",
  "tokio",
@@ -1697,17 +1602,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "uuid"
-version = "1.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
-dependencies = [
- "getrandom 0.4.2",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,51 +1639,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
-]
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.118"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.118"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.118"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
-dependencies = [
- "bumpalo",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.118"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
-dependencies = [
- "unicode-ident",
 ]
 
 [[package]]

--- a/conformance/compatibility-tests/Cargo.toml
+++ b/conformance/compatibility-tests/Cargo.toml
@@ -5,7 +5,7 @@ name = "compatibility-tests"
 publish = false
 version = "0.1.0"
 
-[dependencies]
+[dev-dependencies]
 dns-test = { path = "../dns-test" }
 futures = { version = "0.3.5", default-features = false }
 hickory-net = { path = "../../crates/net", features = ["dnssec-ring", "tokio"] }

--- a/conformance/conformance-tests/Cargo.toml
+++ b/conformance/conformance-tests/Cargo.toml
@@ -5,7 +5,7 @@ name = "conformance-tests"
 publish = false
 version = "0.1.0"
 
-[dependencies]
+[dev-dependencies]
 base64 = "0.22"
 dns-test.path = "../dns-test"
 

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -37,7 +37,7 @@ __https = ["__tls"]
 __quic = ["dep:quinn", "__tls"]
 __h3 = ["__quic"]
 
-webpki-roots = ["dep:webpki-roots", "hickory-net/webpki-roots"]
+webpki-roots = ["hickory-net/webpki-roots"]
 rustls-platform-verifier = ["hickory-net/rustls-platform-verifier"]
 
 dnssec-aws-lc-rs = ["hickory-proto/dnssec-aws-lc-rs", "hickory-net/dnssec-aws-lc-rs", "__dnssec"]
@@ -83,7 +83,6 @@ tokio-rustls = { workspace = true, optional = true }
 toml = { workspace = true, optional = true }
 hickory-net = { workspace = true }
 hickory-proto = { workspace = true, features = ["access-control"] }
-webpki-roots = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
 ipconfig = { workspace = true, optional = true }

--- a/crates/resolver/src/name_server.rs
+++ b/crates/resolver/src/name_server.rs
@@ -297,7 +297,7 @@ impl<P: ConnectionProvider> NameServer<P> {
         self.server_srtt.record(winner_rtt + CANCEL_PENALTY);
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "tokio"))]
     pub(crate) fn test_record_failure(&self) {
         self.server_srtt.record_failure();
     }

--- a/crates/resolver/src/name_server_pool.rs
+++ b/crates/resolver/src/name_server_pool.rs
@@ -133,7 +133,7 @@ impl<P: ConnectionProvider> NameServerPool<P> {
 
 // Type alias for TTL unit tests to use tokio's time pause/advance
 #[cfg(not(feature = "tokio"))]
-type TtlInstant = std::time::Instant;
+type TtlInstant = Instant;
 #[cfg(feature = "tokio")]
 type TtlInstant = tokio::time::Instant;
 

--- a/tests/test-support/Cargo.toml
+++ b/tests/test-support/Cargo.toml
@@ -15,8 +15,7 @@ publish = false
 bytes.workspace = true
 futures-util = { workspace = true, default-features = false, features = ["std", "io"] }
 hickory-proto.workspace = true
-hickory-net.workspace = true
-hickory-resolver = { workspace = true, features = ["tokio"] }
+hickory-net = { workspace = true, features = ["tokio"] }
 metrics.workspace = true
 metrics-util = { workspace = true, features = ["debugging"] }
 tokio = { workspace = true, features = ["net"] }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -69,7 +69,6 @@ __quic = []
 __h3 = []
 
 webpki-roots = [
-    "dep:webpki-roots",
     "hickory-net/webpki-roots",
     "hickory-resolver/webpki-roots",
 ]
@@ -101,7 +100,6 @@ hickory-proto = { workspace = true }
 hickory-net = { workspace = true, features = ["tokio"] }
 hickory-resolver = { workspace = true, features = ["recursor", "system-config", "tokio"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
-webpki-roots = { workspace = true, optional = true }
 
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true


### PR DESCRIPTION
This deletes some unused dependencies in various crates. This was motivated by the `test-support` dependency on `hickory-resolver`. When I was iterating on the `hickory-proto` benchmarks, I noticed that I had to rebuild a chain of workspace crates each time. This reduces both the total number of dependencies needed by that task, and the critical path length for rebuilds.