### PR TITLE
fix: apply per-request timeout for DoH, DoQ, and DoH3 (0.26 backport)

### DIFF
--- a/crates/net/src/h2.rs
+++ b/crates/net/src/h2.rs
@@ -13,6 +13,7 @@ use core::net::SocketAddr;
 use core::pin::Pin;
 use core::str::FromStr;
 use core::task::{Context, Poll};
+use core::time::Duration;
 use std::io;
 use std::sync::Arc;
 
@@ -41,6 +42,7 @@ pub struct HttpsClientStream {
     context: Arc<RequestContext>,
     h2: SendRequest<Bytes>,
     is_shutdown: bool,
+    request_timeout: Option<Duration>,
 }
 
 impl HttpsClientStream {
@@ -54,6 +56,7 @@ impl HttpsClientStream {
             client_config,
             bind_addr: None,
             set_headers: None,
+            request_timeout: None,
         }
     }
 }
@@ -123,11 +126,17 @@ impl DnsRequestSender for HttpsClientStream {
             Err(err) => return NetError::from(err).into(),
         };
 
-        Box::pin(send(
-            self.h2.clone(),
-            Bytes::from(bytes),
-            self.context.clone(),
-        ))
+        let send_fut = send(self.h2.clone(), Bytes::from(bytes), self.context.clone());
+
+        let Some(request_timeout) = self.request_timeout else {
+            return Box::pin(send_fut).into();
+        };
+
+        Box::pin(async move {
+            timeout(request_timeout, send_fut)
+                .await
+                .map_err(|_| NetError::Timeout)?
+        })
         .into()
     }
 
@@ -166,6 +175,7 @@ pub struct HttpsClientStreamBuilder<P> {
     client_config: Arc<ClientConfig>,
     bind_addr: Option<SocketAddr>,
     set_headers: Option<Arc<dyn SetHeaders>>,
+    request_timeout: Option<Duration>,
 }
 
 impl<P: RuntimeProvider> HttpsClientStreamBuilder<P> {
@@ -177,6 +187,14 @@ impl<P: RuntimeProvider> HttpsClientStreamBuilder<P> {
     /// Set the [`SetHeaders`] trait object used to inject dynamic headers into the DoH request
     pub fn set_headers(&mut self, headers: Arc<dyn SetHeaders>) {
         self.set_headers.replace(headers);
+    }
+
+    /// Set the per-request timeout applied to each DNS send over the H2 connection.
+    ///
+    /// When set, each call to [`DnsRequestSender::send_message`] will be cancelled with
+    /// [`NetError::Timeout`] if no response arrives within this duration.
+    pub fn request_timeout(&mut self, timeout: Duration) {
+        self.request_timeout = Some(timeout);
     }
 
     /// Creates a new [`DnsExchange`] wrapping the [`HttpsClientStream`] from this builder
@@ -206,14 +224,20 @@ impl<P: RuntimeProvider> HttpsClientStreamBuilder<P> {
         server_name: Arc<str>,
         path: Arc<str>,
     ) -> impl Future<Output = Result<HttpsClientStream, NetError>> + Send + 'static {
-        connect(
+        let request_timeout = self.request_timeout;
+        let connect_fut = connect(
             self.provider.connect_tcp(name_server, self.bind_addr, None),
             self.client_config,
             name_server,
             server_name,
             path,
             self.set_headers,
-        )
+        );
+        async move {
+            let mut stream = connect_fut.await?;
+            stream.request_timeout = request_timeout;
+            Ok(stream)
+        }
     }
 }
 
@@ -279,6 +303,7 @@ pub fn connect(
             h2,
             context,
             is_shutdown: false,
+            request_timeout: None,
         })
     }
 }
