### PR TITLE
Add conformance test for RFC 6840 section 4.3

### DIFF
--- a/conformance/conformance-tests/src/resolver/dnssec.rs
+++ b/conformance/conformance-tests/src/resolver/dnssec.rs
@@ -5,5 +5,6 @@ mod fixtures;
 mod missing_records;
 mod regression;
 mod rfc4035;
+mod rfc6840;
 mod rfc6975;
 mod scenarios;

--- a/conformance/conformance-tests/src/resolver/dnssec/rfc6840.rs
+++ b/conformance/conformance-tests/src/resolver/dnssec/rfc6840.rs
@@ -1,0 +1,1 @@
+mod section_4_3;

--- a/conformance/conformance-tests/src/resolver/dnssec/rfc6840/section_4_3.rs
+++ b/conformance/conformance-tests/src/resolver/dnssec/rfc6840/section_4_3.rs
@@ -1,0 +1,174 @@
+//! These tests checks whether a resolver correctly treats responses as bogus if
+//! an NSEC or NSEC3 record indicates there is a CNAME record at the QNAME, but
+//! the response does not include it.
+//!
+//! > 4.3.  Check for CNAME
+//!
+//! > Section 5 of RFC4035 says nothing explicit about validating
+//! > responses based on (or that should be based on) CNAMEs.  When
+//! > validating a NOERROR/NODATA response, validators MUST check the CNAME
+//! > bit in the matching NSEC or NSEC3 RR's type bitmap in addition to the
+//! > bit for the query type.
+//!
+//! > Without this check, an attacker could successfully transform a
+//! > positive CNAME response into a NOERROR/NODATA response by (for
+//! > example) simply stripping the CNAME RRset from the response.  A naive
+//! > validator would then note that the QTYPE was not present in the
+//! > matching NSEC/NSEC3 RR, but fail to notice that the CNAME bit was
+//! > set; thus, the response should have been a positive CNAME response.
+//!
+//! <https://datatracker.ietf.org/doc/html/rfc6840#section-4.3>
+//!
+//! A proxy server sits in front of the authoritative server in order to forge
+//! responses that exercise checks related to this requirement. When the
+//! resolver sends a request for `alias.hickory-dns.testing.`, instead of
+//! returning the correct CNAME record, the proxy will make a request for a
+//! different name, and use the DNSSEC records it receives to craft its own
+//! response.
+
+use std::net::Ipv4Addr;
+
+use dns_test::{
+    Error, FQDN, Implementation, Network, PEER, Resolver,
+    client::{Client, DigSettings, DigStatus},
+    name_server::NameServer,
+    record::{A, CNAME, Record, RecordType},
+    zone_file::{Nsec, SignSettings},
+};
+
+#[test]
+fn nodata_check_cname_bit_nsec() -> Result<(), Error> {
+    nodata_check_cname_bit(Nsec::_1)
+}
+
+#[test]
+fn nodata_check_cname_bit_nsec3() -> Result<(), Error> {
+    nodata_check_cname_bit(Nsec::_3 {
+        iterations: 1,
+        opt_out: false,
+        salt: None,
+    })
+}
+
+fn nodata_check_cname_bit(nsec: Nsec) -> Result<(), Error> {
+    let network = Network::new()?;
+    let mut leaf_ns = NameServer::new(&PEER, FQDN::TEST_DOMAIN, &network)?;
+    leaf_ns.add(CNAME {
+        fqdn: FQDN("alias.hickory-dns.testing.")?,
+        ttl: 3600,
+        target: FQDN("www.hickory-dns.testing.")?,
+    });
+    leaf_ns.add(A {
+        fqdn: FQDN("www.hickory-dns.testing.")?,
+        ttl: 3600,
+        ipv4_addr: Ipv4Addr::new(192, 168, 0, 1),
+    });
+
+    let leaf_ns = leaf_ns.sign(SignSettings::default().nsec(nsec))?;
+    let proxy_ns = NameServer::new(
+        &Implementation::test_server(
+            "bogus_no_data_instead_of_cname",
+            vec![leaf_ns.ipv4_addr().to_string()],
+            "both",
+        ),
+        leaf_ns.zone().clone(),
+        &network,
+    )?;
+    let mut root_ns = NameServer::new(&PEER, FQDN::ROOT, &network)?;
+    root_ns.referral_nameserver(&proxy_ns);
+    root_ns.add(leaf_ns.ds().ksk.clone());
+    let root_ns = root_ns.sign(SignSettings::default())?;
+    let trust_anchor = root_ns.trust_anchor();
+    let root_ns = root_ns.start()?;
+    let leaf_ns = leaf_ns.start()?;
+    let proxy_ns = proxy_ns.start()?;
+
+    let client = Client::new(&network)?;
+
+    // Confirm the authoritative server and proxy are producing the expected NSEC or NSEC3 records
+    // in their responses.
+    //
+    // The "real" query is for `alias.hickory-dns.testing.`, while the proxy queries for
+    // `alias9.hickory-dns.testing.` in order to fetch the DNSSEC records it needs. The latter name
+    // was chosen so that it includes whichever NSEC or NSEC3 record matches the name
+    // `alias.hickory-dns.testing.`. Note that if we queried the real authoritative name server for
+    // this same name, we would not get any NSEC or NSEC3 records at all, just the CNAME record and
+    // its RRSIG, since we'd get a positive response. By instead making a query for a name that
+    // doesn't exist, we ensure that we'll get some record nonexistence proof.
+    //
+    // When we use NSEC records, `alias9.hickory-dns.testing.` follows shortly after
+    // `alias.hickory-dns.testing.` due to the canonical DNS name order. When we use NSEC3 records,
+    // `alias9.hickory-dns.testing.` follows shortly after `alias.hickory-dns.testing.` because the
+    // relevant hash values are as follows.
+    //
+    //   $ nsec3hash -r 1 0 1 - alias.hickory-dns.testing.
+    //   alias.hickory-dns.testing. NSEC3 1 0 1 - 2K7LM9HEA6P5C02C1UFTIABK7MMQ98QC
+    //   $ nsec3hash -r 1 0 1 - alias9.hickory-dns.testing.
+    //   alias9.hickory-dns.testing. NSEC3 1 0 1 - 2NTM19O86SIHKN6OEDAFCUS4E81J0F2H
+    //
+    // In both cases, we get the record matching the original query name, so we can build our bogus
+    // no data response.
+    let auth_dig_settings = *DigSettings::default().dnssec();
+    let response = client.dig(
+        auth_dig_settings,
+        leaf_ns.ipv4_addr(),
+        RecordType::A,
+        &FQDN("alias9.hickory-dns.testing.")?,
+    )?;
+    let nsec_present = response.authority.iter().any(|record| {
+        let Record::NSEC(nsec) = record else {
+            return false;
+        };
+        nsec.fqdn.as_str() == "alias.hickory-dns.testing."
+    });
+    let nsec3_present = response.authority.iter().any(|record| {
+        let Record::NSEC3(nsec3) = record else {
+            return false;
+        };
+        nsec3.fqdn.as_str().to_lowercase()
+            == "2k7lm9hea6p5c02c1uftiabk7mmq98qc.hickory-dns.testing."
+    });
+    assert!(
+        nsec_present || nsec3_present,
+        "expected NSEC/NSEC3 records missing from authoritative server response\n{response:#?}"
+    );
+
+    let response = client.dig(
+        auth_dig_settings,
+        proxy_ns.ipv4_addr(),
+        RecordType::A,
+        &FQDN("alias.hickory-dns.testing.")?,
+    )?;
+    let nsec_present = response.authority.iter().any(|record| {
+        let Record::NSEC(nsec) = record else {
+            return false;
+        };
+        nsec.fqdn.as_str() == "alias.hickory-dns.testing."
+    });
+    let nsec3_present = response.authority.iter().any(|record| {
+        let Record::NSEC3(nsec3) = record else {
+            return false;
+        };
+        nsec3.fqdn.as_str().to_lowercase()
+            == "2k7lm9hea6p5c02c1uftiabk7mmq98qc.hickory-dns.testing."
+    });
+    assert!(
+        nsec_present || nsec3_present,
+        "expected NSEC/NSEC3 records missing from proxy server response\n{response:#?}"
+    );
+
+    let resolver = Resolver::new(&network, root_ns.root_hint())
+        .trust_anchor(&trust_anchor)
+        .start()?;
+    let recursive_dig_settings = *DigSettings::default().recurse().dnssec().authentic_data();
+    let response = client.dig(
+        recursive_dig_settings,
+        resolver.ipv4_addr(),
+        RecordType::A,
+        &FQDN("alias.hickory-dns.testing.")?,
+    )?;
+
+    assert_eq!(response.status, DigStatus::SERVFAIL, "{response:#?}");
+
+    Ok(())
+}

