### PR TITLE
Raise minimal versions of dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -100,7 +100,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -602,7 +602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1915,9 +1915,9 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f561214012d3fc240a1f9c817cc4d57f5310910d066069c1b093f766bb5966"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
 dependencies = [
  "either",
  "ipnet",
@@ -2310,7 +2310,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2369,7 +2369,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2582,7 +2582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3275,7 +3275,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,13 +36,13 @@ test-support.path = "tests/test-support"
 
 # logging
 tracing = { version = "0.1.30", default-features = false }
-tracing-subscriber = { version = "0.3", default-features = false }
+tracing-subscriber = { version = "0.3.10", default-features = false }
 thiserror = { version = "2", default-features = false }
 
 # metrics
 hyper = "1.6.0"
 hyper-util = "0.1.11"
-metrics = { version = "0.24.1" }
+metrics = { version = "0.24.2" }
 metrics-exporter-prometheus = { version = "0.18", default-features = false, features = ["http-listener"] }
 metrics-process = "2.4.0"
 # metrics tests
@@ -51,14 +51,14 @@ reqwest = { version = "0.13.1", default-features = false }
 prometheus-parse = "0.2.5"
 
 # async/await
-async-recursion = "1.0.0"
+async-recursion = "1.0.3"
 async-trait = "0.1.43"
 futures = { version = "0.3.5", default-features = false }
 futures-channel = { version = "0.3.5", default-features = false }
 futures-executor = { version = "0.3.5", default-features = false }
 futures-io = { version = "0.3.5", default-features = false }
 futures-util = { version = "0.3.5", default-features = false }
-tokio = "1.21"
+tokio = "1.36"
 tokio-util = "0.7.9"
 parking_lot = "0.12"
 pin-project-lite = "0.2"
@@ -101,7 +101,7 @@ hex = "0.4"
 hostname = "0.4"
 idna = { version = "1.0.3", default-features = false, features = ["alloc", "compiled_data"] }
 ipconfig = "0.3.0"
-ipnet = { version = "2.3.0", default-features = false }
+ipnet = { version = "2.11.0", default-features = false }
 jni = "0.22.1"
 js-sys = "0.3.44"
 libc = "0.2"
@@ -109,7 +109,7 @@ lru-cache = "0.1.2"
 moka = "0.12"
 ndk-context = "0.1.1"
 once_cell = { version = "1.20.0", default-features = false, features = ["critical-section"] }
-prefix-trie = "0.8"
+prefix-trie = "0.8.4"
 rand = { version = "0.10.0", default-features = false, features = ["alloc"] }
 regex = { version = "1.3.4", default-features = false }
 resolv-conf = "0.7.0"
@@ -126,7 +126,7 @@ toml = "1.0.1"
 tower = { version = "0.5", default-features = false }
 tower-http = { version = "0.6", default-features = false }
 url = { version = "2.5.4", default-features = false }
-wasm-bindgen-crate = { version = "0.2.58", package = "wasm-bindgen" }
+wasm-bindgen-crate = { version = "0.2.107", package = "wasm-bindgen" }
 
 [patch.crates-io]
 # tokio = { path = "../tokio/tokio" }

--- a/justfile
+++ b/justfile
@@ -104,7 +104,7 @@ fmt:
     cargo ws exec cargo fmt -- --check
     cargo fmt --manifest-path fuzz/Cargo.toml -- --check
 
-# Audit all depenedencies
+# Audit all dependencies
 audit: init-audit (check '--all-features')
     cargo audit --deny warnings
     cargo audit --file fuzz/Cargo.lock --deny warnings


### PR DESCRIPTION
This bumps minimum versions of dependencies to addresses a few issues like #3642.

* `tracing-subscriber`: 0.3.10 is needed for `EnvFilter::builder()`.
* `metrics`: 0.2.42 is needed for compatibility with newer compilers, due to a change in how pointer casts work for types with lifetime parameters.
* `async-recursion`: 1.0.3 is the first version that fixes mysterious compilation failures.
* `tokio`: 1.36 is required for `JoinSet::try_join_next()`, as reported.
* `ipnet`: 2.11.0 is needed for stable `no_std` support.
* `prefix-trie`: 0.8.4 includes a fix I upstreamed raising its minimum dependency versions on two crates to versions where relevant items were added. This addresses two similar transitive dependency issues.
* `wasm-bindgen`: 0.2.107 includes a fix to its minimum version of `rustversion`, setting it to the version that introduced `rustversion::cfg!()`, which `wasm-bindgen` needs.