### PR TITLE
test-server: Limit the size of response messages

### DIFF
--- a/conformance/test-server/src/handlers.rs
+++ b/conformance/test-server/src/handlers.rs
@@ -1,4 +1,4 @@
-use crate::{Handler, Transport, zone_file};
+use crate::{Handler, Transport, encode_response, max_message_size, zone_file};
 use anyhow::{Context, Error, Result, anyhow};
 use async_trait::async_trait;
 use data_encoding::BASE32_DNSSEC;
@@ -25,8 +25,8 @@ use std::{
 };
 
 /// This handler generates a valid A-record response to any query
-pub(crate) fn base_handler(bytes: &[u8], _transport: Transport) -> Result<Option<Vec<u8>>> {
-    let mut msg = Message::from_vec(bytes)?.into_response();
+pub(crate) fn base_handler(request: Message, _transport: Transport) -> Result<Message> {
+    let mut msg = request.into_response();
     let name = msg.queries[0].name.clone();
 
     msg.metadata.recursion_desired = false;
@@ -34,15 +34,13 @@ pub(crate) fn base_handler(bytes: &[u8], _transport: Transport) -> Result<Option
         name,
         1,
         RData::A(rdata::A([192, 0, 2, 1].into())),
-    ))
-    .to_vec()
-    .map(Some)
-    .with_context(|| "base handler: could not serialize Message")
+    ));
+    Ok(msg)
 }
 
 /// This handler responds to any messages with an incorrect transaction (query) id.
-pub(crate) fn bad_txid_handler(bytes: &[u8], _transport: Transport) -> Result<Option<Vec<u8>>> {
-    let mut msg = Message::from_vec(bytes)?.into_response();
+pub(crate) fn bad_txid_handler(request: Message, _transport: Transport) -> Result<Message> {
+    let mut msg = request.into_response();
     let name = msg.queries[0].name.clone();
 
     msg.metadata.id = if msg.metadata.id == 65535 {
@@ -56,42 +54,30 @@ pub(crate) fn bad_txid_handler(bytes: &[u8], _transport: Transport) -> Result<Op
         name,
         1,
         RData::A(rdata::A([192, 0, 2, 1].into())),
-    ))
-    .to_vec()
-    .map(Some)
-    .with_context(|| "bad txid handler: could not serialize Message")
+    ));
+    Ok(msg)
 }
 
 /// This handler responds to any messages with an empty message (no response records)
-pub(crate) fn empty_response_handler(
-    bytes: &[u8],
-    _transport: Transport,
-) -> Result<Option<Vec<u8>>> {
-    Message::from_vec(bytes)?
-        .into_response()
-        .to_vec()
-        .map(Some)
-        .with_context(|| "empty response handler: could not serialize Message")
+pub(crate) fn empty_response_handler(request: Message, _transport: Transport) -> Result<Message> {
+    Ok(request.into_response())
 }
 
 /// This handler responds to UDP requests with the truncation bit set.  If the test server is
 /// configured to listen via TCP and a request is received over a TCP channel, the truncation bit
 /// is not set.
 pub(crate) fn truncated_response_handler(
-    bytes: &[u8],
+    request: Message,
     transport: Transport,
-) -> Result<Option<Vec<u8>>> {
-    let mut msg = Message::from_vec(bytes)?.into_response();
+) -> Result<Message> {
+    let mut msg = request.into_response();
     let name = msg.queries[0].name.clone();
 
     if name != Name::from_ascii("example.testing.").unwrap()
         && msg.queries[0].query_type != RecordType::TXT
     {
         msg.metadata.response_code = ResponseCode::NXDomain;
-        return msg
-            .to_vec()
-            .map(Some)
-            .with_context(|| "truncated response handler: could not serialize Message");
+        return Ok(msg);
     }
 
     let (protocol_str, counter_str) = match transport {
@@ -121,15 +107,15 @@ pub(crate) fn truncated_response_handler(
         name,
         86400,
         RData::TXT(rdata::TXT::new(vec![protocol_str, counter_str])),
-    ))
-    .to_vec()
-    .map(Some)
-    .with_context(|| "truncated response handler: could not serialize Message")
+    ));
+    Ok(msg)
 }
 
 /// This handler simulates packet loss by not responding to the first query it receives
