### PR TITLE
Raise minimum versions of dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,9 +1927,9 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
 dependencies = [
  "either",
  "ipnet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ test-support.path = "tests/test-support"
 
 # logging
 tracing = { version = "0.1.30", default-features = false }
-tracing-subscriber = { version = "0.3", default-features = false }
+tracing-subscriber = { version = "0.3.10", default-features = false }
 thiserror = { version = "2", default-features = false }
 
 # metrics
@@ -57,7 +57,7 @@ futures-channel = { version = "0.3.5", default-features = false }
 futures-executor = { version = "0.3.5", default-features = false }
 futures-io = { version = "0.3.5", default-features = false }
 futures-util = { version = "0.3.5", default-features = false }
-tokio = "1.21"
+tokio = "1.36"
 tokio-util = "0.7.9"
 parking_lot = "0.12"
 pin-project-lite = "0.2"
@@ -100,7 +100,7 @@ hex = "0.4"
 hostname = "0.4"
 idna = { version = "1.0.3", default-features = false, features = ["alloc", "compiled_data"] }
 ipconfig = "0.3.0"
-ipnet = { version = "2.3.0", default-features = false }
+ipnet = { version = "2.11.0", default-features = false }
 jni = "0.22.1"
 js-sys = "0.3.44"
 libc = "0.2"
@@ -108,7 +108,7 @@ lru-cache = "0.1.2"
 moka = "0.12"
 ndk-context = "0.1.1"
 once_cell = { version = "1.20.0", default-features = false, features = ["critical-section"] }
-prefix-trie = "0.8"
+prefix-trie = "0.8.4"
 rand = { version = "0.10.0", default-features = false, features = ["alloc"] }
 regex = { version = "1.3.4", default-features = false }
 resolv-conf = "0.7.0"
@@ -125,7 +125,7 @@ toml = "1.0.1"
 tower = { version = "0.5", default-features = false }
 tower-http = { version = "0.6", default-features = false }
 url = { version = "2.5.4", default-features = false }
-wasm-bindgen-crate = { version = "0.2.58", package = "wasm-bindgen" }
+wasm-bindgen-crate = { version = "0.2.107", package = "wasm-bindgen" }
 
 [patch.crates-io]
 # tokio = { path = "../tokio/tokio" }

--- a/conformance/Cargo.lock
+++ b/conformance/Cargo.lock
@@ -1281,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
 dependencies = [
  "either",
  "ipnet",


### PR DESCRIPTION
This is a partial backport of #3660, to fix #3642. This raises the minimum versions of various dependencies to ensure all the functionality we use from each is present. I left out the version bumps from #3660 that were related to old dependency versions being incompatible with newer compiler versions, since I'm not backporting the CI job as well, to minimize changes on the release branch, and to avoid having to work around issues deeper in the dependency tree.