### PR TITLE
conformance: inherit test-server dependencies from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,8 @@ critical-section = { version = "1.1.1" }
 criterion = { version = "0.8.2", features = ["async_tokio"] }
 
 # others
+anyhow = "1"
+base64 = "0.22"
 bitflags = "2.4.1"
 bytes = "1"
 cfg-if = "1"

--- a/conformance/test-server/Cargo.toml
+++ b/conformance/test-server/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
-base64 = "0.22"
-clap = { version = "4.0", features = ["derive", "std"] }
-data-encoding = "2.9"
-futures = { version = "0.3", default-features = false }
-hickory-proto = { version = "=0.27.0-alpha.1", path = "../../crates/proto", default-features = false, features = ["std"] }
-hickory-net = { version = "=0.27.0-alpha.1", path = "../../crates/net", default-features = false, features = ["dnssec-aws-lc-rs", "tokio"] }
-tokio = { version = "1.21", features = ["macros", "net", "io-util", "rt-multi-thread"] }
-time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+base64 = { workspace = true }
+clap = { workspace = true, features = ["derive", "std"] }
+data-encoding = { workspace = true }
+futures = { workspace = true, default-features = false }
+hickory-proto = { workspace = true, default-features = false, features = ["std"] }
+hickory-net = { workspace = true, default-features = false, features = ["dnssec-aws-lc-rs", "tokio"] }
+tokio = { workspace = true, features = ["macros", "net", "io-util", "rt-multi-thread"] }
+time = { workspace = true, features = ["formatting", "macros", "parsing"] }


### PR DESCRIPTION
Followup from

- #3607 

that should make managing dependencies easier.