### PR TITLE
fix: apply per-request timeout for DoH, DoQ, and DoH3

### DIFF
--- a/crates/net/src/h2.rs
+++ b/crates/net/src/h2.rs
@@ -42,6 +42,7 @@ pub struct HttpsClientStream {
     context: Arc<RequestContext>,
     h2: SendRequest<Bytes>,
     is_shutdown: bool,
+    request_timeout: Option<Duration>,
 }
 
 impl HttpsClientStream {
@@ -56,6 +57,7 @@ impl HttpsClientStream {
             bind_addr: None,
             set_headers: None,
             connect_timeout: CONNECT_TIMEOUT,
+            request_timeout: None,
         }
     }
 }
@@ -125,11 +127,17 @@ impl DnsRequestSender for HttpsClientStream {
             Err(err) => return NetError::from(err).into(),
         };
 
-        Box::pin(send(
-            self.h2.clone(),
-            Bytes::from(bytes),
-            self.context.clone(),
-        ))
+        let send_fut = send(self.h2.clone(), Bytes::from(bytes), self.context.clone());
+
+        let Some(request_timeout) = self.request_timeout else {
+            return Box::pin(send_fut).into();
+        };
+
+        Box::pin(async move {
+            timeout(request_timeout, send_fut)
+                .await
+                .map_err(|_| NetError::Timeout)?
+        })
         .into()
     }
 
@@ -169,6 +177,7 @@ pub struct HttpsClientStreamBuilder<P> {
     bind_addr: Option<SocketAddr>,
     set_headers: Option<Arc<dyn SetHeaders>>,
     connect_timeout: Duration,
+    request_timeout: Option<Duration>,
 }
 
 impl<P: RuntimeProvider> HttpsClientStreamBuilder<P> {
@@ -187,6 +196,15 @@ impl<P: RuntimeProvider> HttpsClientStreamBuilder<P> {
     /// This controls both the TCP connect and the HTTP/2 handshake timeouts.
     pub fn connect_timeout(mut self, timeout: Duration) -> Self {
         self.connect_timeout = timeout;
+        self
+    }
+
+    /// Set the per-request timeout applied to each DNS send over the H2 connection.
+    ///
+    /// When set, each call to [`DnsRequestSender::send_message`] will be cancelled with
+    /// [`NetError::Timeout`] if no response arrives within this duration.
+    pub fn request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = Some(timeout);
         self
     }
 
@@ -217,7 +235,8 @@ impl<P: RuntimeProvider> HttpsClientStreamBuilder<P> {
         server_name: Arc<str>,
         path: Arc<str>,
     ) -> impl Future<Output = Result<HttpsClientStream, NetError>> + Send + 'static {
-        connect(
+        let request_timeout = self.request_timeout;
+        let connect_fut = connect(
             self.provider.connect_tcp(name_server, self.bind_addr, None),
             self.client_config,
             name_server,
@@ -225,7 +244,12 @@ impl<P: RuntimeProvider> HttpsClientStreamBuilder<P> {
             path,
             self.set_headers,
             self.connect_timeout,
-        )
+        );
+        async move {
+            let mut stream = connect_fut.await?;
+            stream.request_timeout = request_timeout;
+            Ok(stream)
+        }
     }
 }
 
@@ -290,6 +314,7 @@ pub fn connect(
             h2,
             context,
             is_shutdown: false,
+            request_timeout: None,
         })
     }
 }
