### PR TITLE
Fix doc comments at start of files

### DIFF
--- a/conformance/e2e-tests/src/recursor/basic/scenarios.rs
+++ b/conformance/e2e-tests/src/recursor/basic/scenarios.rs
@@ -1,7 +1,7 @@
-/// These scenarios use a single test network with the following records:
-///
-/// example.testing:
-///  www.example.testing IN A 192.0.2.1
+//! These scenarios use a single test network with the following records:
+//!
+//! example.testing:
+//!  www.example.testing IN A 192.0.2.1
 use std::net::Ipv4Addr;
 use std::thread;
 use std::time::Duration;

--- a/conformance/e2e-tests/src/recursor/cname/scenarios.rs
+++ b/conformance/e2e-tests/src/recursor/cname/scenarios.rs
@@ -1,22 +1,22 @@
-/// These scenarios use a single test network with the following records:
-///
-/// example.testing:
-///  www.example.testing IN CNAME www2.example2.testing.
-///  www3.example.testing IN CNAME www4.example2.testing.
-///  www5.example.testing IN CNAME www6.example2.testing.
-///  www7.example.testing IN CNAME www8.example2.testing.
-///  www9.example.testing IN CNAME www10.example2.testing.
-///  www11.example.testing IN CNAME www12.example2.testing.
-///  www13.example.testing IN A 192.0.2.1
-///
-/// example2.testing:
-///  www2.example2.testing IN CNAME www3.example.testing.
-///  www4.example2.testing IN CNAME www5.example.testing.
-///  www6.example2.testing IN CNAME www7.example.testing.
-///  www8.example2.testing IN CNAME www9.example.testing.
-///  www10.example2.testing IN CNAME www11.example.testing.
-///  www12.example2.testing IN CNAME www13.example.testing.
-///
+//! These scenarios use a single test network with the following records:
+//!
+//! example.testing:
+//!  www.example.testing IN CNAME www2.example2.testing.
+//!  www3.example.testing IN CNAME www4.example2.testing.
+//!  www5.example.testing IN CNAME www6.example2.testing.
+//!  www7.example.testing IN CNAME www8.example2.testing.
+//!  www9.example.testing IN CNAME www10.example2.testing.
+//!  www11.example.testing IN CNAME www12.example2.testing.
+//!  www13.example.testing IN A 192.0.2.1
+//!
+//! example2.testing:
+//!  www2.example2.testing IN CNAME www3.example.testing.
+//!  www4.example2.testing IN CNAME www5.example.testing.
+//!  www6.example2.testing IN CNAME www7.example.testing.
+//!  www8.example2.testing IN CNAME www9.example.testing.
+//!  www10.example2.testing IN CNAME www11.example.testing.
+//!  www12.example2.testing IN CNAME www13.example.testing.
+//!
 use std::net::Ipv4Addr;
 use std::thread;
 use std::time::Duration;

--- a/conformance/e2e-tests/src/recursor/delegation/scenarios.rs
+++ b/conformance/e2e-tests/src/recursor/delegation/scenarios.rs
@@ -1,7 +1,7 @@
-/// These scenarios use a single test network with the following records:
-///
-/// example.testing:
-///  www.example.testing IN A 192.0.2.1
+//! These scenarios use a single test network with the following records:
+//!
+//! example.testing:
+//!  www.example.testing IN A 192.0.2.1
 use std::{net::Ipv4Addr, thread, time::Duration};
 
 use dns_test::{

--- a/conformance/e2e-tests/src/recursor/rfc9539/scenarios.rs
+++ b/conformance/e2e-tests/src/recursor/rfc9539/scenarios.rs
@@ -1,4 +1,4 @@
-/// These scenarios test RFC 9539 opportunistic encryption
+//! These scenarios test RFC 9539 opportunistic encryption
 use std::time::Duration;
 
 use dns_test::client::{Client, DigSettings};

--- a/conformance/e2e-tests/src/recursor/security/scenarios.rs
+++ b/conformance/e2e-tests/src/recursor/security/scenarios.rs
@@ -1,4 +1,4 @@
-/// These scenarios use the TestServer which returns invalid answers that should be dropped
+//! These scenarios use the TestServer which returns invalid answers that should be dropped
 use std::{fs, net::Ipv4Addr, thread, time::Duration};
 
 use dns_test::{

--- a/conformance/e2e-tests/src/server/dot/scenarios.rs
+++ b/conformance/e2e-tests/src/server/dot/scenarios.rs
@@ -1,4 +1,4 @@
-/// Tests related to the authoritative server implementation DoT support.
+//! Tests related to the authoritative server implementation DoT support.
 use std::time::Duration;
 
 use dns_test::client::{Client, DigSettings};


### PR DESCRIPTION
This fixes a few doc comments that were accidentally applied to an import statement instead of the enclosing module.