@@ -741,6 +766,79 @@ mod tests {
 
         let msg_from_post = Message::from_vec(bytes.as_ref()).expect("bytes failed");
         assert_eq!(message, msg_from_post);
+    }
+
+    /// Verifies that `request_timeout` cancels a stalled DNS-over-H2 request.
+    ///
+    /// Uses an in-process `tokio::io::duplex` pipe — no TLS or external servers needed.
+    /// The server half accepts the H2 request but never sends a response, simulating
+    /// a hung upstream DoH server. The test asserts that `send_message` returns
+    /// `Err(NetError::Timeout)` within the configured timeout.
+    ///
+    /// This test also serves as the representative coverage for the identical
+    /// `request_timeout` logic in `QuicClientStream` and `H3ClientStream`: all three
+    /// apply the same `tokio::time::timeout` wrapper in `send_message`. In-process
+    /// QUIC/H3 tests are impractical because QUIC mandates TLS with no plain-transport
+    /// equivalent of the duplex trick used here.
+    #[tokio::test]
+    async fn test_request_timeout() {
+        use std::str::FromStr;
+
+        use futures_util::StreamExt as _;
+
+        subscribe();
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+
+        // Both H2 handshakes must run concurrently to exchange SETTINGS frames.
+        let (client_result, server_result) = tokio::join!(
+            h2::client::Builder::new()
+                .enable_push(false)
+                .handshake(client_io),
+            h2::server::handshake(server_io),
+        );
+        let (h2_send, h2_conn) = client_result.expect("client h2 handshake");
+        let mut server_conn = server_result.expect("server h2 handshake");
+
+        tokio::spawn(async move {
+            let _ = h2_conn.await;
+        });
+
+        // Accept the incoming request but hold the `SendResponse` without calling
+        // `send_response` — the client's `response_future.await` will block forever.
+        tokio::spawn(async move {
+            if let Some(Ok((_req, respond))) = server_conn.next().await {
+                tokio::time::sleep(Duration::from_secs(60)).await;
+                drop(respond);
+            }
+        });
+
+        let context = Arc::new(RequestContext {
+            version: Version::Http2,
+            server_name: Arc::from("test.example"),
+            query_path: Arc::from("/dns-query"),
+            set_headers: None,
+        });
+
+        let mut stream = HttpsClientStream {
+            h2: h2_send,
+            context,
+            is_shutdown: false,
+            request_timeout: Some(Duration::from_millis(50)),
+        };
+
+        let mut msg = Message::query();
+        msg.add_query(Query::query(
+            Name::from_str("example.com.").unwrap(),
+            RecordType::A,
+        ));
+        let request = DnsRequest::new(msg, DnsRequestOptions::default());
+
+        let result = stream.send_message(request).first_answer().await;
+        assert!(
+            matches!(result, Err(NetError::Timeout)),
+            "expected Timeout, got: {result:?}"
+        );
     }
 
     #[derive(Debug)]

--- a/crates/net/src/h3/h3_client_stream.rs
+++ b/crates/net/src/h3/h3_client_stream.rs
@@ -11,6 +11,7 @@ use core::net::SocketAddr;
 use core::pin::Pin;
 use core::str::FromStr;
 use core::task::{Context, Poll};
+use core::time::Duration;
 use std::sync::Arc;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
@@ -20,6 +21,7 @@ use h3_quinn::OpenStreams;
 use http::header::{self, CONTENT_LENGTH};
 use quinn::{Endpoint, EndpointConfig, TransportConfig};
 use tokio::sync::mpsc;
+use tokio::time::timeout;
 use tracing::{debug, warn};
 
 use crate::error::NetError;
@@ -44,6 +46,7 @@ pub struct H3ClientStream {
     context: Arc<RequestContext>,
     shutdown_tx: mpsc::Sender<()>,
     is_shutdown: bool,
+    request_timeout: Option<Duration>,
 }
 
 impl H3ClientStream {
@@ -55,6 +58,7 @@ impl H3ClientStream {
             bind_addr: None,
             set_headers: None,
             disable_grease: false,
+            request_timeout: None,
         }
     }
 
@@ -243,11 +247,21 @@ impl DnsRequestSender for H3ClientStream {
             Err(err) => return NetError::from(err).into(),
         };
 
-        Box::pin(Self::inner_send(
+        let send_fut = Self::inner_send(
             self.send_request.clone(),
             Bytes::from(bytes),
             self.context.clone(),
-        ))
+        );
+
+        let Some(request_timeout) = self.request_timeout else {
+            return Box::pin(send_fut).into();
+        };
+
+        Box::pin(async move {
+            timeout(request_timeout, send_fut)
+                .await
+                .map_err(|_| NetError::Timeout)?
+        })
         .into()
     }
 