@@ -752,6 +777,79 @@ mod tests {
 
         let msg_from_post = Message::from_vec(bytes.as_ref()).expect("bytes failed");
         assert_eq!(message, msg_from_post);
+    }
+
+    /// Verifies that `request_timeout` cancels a stalled DNS-over-H2 request.
+    ///
+    /// Uses an in-process `tokio::io::duplex` pipe — no TLS or external servers needed.
+    /// The server half accepts the H2 request but never sends a response, simulating
+    /// a hung upstream DoH server. The test asserts that `send_message` returns
+    /// `Err(NetError::Timeout)` within the configured timeout.
+    ///
+    /// This test also serves as the representative coverage for the identical
+    /// `request_timeout` logic in `QuicClientStream` and `H3ClientStream`: all three
+    /// apply the same `tokio::time::timeout` wrapper in `send_message`. In-process
+    /// QUIC/H3 tests are impractical because QUIC mandates TLS with no plain-transport
+    /// equivalent of the duplex trick used here.
+    #[tokio::test]
+    async fn test_request_timeout() {
+        use std::str::FromStr;
+
+        use futures_util::StreamExt as _;
+
+        subscribe();
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+
+        // Both H2 handshakes must run concurrently to exchange SETTINGS frames.
+        let (client_result, server_result) = tokio::join!(
+            h2::client::Builder::new()
+                .enable_push(false)
+                .handshake(client_io),
+            h2::server::handshake(server_io),
+        );
+        let (h2_send, h2_conn) = client_result.expect("client h2 handshake");
+        let mut server_conn = server_result.expect("server h2 handshake");
+
+        tokio::spawn(async move {
+            let _ = h2_conn.await;
+        });
+
+        // Accept the incoming request but hold the `SendResponse` without calling
+        // `send_response` — the client's `response_future.await` will block forever.
+        tokio::spawn(async move {
+            if let Some(Ok((_req, respond))) = server_conn.next().await {
+                tokio::time::sleep(Duration::from_secs(60)).await;
+                drop(respond);
+            }
+        });
+
+        let context = Arc::new(RequestContext {
+            version: Version::Http2,
+            server_name: Arc::from("test.example"),
+            query_path: Arc::from("/dns-query"),
+            set_headers: None,
+        });
+
+        let mut stream = HttpsClientStream {
+            h2: h2_send,
+            context,
+            is_shutdown: false,
+            request_timeout: Some(Duration::from_millis(50)),
+        };
+
+        let mut msg = Message::query();
+        msg.add_query(Query::new(
+            Name::from_str("example.com.").unwrap(),
+            RecordType::A,
+        ));
+        let request = DnsRequest::new(msg, DnsRequestOptions::default());
+
+        let result = stream.send_message(request).first_answer().await;
+        assert!(
+            matches!(result, Err(NetError::Timeout)),
+            "expected Timeout, got: {result:?}"
+        );
     }
 
     #[derive(Debug)]

--- a/crates/net/src/h3/h3_client_stream.rs
+++ b/crates/net/src/h3/h3_client_stream.rs
@@ -46,6 +46,7 @@ pub struct H3ClientStream {
     context: Arc<RequestContext>,
     shutdown_tx: mpsc::Sender<()>,
     is_shutdown: bool,
+    request_timeout: Option<Duration>,
 }
 
 impl H3ClientStream {
@@ -58,6 +59,7 @@ impl H3ClientStream {
             set_headers: None,
             disable_grease: false,
             connect_timeout: CONNECT_TIMEOUT,
+            request_timeout: None,
         }
     }
 
@@ -246,11 +248,21 @@ impl DnsRequestSender for H3ClientStream {
             Err(err) => return NetError::from(err).into(),
         };
 
-        Box::pin(Self::inner_send(
+        let send_fut = Self::inner_send(
             self.send_request.clone(),
             Bytes::from(bytes),
             self.context.clone(),
-        ))
+        );
+
+        let Some(request_timeout) = self.request_timeout else {
+            return Box::pin(send_fut).into();
+        };
+
+        Box::pin(async move {
+            timeout(request_timeout, send_fut)
+                .await
+                .map_err(|_| NetError::Timeout)?
+        })
         .into()
     }
 
@@ -301,6 +313,7 @@ pub struct H3ClientStreamBuilder {
     set_headers: Option<Arc<dyn SetHeaders>>,
     disable_grease: bool,
     connect_timeout: Duration,
+    request_timeout: Option<Duration>,
 }
 
 impl H3ClientStreamBuilder {
@@ -332,6 +345,15 @@ impl H3ClientStreamBuilder {
     /// This controls the QUIC connect and the HTTP/3 handshake timeouts.
     pub fn connect_timeout(mut self, timeout: Duration) -> Self {
         self.connect_timeout = timeout;
+        self
+    }
+
+    /// Set the per-request timeout applied to each DNS send over the H3 connection.
+    ///
+    /// When set, each call to [`DnsRequestSender::send_message`] will be cancelled with
+    /// [`NetError::Timeout`] if no response arrives within this duration.
+    pub fn request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = Some(timeout);
         self
     }
 
@@ -484,6 +506,7 @@ impl H3ClientStreamBuilder {
             }),
             shutdown_tx,
             is_shutdown: false,
+            request_timeout: self.request_timeout,
         })
     }
 }

