### PR TITLE
Fix recursor nxdomain intermediate ns label

### DIFF
--- a/crates/resolver/src/recursor/handle.rs
+++ b/crates/resolver/src/recursor/handle.rs
@@ -533,8 +533,23 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
 
             let response = match lookup_res {
                 Ok(response) => response,
-                // Short-circuit on NXDOMAIN, per RFC 8020.
-                Err(e) if e.is_nx_domain() => return Err(e),
+                // RFC 8020 NXDOMAIN inference is unreliable for intermediate labels:
+                // zones in the wild commonly return NXDOMAIN for empty non-terminals
+                // (e.g. ns.nflxso.net. NS → NXDOMAIN even though e.ns.nflxso.net. exists).
+                // If we've already discovered a deeper zone, stop the walk and return that
+                // pool — the caller can query the target name against it and get an
+                // authoritative answer. Only propagate NXDOMAIN when we have nothing
+                // better than the root pool to fall back on.
+                Err(e) if e.is_nx_domain() => {
+                    if nameserver_pool.zone().is_some_and(|z| !z.is_root()) {
+                        debug!(
+                            ?zone,
+                            "NXDOMAIN at intermediate label; using deeper known zone"
+                        );
+                        break;
+                    }
+                    return Err(e);
+                }
                 // Short-circuit on timeouts. Requesting a longer name from the same pool would likely
                 // encounter them again.
                 Err(e) if e.is_timeout() => return Err(e),

--- a/crates/resolver/src/recursor/tests.rs
+++ b/crates/resolver/src/recursor/tests.rs
@@ -535,6 +535,130 @@ async fn cache_negative_responses() -> Result<(), NetError> {
     Ok(())
 }
 
+/// Regression test for a bug where the recursor incorrectly applies RFC 8020 NXDOMAIN
+/// inference during NS hostname resolution.
+///
+/// When resolving an out-of-bailiwick NS hostname like `e.ns.nflxso.testing.`, the
+/// recursor walks intermediate labels and queries `ns.nflxso.testing. NS` at the
+/// `nflxso.testing.` authoritative server. If that server returns NXDOMAIN — which is
+/// a zone misconfiguration (it should return NODATA for an empty non-terminal) but is
+/// common in the wild — the recursor concludes via RFC 8020 that `e.ns.nflxso.testing.`
+/// cannot exist. It then abandons resolution without ever issuing `e.ns.nflxso.testing. A`,
+/// leaving the NS pool for `dradis.netflix.testing.` empty and producing `NoConnections`.
+///
+/// This mirrors a real-world failure: `android13.prod.cloud.netflix.com` fails to resolve
+/// because `netflix.com`'s `dradis.netflix.com.` zone is delegated to `e.ns.nflxso.net.`
+/// and `f.ns.nflxso.net.`, but `ns.nflxso.net.` returns NXDOMAIN when queried as NS.
+///
+/// Expected behaviour: when the `nflxso.testing.` zone is already known, the recursor
+/// should query `e.ns.nflxso.testing. A` directly rather than abandoning resolution on
+/// an NXDOMAIN for an intermediate label.
+#[tokio::test]
+#[ignore = "known bug: NXDOMAIN on intermediate NS label incorrectly prevents NS hostname resolution via RFC 8020 inference"]
+async fn ns_hostname_nxdomain_empty_non_terminal() -> Result<(), NetError> {
+    subscribe();
+
+    // Separate IPs so they don't collide with the module-level constants.
+    let netflix_ip: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 0, 6, 1));
+    let nflxso_ip: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 0, 7, 1));
+    let dradis_ip: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 0, 8, 1)); // = resolved IP of e.ns.nflxso.testing.
+    let result_ip: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 1, 1, 1));
+
+    // Zone hierarchy:
+    //   testing.                         → ns at TLD_IP
+    //   netflix.testing.                 → ns.netflix.testing. at netflix_ip
+    //   nflxso.testing.                  → ns.nflxso.testing. at nflxso_ip (with glue)
+    //   dradis.netflix.testing.          → delegated to e.ns.nflxso.testing. (no glue)
+    //   e.ns.nflxso.testing. A           = dradis_ip  (correct answer, but recursor never asks)
+    //   ns.nflxso.testing. NS            = NXDOMAIN   (empty non-terminal; triggers the bug)
+    //   host.dradis.netflix.testing. A   = result_ip  (served at dradis_ip)
+    let tld_zone = Name::from_ascii("testing.")?;
+    let tld_ns = Name::from_ascii("testing.testing.")?;
+    let netflix_zone = Name::from_ascii("netflix.testing.")?;
+    let netflix_ns = Name::from_ascii("ns.netflix.testing.")?;
+    let nflxso_zone = Name::from_ascii("nflxso.testing.")?;
+    let nflxso_ns = Name::from_ascii("ns.nflxso.testing.")?;
+    let dradis_zone = Name::from_ascii("dradis.netflix.testing.")?;
+    let e_ns_nflxso = Name::from_ascii("e.ns.nflxso.testing.")?;
+    let host_dradis = Name::from_ascii("host.dradis.netflix.testing.")?;
+
+    // Clone for the mutation closure (Name is not Copy).
+    let nflxso_ns_for_mutation = nflxso_ns.clone();
+
+    let responses = vec![
+        // Root → testing.
+        MockRecord::ns(ROOT_IP, &tld_zone, &tld_ns),
+        MockRecord::a(ROOT_IP, &tld_ns, TLD_IP)
+            .with_query_name(&tld_zone)
+            .with_query_type(RecordType::NS)
+            .with_section(MockResponseSection::Additional),
+        // TLD → netflix.testing. (glue for in-bailiwick ns.netflix.testing.)
+        MockRecord::ns(TLD_IP, &netflix_zone, &netflix_ns),
+        MockRecord::a(TLD_IP, &netflix_ns, netflix_ip)
+            .with_query_name(&netflix_zone)
+            .with_query_type(RecordType::NS)
+            .with_section(MockResponseSection::Additional),
+        // TLD → nflxso.testing. (glue for in-bailiwick ns.nflxso.testing.)
+        MockRecord::ns(TLD_IP, &nflxso_zone, &nflxso_ns),
+        MockRecord::a(TLD_IP, &nflxso_ns, nflxso_ip)
+            .with_query_name(&nflxso_zone)
+            .with_query_type(RecordType::NS)
+            .with_section(MockResponseSection::Additional),
+        // netflix.testing. → dradis.netflix.testing. delegated to e.ns.nflxso.testing.
+        // No glue: e.ns.nflxso.testing. is out-of-bailiwick for netflix.testing.
+        MockRecord::ns(netflix_ip, &dradis_zone, &e_ns_nflxso),
+        // nflxso.testing. → e.ns.nflxso.testing. A = dradis_ip (the NS address we need to find)
+        MockRecord::a(nflxso_ip, &e_ns_nflxso, dradis_ip),
+        // nflxso.testing. → ns.nflxso.testing. NS query: register a SOA so the handler has
+        // something to return; the mutation below overwrites the response code to NXDOMAIN.
+        // (The zone is misconfigured: ns.nflxso.testing. is an empty non-terminal that should
+        // return NODATA but returns NXDOMAIN instead.)
+        MockRecord::soa(nflxso_ip, &nflxso_zone, &nflxso_zone, &nflxso_ns)
+            .with_query_name(&nflxso_ns)
+            .with_query_type(RecordType::NS),
+        // Dradis zone (served at dradis_ip = resolved address of e.ns.nflxso.testing.)
+        MockRecord::a(dradis_ip, &host_dradis, result_ip),
+    ];
+
+    let handler = MockNetworkHandler::new(responses).with_mutation(Box::new(
+        move |destination: IpAddr, _protocol: Protocol, msg: &mut Message| {
+            if destination == nflxso_ip
+                && msg.queries[0].name == nflxso_ns_for_mutation
+                && msg.queries[0].query_type == RecordType::NS
+            {
+                // Simulate the empty-non-terminal misbehaviour: the zone returns NXDOMAIN
+                // for ns.nflxso.testing. even though e.ns.nflxso.testing. exists beneath it.
+                msg.metadata.response_code = ResponseCode::NXDomain;
+            }
+        },
+    ));
+
+    let recursor = Recursor::with_options(
+        &[ROOT_IP],
+        RecursorOptions {
+            deny_server: Vec::new(),
+            ..RecursorOptions::default()
+        },
+        MockProvider::new(handler),
+    )?;
+
+    let response = recursor
+        .resolve(
+            Query::new(host_dradis.clone(), RecordType::A),
+            Instant::now(),
+            false,
+        )
+        .await?;
+
+    assert_eq!(response.response_code, ResponseCode::NoError);
+    assert_eq!(
+        response.answers,
+        [Record::from_rdata(host_dradis, 3600, result_ip.into())]
+    );
+
+    Ok(())
+}
+
 #[test]
 fn is_subzone_test() {
     use core::str::FromStr;

--- a/crates/resolver/src/recursor/tests.rs
+++ b/crates/resolver/src/recursor/tests.rs
@@ -554,7 +554,6 @@ async fn cache_negative_responses() -> Result<(), NetError> {
 /// should query `e.ns.nflxso.testing. A` directly rather than abandoning resolution on
 /// an NXDOMAIN for an intermediate label.
 #[tokio::test]
-#[ignore = "known bug: NXDOMAIN on intermediate NS label incorrectly prevents NS hostname resolution via RFC 8020 inference"]
 async fn ns_hostname_nxdomain_empty_non_terminal() -> Result<(), NetError> {
     subscribe();
 


### PR DESCRIPTION
Note: this was done mostly by Claude Opus 4.6, I was having issues resolving some domains and started investigating. It looks right to me, created a test case first to demonstrate the issue, fixed it later without changing the test and more importantly I can actually resolve some domains that I couldn't before (but which were resolved when forwarded to e.g. 1.1.1.1 or 8.8.8.8). 

The recursor fails to resolve domains delegated to nameservers whose hostnames have an intermediate label that returns NXDOMAIN (misconfigured empty non-terminal). For example, dradis.netflix.com is delegated to e.ns.nflxso.net and f.ns.nflxso.net. When resolving these NS hostnames, the recursor discovers the nflxso.net zone correctly, but then queries ns.nflxso.net NS to check for a sub-delegation. Netflix's zone returns NXDOMAIN for ns.nflxso.net (an empty non-terminal that should return NODATA). The recursor applies RFC 8020 inference and concludes e.ns.nflxso.net cannot exist —  without ever issuing e.ns.nflxso.net A against the known nflxso.net zone. The resulting NS pool for dradis.netflix.com is empty, producing NoConnections.

Most recursive resolvers (BIND, Unbound, Knot Resolver) handle this because they query the zone for the target name directly rather than walking intermediate labels.

##  To Reproduce

  1. Create a Recursor with default RecursorOptions and DnssecPolicy::ValidateWithStaticKey
  2. Call recursor.resolve(Query::query(Name::from_ascii("android13.prod.cloud.netflix.com."),
  RecordType::A), Instant::now(), false).await
  3. The resolve returns RecursorError wrapping NetError::NoConnections

  The delegation chain is:
  android13.prod.cloud.netflix.com  CNAME  android.prod.dradis.netflix.com
    (zone: dradis.netflix.com, NS = e.ns.nflxso.net / f.ns.nflxso.net, no glue)

  Verification that the NS hostname does exist despite the intermediate NXDOMAIN:
  # ns.nflxso.net returns NXDOMAIN (should be NODATA):
  dig ns.nflxso.net NS @45.57.8.1    # status: NXDOMAIN

  # But e.ns.nflxso.net has a valid A record:
  dig e.ns.nflxso.net A @45.57.8.1   # e.ns.nflxso.net. 3600 IN A 45.57.8.1

  Condensed debug log trace (RUST_LOG=hickory_resolver=debug):

```
  glue not found for name server NS(Name("e.ns.nflxso.net."))
  need glue for zone zone=Name("dradis.netflix.com.")

  adding new name server to cache ip: 45.57.8.1   (nflxso.net)
  adding new name server to cache ip: 45.57.9.1   (nflxso.net)
  found nameservers for nflxso.net.

  querying: ns.nflxso.net. NS
  lookup error: no records found for ns.nflxso.net. NS  (nx_domain: true)

  nameserver hostname lookup failure record_name=e.ns.nflxso.net.
    error=Negative(query: ns.nflxso.net. NS, nx_domain: true)
  nameserver hostname lookup failure record_name=f.ns.nflxso.net.
    error=Negative(query: ns.nflxso.net. NS, nx_domain: true)

  found nameservers for dradis.netflix.com.    ← empty pool
  lookup error: no connections available       ← instant failure
```

  Expected behavior

  When the recursor already knows the zone for a target name (e.g., nflxso.net at 45.57.8.1), it should
  query the zone directly for e.ns.nflxso.net A rather than walking intermediate labels and applying
  NXDOMAIN inference. NXDOMAIN for an intermediate label during NS hostname resolution should not
  prevent querying for the actual target, since zones in the wild return NXDOMAIN for empty
  non-terminals.

  System:
  - OS: Ubuntu 24.04 (Hetzner VPS)
  - Architecture: x86_64
  - rustc version: 1.94.0

  Version:
  Crate: resolver (recursor feature)
  Version: 0.26.0

  Additional context

  Strictly speaking, Netflix's nflxso.net zone is wrong to return NXDOMAIN for ns.nflxso.net when
  e.ns.nflxso.net and f.ns.nflxso.net exist beneath it — but this pattern exists in the wild and other
  resolvers handle it gracefully.

  The relevant code path is in handle.rs where append_ips_from_lookup resolves NS hostnames by walking
  the delegation hierarchy. When ns.nflxso.net NS returns NXDOMAIN, the Negative error with nx_domain:
  true is propagated as a "nameserver hostname lookup failure" and the NS hostname is dropped from the
  pool.