### PR TITLE
Backport rustsec 2026 0119

### DIFF
--- a/crates/proto/benches/lib.rs
+++ b/crates/proto/benches/lib.rs
@@ -3,8 +3,11 @@
 
 extern crate test;
 
-use hickory_proto::op::{Header, Message, MessageType, OpCode, ResponseCode};
-use hickory_proto::rr::Record;
+use hickory_proto::op::{
+    Header, HeaderCounts, Message, MessageType, Metadata, OpCode, ResponseCode,
+};
+use hickory_proto::rr::rdata::PTR;
+use hickory_proto::rr::{Name, RData, Record, RecordType};
 use hickory_proto::serialize::binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder};
 
 use test::Bencher;
@@ -91,6 +94,31 @@ fn bench_emit_message_no_reservation(b: &mut Bencher) {
         let mut byte_vec: Vec<u8> = Vec::with_capacity(0);
         let mut encoder = BinEncoder::new(&mut byte_vec);
         message.emit(&mut encoder)
+    })
+}
+
+#[bench]
+fn bench_emit_message_cve_2024_8508(b: &mut Bencher) {
+    let mut message = Message::response(10, OpCode::Update);
+    for i in 0..20 {
+        for j in 0..10 {
+            for k in 0..10 {
+                let record = Record::from_rdata(
+                    Name::parse(&format!("l{i}.l{j}.l{k}.example."), None).unwrap(),
+                    86400,
+                    RData::PTR(PTR(
+                        Name::parse(&format!("l{i}.l{j}.l{k}.test."), None).unwrap()
+                    )),
+                );
+                message.add_answer(record);
+            }
+        }
+    }
+    let mut buffer = Vec::with_capacity(u16::MAX as usize);
+    b.iter(|| {
+        let mut encoder = BinEncoder::new(&mut buffer);
+        message.emit(&mut encoder).unwrap();
+        buffer.clear();
     })
 }
 

