### PR TITLE
`test-server` cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2677,7 +2677,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
  "clap",
  "data-encoding",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,6 @@ criterion = { version = "0.8.2", features = ["async_tokio"] }
 
 # others
 anyhow = "1"
-base64 = "0.22"
 bitflags = "2.4.1"
 bytes = "1"
 cfg-if = "1"

--- a/conformance/test-server/Cargo.toml
+++ b/conformance/test-server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "test-server"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 anyhow = { workspace = true }

--- a/conformance/test-server/Cargo.toml
+++ b/conformance/test-server/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-base64 = { workspace = true }
 clap = { workspace = true, features = ["derive", "std"] }
 data-encoding = { workspace = true }
 futures = { workspace = true, default-features = false }

--- a/conformance/test-server/src/zone_file.rs
+++ b/conformance/test-server/src/zone_file.rs
@@ -1,7 +1,6 @@
 use std::{fs, path::Path};
 
-use base64::prelude::*;
-use data_encoding::{BASE32_DNSSEC, HEXUPPER};
+use data_encoding::{BASE32_DNSSEC, BASE64, HEXUPPER};
 use hickory_proto::{
     dnssec::{
         Algorithm, Nsec3HashAlgorithm, PublicKeyBuf,
@@ -85,7 +84,7 @@ pub(crate) fn parse_zone_file(path: &Path) -> Result<Vec<Record>, String> {
             "RRSIG" => {
                 let date_format = format_description!("[year][month][day][hour][minute][second]");
                 let sig_base64 = tokens[12..].join("");
-                let sig_bytes = &BASE64_STANDARD
+                let sig_bytes = &BASE64
                     .decode(sig_base64.as_bytes())
                     .map_err(|e| format!("RRSIG signature decode error: {e:?}"))?;
 
@@ -194,7 +193,7 @@ pub(crate) fn parse_zone_file(path: &Path) -> Result<Vec<Record>, String> {
             }
             "DNSKEY" => {
                 let key_base64 = tokens[7..].join("");
-                let key_bytes = &BASE64_STANDARD.decode(key_base64.as_bytes()).map_err(|e| {
+                let key_bytes = &BASE64.decode(key_base64.as_bytes()).map_err(|e| {
                     format!("DNSKEY base64 key decode error: {e:?} for {key_base64}")
                 })?;
 


### PR DESCRIPTION
This replaces our one use of `base64` with `data-encoding`, and sets `publish = false` in the Cargo manifest for `test-server`.