### PR TITLE
Change `docker build` to use plain progress output

### DIFF
--- a/conformance/dns-test/src/container.rs
+++ b/conformance/dns-test/src/container.rs
@@ -169,6 +169,9 @@ impl Container {
                 // the `--load` flag may be necessary, in order to load the resulting image as a
                 // local Docker image.
                 command.env("DOCKER_BUILDKIT", "1");
+                // Disable terminal redrawing, since the progress output may be interleaved with
+                // other output.
+                command.env("BUILDKIT_PROGRESS", "plain");
 
                 if let Image::Hickory {
                     crypto_provider, ..


### PR DESCRIPTION
This switches the progress format of `docker build` from `tty` to `plain`. The output may get interleaved with output from the test harness, or even other invocations of `docker build`, so using plain output will result in less bad visual artifacts.