--- a/crates/proto/src/rr/domain/name.rs
+++ b/crates/proto/src/rr/domain/name.rs
@@ -622,26 +622,30 @@ impl Name {
         let last_index = encoder.offset();
         // now search for other labels already stored matching from the beginning label, strip then to the end
         //   if it's not found, then store this as a new label
-        for label_idx in &labels_written {
-            match encoder.get_label_pointer(*label_idx, last_index) {
-                // if writing canonical and already found, continue
-                Some(_) if canonical => continue,
-                Some(loc) if !canonical => {
-                    // reset back to the beginning of this label, and then write the pointer...
-                    encoder.set_offset(*label_idx);
-                    encoder.trim();
-
-                    // write out the pointer marker
-                    //  or'd with the location which shouldn't be larger than this 2^14 or 16k
-                    encoder.emit_u16(0xC000u16 | (loc & 0x3FFFu16))?;
-
-                    // we found a pointer don't write more, break
-                    return Ok(());
+        if ! canonical {
+            for label_idx in &labels_written {
+                match encoder.get_label_pointer(*label_idx, last_index) {
+                    Some(loc) if loc & 0xC000 == 0 => {
+                        // reset back to the beginning of this label, and then write the pointer...
+                        encoder.set_offset(*label_idx);
+                        encoder.trim();
+                        // write out the pointer marker
+                        //  or'd with the location which is less than 2^14
+                        encoder.emit_u16(0xC000u16 | loc)?;
+                        // we found a pointer don't write more, break
+                        return Ok(());
+                    }
+                    _ => {
+                        // no existing label exists, store this new one.
+                        encoder.store_label_pointer(*label_idx, last_index);
+                    }
                 }
-                _ => {
-                    // no existing label exists, store this new one.
-                    encoder.store_label_pointer(*label_idx, last_index);
-                }
+            }
+        } else {
+            // Compression is disabled for either this name or the entire message. Just attempt to
+            // store the label pointers, in case they'll be used by an eligible RData type later.
+            for label_idx in &labels_written {
+                encoder.store_label_pointer(*label_idx, last_index);
             }
         }
 

--- a/crates/proto/src/rr/domain/name.rs
+++ b/crates/proto/src/rr/domain/name.rs
@@ -622,7 +622,10 @@ impl Name {
         let last_index = encoder.offset();
         // now search for other labels already stored matching from the beginning label, strip then to the end
         //   if it's not found, then store this as a new label
-        if ! canonical {
+        if ! canonical
+            && encoder.compressed_name_count < COMPRESSED_NAME_LIMIT
+        {
+            encoder.compressed_name_count += 1;
             for label_idx in &labels_written {
                 match encoder.get_label_pointer(*label_idx, last_index) {
                     Some(loc) if loc & 0xC000 == 0 => {
@@ -1101,6 +1104,12 @@ impl BinEncodable for Name {
         self.emit_as_canonical(encoder, is_canonical_names)
     }
 }
+
+/// Maximum number of names for which name compression will be attempted per message.
+///
+/// This limit matches that from Unbound, see
+/// <https://nlnetlabs.nl/downloads/unbound/patch_CVE-2024-8508.diff>.
+const COMPRESSED_NAME_LIMIT: usize = 120;
 
 impl<'r> BinDecodable<'r> for Name {
     /// parses the chain of labels

--- a/crates/proto/src/serialize/binary/encoder.rs
+++ b/crates/proto/src/serialize/binary/encoder.rs
@@ -243,7 +243,7 @@ impl<'a> BinEncoder<'a> {
         assert!(start <= (u16::MAX as usize));
         assert!(end <= (u16::MAX as usize));
         assert!(start <= end);
-        if self.offset < 0x3FFF_usize {
+        if self.offset < 0x3FFF_usize && self.name_pointers.len() < COMPRESSION_CANDIDATE_LIMIT {
             self.name_pointers
                 .push((start, self.slice_of(start, end).to_vec())); // the next char will be at the len() location
         }
@@ -430,6 +430,13 @@ impl<'a> BinEncoder<'a> {
         }
     }
 }
+
+/// Maximum number of label pointers we will store for later use in name compression.
+///
+/// This is chosen to be a power of two, so that we use the full capacity of the backing vector.
+/// With the current limits, name compression searches make up a small portion of the time it takes
+/// to encode pathologically large messages.
+const COMPRESSION_CANDIDATE_LIMIT: usize = 64;
 
 /// A trait to return the size of a type as it will be encoded in DNS
 ///

--- a/crates/proto/src/serialize/binary/encoder.rs
+++ b/crates/proto/src/serialize/binary/encoder.rs
@@ -97,6 +97,8 @@ pub struct BinEncoder<'a> {
     name_pointers: Vec<(usize, Vec<u8>)>,
     mode: EncodeMode,
     canonical_names: bool,
+    /// Number of names encoded with compression enabled.
+    pub(crate) compressed_name_count: usize,
 }
 
 impl<'a> BinEncoder<'a> {
@@ -136,6 +138,7 @@ impl<'a> BinEncoder<'a> {
             name_pointers: Vec::new(),
             mode,
             canonical_names: false,
+            compressed_name_count: 0,
         }
     }
 


### PR DESCRIPTION
In Sequoia, we are currently stuck on Hickory 0.24, because [some of our downstreams still rely on OpenSSL](https://github.com/hickory-dns/hickory-dns/issues/3452), which was removed in 0.25.

This merge request attempts to backport the fix for [RUSTSEC-2026-0119](https://rustsec.org/advisories/RUSTSEC-2026-0119.html) to the 0.24 branch.

I'm not completely confident that the fix is correct.  My main uncertainty has to do with
https://github.com/hickory-dns/hickory-dns/commit/6e70e931515286a701b00ce91b06988eb71e89ef .
In that code, `compression` is derived as follows

```
        let compression = matches!(encoder.name_encoding(), NameEncoding::Compressed);
```

0.24 does not have `name_encoding` or `NameEncoding`.  But the documentation for `emit_as_canonical` says:

```
    /// Emits the canonical version of the name to the encoder.
    ///
    /// In canonical form, there will be no pointers written to the encoder (i.e. no compression).
    pub fn emit_as_canonical(
        &self,
        encoder: &mut BinEncoder<'_>,
        canonical: bool,
    ) -> ProtoResult<()> {
```

As such, I assume that `! canonical` is equivalent.

This uncertainty is amplified, because there doesn't appear a unit test that checks for the bug.

As such, if you are willing to do a new release on the 0.24 line, I'd appreciate a review.