### PR TITLE
access: add opt-in strict-allowlist mode for allow_networks

### DIFF
--- a/bin/src/config/mod.rs
+++ b/bin/src/config/mod.rs
@@ -160,6 +160,15 @@ pub(crate) struct Config {
     /// Networks allowed to access the server
     #[serde(default)]
     pub(crate) allow_networks: Vec<IpNet>,
+    /// When `true`, `allow_networks` acts as a firewall-style strict
+    /// allowlist: a non-empty allow list refuses any source IP not
+    /// explicitly listed for that family, regardless of the deny list.
+    /// When `false` (the default), the original carve-out semantics
+    /// apply — allow rules act as exceptions to the deny list and an
+    /// IP outside both is permitted whenever any deny entry exists.
+    /// See `crates/server/src/access.rs` for the full contract.
+    #[serde(default)]
+    pub(crate) allow_networks_strict: bool,
     /// UDP socket configuration options.
     #[serde(default)]
     pub(crate) udp_socket: UdpSocketConfig,

--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -295,6 +295,7 @@ impl DnsServer {
             http_endpoint,
             deny_networks,
             allow_networks,
+            allow_networks_strict,
             udp_socket: udp_socket_config,
             tcp_socket: tcp_socket_config,
         } = config;
@@ -337,7 +338,12 @@ impl DnsServer {
 
         // now, run the server, based on the config
         #[cfg_attr(not(feature = "__tls"), allow(unused_mut))]
-        let mut server = Server::with_access(catalog, deny_networks, allow_networks);
+        let mut server = Server::with_access_strict(
+            catalog,
+            deny_networks,
+            allow_networks,
+            allow_networks_strict,
+        );
 
         let mut listen_addrs = listen_addrs_ipv4
             .into_iter()

--- a/crates/server/src/access.rs
+++ b/crates/server/src/access.rs
@@ -5,15 +5,38 @@ use prefix_trie::{Prefix, PrefixSet};
 
 /// Type to evaluate access from a source address for accessing the server.
 ///
-/// Allowed networks will override denied networks, i.e. if a network is allowed, the deny rules will not be evaluated.
-/// Allowed networks are processed in the context of denied networks, that is, if there are no denied networks, then
-///   the allowed list will effectively deny access to anything that's not in the allowed list. On the other hand, if
-///   denied networks are specified, then allowed networks will only apply if the deny rule matched, but otherwise the
-///   address will be allowed.
+/// Two modes are available:
+///
+/// **Default (carve-out) mode** — preserved for backwards compatibility.
+/// Allowed networks override denied networks: if a network is allowed,
+/// the deny rules will not be evaluated. Allowed networks are processed
+/// in the context of denied networks, that is, if there are no denied
+/// networks, then the allowed list will effectively deny access to
+/// anything that's not in the allowed list. On the other hand, if
+/// denied networks are specified, then allowed networks will only apply
+/// if the deny rule matched, but otherwise the address will be allowed.
+///
+/// **Strict-allowlist mode** — enabled by `set_strict_allow(true)` or the
+/// `allow_networks_strict = true` config field. `allow_networks` acts
+/// as a firewall-style allowlist: when the family-specific allow list
+/// is non-empty, any source IP that doesn't match an allow entry is
+/// refused regardless of the deny list. The deny list is still honoured
+/// for IPs that do match an allow entry (more-specific deny wins,
+/// matching the default mode's precedence).
+///
+/// Strict mode is scoped per address family: if you list only IPv4
+/// allow rules, IPv6 traffic falls back to the default-mode logic for
+/// its own family — operators who want to block other families add
+/// explicit deny rules there.
 #[derive(Default)]
 pub(crate) struct AccessControl {
     ipv4: InnerAccessControl<Ipv4Net>,
     ipv6: InnerAccessControl<Ipv6Net>,
+    /// When true, a non-empty allow list for a family rejects every
+    /// source IP in that family that isn't explicitly listed —
+    /// firewall-style semantics. Off by default to keep the original
+    /// carve-out behaviour for existing operators.
+    strict_allow: bool,
 }
 
 impl AccessControl {
@@ -45,6 +68,17 @@ impl AccessControl {
         }
     }
 
+    /// Toggle strict-allowlist semantics on this controller.
+    ///
+    /// When `strict` is `true`, a non-empty allow list rejects every
+    /// source IP in that family that isn't explicitly listed (see the
+    /// struct-level docs for the precise contract). When `false` —
+    /// the default — the carve-out semantics that have shipped since
+    /// the access-control feature was introduced are preserved.
+    pub(crate) fn set_strict_allow(&mut self, strict: bool) {
+        self.strict_allow = strict;
+    }
+
     /// Evaluate the IP address against the allowed networks
     ///
     /// # Arguments
@@ -60,12 +94,12 @@ impl AccessControl {
             IpAddr::V4(v4) => {
                 let v4 = Ipv4Net::from(v4);
 
-                self.ipv4.allow(&v4)
+                self.ipv4.allow(&v4, self.strict_allow)
             }
             IpAddr::V6(v6) => {
                 let v6 = Ipv6Net::from(v6);
 
-                self.ipv6.allow(&v6)
+                self.ipv6.allow(&v6, self.strict_allow)
             }
         }
     }
@@ -85,29 +119,48 @@ impl<I: Prefix> InnerAccessControl<I> {
     /// # Arguments
     ///
     /// * `ip` - source ip address to evaluate
+    /// * `strict_allow` - when `true`, treat `allow` as a strict
+    ///   firewall-style allowlist for this family: a non-empty allow
+    ///   list refuses any source IP that doesn't match an allow
+    ///   entry, even if the deny list wouldn't otherwise reject it.
+    ///   See `AccessControl`'s struct docs for the precise contract.
+    ///   When `false` (the default), the original carve-out semantics
+    ///   apply.
     ///
     /// # Return
     ///
     /// Ok if access is granted, Err otherwise
     #[must_use]
-    fn allow(&self, ip: &I) -> bool {
+    fn allow(&self, ip: &I, strict_allow: bool) -> bool {
         // If there are no allows or denies specified, we will always default to allow.
         // Allows without denies always translate to deny all except those in the allow list.
         // Denies without allows only deny those in the specified deny list.
         // If there are both allow and deny lists, then the deny list takes precedent with the allow list
-        //  overriding the deny if it is more specific.
+        //  overriding the deny if it is more specific (carve-out mode) — unless
+        //  `strict_allow` is set, in which case an unmatched source is refused as long as the allow list
+        //  has any entry for this family.
         match (self.deny.get_lpm(ip), self.allow.get_lpm(ip)) {
             (Some(denied), Some(allowed)) => allowed.prefix_len() > denied.prefix_len(),
             (Some(_denied), None) => false,
             (None, Some(_allowed)) => true,
-            (None, None) => match (
-                self.deny.iter().next().is_some(),
-                self.allow.iter().next().is_some(),
-            ) {
-                (true, _) => true,      // there are deny entries, but this isn't one
-                (false, true) => false, // there are only allow entries, but this isn't one
-                (false, false) => true, // there are no entries
-            },
+            (None, None) => {
+                let has_deny = self.deny.iter().next().is_some();
+                let has_allow = self.allow.iter().next().is_some();
+                // Strict-allowlist short-circuit: as soon as the
+                // operator listed any allow entry for this family,
+                // an unmatched source is refused regardless of the
+                // deny list's contents. Only kicks in when the
+                // caller opts into strict mode; otherwise the
+                // existing (carve-out) fall-through runs.
+                if strict_allow && has_allow {
+                    return false;
+                }
+                match (has_deny, has_allow) {
+                    (true, _) => true,      // there are deny entries, but this isn't one
+                    (false, true) => false, // there are only allow entries, but this isn't one
+                    (false, false) => true, // there are no entries
+                }
+            }
         }
     }
 }
@@ -214,5 +267,108 @@ mod tests {
 
         assert!(!access.allow("::ffff:10.2.3.4".parse().unwrap()));
         assert!(access.allow("::ffff:10.1.2.3".parse().unwrap()));
+    }
+
+    // --- strict-allowlist mode ---------------------------------------
+    //
+    // `set_strict_allow(true)` flips the semantics so `allow_networks`
+    // acts as a firewall-style allowlist: an unmatched source is
+    // refused even when the deny list has nothing to say about it.
+    // These tests pin down the documented contract.
+
+    // Without strict mode (default), an IP outside both lists is
+    // allowed when any deny entry exists — the original carve-out
+    // semantics. Pin that here so a future refactor can't silently
+    // regress the default.
+    #[test]
+    fn test_default_mode_allows_unmatched_when_deny_set() {
+        let mut access = AccessControl::default();
+        access.insert_deny(["192.168.0.0/16".parse().unwrap()]);
+        access.insert_allow(["192.168.1.0/24".parse().unwrap()]);
+
+        // Unmatched source: not in deny, not in allow. Carve-out
+        // semantics let it through.
+        assert!(access.allow("10.0.0.1".parse().unwrap()));
+    }
+
+    // Strict mode: same allow/deny pair, but the unmatched source is
+    // refused because the allow list is non-empty.
+    #[test]
+    fn test_strict_mode_refuses_unmatched_when_allow_set() {
+        let mut access = AccessControl::default();
+        access.insert_deny(["192.168.0.0/16".parse().unwrap()]);
+        access.insert_allow(["192.168.1.0/24".parse().unwrap()]);
+        access.set_strict_allow(true);
+
+        assert!(!access.allow("10.0.0.1".parse().unwrap()));
+        // Allowed entries still pass (allow overrides deny when more
+        // specific — same as the default mode).
+        assert!(access.allow("192.168.1.1".parse().unwrap()));
+        // Deny entries that aren't carved out still refused.
+        assert!(!access.allow("192.168.2.1".parse().unwrap()));
+    }
+
+    // Strict mode with an allow-only list behaves exactly like the
+    // default — every unmatched source already gets refused via the
+    // existing `(false, true)` arm. Test verifies the strict flag
+    // doesn't break that case.
+    #[test]
+    fn test_strict_mode_allow_only_matches_default() {
+        let mut access = AccessControl::default();
+        access.insert_allow(["192.168.1.0/24".parse().unwrap()]);
+        access.set_strict_allow(true);
+
+        assert!(access.allow("192.168.1.1".parse().unwrap()));
+        assert!(!access.allow("192.168.2.1".parse().unwrap()));
+        assert!(!access.allow("10.0.0.1".parse().unwrap()));
+    }
+
+    // Strict mode with a deny-only list should NOT lock everyone out.
+    // The short-circuit only fires when the allow list has entries
+    // for the family.
+    #[test]
+    fn test_strict_mode_deny_only_unaffected() {
+        let mut access = AccessControl::default();
+        access.insert_deny(["192.168.0.0/16".parse().unwrap()]);
+        access.set_strict_allow(true);
+
+        // No allow entries → strict has nothing to enforce → default
+        // deny-only semantics: anything outside deny is allowed.
+        assert!(access.allow("10.0.0.1".parse().unwrap()));
+        assert!(!access.allow("192.168.5.5".parse().unwrap()));
+    }
+
+    // Strict mode is scoped per family. v4 allow rules don't lock out
+    // v6 traffic — operators who want both families locked down add
+    // explicit v6 entries.
+    #[test]
+    fn test_strict_mode_per_family_scope() {
+        let mut access = AccessControl::default();
+        access.insert_allow(["192.168.1.0/24".parse().unwrap()]);
+        access.set_strict_allow(true);
+
+        // v4 client outside the allow list → refused.
+        assert!(!access.allow("10.0.0.1".parse().unwrap()));
+        // v6 client → the v6 family has no allow entries, so strict
+        // has nothing to enforce and the source is allowed.
+        assert!(access.allow("2001:db8::1".parse().unwrap()));
+    }
+
+    // Strict mode honours the more-specific-wins precedence between
+    // overlapping allow and deny rules — same as default mode.
+    #[test]
+    fn test_strict_mode_more_specific_deny_wins() {
+        let mut access = AccessControl::default();
+        access.insert_allow(["10.0.0.0/8".parse().unwrap()]);
+        access.insert_deny(["10.99.0.0/24".parse().unwrap()]);
+        access.set_strict_allow(true);
+
+        // In the allow set, deny doesn't apply → allow.
+        assert!(access.allow("10.1.2.3".parse().unwrap()));
+        // In a deny that's more specific than its overlapping allow
+        // → refuse.
+        assert!(!access.allow("10.99.0.5".parse().unwrap()));
+        // Outside the allow set → refuse (strict semantics).
+        assert!(!access.allow("172.16.0.1".parse().unwrap()));
     }
 }

--- a/crates/server/src/server/mod.rs
+++ b/crates/server/src/server/mod.rs
@@ -87,9 +87,26 @@ impl<T: RequestHandler> Server<T> {
         denied_networks: impl IntoIterator<Item = IpNet>,
         allowed_networks: impl IntoIterator<Item = IpNet>,
     ) -> Self {
+        Self::with_access_strict(handler, denied_networks, allowed_networks, false)
+    }
+
+    /// Creates a new ServerFuture with the specified Handler, denied/allowed networks,
+    /// and strict-allowlist semantics on the access controller.
+    ///
+    /// When `strict_allow` is `true`, a non-empty allow list refuses any source IP
+    /// not explicitly listed regardless of the deny list (firewall-style). When
+    /// `false`, the controller preserves the default carve-out semantics that
+    /// `with_access` has always shipped.
+    pub fn with_access_strict(
+        handler: T,
+        denied_networks: impl IntoIterator<Item = IpNet>,
+        allowed_networks: impl IntoIterator<Item = IpNet>,
+        strict_allow: bool,
+    ) -> Self {
         let mut access = AccessControl::default();
         access.insert_deny(denied_networks);
         access.insert_allow(allowed_networks);
+        access.set_strict_allow(strict_allow);
 
         Self {
             context: Arc::new(ServerContext {


### PR DESCRIPTION
## Summary

Adds an opt-in `allow_networks_strict` config field (defaults to `false`) that switches `allow_networks` from carve-out semantics to firewall-style strict-allowlist semantics. When enabled, a non-empty allow list for a family rejects any source IP not explicitly listed, regardless of the deny list. Default behavior is unchanged — existing TOMLs parse the same and serve the same answers.

Plumbed through `AccessControl::set_strict_allow()` + a new `Server::with_access_strict()` constructor that delegates from `Server::with_access()` so external callers don't need to touch their code unless they want the new mode.

## Motivation

The current `allow_networks` / `deny_networks` interaction is documented and consistent with comments in the code. (`crates/server/src/access.rs` struct docs), But it surprises operators within the Department of Defense who reach for `allow_networks` expecting firewall semantics:

In practice, this means an operator who configures:

```toml
allow_networks = ["10.0.0.0/8"]
deny_networks  = ["10.99.0.0/24"]
```

…and reasonably expects "only to allow `10.0.0.0/8`, and additionally deny `10.99.0.0/24` with an explicit deny-all" instead gets "allow `10.0.0.0/8`, deny `10.99.0.0/24`, and silently allow everyone else." 

The bare `(true, _) => true` arm in `InnerAccessControl::allow()` returns `true` for any source outside both lists as long as `deny_networks` has at least one entry. That's a defensible carve-out design that's been in the codebase since the access feature landed, and existing operators may rely on it. Rather than break the default, this PR adds an opt-in for operators who have a more strict requirement:

```toml
allow_networks = ["10.0.0.0/8"]
deny_networks  = ["10.99.0.0/24"]
allow_networks_strict = true
```

Now a client not in the allow list (e.g. 172.30.42.3 returns Refused), matching the "allowlist" mental model operators brought from firewall tooling expect. Just the way the DoD likes to operate.

## Changes

| File | Diff |
| --- | --- |
| `crates/server/src/access.rs` | New `AccessControl::strict_allow: bool` field + `set_strict_allow()` setter. `InnerAccessControl::allow()` takes a `strict_allow: bool` param; when set and the family's allow list is non-empty, an unmatched source short-circuits to `false`. Existing fall-through preserved otherwise. Struct docs split into "Default (carve-out) mode" + "Strict-allowlist mode" sections so future readers see both contracts upfront. |
| `crates/server/src/server/mod.rs` | New `Server::with_access_strict()` constructor takes the bool. `Server::with_access()` now delegates with `strict_allow = false` so existing callers are unaffected. |
| `bin/src/config/mod.rs` | New `allow_networks_strict: bool` config field, `#[serde(default)]`. Existing TOMLs that don't set it deserialize unchanged. |
| `bin/src/lib.rs` | Destructures the new field; routes through `Server::with_access_strict()`. |

## Test plan

New unit tests in `crates/server/src/access.rs` covering:

- **`test_default_mode_allows_unmatched_when_deny_set`** — pins down the existing carve-out fall-through so a future refactor can't silently regress it.
- **`test_strict_mode_refuses_unmatched_when_allow_set`** — the headline new behavior.
- **`test_strict_mode_allow_only_matches_default`** — strict mode is a no-op when only `allow_networks` is set.
- **`test_strict_mode_deny_only_unaffected`** — empty allow list with strict on doesn't lock anyone out.
- **`test_strict_mode_per_family_scope`** — v4 strict rules don't lock out v6 traffic with no v6 allow entries.
- **`test_strict_mode_more_specific_deny_wins`** — strict honors the same precedence as default for overlapping rules.


End-to-end verification against a `cargo build --release --features "prometheus-metrics dnssec-ring tls-ring https-ring"` binary running in a container:

| Setup | Source | Expected | Actual |
| --- | --- | --- | --- |
| `allow_networks=[10.0.0.0/8], deny_networks=[10.99.0.0/24], allow_networks_strict=true` | `172.30.42.3` | `Refused` | `Refused` (`request:Refused src:udp://172.30.42.3` in server log) |
| `allow_networks=[10.0.0.0/8, 172.30.0.0/16], allow_networks_strict=true` | `172.30.42.3` | `NoError` | resolved |
| `allow_networks=[10.0.0.0/8, 172.30.0.0/16], deny_networks=[172.30.42.0/24], allow_networks_strict=true` | `172.30.42.3` | `Refused` (more-specific deny wins) | `Refused` |
| No ACLs configured | `172.30.42.3` | `NoError` (open default) | resolved |

## Backward compatibility

- TOML schema: additive — `allow_networks_strict` defaults to `false` via `#[serde(default)]`. Stock configs parse and validate unchanged.
- API: `Server::with_access(...)` is bytecode-identical to before (delegates with `false`). New callers who want strict mode use `Server::with_access_strict(...)`.
- Behavior: every existing test that exercises the default carve-out semantics continues to pass without modification.

## Docs

`AccessControl`'s struct doc now opens with a **Default (carve-out) mode** / **Strict-allowlist mode** split, so the two contracts are visible side by side, including the per-family scoping rule for strict mode. The inner fn doc explains the `strict_allow` parameter and points back to the struct-level reference for the full contract.

Please ask any questions you have.