@@ -297,6 +311,7 @@ pub struct H3ClientStreamBuilder {
     bind_addr: Option<SocketAddr>,
     set_headers: Option<Arc<dyn SetHeaders>>,
     disable_grease: bool,
+    request_timeout: Option<Duration>,
 }
 
 impl H3ClientStreamBuilder {
@@ -320,6 +335,15 @@ impl H3ClientStreamBuilder {
     /// Sets whether to disable GREASE
     pub fn disable_grease(mut self, disable_grease: bool) -> Self {
         self.disable_grease = disable_grease;
+        self
+    }
+
+    /// Set the per-request timeout applied to each DNS send over the H3 connection.
+    ///
+    /// When set, each call to [`DnsRequestSender::send_message`] will be cancelled with
+    /// [`NetError::Timeout`] if no response arrives within this duration.
+    pub fn request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = Some(timeout);
         self
     }
 
@@ -463,6 +487,7 @@ impl H3ClientStreamBuilder {
             }),
             shutdown_tx,
             is_shutdown: false,
+            request_timeout: self.request_timeout,
         })
     }
 }

--- a/crates/net/src/quic/quic_client_stream.rs
+++ b/crates/net/src/quic/quic_client_stream.rs
@@ -11,6 +11,7 @@ use core::{
     net::SocketAddr,
     pin::Pin,
     task::{Context, Poll},
+    time::Duration,
 };
 use std::io;
 use std::sync::Arc;
@@ -41,6 +42,7 @@ pub struct QuicClientStream {
     server_name: Arc<str>,
     name_server: SocketAddr,
     is_shutdown: bool,
+    request_timeout: Option<Duration>,
 }
 
 impl Display for QuicClientStream {
@@ -167,7 +169,18 @@ impl DnsRequestSender for QuicClientStream {
             panic!("can not send messages after stream is shutdown")
         }
 
-        Box::pin(Self::inner_send(self.quic_connection.clone(), request)).into()
+        let send_fut = Self::inner_send(self.quic_connection.clone(), request);
+
+        let Some(request_timeout) = self.request_timeout else {
+            return Box::pin(send_fut).into();
+        };
+
+        Box::pin(async move {
+            timeout(request_timeout, send_fut)
+                .await
+                .map_err(|_| NetError::Timeout)?
+        })
+        .into()
     }
 
     fn shutdown(&mut self) {
@@ -199,6 +212,7 @@ pub struct QuicClientStreamBuilder {
     crypto_config: Option<rustls::ClientConfig>,
     transport_config: Arc<TransportConfig>,
     bind_addr: Option<SocketAddr>,
+    request_timeout: Option<Duration>,
 }
 
 impl QuicClientStreamBuilder {
@@ -211,6 +225,15 @@ impl QuicClientStreamBuilder {
     /// Sets the address to connect from.
     pub fn bind_addr(mut self, bind_addr: SocketAddr) -> Self {
         self.bind_addr = Some(bind_addr);
+        self
+    }
+
+    /// Set the per-request timeout applied to each DNS send over the QUIC connection.
+    ///
+    /// When set, each call to [`DnsRequestSender::send_message`] will be cancelled with
+    /// [`NetError::Timeout`] if no response arrives within this duration.
+    pub fn request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = Some(timeout);
         self
     }
 
@@ -321,6 +344,7 @@ impl QuicClientStreamBuilder {
             server_name,
             name_server,
             is_shutdown: false,
+            request_timeout: self.request_timeout,
         })
     }
 }
@@ -377,6 +401,7 @@ impl Default for QuicClientStreamBuilder {
             crypto_config: None,
             transport_config: Arc::new(transport_config),
             bind_addr: None,
+            request_timeout: None,
         }
     }
 }

