### PR TITLE
Retry cache priming requests

### DIFF
--- a/conformance/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_5.rs
+++ b/conformance/conformance-tests/src/resolver/dnssec/rfc4035/section_4/section_4_5.rs
@@ -23,13 +23,9 @@ fn caches_dnssec_records() -> Result<(), Error> {
     let client = Client::new(network)?;
     let settings = *DigSettings::default().dnssec().recurse().retries(0);
 
-    // query twice; eavesdrop second query
-    let mut tshark = None;
-    for i in 0..2 {
-        if i == 1 {
-            tshark = Some(resolver.eavesdrop_udp()?);
-        }
-
+    // When using BIND, try to work around nondeterminism by making more priming requests.
+    let iterations = if dns_test::SUBJECT.is_bind() { 5 } else { 1 };
+    for _ in 0..iterations {
         let ans = client.dig(settings, resolver.ipv4_addr(), RecordType::SOA, &FQDN::ROOT)?;
         let [answer, rrsig] = ans.answer.try_into().unwrap();
 
@@ -37,7 +33,14 @@ fn caches_dnssec_records() -> Result<(), Error> {
         assert!(matches!(rrsig, Record::RRSIG(_)));
     }
 
-    let mut tshark = tshark.unwrap();
+    let mut tshark = resolver.eavesdrop_udp()?;
+
+    let ans = client.dig(settings, resolver.ipv4_addr(), RecordType::SOA, &FQDN::ROOT)?;
+    let [answer, rrsig] = ans.answer.try_into().unwrap();
+
+    assert!(matches!(answer, Record::SOA(_)));
+    assert!(matches!(rrsig, Record::RRSIG(_)));
+
     tshark.wait_for_capture()?;
 
     let captures = tshark.terminate()?;
@@ -117,16 +120,20 @@ fn caches_intermediate_records() -> Result<(), Error> {
     let client = Client::new(resolver.network())?;
     let settings = *DigSettings::default().recurse().authentic_data().retries(0);
 
-    let output = client.dig(settings, resolver_addr, RecordType::A, &leaf_fqdn)?;
+    // When using BIND, try to work around nondeterminism by making more priming requests.
+    let iterations = if dns_test::SUBJECT.is_bind() { 5 } else { 1 };
+    for _ in 0..iterations {
+        let output = client.dig(settings, resolver_addr, RecordType::A, &leaf_fqdn)?;
 
-    assert!(output.status.is_noerror());
-    assert!(output.flags.authenticated_data);
+        assert!(output.status.is_noerror());
+        assert!(output.flags.authenticated_data);
 
-    let [a] = output.answer.try_into().unwrap();
-    let a = a.try_into_a().unwrap();
+        let [a] = output.answer.try_into().unwrap();
+        let a = a.try_into_a().unwrap();
 
-    assert_eq!(leaf_fqdn, a.fqdn);
-    assert_eq!(leaf_ipv4_addr, a.ipv4_addr);
+        assert_eq!(leaf_fqdn, a.fqdn);
+        assert_eq!(leaf_ipv4_addr, a.ipv4_addr);
+    }
 
     let mut tshark = resolver.eavesdrop_udp()?;
 


### PR DESCRIPTION
I have noticed that when the `caches_intermediate_records` runs against BIND, I sometimes see a different sequence of operations in the log, which eventually leads to the resolver making a DS query after the second request is issued, causing a test failure. BIND's record cache is a concurrent data structure that allows for access to old snapshots, so I was thinking we might be running into some sort of race condition or other nondeterminism, either during the initial resolution or after it, which leads to this behavior. This PR tries to work around this issue by making the initial priming request multiple times, in the hopes that this gives us more chances to store records of interest in the cache, and make them visible to future queries.