### PR TITLE
fix docstring for LookupIpStrategy

### DIFF
--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -720,12 +720,12 @@ pub enum LookupIpStrategy {
     Ipv6Only,
     /// Query for A and AAAA in parallel, ordering A before AAAA
     Ipv4AndIpv6,
-    /// Query for AAAA and A in parallel, ordering AAAA before A
+    /// Query for AAAA and A in parallel, ordering AAAA before A (default)
     #[default]
     Ipv6AndIpv4,
     /// Query for Ipv6 if that fails, query for Ipv4
     Ipv6thenIpv4,
-    /// Query for Ipv4 if that fails, query for Ipv6 (default)
+    /// Query for Ipv4 if that fails, query for Ipv6
     Ipv4thenIpv6,
 }
 


### PR DESCRIPTION
The default was changed from `Ipv4thenIpv6` to `Ipv4AndIpv6` in 2a85ccfb5ab8bd88777413a133de8210b724433a (and then to `Ipv6AndIpv4` in a83c905641e36ca608785c8f38a95fd95bf00f0b), but the docstring was left incorrect...