### PR TITLE
fix(resolver): thread bind_addr through TLS and HTTPS connections (backport to 0.26)

### DIFF
--- a/crates/net/src/tls.rs
+++ b/crates/net/src/tls.rs
@@ -51,6 +51,41 @@ pub type TlsClientStream<S> =
 pub async fn tls_exchange<P: RuntimeProvider<Tcp = S>, S: DnsTcpStream>(
     remote_addr: SocketAddr,
     server_name: ServerName<'static>,
+    config: ClientConfig,
+    timeout: Duration,
+    max_active_requests: Option<usize>,
+    provider: P,
+) -> Result<DnsExchange<P>, NetError> {
+    tls_exchange_with_bind_addr(
+        remote_addr,
+        None,
+        server_name,
+        config,
+        timeout,
+        max_active_requests,
+        provider,
+    )
+    .await
+}
+
+/// Create a new [`DnsExchange`] wrapped around a multiplexed [`TlsClientStream`],
+/// optionally binding the underlying TCP socket to a local address.
+///
+/// # Arguments
+///
+/// * `remote_addr` - Address of the remote nameserver
+/// * `bind_addr` - Local address to bind the outgoing TCP socket to. When `None`, the OS picks.
+/// * `server_name` - TLS server name for certificate validation
+/// * `config` - TLS client configuration
+/// * `timeout` - Timeout for requests
+/// * `max_active_requests` - Optional limit on concurrent in-flight requests.
+///   If `None`, uses the default (32).
+/// * `provider` - Runtime provider for spawning background tasks
+#[allow(clippy::too_many_arguments)]
+pub async fn tls_exchange_with_bind_addr<P: RuntimeProvider<Tcp = S>, S: DnsTcpStream>(
+    remote_addr: SocketAddr,
+    bind_addr: Option<SocketAddr>,
+    server_name: ServerName<'static>,
     mut config: ClientConfig,
     timeout: Duration,
     max_active_requests: Option<usize>,
@@ -60,7 +95,7 @@ pub async fn tls_exchange<P: RuntimeProvider<Tcp = S>, S: DnsTcpStream>(
     config.enable_sni = false;
 
     let stream = provider
-        .connect_tcp(remote_addr, None, Some(timeout))
+        .connect_tcp(remote_addr, bind_addr, Some(timeout))
         .await?;
     let (future, sender) = tls_client_connect_with_future(
         stream,

--- a/crates/resolver/src/connection_provider.rs
+++ b/crates/resolver/src/connection_provider.rs
@@ -32,7 +32,7 @@ use crate::net::h3::H3ClientStream;
 #[cfg(feature = "__quic")]
 use crate::net::quic::QuicClientStream;
 #[cfg(feature = "__tls")]
-use crate::net::tls::{client_config, default_provider, tls_exchange};
+use crate::net::tls::{client_config, default_provider, tls_exchange_with_bind_addr};
 use crate::{
     config::{ConnectionConfig, ProtocolConfig},
     name_server_pool::PoolContext,
@@ -114,8 +114,9 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
                 };
 
                 let server_name = server_name.to_owned();
-                Ok(Box::pin(tls_exchange(
+                Ok(Box::pin(tls_exchange_with_bind_addr(
                     remote_addr,
+                    config.bind_addr,
                     server_name,
                     cx.tls.clone(),
                     cx.options.timeout,
@@ -124,13 +125,18 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
                 )))
             }
             #[cfg(feature = "__https")]
-            (ProtocolConfig::Https { server_name, path }, _) => Ok(Box::pin(
-                HttpsClientStream::builder(Arc::new(cx.tls.clone()), self.clone()).exchange(
+            (ProtocolConfig::Https { server_name, path }, _) => {
+                let mut builder =
+                    HttpsClientStream::builder(Arc::new(cx.tls.clone()), self.clone());
+                if let Some(bind_addr) = config.bind_addr {
+                    builder.bind_addr(bind_addr);
+                }
+                Ok(Box::pin(builder.exchange(
                     remote_addr,
                     server_name.clone(),
                     path.clone(),
-                ),
-            )),
+                )))
+            }
 
             #[cfg(feature = "__quic")]
             (ProtocolConfig::Quic { server_name }, Some(binder)) => {


### PR DESCRIPTION
Backport of #3648 to `release/0.26` per @djc's request.

Same fix, adjusted to the 0.26 shape:

- `tls_exchange_with_bind_addr` mirrors main's additive function but uses the single `timeout: Duration` parameter that 0.26 still has (no `connect_timeout` split). `tls_exchange` delegates with `bind_addr=None`, so its public signature is unchanged.
- HTTPS branch in `connection_provider.rs` chains `HttpsClientStreamBuilder::bind_addr(...)` when `config.bind_addr` is `Some`. Dropped the `.connect_timeout(...)` call from the main diff because that builder method doesn't exist in 0.26.

Semver-compatible — `tls_exchange`'s public signature is unchanged, the new function is purely additive, and the HTTPS change is an internal call site in `hickory-resolver`. UDP / TCP / QUIC / H3 paths are untouched.

Local checks:
- `cargo build -p hickory-resolver -p hickory-net` ✅
- `cargo test  -p hickory-resolver -p hickory-net` — 125 passed, 3 ignored ✅
- `cargo clippy -p hickory-resolver -p hickory-net -- -D warnings` ✅
- `cargo fmt --check` ✅

Closes the loop on #2087 for the 0.26 line.