--- a/crates/resolver/src/connection_provider.rs
+++ b/crates/resolver/src/connection_provider.rs
@@ -128,6 +128,7 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
             (ProtocolConfig::Https { server_name, path }, _) => {
                 let mut builder =
                     HttpsClientStream::builder(Arc::new(cx.tls.clone()), self.clone());
+                builder.request_timeout(cx.options.timeout);
                 if let Some(bind_addr) = config.bind_addr {
                     builder.bind_addr(bind_addr);
                 }
@@ -148,6 +149,7 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
                 Ok(Box::pin(
                     QuicClientStream::builder()
                         .crypto_config(cx.tls.clone())
+                        .request_timeout(cx.options.timeout)
                         .exchange(
                             binder.bind_quic(bind_addr, remote_addr)?,
                             remote_addr,
@@ -174,6 +176,7 @@ impl<P: RuntimeProvider> ConnectionProvider for P {
                     H3ClientStream::builder()
                         .crypto_config(cx.tls.clone())
                         .disable_grease(*disable_grease)
+                        .request_timeout(cx.options.timeout)
                         .exchange(
                             binder.bind_quic(bind_addr, remote_addr)?,
                             remote_addr,


### PR DESCRIPTION
## Backport: Apply per-request timeout for DoH, DoQ, and DoH3
 
Backport of #[3684] to `release/0.26`.
 
---
 
### Problem
 
`ResolverOpts::timeout` is silently ignored for DNS-over-HTTPS (DoH),
DNS-over-QUIC (DoQ), and DNS-over-HTTP/3 (DoH3) connections. If an
upstream server accepts a connection but never responds to a DNS query
(e.g. a silently dropped request, a stalled server), the client hangs
indefinitely. UDP and TCP/TLS are unaffected — they go through
`DnsMultiplexer` which already applies the per-request timeout.
 
### Root cause
 
[HttpsClientStream](cci:2://file:///Users/dsundquist/workspace/hickory-dns-gh/crates/net/src/h2.rs:40:0-45:1), [QuicClientStream](cci:2://file:///Users/dsundquist/workspace/hickory-dns-gh/crates/net/src/quic/quic_client_stream.rs:39:0-45:1), and [H3ClientStream](cci:2://file:///Users/dsundquist/workspace/hickory-dns-gh/crates/net/src/h3/h3_client_stream.rs:41:0-49:1) each
implement [DnsRequestSender::send_message](cci:1://file:///Users/dsundquist/workspace/hickory-dns-gh/crates/net/src/h3/h3_client_stream.rs:185:4-265:5) directly, bypassing
`DnsMultiplexer`. Nothing wrapped their inner send futures with a
timeout.
 
### Fix
 
Added `request_timeout: Option<Duration>` to each stream struct and its
builder. When set, [send_message](cci:1://file:///Users/dsundquist/workspace/hickory-dns-gh/crates/net/src/h3/h3_client_stream.rs:185:4-265:5) wraps the send future with
`tokio::time::timeout(request_timeout, ...)` and maps an elapsed timeout
to `NetError::Timeout`. The [connection_provider.rs](cci:7://file:///Users/dsundquist/workspace/hickory-dns-gh/crates/resolver/src/connection_provider.rs:0:0-0:0) wiring passes
`cx.options.timeout` into each builder, matching the existing behaviour
for UDP/TCP/TLS.
 
The connect-phase timeout (`CONNECT_TIMEOUT`, hardcoded at 2s) is
unchanged — this fix is scoped to per-request timeouts only.
 
### Testing
 
Added [test_request_timeout](cci:1://file:///Users/dsundquist/workspace/hickory-dns-gh/crates/net/src/h2.rs:770:4-841:5) to [crates/net/src/h2.rs](cci:7://file:///Users/dsundquist/workspace/hickory-dns-gh/crates/net/src/h2.rs:0:0-0:0): an in-process
`tokio::io::duplex` pair is used to establish a real H2 connection
without TLS. The server half accepts the request but never responds;
the test asserts [send_message](cci:1://file:///Users/dsundquist/workspace/hickory-dns-gh/crates/net/src/h3/h3_client_stream.rs:185:4-265:5) returns `Err(NetError::Timeout)` within
the configured deadline. This test also covers the identical logic in
[QuicClientStream](cci:2://file:///Users/dsundquist/workspace/hickory-dns-gh/crates/net/src/quic/quic_client_stream.rs:39:0-45:1) and [H3ClientStream](cci:2://file:///Users/dsundquist/workspace/hickory-dns-gh/crates/net/src/h3/h3_client_stream.rs:41:0-49:1) — in-process QUIC/H3 tests are
impractical as QUIC mandates TLS with no plain-transport equivalent of
the duplex trick.