### PR TITLE
fix(resolver): thread bind_addr through TLS and HTTPS connections

### DIFF
--- a/crates/net/src/tls.rs
+++ b/crates/net/src/tls.rs
@@ -52,6 +52,44 @@ pub type TlsClientStream<S> =
 pub async fn tls_exchange<P: RuntimeProvider<Tcp = S>, S: DnsTcpStream>(
     remote_addr: SocketAddr,
     server_name: ServerName<'static>,
+    config: ClientConfig,
+    timeout: Duration,
+    connect_timeout: Duration,
+    max_active_requests: Option<usize>,
+    provider: P,
+) -> Result<DnsExchange<P>, NetError> {
+    tls_exchange_with_bind_addr(
+        remote_addr,
+        None,
+        server_name,
+        config,
+        timeout,
+        connect_timeout,
+        max_active_requests,
+        provider,
+    )
+    .await
+}
+
+/// Create a new [`DnsExchange`] wrapped around a multiplexed [`TlsClientStream`],
+/// optionally binding the underlying TCP socket to a local address.
+///
+/// # Arguments
+///
+/// * `remote_addr` - Address of the remote nameserver
+/// * `bind_addr` - Local address to bind the outgoing TCP socket to. When `None`, the OS picks.
+/// * `server_name` - TLS server name for certificate validation
+/// * `config` - TLS client configuration
+/// * `timeout` - Timeout for requests
+/// * `connect_timeout` - Timeout for the TCP connect step
+/// * `max_active_requests` - Optional limit on concurrent in-flight requests.
+///   If `None`, uses the default (32).
+/// * `provider` - Runtime provider for spawning background tasks
+#[allow(clippy::too_many_arguments)]
+pub async fn tls_exchange_with_bind_addr<P: RuntimeProvider<Tcp = S>, S: DnsTcpStream>(
+    remote_addr: SocketAddr,
+    bind_addr: Option<SocketAddr>,
+    server_name: ServerName<'static>,
     mut config: ClientConfig,
     timeout: Duration,
     connect_timeout: Duration,
@@ -62,7 +100,7 @@ pub async fn tls_exchange<P: RuntimeProvider<Tcp = S>, S: DnsTcpStream>(
     config.enable_sni = false;
 
     let stream = provider
-        .connect_tcp(remote_addr, None, Some(connect_timeout))
+        .connect_tcp(remote_addr, bind_addr, Some(connect_timeout))
         .await?;
     let (future, sender) = tls_client_connect_with_future(
         stream,

--- a/crates/resolver/src/connection_provider.rs
+++ b/crates/resolver/src/connection_provider.rs
@@ -32,7 +32,7 @@ use crate::net::h3::H3ClientStream;
 #[cfg(feature = "__quic")]
 use crate::net::quic::QuicClientStream;
 #[cfg(feature = "__tls")]
-use crate::net::tls::{client_config, default_provider, tls_exchange};
+use crate::net::tls::{client_config, default_provider, tls_exchange_with_bind_addr};
 use crate::{
     config::{ConnectionConfig, ProtocolConfig},
     name_server_pool::PoolContext,
@@ -115,8 +115,9 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
                 };
 
                 let server_name = server_name.to_owned();
-                Ok(Box::pin(tls_exchange(
+                Ok(Box::pin(tls_exchange_with_bind_addr(
                     remote_addr,
+                    config.bind_addr,
                     server_name,
                     cx.tls.clone(),
                     cx.options.timeout,
@@ -126,11 +127,19 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
                 )))
             }
             #[cfg(feature = "__https")]
-            (ProtocolConfig::Https { server_name, path }, _) => Ok(Box::pin(
-                HttpsClientStream::builder(Arc::new(cx.tls.clone()), self.clone())
-                    .connect_timeout(cx.options.connect_timeout)
-                    .exchange(remote_addr, server_name.clone(), path.clone()),
-            )),
+            (ProtocolConfig::Https { server_name, path }, _) => {
+                let mut builder =
+                    HttpsClientStream::builder(Arc::new(cx.tls.clone()), self.clone())
+                        .connect_timeout(cx.options.connect_timeout);
+                if let Some(bind_addr) = config.bind_addr {
+                    builder.bind_addr(bind_addr);
+                }
+                Ok(Box::pin(builder.exchange(
+                    remote_addr,
+                    server_name.clone(),
+                    path.clone(),
+                )))
+            }
 
             #[cfg(feature = "__quic")]
             (ProtocolConfig::Quic { server_name }, Some(binder)) => {


### PR DESCRIPTION
Closes #2087.

NameServerConfig.bind_addr was honored for UDP, TCP, QUIC, and H3 paths but ignored for TLS (DoT) and HTTPS (DoH). On hosts with multiple addresses this made it impossible to control the source IP for outbound TLS/HTTPS DNS queries.

For TLS, add tls_exchange_with_bind_addr alongside the existing tls_exchange. tls_exchange now delegates with bind_addr=None, preserving its public signature. The new function mirrors the existing tls_client_connect_with_bind_addr pattern in the same module.

For HTTPS, HttpsClientStreamBuilder already exposes .bind_addr(...); the resolver simply was not calling it. The connection provider now chains it when config.bind_addr is Some.

Semver-compatible: tls_exchange's public signature is unchanged, the new function is additive, the HTTPS change is purely an internal call site in hickory-resolver. UDP/TCP/QUIC/H3 behavior is unchanged.