--- a/crates/net/src/quic/quic_client_stream.rs
+++ b/crates/net/src/quic/quic_client_stream.rs
@@ -42,6 +42,7 @@ pub struct QuicClientStream {
     server_name: Arc<str>,
     name_server: SocketAddr,
     is_shutdown: bool,
+    request_timeout: Option<Duration>,
 }
 
 impl Display for QuicClientStream {
@@ -168,7 +169,18 @@ impl DnsRequestSender for QuicClientStream {
             panic!("can not send messages after stream is shutdown")
         }
 
-        Box::pin(Self::inner_send(self.quic_connection.clone(), request)).into()
+        let send_fut = Self::inner_send(self.quic_connection.clone(), request);
+
+        let Some(request_timeout) = self.request_timeout else {
+            return Box::pin(send_fut).into();
+        };
+
+        Box::pin(async move {
+            timeout(request_timeout, send_fut)
+                .await
+                .map_err(|_| NetError::Timeout)?
+        })
+        .into()
     }
 
     fn shutdown(&mut self) {
@@ -201,6 +213,7 @@ pub struct QuicClientStreamBuilder {
     transport_config: Arc<TransportConfig>,
     bind_addr: Option<SocketAddr>,
     connect_timeout: Duration,
+    request_timeout: Option<Duration>,
 }
 
 impl QuicClientStreamBuilder {
@@ -219,6 +232,15 @@ impl QuicClientStreamBuilder {
     /// Override the connect timeout (default: 2 seconds).
     pub fn connect_timeout(mut self, timeout: Duration) -> Self {
         self.connect_timeout = timeout;
+        self
+    }
+
+    /// Set the per-request timeout applied to each DNS send over the QUIC connection.
+    ///
+    /// When set, each call to [`DnsRequestSender::send_message`] will be cancelled with
+    /// [`NetError::Timeout`] if no response arrives within this duration.
+    pub fn request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = Some(timeout);
         self
     }
 
@@ -333,6 +355,7 @@ impl QuicClientStreamBuilder {
             server_name,
             name_server,
             is_shutdown: false,
+            request_timeout: self.request_timeout,
         })
     }
 }
@@ -379,6 +402,7 @@ impl Default for QuicClientStreamBuilder {
             transport_config: Arc::new(transport_config),
             bind_addr: None,
             connect_timeout: CONNECT_TIMEOUT,
+            request_timeout: None,
         }
     }
 }

--- a/crates/resolver/src/connection_provider.rs
+++ b/crates/resolver/src/connection_provider.rs
@@ -130,7 +130,8 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
             (ProtocolConfig::Https { server_name, path }, _) => {
                 let mut builder =
                     HttpsClientStream::builder(Arc::new(cx.tls.clone()), self.clone())
-                        .connect_timeout(cx.options.connect_timeout);
+                        .connect_timeout(cx.options.connect_timeout)
+                        .request_timeout(cx.options.timeout);
                 if let Some(bind_addr) = config.bind_addr {
                     builder.bind_addr(bind_addr);
                 }
@@ -152,6 +153,7 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
                     QuicClientStream::builder()
                         .crypto_config(cx.tls.clone())
                         .connect_timeout(cx.options.connect_timeout)
+                        .request_timeout(cx.options.timeout)
                         .exchange(
                             binder.bind_quic(bind_addr, remote_addr)?,
                             remote_addr,
@@ -179,6 +181,7 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
                         .crypto_config(cx.tls.clone())
                         .disable_grease(*disable_grease)
                         .connect_timeout(cx.options.connect_timeout)
+                        .request_timeout(cx.options.timeout)
                         .exchange(
                             binder.bind_quic(bind_addr, remote_addr)?,
                             remote_addr,


### PR DESCRIPTION
*Problem:* ResolverOpts::timeout was silently ignored for DoH, DoQ, and DoH3 — only the connect-phase timeout was applied

*Root cause:* All three protocols bypass DnsMultiplexer (which handles per-request timeouts for UDP/TCP/TLS) and call DnsExchange::from_stream directly with no equivalent mechanism

*Fix:* Added request_timeout: Option<Duration> to each stream builder; send_message wraps the send future with tokio::time::timeout when set; wired cx.options.timeout in connection_provider.rs for all three protocols

*Test:* h2::tests::test_request_timeout — in-process duplex H2 pair, server hangs, verifies Err(NetError::Timeout) fires; covers QUIC/H3 by shared logic (explain why no QUIC/H3 tests)