### PR TITLE
system_conf/apple: skip nameservers with unparseable IPs instead of failing the whole load

### DIFF
--- a/crates/resolver/src/system_conf/apple.rs
+++ b/crates/resolver/src/system_conf/apple.rs
@@ -10,6 +10,7 @@ use system_configuration::{
     },
     dynamic_store::SCDynamicStoreBuilder,
 };
+use tracing::warn;
 
 use crate::config::{NameServerConfig, ResolverConfig, ResolverOpts};
 
@@ -33,9 +34,18 @@ pub fn read_system_conf() -> Result<(ResolverConfig, ResolverOpts), ProtoError> 
 
     let mut nameservers = Vec::with_capacity(nameservers_cf.len() as usize);
     for n in &*nameservers_cf {
-        let addr = IpAddr::from_str(&Cow::from(&*n))
-            .map_err(|e| format!("failed to parse nameserver address: {e}"))?;
-
+        let s = Cow::from(&*n);
+        let addr = match IpAddr::from_str(&s) {
+            Ok(addr) => addr,
+            Err(e) => {
+                warn!(
+                    nameserver = %s,
+                    error = %e,
+                    "ignoring unparseable nameserver"
+                );
+                continue;
+            }
+        };
         nameservers.push(NameServerConfig::udp_and_tcp(addr));
     }
 


### PR DESCRIPTION
## Summary

On macOS, `hickory_resolver::system_conf::apple::read_system_conf` calls `IpAddr::from_str` on every string returned from the System Configuration `ServerAddresses` key and propagates the first parse error with `?`. A single unparseable entry (in practice an IPv6 link-local nameserver with a zone identifier like `fe80::1%en0`, which `IpAddr::from_str` rejects) therefore discards the entire nameserver list and leaves callers unable to resolve anything.

The fix mirrors what the sibling [`system_conf/android.rs`](https://github.com/hickory-dns/hickory-dns/blob/main/crates/resolver/src/system_conf/android.rs) module already does for invalid entries: log a warning and `continue` past the bad nameserver rather than propagating. The top-level `Err` paths for SCDynamicStore access failures, missing keys, etc. are left intact, since those still indicate the whole SC lookup is broken.

Fixes hickory-dns/hickory-dns#3667. Unblocks cargo-bins/cargo-binstall#2567.

## Reproduction

Before the fix, on a macOS machine whose router advertises IPv6 DNS:

```
IpAddr::from_str("fe80::1%en0") -> Err(AddrParseError(Ip))
read_system_conf ERR: failed to parse nameserver address: invalid IP address syntax
```

After the fix:

```
IpAddr::from_str("fe80::1%en0") -> Err(AddrParseError(Ip))
read_system_conf OK, nameservers:
  NameServerConfig { ip: <local IPv4>, ... }
  NameServerConfig { ip: <local global IPv6>, ... }
```

The link-local entry is intentionally absent post-fix — the global entries macOS emits alongside it are sufficient to resolve.

## Future work: actual link-local nameserver support

This PR does **not** plumb the `%zone` suffix into a `scope_id` so link-local nameservers become queryable. Doing so would touch `NameServerConfig::ip: IpAddr` (which carries no scope id) and the socket-construction paths underneath, and would be a public API change worth a separate discussion. I'd suggest considering it for a future release if there's appetite — happy to follow up.

## Test plan

- [x] `cargo build --target aarch64-apple-darwin -p hickory-resolver`
- [x] `cargo clippy --target aarch64-apple-darwin -p hickory-resolver --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --target aarch64-apple-darwin -p hickory-resolver` (86 unit + 1 integration + 4 doc tests pass)

No public API changes. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)