-pub(crate) fn packet_loss_handler(bytes: &[u8], _transport: Transport) -> Result<Option<Vec<u8>>> {
-    let mut msg = Message::from_vec(bytes)?.into_response();
+pub(crate) fn packet_loss_handler(bytes: &[u8], transport: Transport) -> Result<Option<Vec<u8>>> {
+    let request = Message::from_vec(bytes)?;
+    let max_message_size = max_message_size(&request, transport);
+    let mut msg = request.into_response();
     let query = msg.queries[0].clone();
     let name = query.name.clone();
     let q_type = query.query_type;
@@ -150,14 +136,12 @@ pub(crate) fn packet_loss_handler(bytes: &[u8], _transport: Transport) -> Result
         msg.metadata.response_code = ResponseCode::NXDomain;
     }
 
-    msg.to_vec()
-        .map(Some)
-        .with_context(|| "packet loss handler: could not serialize Message")
+    Ok(Some(encode_response(&msg, max_message_size)?))
 }
 
 /// This handler does not preserve the case of query names in responses.
-pub(crate) fn bad_case_handler(bytes: &[u8], transport: Transport) -> Result<Option<Vec<u8>>> {
-    let mut msg = Message::from_vec(bytes)?.into_response();
+pub(crate) fn bad_case_handler(request: Message, transport: Transport) -> Result<Message> {
+    let mut msg = request.into_response();
     let mut queries = msg.queries;
 
     // This doesn't use Name::randomize_case_labels since that doesn't guarantee
@@ -185,23 +169,21 @@ pub(crate) fn bad_case_handler(bytes: &[u8], transport: Transport) -> Result<Opt
             Transport::Tcp => [192, 0, 2, 2].into(),
             Transport::Udp => [192, 0, 2, 1].into(),
         })),
-    ))
-    .to_vec()
-    .map(Some)
-    .with_context(|| "bad case handler: could not serialize Message")
+    ));
+    Ok(msg)
 }
 
 /// This handler generates a large number of lengthy CNAME records to resolve