--- a/conformance/test-server/src/handlers.rs
+++ b/conformance/test-server/src/handlers.rs
@@ -1,5 +1,5 @@
 use crate::{Handler, Transport, zone_file};
-use anyhow::{Context, Error, Result};
+use anyhow::{Context, Error, Result, anyhow};
 use async_trait::async_trait;
 use data_encoding::BASE32_DNSSEC;
 use hickory_net::{
@@ -13,13 +13,13 @@ use hickory_proto::{
         Nsec3HashAlgorithm,
         rdata::{DNSSECRData, NSEC3, NSEC3PARAM, RRSIG},
     },
-    op::{DnsRequest, DnsRequestOptions, Message, MessageType, ResponseCode},
+    op::{DnsRequest, DnsRequestOptions, Message, MessageType, Query, ResponseCode},
     rr::{RData, Record, RecordType, domain::Name, rdata},
 };
 use std::{
     env,
     net::IpAddr,
-    ops::DerefMut,
+    ops::{Deref, DerefMut},
     path::Path,
     sync::atomic::{AtomicBool, AtomicU8, Ordering},
 };
@@ -699,6 +699,104 @@ impl Handler for DropRrsetHandler {
                 true
             });
         }
+
+        response.metadata.id = id;
+        Ok(Some(
+            response.to_vec().context("error serializing response")?,
+        ))
+    }
+}
+
+/// This handler proxies requests to another server, and reassembles a bogus no data response
+/// in place of a positive CNAME response.
+pub(crate) struct BogusNoDataInsteadOfCname {
+    ip_address: IpAddr,
+}
+
+impl BogusNoDataInsteadOfCname {
+    pub(crate) fn new(ip_address: IpAddr) -> Self {
+        Self { ip_address }
+    }
+}
+
+#[async_trait]
+impl Handler for BogusNoDataInsteadOfCname {
+    async fn handle(&self, bytes: &[u8], _transport: Transport) -> Result<Option<Vec<u8>>> {
+        let (future, sender) = TcpClientStream::new(
+            (self.ip_address, 53).into(),
+            None,
+            None,
+            TokioRuntimeProvider::new(),
+        );
+        let (client, bg) = Client::<TokioRuntimeProvider>::new(future.await?, sender);
+        tokio::task::spawn(bg);
+
+        let query_message = Message::from_vec(bytes).context("erorr parsing query into message")?;
+        let query_request = DnsRequest::new(query_message, DnsRequestOptions::default());
+        let id = query_request.id;
+
+        let positive_cname_query_name = Name::parse("alias.hickory-dns.testing.", None).unwrap();
+
+        let mut response = if query_request.queries[0].name == positive_cname_query_name {
+            // This query was chosen so that the NSEC/NSEC3 record covering the query name will be
+            // the same as the NSEC/NSEC3 record that matches the name "alias.hickory-dns.testing.".
+            let negative_query = Query::new(
+                Name::parse("alias9.hickory-dns.testing.", None).unwrap(),
+                RecordType::A,
+            );
+            let mut options = DnsRequestOptions::default();
+            options.use_edns = true;
+            options.edns_set_dnssec_ok = true;
+            let request = DnsRequest::from_query(negative_query, options);
+            let mut response = client
+                .send(request)
+                .first_answer()
+                .await
+                .context("error sending proxied query")?;
+
+            // Confirm that the expected NSEC/NSEC3 records are present.
+            let nsec_name = Name::parse("alias.hickory-dns.testing.", None).unwrap();
+            let nsec3_name = Name::parse(
+                "2k7lm9hea6p5c02c1uftiabk7mmq98qc.hickory-dns.testing.",
+                None,
+            )
+            .unwrap();
+            let nsec_present = response
+                .authorities
+                .iter()
+                .any(|record| record.record_type() == RecordType::NSEC && record.name == nsec_name);
+            let nsec3_present = response.authorities.iter().any(|record| {
+                record.record_type() == RecordType::NSEC3 && record.name == nsec3_name
+            });
+            let dnssec_ok = query_request
+                .edns
+                .as_ref()
+                .is_some_and(|edns| edns.flags().dnssec_ok);
+            if dnssec_ok && !nsec_present && !nsec3_present {
+                return Err(anyhow!(
+                    "Expected NSEC/NSEC3 records missing\n{:#?}",
+                    response.deref()
+                ));
+            }
+
+            if response.response_code != ResponseCode::NXDomain {
+                return Err(anyhow!("Unexpected response code"));
+            }
+
+            // Overwrite the response code as if this were a no data response, even though a CNAME
+            // record exists.
+            response.metadata.response_code = ResponseCode::NoError;
+            // Overwrite the query with the client's original query.
+            response.queries = query_request.queries.clone();
+            response
+        } else {
+            // Proxy any other queries.
+            client
+                .send(query_request)
+                .first_answer()
+                .await
+                .context("error sending proxied query")?
+        };
 
         response.metadata.id = id;
         Ok(Some(

--- a/conformance/test-server/src/main.rs
+++ b/conformance/test-server/src/main.rs
@@ -18,10 +18,10 @@ use tokio::net::{TcpListener, UdpSocket};
 
 mod handlers;
 use handlers::{
-    DropRrsetHandler, bad_case_handler, bad_txid_handler, bailiwick_handler, base_handler,
-    cname_loop_handler, empty_response_handler, nsec3_nocover_handler, packet_loss_handler,
-    parent_ns_in_authority_handler, qr_not_response_force_tcp_handler, qr_not_response_handler,
-    truncated_response_handler,
+    BogusNoDataInsteadOfCname, DropRrsetHandler, bad_case_handler, bad_txid_handler,
+    bailiwick_handler, base_handler, cname_loop_handler, empty_response_handler,
+    nsec3_nocover_handler, packet_loss_handler, parent_ns_in_authority_handler,
+    qr_not_response_force_tcp_handler, qr_not_response_handler, truncated_response_handler,
 };
 mod zone_file;
 
@@ -85,6 +85,9 @@ enum HandlerArg {
         name: Name,
         record_type: RecordType,
     },
+    BogusNoDataInsteadOfCname {
+        ip_address: IpAddr,
+    },
 }
 
 impl HandlerArg {
@@ -107,11 +110,14 @@ impl HandlerArg {
                 name,
                 record_type,
             } => DROP_HANDLER.get_or_init(|| DropRrsetHandler::new(ip_address, name, record_type)),
+            Self::BogusNoDataInsteadOfCname { ip_address } => BOGUS_NO_DATA_CNAME_HANDLER
+                .get_or_init(|| BogusNoDataInsteadOfCname::new(ip_address)),
         }
     }
 }
 
 static DROP_HANDLER: OnceLock<DropRrsetHandler> = OnceLock::new();
+static BOGUS_NO_DATA_CNAME_HANDLER: OnceLock<BogusNoDataInsteadOfCname> = OnceLock::new();
 
 struct UdpServer {
     udp: UdpSocket,


### PR DESCRIPTION
This adds a conformance test that confirms we're checking the CNAME bit in NSEC and NSEC3 records when validating no data responses. See https://datatracker.ietf.org/doc/html/rfc6840#section-4.3. Hickory DNS passes this test already, but I figure it would be useful to add a test for it.

The test works by putting a proxy in front of another name server, fetching an NSEC or NSEC3 record for the target query name with another crafted query, and forging a no data response that omits the CNAME record at the query name, using the previously fetched signed NSEC or NSEC3 record.