### PR TITLE
Recursor: Preserve answer and authority section records when following CNAME record

### DIFF
--- a/conformance/conformance-tests/src/resolver/dns/scenarios/cname.rs
+++ b/conformance/conformance-tests/src/resolver/dns/scenarios/cname.rs
@@ -490,7 +490,6 @@ fn signed_zone_negative() -> Result<(), Error> {
 /// Tests how a non-validating resolver handles DNSSEC records when following a CNAME alias at a
 /// wildcard name, and getting a positive response.
 #[test]
-#[ignore = "hickory does not include NSEC/NSEC3 records from CNAME response"]
 fn signed_wildcard_cname_positive() -> Result<(), Error> {
     let (_network, _nameservers, resolver, client) = setup_signed_zone()?;
     let output = client.dig(

--- a/conformance/conformance-tests/src/resolver/dns/scenarios/cname.rs
+++ b/conformance/conformance-tests/src/resolver/dns/scenarios/cname.rs
@@ -488,6 +488,211 @@ fn signed_zone_negative() -> Result<(), Error> {
     Ok(())
 }
 
+/// Tests how a non-validating resolver handles DNSSEC records when following a CNAME alias at a
+/// wildcard name, and getting a positive response.
+#[test]
+#[ignore = "hickory does not include NSEC/NSEC3 records from CNAME response"]
+fn signed_wildcard_cname_positive() -> Result<(), Error> {
+    let (_network, _nameservers, resolver, client) = setup_signed_zone()?;
+    let output = client.dig(
+        *DigSettings::default().recurse().dnssec(),
+        resolver.ipv4_addr(),
+        RecordType::A,
+        &FQDN::EXAMPLE_SUBDOMAIN
+            .push_label("wildcard")
+            .push_label("a"),
+    )?;
+    assert_eq!(output.status, DigStatus::NOERROR, "{output:#?}");
+    assert!(
+        output.answer.iter().any(|record| {
+            let Record::CNAME(CNAME { fqdn, .. }) = record else {
+                return false;
+            };
+            fqdn.as_str() == "a.wildcard.example.hickory-dns.testing."
+        }),
+        "CNAME record is missing {output:#?}"
+    );
+    assert!(
+        output.answer.iter().any(|record| {
+            let Record::RRSIG(RRSIG { fqdn, .. }) = record else {
+                return false;
+            };
+            fqdn.as_str() == "a.wildcard.example.hickory-dns.testing."
+        }),
+        "RRSIG record for CNAME is missing {output:#?}"
+    );
+    assert!(
+        output.answer.iter().any(|record| {
+            let Record::A(A { fqdn, .. }) = record else {
+                return false;
+            };
+            fqdn.as_str() == "host.other.hickory-dns.testing."
+        }),
+        "A record is missing {output:#?}"
+    );
+    assert!(
+        output.answer.iter().any(|record| {
+            let Record::RRSIG(RRSIG { fqdn, .. }) = record else {
+                return false;
+            };
+            fqdn.as_str() == "host.other.hickory-dns.testing."
+        }),
+        "RRSIG record for A is missing {output:#?}"
+    );
+    // Covers the query name:
+    //
+    //   $ nsec3hash -r 1 0 1 - a.wildcard.example.hickory-dns.testing.
+    //   a.wildcard.example.hickory-dns.testing. NSEC3 1 0 1 - GUAC3Q6G2FI6QTTH3JSJ242EFP6R57I2
+    assert!(
+        output.authority.iter().any(|record| {
+            let Record::NSEC3(NSEC3 {
+                fqdn,
+                next_hashed_owner_name,
+                ..
+            }) = record
+            else {
+                return false;
+            };
+            fqdn.as_str() == "8hk47tugdqehn13l08a2l9a7l29q25rj.example.hickory-dns.testing."
+                && next_hashed_owner_name == "L8L2LQT9T5KG7FK253IDLC5534CQ3RNN"
+        }),
+        "NSEC3 record from zone with CNAME is missing {output:#?}"
+    );
+    assert!(
+        output.authority.iter().any(|record| {
+            let Record::RRSIG(RRSIG { fqdn, .. }) = record else {
+                return false;
+            };
+            fqdn.as_str() == "8hk47tugdqehn13l08a2l9a7l29q25rj.example.hickory-dns.testing."
+        }),
+        "RRSIG record for NSEC3 is missing {output:#?}"
+    );
+    Ok(())
+}
+
+/// Tests how a non-validating resolver handles DNSSEC records when following a CNAME alias at a
+/// wildcard name, and getting a negative response.
+#[test]
+#[ignore = "hickory does not include CNAME chain in response"]
+fn signed_wildcard_cname_negative() -> Result<(), Error> {
+    let (_network, _nameservers, resolver, client) = setup_signed_zone()?;
+    let output = client.dig(
+        *DigSettings::default().recurse().dnssec(),
+        resolver.ipv4_addr(),
+        RecordType::A,
+        &FQDN::EXAMPLE_SUBDOMAIN
+            .push_label("wildcard-negative")
+            .push_label("a"),
+    )?;
+    assert_eq!(output.status, DigStatus::NXDOMAIN, "{output:#?}");
+    assert!(
+        output.answer.iter().any(|record| {
+            let Record::CNAME(CNAME { fqdn, target, .. }) = record else {
+                return false;
+            };
+            fqdn.as_str() == "a.wildcard-negative.example.hickory-dns.testing."
+                && target.as_str() == "wrong.other.hickory-dns.testing."
+        }),
+        "CNAME record is missing {output:#?}"
+    );
+    assert!(
+        output.answer.iter().any(|record| {
+            let Record::RRSIG(RRSIG { fqdn, .. }) = record else {
+                return false;
+            };
+            fqdn.as_str() == "a.wildcard-negative.example.hickory-dns.testing."
+        }),
+        "RRSIG record for CNAME is missing {output:#?}"
+    );
+    // Covers the query name:
+    //
+    //   $ nsec3hash -r 1 0 1 - a.wildcard-negative.example.hickory-dns.testing.
+    //   a.wildcard-negative.example.hickory-dns.testing. NSEC3 1 0 1 - 8RLUPEAJKRATE893HJ62EIAUIQCJM676
+    assert!(
+        output.authority.iter().any(|record| {
+            let Record::NSEC3(NSEC3 {
+                fqdn,
+                next_hashed_owner_name,
+                ..
+            }) = record
+            else {
+                return false;
+            };
+            fqdn.as_str() == "8hk47tugdqehn13l08a2l9a7l29q25rj.example.hickory-dns.testing."
+                && next_hashed_owner_name == "L8L2LQT9T5KG7FK253IDLC5534CQ3RNN"
+        }),
+        "NSEC3 record from zone with CNAME is missing {output:#?}"
+    );
+    assert!(
+        output.authority.iter().any(|record| {
+            let Record::RRSIG(RRSIG { fqdn, .. }) = record else {
+                return false;
+            };
+            fqdn.as_str() == "8hk47tugdqehn13l08a2l9a7l29q25rj.example.hickory-dns.testing."
+        }),
+        "RRSIG record for NSEC3 is missing {output:#?}"
+    );
+    // Covers the target of the CNAME record:
+    //
+    //   $ nsec3hash -r 1 0 1 - wrong.other.hickory-dns.testing.
+    //   wrong.other.hickory-dns.testing. NSEC3 1 0 1 - TV5CS5RQP27NUBADJ7H0Q3DE7T7F8VNA
+    assert!(
+        output.authority.iter().any(|record| {
+            let Record::NSEC3(NSEC3 {
+                fqdn,
+                next_hashed_owner_name,
+                ..
+            }) = record
+            else {
+                return false;
+            };
+            fqdn.as_str() == "722c77kkod0lhnnr7d9rnbit9647rdus.other.hickory-dns.testing."
+                && next_hashed_owner_name == "UVQ6A2S4RMV0MRON9KOT3N6TH7RGC8QM"
+        }),
+        "NSEC3 record covering target name is missing {output:#?}"
+    );
+    assert!(
+        output.authority.iter().any(|record| {
+            let Record::RRSIG(RRSIG { fqdn, .. }) = record else {
+                return false;
+            };
+            fqdn.as_str() == "722c77kkod0lhnnr7d9rnbit9647rdus.other.hickory-dns.testing."
+        }),
+        "RRSIG record for NSEC3 is missing {output:#?}"
+    );
+    // Matches the next closest encloser and covers the wildcard at it.
+    //
+    //   $ nsec3hash -r 1 0 1 - other.hickory-dns.testing.
+    //   other.hickory-dns.testing. NSEC3 1 0 1 - UVQ6A2S4RMV0MRON9KOT3N6TH7RGC8QM
+    //   $ nsec3hash -r 1 0 1 - *.other.hickory-dns.testing.
+    //   *.other.hickory-dns.testing. NSEC3 1 0 1 - V5O27Q1MQGOT5GN79U1QIQEM1TKQHNAK
+    assert!(
+        output.authority.iter().any(|record| {
+            let Record::NSEC3(NSEC3 {
+                fqdn,
+                next_hashed_owner_name,
+                ..
+            }) = record
+            else {
+                return false;
+            };
+            fqdn.as_str() == "uvq6a2s4rmv0mron9kot3n6th7rgc8qm.other.hickory-dns.testing."
+                && next_hashed_owner_name == "3F1DNPG4E4GP4AU4IHFBSR2MEJLQTFOC"
+        }),
+        "NSEC3 record for wildcard proof is missing {output:#?}"
+    );
+    assert!(
+        output.authority.iter().any(|record| {
+            let Record::RRSIG(RRSIG { fqdn, .. }) = record else {
+                return false;
+            };
+            fqdn.as_str() == "uvq6a2s4rmv0mron9kot3n6th7rgc8qm.other.hickory-dns.testing."
+        }),
+        "RRSIG record for NSEC3 is missing {output:#?}"
+    );
+    Ok(())
+}
+
 #[allow(clippy::type_complexity)]
 fn setup_signed_zone() -> Result<(Network, Vec<NameServer<Running>>, Resolver, Client), Error> {
     let network = Network::new()?;
@@ -500,6 +705,20 @@ fn setup_signed_zone() -> Result<(Network, Vec<NameServer<Running>>, Resolver, C
     });
     leaf_1_ns.add(CNAME {
         fqdn: FQDN::EXAMPLE_SUBDOMAIN.push_label("alias-negative"),
+        ttl: 3600,
+        target: FQDN::TEST_DOMAIN.push_label("other").push_label("wrong"),
+    });
+    leaf_1_ns.add(CNAME {
+        fqdn: FQDN::EXAMPLE_SUBDOMAIN
+            .push_label("wildcard")
+            .push_label("*"),
+        ttl: 3600,
+        target: FQDN::TEST_DOMAIN.push_label("other").push_label("host"),
+    });
+    leaf_1_ns.add(CNAME {
+        fqdn: FQDN::EXAMPLE_SUBDOMAIN
+            .push_label("wildcard-negative")
+            .push_label("*"),
         ttl: 3600,
         target: FQDN::TEST_DOMAIN.push_label("other").push_label("wrong"),
     });

--- a/conformance/conformance-tests/src/resolver/dns/scenarios/cname.rs
+++ b/conformance/conformance-tests/src/resolver/dns/scenarios/cname.rs
@@ -399,7 +399,6 @@ fn signed_zone_positive() -> Result<(), Error> {
 /// Tests how a non-validating resolver handles DNSSEC records when following a CNAME alias and
 /// getting a negative response.
 #[test]
-#[ignore = "hickory does not include CNAME chain in response"]
 fn signed_zone_negative() -> Result<(), Error> {
     let (_network, _nameservers, resolver, client) = setup_signed_zone()?;
     let output = client.dig(

--- a/conformance/conformance-tests/src/resolver/dns/scenarios/cname.rs
+++ b/conformance/conformance-tests/src/resolver/dns/scenarios/cname.rs
@@ -572,7 +572,6 @@ fn signed_wildcard_cname_positive() -> Result<(), Error> {
 /// Tests how a non-validating resolver handles DNSSEC records when following a CNAME alias at a
 /// wildcard name, and getting a negative response.
 #[test]
-#[ignore = "hickory does not include CNAME chain in response"]
 fn signed_wildcard_cname_negative() -> Result<(), Error> {
     let (_network, _nameservers, resolver, client) = setup_signed_zone()?;
     let output = client.dig(

--- a/conformance/conformance-tests/src/resolver/dns/scenarios/cname.rs
+++ b/conformance/conformance-tests/src/resolver/dns/scenarios/cname.rs
@@ -4,7 +4,8 @@ use dns_test::{
     Error, FQDN, Network, PEER, Resolver,
     client::{Client, DigSettings, DigStatus},
     name_server::{Graph, NameServer, Running, Sign},
-    record::{A, CNAME, Record, RecordType},
+    record::{A, CNAME, NSEC3, RRSIG, Record, RecordType},
+    zone_file::SignSettings,
 };
 
 #[test]
@@ -330,6 +331,206 @@ fn setup_cname_cross_zone() -> Result<(Network, Vec<NameServer<Running>>, Resolv
     root_ns.referral_nameserver(&tld_ns);
     let root = root_ns.root_hint();
 
+    let nameservers = vec![
+        leaf_1_ns.start()?,
+        leaf_2_ns.start()?,
+        domain_ns.start()?,
+        tld_ns.start()?,
+        root_ns.start()?,
+    ];
+
+    let resolver = Resolver::new(&network, root).start()?;
+    let client = Client::new(&network)?;
+
+    Ok((network, nameservers, resolver, client))
+}
+
+/// Tests how a non-validating resolver handles DNSSEC records when following a CNAME alias and
+/// getting a positive response.
+#[test]
+fn signed_zone_positive() -> Result<(), Error> {
+    let (_network, _nameservers, resolver, client) = setup_signed_zone()?;
+    let output = client.dig(
+        *DigSettings::default().recurse().dnssec(),
+        resolver.ipv4_addr(),
+        RecordType::A,
+        &FQDN::EXAMPLE_SUBDOMAIN.push_label("alias"),
+    )?;
+    assert_eq!(output.status, DigStatus::NOERROR, "{output:#?}");
+    assert!(
+        output.answer.iter().any(|record| {
+            let Record::CNAME(CNAME { fqdn, .. }) = record else {
+                return false;
+            };
+            fqdn.as_str() == "alias.example.hickory-dns.testing."
+        }),
+        "CNAME record is missing {output:#?}"
+    );
+    assert!(
+        output.answer.iter().any(|record| {
+            let Record::RRSIG(RRSIG { fqdn, .. }) = record else {
+                return false;
+            };
+            fqdn.as_str() == "alias.example.hickory-dns.testing."
+        }),
+        "RRSIG record for CNAME is missing {output:#?}"
+    );
+    assert!(
+        output.answer.iter().any(|record| {
+            let Record::A(A { fqdn, .. }) = record else {
+                return false;
+            };
+            fqdn.as_str() == "host.other.hickory-dns.testing."
+        }),
+        "A record is missing {output:#?}"
+    );
+    assert!(
+        output.answer.iter().any(|record| {
+            let Record::RRSIG(RRSIG { fqdn, .. }) = record else {
+                return false;
+            };
+            fqdn.as_str() == "host.other.hickory-dns.testing."
+        }),
+        "RRSIG record for A is missing {output:#?}"
+    );
+    Ok(())
+}
+
+/// Tests how a non-validating resolver handles DNSSEC records when following a CNAME alias and
+/// getting a negative response.
+#[test]
+#[ignore = "hickory does not include CNAME chain in response"]
+fn signed_zone_negative() -> Result<(), Error> {
+    let (_network, _nameservers, resolver, client) = setup_signed_zone()?;
+    let output = client.dig(
+        *DigSettings::default().recurse().dnssec(),
+        resolver.ipv4_addr(),
+        RecordType::A,
+        &FQDN::EXAMPLE_SUBDOMAIN.push_label("alias-negative"),
+    )?;
+    assert_eq!(output.status, DigStatus::NXDOMAIN, "{output:#?}");
+    assert!(
+        output.answer.iter().any(|record| {
+            let Record::CNAME(CNAME { fqdn, .. }) = record else {
+                return false;
+            };
+            fqdn.as_str() == "alias-negative.example.hickory-dns.testing."
+        }),
+        "CNAME record is missing {output:#?}"
+    );
+    assert!(
+        output.answer.iter().any(|record| {
+            let Record::RRSIG(RRSIG { fqdn, .. }) = record else {
+                return false;
+            };
+            fqdn.as_str() == "alias-negative.example.hickory-dns.testing."
+        }),
+        "RRSIG record for CNAME is missing {output:#?}"
+    );
+    // Covers the target of the CNAME record:
+    //
+    //   $ nsec3hash -r 1 0 1 - wrong.other.hickory-dns.testing.
+    //   wrong.other.hickory-dns.testing. NSEC3 1 0 1 - TV5CS5RQP27NUBADJ7H0Q3DE7T7F8VNA
+    assert!(
+        output.authority.iter().any(|record| {
+            let Record::NSEC3(NSEC3 {
+                fqdn,
+                next_hashed_owner_name,
+                ..
+            }) = record
+            else {
+                return false;
+            };
+            fqdn.as_str() == "722c77kkod0lhnnr7d9rnbit9647rdus.other.hickory-dns.testing."
+                && next_hashed_owner_name == "UVQ6A2S4RMV0MRON9KOT3N6TH7RGC8QM"
+        }),
+        "NSEC3 record covering name is missing {output:#?}"
+    );
+    assert!(
+        output.authority.iter().any(|record| {
+            let Record::RRSIG(RRSIG { fqdn, .. }) = record else {
+                return false;
+            };
+            fqdn.as_str() == "722c77kkod0lhnnr7d9rnbit9647rdus.other.hickory-dns.testing."
+        }),
+        "RRSIG record for NSEC3 is missing {output:#?}"
+    );
+    // Matches the next closest encloser and covers the wildcard at it.
+    //
+    //   $ nsec3hash -r 1 0 1 - other.hickory-dns.testing.
+    //   other.hickory-dns.testing. NSEC3 1 0 1 - UVQ6A2S4RMV0MRON9KOT3N6TH7RGC8QM
+    //   $ nsec3hash -r 1 0 1 - *.other.hickory-dns.testing.
+    //   *.other.hickory-dns.testing. NSEC3 1 0 1 - V5O27Q1MQGOT5GN79U1QIQEM1TKQHNAK
+    assert!(
+        output.authority.iter().any(|record| {
+            let Record::NSEC3(NSEC3 {
+                fqdn,
+                next_hashed_owner_name,
+                ..
+            }) = record
+            else {
+                return false;
+            };
+            fqdn.as_str() == "uvq6a2s4rmv0mron9kot3n6th7rgc8qm.other.hickory-dns.testing."
+                && next_hashed_owner_name == "3F1DNPG4E4GP4AU4IHFBSR2MEJLQTFOC"
+        }),
+        "NSEC3 record for wildcard proof is missing {output:#?}"
+    );
+    assert!(
+        output.authority.iter().any(|record| {
+            let Record::RRSIG(RRSIG { fqdn, .. }) = record else {
+                return false;
+            };
+            fqdn.as_str() == "uvq6a2s4rmv0mron9kot3n6th7rgc8qm.other.hickory-dns.testing."
+        }),
+        "RRSIG record for NSEC3 is missing {output:#?}"
+    );
+    Ok(())
+}
+
+#[allow(clippy::type_complexity)]
+fn setup_signed_zone() -> Result<(Network, Vec<NameServer<Running>>, Resolver, Client), Error> {
+    let network = Network::new()?;
+
+    let mut leaf_1_ns = NameServer::new(&PEER, FQDN::EXAMPLE_SUBDOMAIN, &network)?;
+    leaf_1_ns.add(CNAME {
+        fqdn: FQDN::EXAMPLE_SUBDOMAIN.push_label("alias"),
+        ttl: 3600,
+        target: FQDN::TEST_DOMAIN.push_label("other").push_label("host"),
+    });
+    leaf_1_ns.add(CNAME {
+        fqdn: FQDN::EXAMPLE_SUBDOMAIN.push_label("alias-negative"),
+        ttl: 3600,
+        target: FQDN::TEST_DOMAIN.push_label("other").push_label("wrong"),
+    });
+    let leaf_1_ns = leaf_1_ns.sign(SignSettings::default())?;
+
+    let mut leaf_2_ns = NameServer::new(&PEER, FQDN::TEST_DOMAIN.push_label("other"), &network)?;
+    leaf_2_ns.add(A {
+        fqdn: FQDN::TEST_DOMAIN.push_label("other").push_label("host"),
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 168, 1, 1),
+    });
+    let leaf_2_ns = leaf_2_ns.sign(SignSettings::default())?;
+
+    let mut domain_ns = NameServer::new(&PEER, FQDN::TEST_DOMAIN, &network)?;
+    domain_ns.referral_nameserver(&leaf_1_ns);
+    domain_ns.add(leaf_1_ns.ds().ksk.clone());
+    domain_ns.referral_nameserver(&leaf_2_ns);
+    domain_ns.add(leaf_2_ns.ds().ksk.clone());
+    let domain_ns = domain_ns.sign(SignSettings::default())?;
+
+    let mut tld_ns = NameServer::new(&PEER, FQDN::TEST_TLD, &network)?;
+    tld_ns.referral_nameserver(&domain_ns);
+    tld_ns.add(domain_ns.ds().ksk.clone());
+    let tld_ns = tld_ns.sign(SignSettings::default())?;
+
+    let mut root_ns = NameServer::new(&PEER, FQDN::ROOT, &network)?;
+    root_ns.referral_nameserver(&tld_ns);
+    root_ns.add(tld_ns.ds().ksk.clone());
+    let root_ns = root_ns.sign(SignSettings::default())?;
+
+    let root = root_ns.root_hint();
     let nameservers = vec![
         leaf_1_ns.start()?,
         leaf_2_ns.start()?,

--- a/conformance/conformance-tests/src/resolver/dnssec/missing_records/rfc_4035_appendix_b.rs
+++ b/conformance/conformance-tests/src/resolver/dnssec/missing_records/rfc_4035_appendix_b.rs
@@ -166,7 +166,6 @@ fn no_data_error() -> Result<(), Error> {
 
 /// Based on RFC 4035 section B.6.
 #[test]
-#[ignore = "hickory recursor does not include NSEC record proving wildcard expansion"]
 fn wildcard_expansion() -> Result<(), Error> {
     let network = Network::new()?;
     let leaf_ns = build_zone(&network)?;

--- a/conformance/conformance-tests/src/resolver/dnssec/missing_records/rfc_5155_appendix_b.rs
+++ b/conformance/conformance-tests/src/resolver/dnssec/missing_records/rfc_5155_appendix_b.rs
@@ -149,7 +149,6 @@ fn no_data_error_empty_non_terminal() -> Result<(), Error> {
 
 /// Based on RFC 5155 section B.4.
 #[test]
-#[ignore = "hickory recursor does not include NSEC3 records proving wildcard expansion"]
 fn wildcard_expansion() -> Result<(), Error> {
     let network = Network::new()?;
     let leaf_ns = build_zone(&network)?;

--- a/crates/net/src/error.rs
+++ b/crates/net/src/error.rs
@@ -263,78 +263,91 @@ impl DnsError {
         debug!("response: {}", *response);
 
         match response.response_code {
-                Refused => Err(Self::ResponseCode(Refused)),
-                code @ ServFail
-                | code @ FormErr
-                | code @ NotImp
-                | code @ YXDomain
-                | code @ YXRRSet
-                | code @ NXRRSet
-                | code @ NotAuth
-                | code @ NotZone
-                | code @ BADVERS
-                | code @ BADSIG
-                | code @ BADKEY
-                | code @ BADTIME
-                | code @ BADMODE
-                | code @ BADNAME
-                | code @ BADALG
-                | code @ BADTRUNC
-                | code @ BADCOOKIE => Err(Self::ResponseCode(code)),
-                // Some NXDOMAIN responses contain CNAME referrals, that will not be an error
-                code @ NXDomain |
-                // No answers are available, CNAME referrals are not failures
-                code @ NoError
-                if !response.contains_answer() && !response.truncation => {
-                    let soa = response.soa().as_ref().map(RecordRef::to_owned);
+            Refused => Err(Self::ResponseCode(Refused)),
+            code @ ServFail
+            | code @ FormErr
+            | code @ NotImp
+            | code @ YXDomain
+            | code @ YXRRSet
+            | code @ NXRRSet
+            | code @ NotAuth
+            | code @ NotZone
+            | code @ BADVERS
+            | code @ BADSIG
+            | code @ BADKEY
+            | code @ BADTIME
+            | code @ BADMODE
+            | code @ BADNAME
+            | code @ BADALG
+            | code @ BADTRUNC
+            | code @ BADCOOKIE => Err(Self::ResponseCode(code)),
+            // Handle name error and no data responses. Some NXDOMAIN responses contain CNAME
+            // referrals, that will not be an error. In the no data case, no answers are available,
+            // CNAME referrals are not failures.
+            code @ NXDomain | code @ NoError
+                if !response.contains_answer() && !response.truncation =>
+            {
+                let soa = response.soa().as_ref().map(RecordRef::to_owned);
 
-                    // Collect any referral nameservers and associated glue records
-                    let mut referral_name_servers = vec![];
-                    for ns in response.authorities.iter().filter(|ns| ns.record_type() == RecordType::NS) {
-                        let glue = response
-                            .additionals
-                            .iter()
-                            .filter_map(|record| {
-                                if let RData::NS(ns_data) = &ns.data {
-                                    if record.name == **ns_data && matches!(&record.data, RData::A(_) | RData::AAAA(_)) {
-                                        return Some(Record::to_owned(record));
-                                    }
+                // Collect any referral nameservers and associated glue records
+                let mut referral_name_servers = vec![];
+                let iter = response
+                    .authorities
+                    .iter()
+                    .filter(|ns| ns.record_type() == RecordType::NS);
+                for ns in iter {
+                    let glue = response
+                        .additionals
+                        .iter()
+                        .filter_map(|record| {
+                            if let RData::NS(ns_data) = &ns.data {
+                                if record.name == **ns_data
+                                    && matches!(&record.data, RData::A(_) | RData::AAAA(_))
+                                {
+                                    return Some(Record::to_owned(record));
                                 }
+                            }
 
-                                None
-                            })
-                            .collect::<Vec<Record>>();
-                        referral_name_servers.push(ForwardNSData { ns: Record::to_owned(ns), glue: glue.into() })
-                    }
-
-                    let option_ns = if !referral_name_servers.is_empty() {
-                        Some(referral_name_servers.into())
-                    } else {
-                        None
-                    };
-
-                    let authorities = if !response.authorities.is_empty() {
-                        Some(response.authorities.to_owned().into())
-                    } else {
-                        None
-                    };
-
-                    let negative_ttl = response.negative_ttl();
-                    let query = response.into_message().queries.drain(..).next().unwrap_or_else(Query::root);
-
-                    Err(Self::NoRecordsFound(NoRecords {
-                        query: Box::new(query),
-                        soa: soa.map(Box::new),
-                        ns: option_ns,
-                        negative_ttl,
-                        response_code: code,
-                        authorities,
-                    }))
+                            None
+                        })
+                        .collect::<Vec<Record>>();
+                    referral_name_servers.push(ForwardNSData {
+                        ns: Record::to_owned(ns),
+                        glue: glue.into(),
+                    })
                 }
-                NXDomain
-                | NoError
-                | Unknown(_) => Ok(response),
+
+                let option_ns = if !referral_name_servers.is_empty() {
+                    Some(referral_name_servers.into())
+                } else {
+                    None
+                };
+
+                let authorities = if !response.authorities.is_empty() {
+                    Some(response.authorities.to_owned().into())
+                } else {
+                    None
+                };
+
+                let negative_ttl = response.negative_ttl();
+                let query = response
+                    .into_message()
+                    .queries
+                    .drain(..)
+                    .next()
+                    .unwrap_or_else(Query::root);
+
+                Err(Self::NoRecordsFound(NoRecords {
+                    query: Box::new(query),
+                    soa: soa.map(Box::new),
+                    ns: option_ns,
+                    negative_ttl,
+                    response_code: code,
+                    authorities,
+                }))
             }
+            NXDomain | NoError | Unknown(_) => Ok(response),
+        }
     }
 }
 

--- a/crates/net/src/error.rs
+++ b/crates/net/src/error.rs
@@ -286,8 +286,6 @@ impl DnsError {
                 // No answers are available, CNAME referrals are not failures
                 code @ NoError
                 if !response.contains_answer() && !response.truncation => {
-                    // TODO: if authoritative, this is cacheable, store a TTL (currently that requires time, need a "now" here)
-                    // let valid_until = if response.authoritative() { now + response.negative_ttl() };
                     let soa = response.soa().as_ref().map(RecordRef::to_owned);
 
                     // Collect any referral nameservers and associated glue records

--- a/crates/net/src/error.rs
+++ b/crates/net/src/error.rs
@@ -323,6 +323,12 @@ impl DnsError {
                     None
                 };
 
+                let answers = if !response.answers.is_empty() {
+                    Some(response.answers.to_owned().into())
+                } else {
+                    None
+                };
+
                 let authorities = if !response.authorities.is_empty() {
                     Some(response.authorities.to_owned().into())
                 } else {
@@ -343,6 +349,7 @@ impl DnsError {
                     ns: option_ns,
                     negative_ttl,
                     response_code: code,
+                    answers,
                     authorities,
                 }))
             }
@@ -368,6 +375,8 @@ pub struct NoRecords {
     /// ResponseCode, if `NXDOMAIN`, the domain does not exist (and no other types).
     ///   If `NoError`, then the domain exists but there exist either other types at the same label, or subzones of that label.
     pub response_code: ResponseCode,
+    /// Answer section records from the response. These may be necessary for a CNAME chain.
+    pub answers: Option<Arc<[Record]>>,
     /// Authority records from the query. These are important to preserve for DNSSEC validation.
     pub authorities: Option<Arc<[Record]>>,
 }
@@ -381,6 +390,7 @@ impl NoRecords {
             ns: None,
             negative_ttl: None,
             response_code,
+            answers: None,
             authorities: None,
         }
     }

--- a/crates/net/src/error.rs
+++ b/crates/net/src/error.rs
@@ -317,23 +317,14 @@ impl DnsError {
                     })
                 }
 
-                let option_ns = if !referral_name_servers.is_empty() {
-                    Some(referral_name_servers.into())
-                } else {
-                    None
-                };
+                let option_ns =
+                    (!referral_name_servers.is_empty()).then(|| Arc::from(referral_name_servers));
 
-                let answers = if !response.answers.is_empty() {
-                    Some(response.answers.to_owned().into())
-                } else {
-                    None
-                };
+                let answers =
+                    (!response.answers.is_empty()).then(|| Arc::from(response.answers.as_slice()));
 
-                let authorities = if !response.authorities.is_empty() {
-                    Some(response.authorities.to_owned().into())
-                } else {
-                    None
-                };
+                let authorities = (!response.authorities.is_empty())
+                    .then(|| Arc::from(response.authorities.as_slice()));
 
                 let negative_ttl = response.negative_ttl();
                 let query = response

--- a/crates/resolver/src/recursor/error.rs
+++ b/crates/resolver/src/recursor/error.rs
@@ -218,6 +218,7 @@ impl From<AuthorityData> for NoRecords {
 
         let mut new = Self::new(data.query, response_code);
         new.soa = data.soa;
+        new.answers = data.answers;
         new.authorities = data.authorities;
         new
     }

--- a/crates/resolver/src/recursor/error.rs
+++ b/crates/resolver/src/recursor/error.rs
@@ -138,6 +138,7 @@ impl From<NetError> for RecursorError {
                 soa: no_records.soa,
                 no_records_found: true,
                 nx_domain: matches!(no_records.response_code, ResponseCode::NXDomain),
+                answers: None,
                 authorities: no_records.authorities,
             })
         }
@@ -202,6 +203,8 @@ pub struct AuthorityData {
     pub no_records_found: bool,
     /// IS nx domain?
     pub nx_domain: bool,
+    /// Answer records
+    pub answers: Option<Arc<[Record]>>,
     /// Authority records
     pub authorities: Option<Arc<[Record]>>,
 }

--- a/crates/resolver/src/recursor/handle.rs
+++ b/crates/resolver/src/recursor/handle.rs
@@ -328,6 +328,7 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
         RecursorError::recursion_exceeded(self.recursion_limit, depth, &query.name)?;
 
         let mut cname_chain = vec![];
+        let mut cname_chain_authorities = vec![];
 
         for rec in response.all_sections() {
             let CNAME(name) = &rec.data else {
@@ -366,7 +367,7 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
             {
                 Ok(cname_r) => cname_r,
                 Err(RecursorError::Negative(mut authority_data)) => {
-                    // Add CNAME chain to negative response.
+                    // Add records from CNAME chain to negative response.
                     let negative_response_answers =
                         authority_data.answers.as_deref().unwrap_or_default();
                     let mut answers = Vec::with_capacity(
@@ -378,6 +379,19 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
                     answers.extend(cname_chain.into_iter());
                     answers.extend(negative_response_answers.iter().cloned());
                     authority_data.answers = Some(Arc::from(answers));
+
+                    let negative_response_authorities =
+                        authority_data.authorities.as_deref().unwrap_or_default();
+                    let mut authorities = Vec::with_capacity(
+                        response.authorities.len()
+                            + cname_chain_authorities.len()
+                            + negative_response_authorities.len(),
+                    );
+                    authorities.extend(response.authorities.iter().cloned());
+                    authorities.extend(cname_chain_authorities.into_iter());
+                    authorities.extend(negative_response_authorities.iter().cloned());
+                    authority_data.authorities = Some(Arc::from(authorities));
+
                     return Err(RecursorError::Negative(authority_data));
                 }
                 Err(e) => {
@@ -402,11 +416,36 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
 
                 None
             }));
+            cname_chain_authorities.extend(response.authorities.iter().cloned());
         }
 
-        if !cname_chain.is_empty() {
-            response.answers.extend(cname_chain);
-        }
+        response.answers.extend(cname_chain);
+        response.authorities.extend(cname_chain_authorities);
+
+        // Drop referral-related records from response.
+        //
+        // As noted in the definition of "Referrals" from RFC 8499, responses with CNAME records may
+        // include a referral to another zone closer to the CNAME's target, along with glue records.
+        // The recursor should not include these in its final response.
+        let name_server_names = response
+            .authorities
+            .iter()
+            .flat_map(|record| match &record.data {
+                RData::NS(NS(name)) => Some(name.clone()),
+                _ => None,
+            })
+            .collect::<HashSet<_>>();
+        response.authorities.retain(|record| match &record.data {
+            rdata if rdata.record_type() == RecordType::NS => false,
+            #[cfg(feature = "__dnssec")]
+            RData::DNSSEC(DNSSECRData::RRSIG(rrsig)) => {
+                rrsig.input().type_covered != RecordType::NS
+            }
+            _ => true,
+        });
+        response
+            .additionals
+            .retain(|record| !name_server_names.contains(&record.name));
 
         Ok(response)
     }
@@ -875,8 +914,6 @@ mod for_dnssec {
                     Err(e) => return Err(NetError::from(e)),
                 };
 
-                // `DnssecDnsHandle` will only look at the answer section of the message so
-                // we can put "stubs" in the other fields
                 let mut msg = Message::query();
 
                 msg.add_answers(response.answers.iter().cloned());

--- a/crates/resolver/src/recursor/handle.rs
+++ b/crates/resolver/src/recursor/handle.rs
@@ -365,6 +365,21 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
                 .await
             {
                 Ok(cname_r) => cname_r,
+                Err(RecursorError::Negative(mut authority_data)) => {
+                    // Add CNAME chain to negative response.
+                    let negative_response_answers =
+                        authority_data.answers.as_deref().unwrap_or_default();
+                    let mut answers = Vec::with_capacity(
+                        response.answers.len()
+                            + cname_chain.len()
+                            + negative_response_answers.len(),
+                    );
+                    answers.extend(response.answers.iter().cloned());
+                    answers.extend(cname_chain.into_iter());
+                    answers.extend(negative_response_answers.iter().cloned());
+                    authority_data.answers = Some(Arc::from(answers));
+                    return Err(RecursorError::Negative(authority_data));
+                }
                 Err(e) => {
                     return Err(e);
                 }
@@ -474,6 +489,7 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
                 soa: None,
                 no_records_found: false,
                 nx_domain: true,
+                answers: None,
                 authorities: None,
             }));
         }

--- a/crates/server/src/zone_handler/catalog.rs
+++ b/crates/server/src/zone_handler/catalog.rs
@@ -1084,6 +1084,14 @@ async fn build_forwarded_response(
                 response_meta.response_code = ResponseCode::NXDomain;
             }
 
+            let answers = match e.answers() {
+                Some(answers) => AuthLookup::answers(
+                    LookupRecords::Section(answers.iter().cloned().collect()),
+                    None,
+                ),
+                None => AuthLookup::default(),
+            };
+
             // Collect all of the authority records, except the SOA
             let authorities = if let Some(authorities) = e.authorities() {
                 let authorities = authorities
@@ -1117,14 +1125,14 @@ async fn build_forwarded_response(
                 let soa = soa.into_record_of_rdata();
 
                 ResponseParts {
-                    answers: AuthLookup::default(),
+                    answers,
                     soa: Some(soa),
                     authorities,
                     additionals: AuthLookup::default(),
                 }
             } else {
                 ResponseParts {
-                    answers: AuthLookup::default(),
+                    answers,
                     soa: None,
                     authorities,
                     additionals: AuthLookup::default(),

--- a/crates/server/src/zone_handler/catalog.rs
+++ b/crates/server/src/zone_handler/catalog.rs
@@ -29,7 +29,7 @@ use crate::{
     proto::{
         op::{Edns, LowerQuery, Message, MessageType, Metadata, OpCode, ResponseCode},
         rr::{
-            LowerName, RecordSet, RecordType,
+            LowerName, Record, RecordType,
             rdata::opt::{EdnsCode, EdnsOption, NSIDPayload},
         },
     },
@@ -1046,14 +1046,10 @@ async fn build_forwarded_response(
     }
 
     struct ResponseParts {
-        answers: Answer,
+        answers: AuthLookup,
+        soa: Option<Record>,
         authorities: AuthLookup,
         additionals: AuthLookup,
-    }
-
-    enum Answer {
-        Normal(AuthLookup),
-        NoRecords(AuthLookup),
     }
 
     #[cfg_attr(not(feature = "__dnssec"), allow(unused_mut))]
@@ -1069,13 +1065,15 @@ async fn build_forwarded_response(
                 AuthLookup::answers(LookupRecords::Section(lookup.additionals().to_vec()), None);
 
             ResponseParts {
-                answers: Answer::Normal(answers),
+                answers,
+                soa: None,
                 authorities,
                 additionals,
             }
         }
         Ok(l) => ResponseParts {
-            answers: Answer::Normal(l),
+            answers: l,
+            soa: None,
             authorities: AuthLookup::default(),
             additionals: AuthLookup::default(),
         },
@@ -1117,17 +1115,17 @@ async fn build_forwarded_response(
 
             if let Some(soa) = e.into_soa() {
                 let soa = soa.into_record_of_rdata();
-                let record_set = Arc::new(RecordSet::from(soa));
-                let records = LookupRecords::new(LookupOptions::default(), record_set);
 
                 ResponseParts {
-                    answers: Answer::NoRecords(AuthLookup::answers(records, None)),
+                    answers: AuthLookup::default(),
+                    soa: Some(soa),
                     authorities,
                     additionals: AuthLookup::default(),
                 }
             } else {
                 ResponseParts {
-                    answers: Answer::Normal(AuthLookup::default()),
+                    answers: AuthLookup::default(),
+                    soa: None,
                     authorities,
                     additionals: AuthLookup::default(),
                 }
@@ -1143,17 +1141,17 @@ async fn build_forwarded_response(
 
             if let Some(soa) = response.soa() {
                 let soa = soa.to_owned().into_record_of_rdata();
-                let record_set = Arc::new(RecordSet::from(soa));
-                let records = LookupRecords::new(LookupOptions::default(), record_set);
 
                 ResponseParts {
-                    answers: Answer::NoRecords(AuthLookup::answers(records, None)),
+                    answers: AuthLookup::default(),
+                    soa: Some(soa),
                     authorities: AuthLookup::default(),
                     additionals: AuthLookup::default(),
                 }
             } else {
                 ResponseParts {
-                    answers: Answer::Normal(AuthLookup::default()),
+                    answers: AuthLookup::default(),
+                    soa: None,
                     authorities: AuthLookup::default(),
                     additionals: AuthLookup::default(),
                 }
@@ -1163,7 +1161,8 @@ async fn build_forwarded_response(
             response_meta.response_code = ResponseCode::ServFail;
             debug!(error = ?e, "error resolving");
             ResponseParts {
-                answers: Answer::Normal(AuthLookup::default()),
+                answers: AuthLookup::default(),
+                soa: None,
                 authorities: AuthLookup::default(),
                 additionals: AuthLookup::default(),
             }
@@ -1197,8 +1196,8 @@ async fn build_forwarded_response(
         //
         // we may want to interpret (B) as allowed ("MAY be skipped") as a form of optimization in
         // the future to reduce the number of network transactions that a CD=1 query needs.
-        match &mut response_parts.answers {
-            Answer::Normal(answers) => match DnssecSummary::from_records(answers.iter()) {
+        if response_parts.soa.is_none() {
+            match DnssecSummary::from_records(response_parts.answers.iter()) {
                 DnssecSummary::Secure
                     if (request_meta.authentic_data || lookup_options.dnssec_ok) =>
                 {
@@ -1208,39 +1207,36 @@ async fn build_forwarded_response(
                 DnssecSummary::Bogus if !request_meta.checking_disabled => {
                     response_meta.response_code = ResponseCode::ServFail;
                     // do not return Bogus records when CD=0
-                    *answers = AuthLookup::default();
+                    response_parts.answers = AuthLookup::default();
                 }
                 _ => {}
-            },
-            Answer::NoRecords(soa) => {
-                match DnssecSummary::from_records(response_parts.authorities.iter()) {
-                    DnssecSummary::Secure
-                        if (request_meta.authentic_data || lookup_options.dnssec_ok) =>
-                    {
-                        trace!("setting ad header");
-                        response_meta.authentic_data = true;
-                    }
-                    DnssecSummary::Bogus if !request_meta.checking_disabled => {
-                        response_meta.response_code = ResponseCode::ServFail;
-                        // do not return Bogus records when CD=0
-                        *soa = AuthLookup::default();
-                        trace!("clearing SOA record from response");
-                    }
-                    _ => {}
+            }
+        } else {
+            match DnssecSummary::from_records(response_parts.authorities.iter()) {
+                DnssecSummary::Secure
+                    if (request_meta.authentic_data || lookup_options.dnssec_ok) =>
+                {
+                    trace!("setting ad header");
+                    response_meta.authentic_data = true;
                 }
+                DnssecSummary::Bogus if !request_meta.checking_disabled => {
+                    response_meta.response_code = ResponseCode::ServFail;
+                    // do not return Bogus records when CD=0
+                    trace!("clearing SOA record from response");
+                    response_parts.soa = None;
+                }
+                _ => {}
             }
         }
     }
 
     message.metadata = response_meta;
 
-    match response_parts.answers {
-        Answer::Normal(answers) => {
-            message.answers.extend(answers.iter().cloned());
-        }
-        Answer::NoRecords(soa) => {
-            message.authorities.extend(soa.iter().cloned());
-        }
+    message
+        .answers
+        .extend(response_parts.answers.iter().cloned());
+    if let Some(soa) = response_parts.soa {
+        message.authorities.push(soa);
     }
     message
         .authorities
@@ -1263,7 +1259,7 @@ mod tests {
     use crate::proto::{
         op::{MessageType, OpCode, Query},
         rr::{
-            Name, RData, Record, RecordType,
+            Name, RData, Record, RecordSet, RecordType,
             rdata::{A, SOA},
         },
     };

--- a/crates/server/src/zone_handler/catalog.rs
+++ b/crates/server/src/zone_handler/catalog.rs
@@ -1108,50 +1108,48 @@ async fn build_forwarded_response(
             };
 
             // Collect all of the authority records, except the SOA
-            let authorities = if let Some(authorities) = e.authorities() {
-                let authorities = authorities
-                    .iter()
-                    .filter_map(|record| {
-                        // if we have another record (probably a dnssec record) that
-                        // matches the query name, but wasn't included in the answers
-                        // section, change the NXDomain response to NoError
-                        if record.name == **query.name() {
-                            debug!(
-                                query_name = %query.name(),
-                                ?record,
-                                "changing response code from NXDomain to NoError due to other record",
-                            );
-                            response_meta.response_code = ResponseCode::NoError;
-                        }
+            let authorities = match e.authorities() {
+                Some(authorities) => {
+                    let authorities = authorities
+                        .iter()
+                        .filter_map(|record| {
+                            // if we have another record (probably a dnssec record) that
+                            // matches the query name, but wasn't included in the answers
+                            // section, change the NXDomain response to NoError
+                            if record.name == **query.name() {
+                                debug!(
+                                    query_name = %query.name(),
+                                    ?record,
+                                    "changing response code from NXDomain to NoError due to other record",
+                                );
+                                response_meta.response_code = ResponseCode::NoError;
+                            }
 
-                        match record.record_type() {
-                            RecordType::SOA => None,
-                            _ => Some(record.clone()),
-                        }
-                    })
-                    .collect();
+                            match record.record_type() {
+                                RecordType::SOA => None,
+                                _ => Some(record.clone()),
+                            }
+                        })
+                        .collect();
 
-                AuthLookup::answers(LookupRecords::Section(authorities), None)
-            } else {
-                AuthLookup::default()
+                    AuthLookup::answers(LookupRecords::Section(authorities), None)
+                }
+                None => AuthLookup::default(),
             };
 
-            if let Some(soa) = e.into_soa() {
-                let soa = soa.into_record_of_rdata();
-
-                ResponseParts {
+            match e.into_soa() {
+                Some(soa) => ResponseParts {
                     answers,
-                    soa: Some(soa),
+                    soa: Some(soa.into_record_of_rdata()),
                     authorities,
                     additionals: AuthLookup::default(),
-                }
-            } else {
-                ResponseParts {
+                },
+                None => ResponseParts {
                     answers,
                     soa: None,
                     authorities,
                     additionals: AuthLookup::default(),
-                }
+                },
             }
         }
         #[cfg(all(feature = "__dnssec", feature = "recursor"))]
@@ -1162,22 +1160,19 @@ async fn build_forwarded_response(
         )))) if proof.is_insecure() => {
             response_meta.response_code = response.response_code;
 
-            if let Some(soa) = response.soa() {
-                let soa = soa.to_owned().into_record_of_rdata();
-
-                ResponseParts {
+            match response.soa() {
+                Some(soa) => ResponseParts {
                     answers: AuthLookup::default(),
-                    soa: Some(soa),
+                    soa: Some(soa.to_owned().into_record_of_rdata()),
                     authorities: AuthLookup::default(),
                     additionals: AuthLookup::default(),
-                }
-            } else {
-                ResponseParts {
+                },
+                None => ResponseParts {
                     answers: AuthLookup::default(),
                     soa: None,
                     authorities: AuthLookup::default(),
                     additionals: AuthLookup::default(),
-                }
+                },
             }
         }
         Err(e) => {

--- a/crates/server/src/zone_handler/catalog.rs
+++ b/crates/server/src/zone_handler/catalog.rs
@@ -1045,13 +1045,19 @@ async fn build_forwarded_response(
         return message;
     }
 
+    struct ResponseParts {
+        answers: Answer,
+        authorities: AuthLookup,
+        additionals: AuthLookup,
+    }
+
     enum Answer {
         Normal(AuthLookup),
         NoRecords(AuthLookup),
     }
 
     #[cfg_attr(not(feature = "__dnssec"), allow(unused_mut))]
-    let (mut answers, authorities, additionals) = match response {
+    let mut response_parts = match response {
         #[cfg(feature = "resolver")]
         Ok(AuthLookup::Resolved(lookup)) => {
             // Extract each section from the Lookup to preserve section structure
@@ -1062,13 +1068,17 @@ async fn build_forwarded_response(
             let additionals =
                 AuthLookup::answers(LookupRecords::Section(lookup.additionals().to_vec()), None);
 
-            (Answer::Normal(answers), authorities, additionals)
+            ResponseParts {
+                answers: Answer::Normal(answers),
+                authorities,
+                additionals,
+            }
         }
-        Ok(l) => (
-            Answer::Normal(l),
-            AuthLookup::default(),
-            AuthLookup::default(),
-        ),
+        Ok(l) => ResponseParts {
+            answers: Answer::Normal(l),
+            authorities: AuthLookup::default(),
+            additionals: AuthLookup::default(),
+        },
         Err(e) if e.is_no_records_found() || e.is_nx_domain() => {
             debug!(error = ?e, "error resolving");
 
@@ -1110,17 +1120,17 @@ async fn build_forwarded_response(
                 let record_set = Arc::new(RecordSet::from(soa));
                 let records = LookupRecords::new(LookupOptions::default(), record_set);
 
-                (
-                    Answer::NoRecords(AuthLookup::answers(records, None)),
+                ResponseParts {
+                    answers: Answer::NoRecords(AuthLookup::answers(records, None)),
                     authorities,
-                    AuthLookup::default(),
-                )
+                    additionals: AuthLookup::default(),
+                }
             } else {
-                (
-                    Answer::Normal(AuthLookup::default()),
+                ResponseParts {
+                    answers: Answer::Normal(AuthLookup::default()),
                     authorities,
-                    AuthLookup::default(),
-                )
+                    additionals: AuthLookup::default(),
+                }
             }
         }
         #[cfg(all(feature = "__dnssec", feature = "recursor"))]
@@ -1136,27 +1146,27 @@ async fn build_forwarded_response(
                 let record_set = Arc::new(RecordSet::from(soa));
                 let records = LookupRecords::new(LookupOptions::default(), record_set);
 
-                (
-                    Answer::NoRecords(AuthLookup::answers(records, None)),
-                    AuthLookup::default(),
-                    AuthLookup::default(),
-                )
+                ResponseParts {
+                    answers: Answer::NoRecords(AuthLookup::answers(records, None)),
+                    authorities: AuthLookup::default(),
+                    additionals: AuthLookup::default(),
+                }
             } else {
-                (
-                    Answer::Normal(AuthLookup::default()),
-                    AuthLookup::default(),
-                    AuthLookup::default(),
-                )
+                ResponseParts {
+                    answers: Answer::Normal(AuthLookup::default()),
+                    authorities: AuthLookup::default(),
+                    additionals: AuthLookup::default(),
+                }
             }
         }
         Err(e) => {
             response_meta.response_code = ResponseCode::ServFail;
             debug!(error = ?e, "error resolving");
-            (
-                Answer::Normal(AuthLookup::default()),
-                AuthLookup::default(),
-                AuthLookup::default(),
-            )
+            ResponseParts {
+                answers: Answer::Normal(AuthLookup::default()),
+                authorities: AuthLookup::default(),
+                additionals: AuthLookup::default(),
+            }
         }
     };
 
@@ -1187,7 +1197,7 @@ async fn build_forwarded_response(
         //
         // we may want to interpret (B) as allowed ("MAY be skipped") as a form of optimization in
         // the future to reduce the number of network transactions that a CD=1 query needs.
-        match &mut answers {
+        match &mut response_parts.answers {
             Answer::Normal(answers) => match DnssecSummary::from_records(answers.iter()) {
                 DnssecSummary::Secure
                     if (request_meta.authentic_data || lookup_options.dnssec_ok) =>
@@ -1202,27 +1212,29 @@ async fn build_forwarded_response(
                 }
                 _ => {}
             },
-            Answer::NoRecords(soa) => match DnssecSummary::from_records(authorities.iter()) {
-                DnssecSummary::Secure
-                    if (request_meta.authentic_data || lookup_options.dnssec_ok) =>
-                {
-                    trace!("setting ad header");
-                    response_meta.authentic_data = true;
+            Answer::NoRecords(soa) => {
+                match DnssecSummary::from_records(response_parts.authorities.iter()) {
+                    DnssecSummary::Secure
+                        if (request_meta.authentic_data || lookup_options.dnssec_ok) =>
+                    {
+                        trace!("setting ad header");
+                        response_meta.authentic_data = true;
+                    }
+                    DnssecSummary::Bogus if !request_meta.checking_disabled => {
+                        response_meta.response_code = ResponseCode::ServFail;
+                        // do not return Bogus records when CD=0
+                        *soa = AuthLookup::default();
+                        trace!("clearing SOA record from response");
+                    }
+                    _ => {}
                 }
-                DnssecSummary::Bogus if !request_meta.checking_disabled => {
-                    response_meta.response_code = ResponseCode::ServFail;
-                    // do not return Bogus records when CD=0
-                    *soa = AuthLookup::default();
-                    trace!("clearing SOA record from response");
-                }
-                _ => {}
-            },
+            }
         }
     }
 
     message.metadata = response_meta;
 
-    match answers {
+    match response_parts.answers {
         Answer::Normal(answers) => {
             message.answers.extend(answers.iter().cloned());
         }
@@ -1230,8 +1242,12 @@ async fn build_forwarded_response(
             message.authorities.extend(soa.iter().cloned());
         }
     }
-    message.authorities.extend(authorities.iter().cloned());
-    message.additionals.extend(additionals.iter().cloned());
+    message
+        .authorities
+        .extend(response_parts.authorities.iter().cloned());
+    message
+        .additionals
+        .extend(response_parts.additionals.iter().cloned());
 
     // Strip DNSSEC records from all applicable sections based on the DNSSEC OK setting.
     message.maybe_strip_dnssec_records(lookup_options.dnssec_ok)

--- a/crates/server/src/zone_handler/catalog.rs
+++ b/crates/server/src/zone_handler/catalog.rs
@@ -1071,6 +1071,21 @@ async fn build_forwarded_response(
                 additionals,
             }
         }
+        Ok(AuthLookup::Response(message)) => {
+            // Extract each section from the Message to preserve section structure.
+            ResponseParts {
+                answers: AuthLookup::answers(LookupRecords::Section(message.answers.clone()), None),
+                soa: None,
+                authorities: AuthLookup::answers(
+                    LookupRecords::Section(message.authorities.clone()),
+                    None,
+                ),
+                additionals: AuthLookup::answers(
+                    LookupRecords::Section(message.additionals.clone()),
+                    None,
+                ),
+            }
+        }
         Ok(l) => ResponseParts {
             answers: l,
             soa: None,

--- a/crates/server/src/zone_handler/mod.rs
+++ b/crates/server/src/zone_handler/mod.rs
@@ -432,6 +432,22 @@ impl LookupError {
         }
     }
 
+    /// Return answer records
+    pub fn answers(&self) -> Option<Arc<[Record]>> {
+        match self {
+            Self::NetError(NetError::Dns(DnsError::NoRecordsFound(NoRecords {
+                answers, ..
+            }))) => answers.clone(),
+            #[cfg(feature = "recursor")]
+            Self::RecursiveError(RecursorError::Negative(fwd)) => fwd.answers.clone(),
+            #[cfg(feature = "recursor")]
+            Self::RecursiveError(RecursorError::Net(NetError::Dns(DnsError::NoRecordsFound(
+                NoRecords { answers, .. },
+            )))) => answers.clone(),
+            _ => None,
+        }
+    }
+
     /// Return authority records
     pub fn authorities(&self) -> Option<Arc<[Record]>> {
         match self {

--- a/crates/server/src/zone_handler/mod.rs
+++ b/crates/server/src/zone_handler/mod.rs
@@ -433,35 +433,35 @@ impl LookupError {
     }
 
     /// Return answer records
-    pub fn answers(&self) -> Option<Arc<[Record]>> {
+    pub fn answers(&self) -> Option<&Arc<[Record]>> {
         match self {
             Self::NetError(NetError::Dns(DnsError::NoRecordsFound(NoRecords {
                 answers, ..
-            }))) => answers.clone(),
+            }))) => answers.as_ref(),
             #[cfg(feature = "recursor")]
-            Self::RecursiveError(RecursorError::Negative(fwd)) => fwd.answers.clone(),
+            Self::RecursiveError(RecursorError::Negative(fwd)) => fwd.answers.as_ref(),
             #[cfg(feature = "recursor")]
             Self::RecursiveError(RecursorError::Net(NetError::Dns(DnsError::NoRecordsFound(
                 NoRecords { answers, .. },
-            )))) => answers.clone(),
+            )))) => answers.as_ref(),
             _ => None,
         }
     }
 
     /// Return authority records
-    pub fn authorities(&self) -> Option<Arc<[Record]>> {
+    pub fn authorities(&self) -> Option<&Arc<[Record]>> {
         match self {
             Self::NetError(NetError::Dns(DnsError::NoRecordsFound(NoRecords {
                 authorities,
                 ..
-            }))) => authorities.clone(),
+            }))) => authorities.as_ref(),
             Self::NetError(_) => None,
             #[cfg(feature = "recursor")]
-            Self::RecursiveError(RecursorError::Negative(fwd)) => fwd.authorities.clone(),
+            Self::RecursiveError(RecursorError::Negative(fwd)) => fwd.authorities.as_ref(),
             #[cfg(feature = "recursor")]
             Self::RecursiveError(RecursorError::Net(NetError::Dns(DnsError::NoRecordsFound(
                 NoRecords { authorities, .. },
-            )))) => authorities.clone(),
+            )))) => authorities.as_ref(),
             _ => None,
         }
     }


### PR DESCRIPTION
This branch first adds some conformance tests with a DNSSEC-aware but non-validating resolver, to confirm that all necessary records from both a CNAME response and another response for the target of the CNAME are included in the resolver's final response. We need to include the initial CNAME record when the subsequent query gets a negative response. We need to preserve NSEC/NSEC3 records from both responses for either wildcard proofs or negative response proofs. Lastly, we need to preserve RRSIGs for all of the above. Fixing these issues requires changes to `resolve_cnames()`, additional fields in error types, and changes to `build_forwarded_response()` in the catalog.