-pub(crate) fn cname_loop_handler(bytes: &[u8], _transport: Transport) -> Result<Option<Vec<u8>>> {
-    let mut msg = Message::from_vec(bytes)?.into_response();
+pub(crate) fn cname_loop_handler(request: Message, _transport: Transport) -> Result<Message> {
+    let mut msg = request.into_response();
     let name = msg.queries[0].name.clone();
 
     let Some(host) = name.iter().next() else {
-        return Ok(None);
+        return Err(anyhow!("did not expect QNAME to be the root"));
     };
 
     let Ok(host_str) = std::str::from_utf8(host) else {
-        return Ok(None);
+        return Err(anyhow!("invalid UTF-8 in QNAME"));
     };
 
     let round = host_str
@@ -231,9 +213,7 @@ pub(crate) fn cname_loop_handler(bytes: &[u8], _transport: Transport) -> Result<
 
     msg.metadata.authoritative = true;
     msg.metadata.recursion_desired = false;
-    msg.to_vec()
-        .map(Some)
-        .with_context(|| "cname loop handler: could not serialize Message")
+    Ok(msg)
 }
 
 /// This handler is for testing that NSEC3 coverage validation. It should respond to queries in the
@@ -243,11 +223,8 @@ pub(crate) fn cname_loop_handler(bytes: &[u8], _transport: Transport) -> Result<
 ///  * A query for subdomain-0.hickory-dns.testing. - Return correct A + RRSIG RRset.
 ///  * A query for validnx.hickory-dns.testing. - Return NXDOMAIN + valid NSEC3/RRSIG RRSet.
 ///  * A query for any other name - Return NXDOMAIN + invalid (non-covering) NSEC3/RRSIG RRset.
-pub(crate) fn nsec3_nocover_handler(
-    bytes: &[u8],
-    _transport: Transport,
-) -> Result<Option<Vec<u8>>> {
-    let mut msg = Message::from_vec(bytes)?.into_response();
+pub(crate) fn nsec3_nocover_handler(request: Message, _transport: Transport) -> Result<Message> {
+    let mut msg = request.into_response();
     let query_name = msg.queries[0].name.clone();
     let query_type = msg.queries[0].query_type;
 
@@ -258,11 +235,7 @@ pub(crate) fn nsec3_nocover_handler(
     let records = zone_file::parse_zone_file(Path::new(
         &env::var("ZONE_FILE").unwrap_or("/etc/zones/main.zone".to_string()),
     ))
-    .map_err(|e| {
-        Error::msg(format!(
-            "nsec3_nocover handler: unable to load zone file: {e:?}"
-        ))
-    })?;
+    .map_err(|message| anyhow!("nsec3_nocover handler: unable to load zone file: {message}"))?;
 
     match query_type {
         RecordType::DNSKEY | RecordType::SOA => {
@@ -464,17 +437,15 @@ pub(crate) fn nsec3_nocover_handler(
     msg.metadata.recursion_available = true;
     msg.metadata.authoritative = true;
     msg.metadata.authentic_data = true;
-    msg.to_vec()
-        .map(Some)
-        .with_context(|| "nsec3 no cover handler: could not serialize Message")
+    Ok(msg)
 }
 
 /// This handler generates a response with a an out-of-bailiwick record included.  There are two
 /// variations: a CNAME test that returns an out of bailiwick response for that is part of a CNAME
 /// chain, and a default case that returns a superfluous out of bailiwick record along with a
 /// responsive A record.
-pub(crate) fn bailiwick_handler(bytes: &[u8], _transport: Transport) -> Result<Option<Vec<u8>>> {
-    let mut msg = Message::from_vec(bytes)?.into_response();
+pub(crate) fn bailiwick_handler(request: Message, _transport: Transport) -> Result<Message> {
+    let mut msg = request.into_response();
     let name = msg.queries[0].name.clone();
 
     if name == Name::from_ascii("cname.example.testing.")? {
@@ -502,9 +473,7 @@ pub(crate) fn bailiwick_handler(bytes: &[u8], _transport: Transport) -> Result<O
     }
 
     msg.metadata.recursion_desired = false;
-    msg.to_vec()
-        .map(Some)
-        .with_context(|| "base handler: could not serialize Message")
+    Ok(msg)
 }
 
 /// This handler simulates an authoritative server that includes parent NS records
@@ -522,10 +491,10 @@ pub(crate) fn bailiwick_handler(bytes: &[u8], _transport: Transport) -> Result<O
 /// `example.testing.`), both records pass the bailiwick filter and resolution
 /// succeeds.
 pub(crate) fn parent_ns_in_authority_handler(
-    bytes: &[u8],
+    request: Message,
     _transport: Transport,
-) -> Result<Option<Vec<u8>>> {
-    let mut msg = Message::from_vec(bytes)?.into_response();
+) -> Result<Message> {
+    let mut msg = request.into_response();
     let name = msg.queries[0].name.clone();
     let q_type = msg.queries[0].query_type;
 
@@ -580,18 +549,13 @@ pub(crate) fn parent_ns_in_authority_handler(
         msg.metadata.response_code = ResponseCode::NXDomain;
     }
 
-    msg.to_vec()
-        .map(Some)
-        .with_context(|| "parent_ns_in_authority handler: could not serialize Message")
+    Ok(msg)
 }
 
 /// This handler generates a response with QR=0 (Query type instead of Response type).
 /// Such responses should be rejected by resolvers as invalid.
-pub(crate) fn qr_not_response_handler(
-    bytes: &[u8],
-    _transport: Transport,
-) -> Result<Option<Vec<u8>>> {
-    let mut msg = Message::from_vec(bytes)?.into_response();
+pub(crate) fn qr_not_response_handler(request: Message, _transport: Transport) -> Result<Message> {
+    let mut msg = request; // skip into_response()
     let name = msg.queries[0].name.clone();
 
     msg.metadata.message_type = MessageType::Query;
@@ -600,28 +564,24 @@ pub(crate) fn qr_not_response_handler(
         name,
         1,
         RData::A(rdata::A([192, 0, 2, 1].into())),
-    ))
-    .to_vec()
-    .map(Some)
-    .with_context(|| "qr_not_response handler: could not serialize Message")
+    ));
+
+    Ok(msg)
 }
 
 /// This handler forces TCP by returning truncated on UDP, then returns QR=0 on TCP.
 /// Used to test QR validation over TCP connections.
 pub(crate) fn qr_not_response_force_tcp_handler(
-    bytes: &[u8],
+    request: Message,
     transport: Transport,
-) -> Result<Option<Vec<u8>>> {
-    let mut msg = Message::from_vec(bytes)?.into_response();
+) -> Result<Message> {
+    let mut msg = request.into_response();
     let name = msg.queries[0].name.clone();
 
     match transport {
         Transport::Udp => {
             msg.metadata.truncation = true;
             msg.metadata.authoritative = true;
-            msg.to_vec()
-                .map(Some)
-                .with_context(|| "qr_not_response_force_tcp handler: could not serialize Message")
         }
         Transport::Tcp => {
             msg.metadata.message_type = MessageType::Query;
@@ -630,12 +590,10 @@ pub(crate) fn qr_not_response_force_tcp_handler(
                 name,
                 1,
                 RData::A(rdata::A([192, 0, 2, 1].into())),
-            ))
-            .to_vec()
-            .map(Some)
-            .with_context(|| "qr_not_response_force_tcp handler: could not serialize Message")
+            ));
         }
     }
+    Ok(msg)
 }
 
 /// This handler proxies requests to another server, and drops a specific record set from responses.
@@ -657,7 +615,7 @@ impl DropRrsetHandler {
 
 #[async_trait]
 impl Handler for DropRrsetHandler {
-    async fn handle(&self, bytes: &[u8], _transport: Transport) -> Result<Option<Vec<u8>>> {
+    async fn handle(&self, bytes: &[u8], transport: Transport) -> Result<Option<Vec<u8>>> {
         let (future, sender) = TcpClientStream::new(
             (self.ip_address, 53).into(),
             None,
@@ -668,6 +626,7 @@ impl Handler for DropRrsetHandler {
         tokio::task::spawn(bg);
 
         let query_message = Message::from_vec(bytes).context("error parsing query into message")?;
+        let max_message_size = max_message_size(&query_message, transport);
         let query_request = DnsRequest::new(query_message, DnsRequestOptions::default());
         let id = query_request.id;
 
@@ -701,9 +660,7 @@ impl Handler for DropRrsetHandler {
         }
 
         response.metadata.id = id;
-        Ok(Some(
-            response.to_vec().context("error serializing response")?,
-        ))
+        Ok(Some(encode_response(&response, max_message_size)?))
     }
 }
 
@@ -721,7 +678,7 @@ impl BogusNoDataInsteadOfCname {
 
 #[async_trait]
 impl Handler for BogusNoDataInsteadOfCname {
-    async fn handle(&self, bytes: &[u8], _transport: Transport) -> Result<Option<Vec<u8>>> {
+    async fn handle(&self, bytes: &[u8], transport: Transport) -> Result<Option<Vec<u8>>> {
         let (future, sender) = TcpClientStream::new(
             (self.ip_address, 53).into(),
             None,
@@ -732,6 +689,7 @@ impl Handler for BogusNoDataInsteadOfCname {
         tokio::task::spawn(bg);
 
         let query_message = Message::from_vec(bytes).context("erorr parsing query into message")?;
+        let max_message_size = max_message_size(&query_message, transport);
         let query_request = DnsRequest::new(query_message, DnsRequestOptions::default());
         let id = query_request.id;
 
@@ -799,9 +757,7 @@ impl Handler for BogusNoDataInsteadOfCname {
         };
 
         response.metadata.id = id;
-        Ok(Some(
-            response.to_vec().context("error serializing response")?,
-        ))
+        Ok(Some(encode_response(&response, max_message_size)?))
     }
 }
 

--- a/conformance/test-server/src/main.rs
+++ b/conformance/test-server/src/main.rs
@@ -3,7 +3,6 @@ use std::{
     sync::OnceLock,
 };
 
-#[cfg(test)]
 use anyhow::Context;
 use anyhow::Result;
 use async_trait::async_trait;
@@ -13,6 +12,7 @@ use hickory_net::{DnsStreamHandle, runtime::iocompat::AsyncIoTokioAsStd, tcp::Tc
 use hickory_proto::{
     op::{Message, SerialMessage},
     rr::{Name, RecordType},
+    serialize::binary::{BinEncodable, BinEncoder},
 };
 use tokio::net::{TcpListener, UdpSocket};
 
@@ -93,18 +93,20 @@ enum HandlerArg {
 impl HandlerArg {
     fn into_handler(self) -> &'static dyn Handler {
         match self {
-            Self::Bailiwick => &bailiwick_handler,
-            Self::Base => &base_handler,
-            Self::BadCase => &bad_case_handler,
-            Self::BadTxid => &bad_txid_handler,
-            Self::CnameLoop => &cname_loop_handler,
-            Self::EmptyResponse => &empty_response_handler,
-            Self::Nsec3Nocover => &nsec3_nocover_handler,
-            Self::ParentNsInAuthority => &parent_ns_in_authority_handler,
-            Self::PacketLoss => &packet_loss_handler,
-            Self::TruncatedResponse => &truncated_response_handler,
-            Self::QrNotResponse => &qr_not_response_handler,
-            Self::QrNotResponseForceTcp => &qr_not_response_force_tcp_handler,
+            Self::Bailiwick => &(bailiwick_handler as HandlerMessageFnPtr),
+            Self::Base => &(base_handler as HandlerMessageFnPtr),
+            Self::BadCase => &(bad_case_handler as HandlerMessageFnPtr),
+            Self::BadTxid => &(bad_txid_handler as HandlerMessageFnPtr),
+            Self::CnameLoop => &(cname_loop_handler as HandlerMessageFnPtr),
+            Self::EmptyResponse => &(empty_response_handler as HandlerMessageFnPtr),
+            Self::Nsec3Nocover => &(nsec3_nocover_handler as HandlerMessageFnPtr),
+            Self::ParentNsInAuthority => &(parent_ns_in_authority_handler as HandlerMessageFnPtr),
+            Self::PacketLoss => &(packet_loss_handler as HandlerBytesFnPtr),
+            Self::TruncatedResponse => &(truncated_response_handler as HandlerMessageFnPtr),
+            Self::QrNotResponse => &(qr_not_response_handler as HandlerMessageFnPtr),
+            Self::QrNotResponseForceTcp => {
+                &(qr_not_response_force_tcp_handler as HandlerMessageFnPtr)
+            }
             Self::DropRrset {
                 ip_address,
                 name,
@@ -233,7 +235,7 @@ impl TcpServer {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 enum Transport {
     Tcp,
     Udp,
@@ -244,14 +246,57 @@ trait Handler: Send + Sync {
     async fn handle(&self, bytes: &[u8], transport: Transport) -> Result<Option<Vec<u8>>>;
 }
 
+/// Synchronous handler function that operates on byte arrays.
+type HandlerBytesFnPtr = fn(&[u8], Transport) -> Result<Option<Vec<u8>>>;
+
+/// Implementation for function pointers using raw byte arrays.
+///
+/// This allows for maximal flexibility, including improperly encoded messages, direct control over
+/// the truncation flag, and failing to respond to queries. Asynchronous operations are not
+/// supported, so this cannot be used to proxy requests to another server.
 #[async_trait]
-impl<T> Handler for T
-where
-    T: (Fn(&[u8], Transport) -> Result<Option<Vec<u8>>>) + Send + Sync + 'static,
-{
+impl Handler for HandlerBytesFnPtr {
     async fn handle(&self, bytes: &[u8], transport: Transport) -> Result<Option<Vec<u8>>> {
         self(bytes, transport)
     }
+}
+
+/// Synchronous handler function that operates on messages.
+type HandlerMessageFnPtr = fn(Message, Transport) -> Result<Message>;
+
+/// Implementation for function pointers using [`Message`] structs.
+///
+/// This handles common message decoding and encoding before and after calling the function,
+/// including setting the truncation flag when necessary.
+#[async_trait]
+impl Handler for HandlerMessageFnPtr {
+    async fn handle(&self, bytes: &[u8], transport: Transport) -> Result<Option<Vec<u8>>> {
+        let request = Message::from_vec(bytes)?;
+        let max_message_size = max_message_size(&request, transport);
+        let response_msg = self(request, transport)?;
+        Ok(Some(encode_response(&response_msg, max_message_size)?))
+    }
+}
+
+/// Chooses the maximum message size based on the EDNS(0) OPT pseudo-record and the transport
+/// protocol.
+fn max_message_size(message: &Message, transport: Transport) -> u16 {
+    match (transport, &message.edns) {
+        (Transport::Tcp, _) => u16::MAX,
+        (Transport::Udp, Some(edns)) => edns.max_payload(),
+        (Transport::Udp, None) => 512,
+    }
+}
+
+/// Serialize a message, with the given size limit.
+fn encode_response(message: &Message, max_message_size: u16) -> Result<Vec<u8>> {
+    let mut buffer = Vec::with_capacity(max_message_size as usize);
+    let mut encoder = BinEncoder::new(&mut buffer);
+    encoder.set_max_size(max_message_size);
+    message
+        .emit(&mut encoder)
+        .context("could not serialize Message")?;
+    Ok(buffer)
 }
 
 #[cfg(test)]
@@ -270,7 +315,7 @@ mod test {
     };
     use hickory_proto::rr::{DNSClass, RData, RecordType, domain::Name, rdata};
 
-    use crate::{Transport, base_handler};
+    use crate::{HandlerArg, Transport};
 
     #[tokio::test]
     async fn tcp_msg() -> Result<()> {
@@ -296,7 +341,7 @@ mod test {
     async fn multiple_tcp_msg() -> Result<()> {
         let tcp = super::TcpServer::new((Ipv4Addr::LOCALHOST, 0).into()).await?;
         let tcp_peer = tcp.addr()?;
-        let _handle = tokio::spawn(tcp.run(&base_handler));
+        let _handle = tokio::spawn(tcp.run(HandlerArg::Base.into_handler()));
 
         let (future, sender) =
             TcpClientStream::new(tcp_peer, None, None, TokioRuntimeProvider::new());
@@ -334,7 +379,7 @@ mod test {
             Transport::Tcp => {
                 let tcp = super::TcpServer::new(socket).await?;
                 let tcp_peer = tcp.addr()?;
-                let _handle = tokio::spawn(tcp.run(&base_handler));
+                let _handle = tokio::spawn(tcp.run(HandlerArg::Base.into_handler()));
                 let (future, sender) =
                     TcpClientStream::new(tcp_peer, None, None, TokioRuntimeProvider::new());
                 let (client, bg) = Client::<TokioRuntimeProvider>::new(future.await?, sender);
@@ -344,7 +389,7 @@ mod test {
             Transport::Udp => {
                 let udp = super::UdpServer::new(socket).await?;
                 let udp_peer = udp.addr()?;
-                let _handle = tokio::spawn(udp.run(&base_handler));
+                let _handle = tokio::spawn(udp.run(HandlerArg::Base.into_handler()));
                 let conn = UdpClientStream::builder(udp_peer, TokioRuntimeProvider::new()).build();
                 let (client, bg) = Client::from_sender(conn);
                 let _handle = tokio::spawn(bg);


### PR DESCRIPTION
This changes the `test-server` handlers to always use relevant message size limits when encoding response messages, instead of just using `to_vec()`. This is a follow-up improvement to the issue discussed in https://github.com/hickory-dns/hickory-dns/pull/3613#issuecomment-4347160396. When using UDP, we need to read the EDNS message size limit (if present), and keep our response within that. I replaced the blanket implementation of `Handler` with implementations for two different function pointer types, one more general and one for the common case where there's no change to message encoding and decoding. This lets us avoid additional boilerplate in individual handler functions to handle encoding/decoding and pass the message size.