### PR TITLE
resolver: Export per-connection query metrics

### DIFF
--- a/crates/net/src/error.rs
+++ b/crates/net/src/error.rs
@@ -206,6 +206,98 @@ impl NetError {
             _ => None,
         }
     }
+
+    /// Returns a representative string of the error for use as a metrics label.
+    pub fn as_metrics_label(&self) -> &'static str {
+        match self {
+            Self::Busy => "busy",
+            #[cfg(any(feature = "__https", feature = "__h3"))]
+            Self::Decode(_) => "http_header_decode",
+            Self::Dns(dns_err) => dns_err.as_metrics_label(),
+            #[cfg(feature = "__https")]
+            Self::H2(_) => "http2",
+            #[cfg(feature = "__h3")]
+            Self::H3(_) => "http3",
+            Self::ParseInt(_) => "parse_header_value",
+            Self::NoConnections => "no_connections",
+            Self::Proto(_) => "proto",
+            Self::Io(e) => {
+                use std::io::ErrorKind::*;
+                match e.kind() {
+                    NotFound => "io_not_found",
+                    PermissionDenied => "io_permission_denied",
+                    ConnectionRefused => "io_connection_refused",
+                    ConnectionReset => "io_connection_reset",
+                    HostUnreachable => "io_host_unreachable",
+                    NetworkUnreachable => "io_network_unreachable",
+                    ConnectionAborted => "io_connection_aborted",
+                    NotConnected => "io_not_connected",
+                    AddrInUse => "io_addr_in_use",
+                    AddrNotAvailable => "io_addr_not_available",
+                    NetworkDown => "io_network_down",
+                    BrokenPipe => "io_broken_pipe",
+                    AlreadyExists => "io_already_exists",
+                    WouldBlock => "io_would_block",
+                    InvalidInput => "io_invalid_input",
+                    InvalidData => "io_invalid_data",
+                    TimedOut => "io_timed_out",
+                    WriteZero => "io_write_zero",
+                    QuotaExceeded => "io_quota_exceeded",
+                    ResourceBusy => "io_resource_busy",
+                    Deadlock => "io_deadlock",
+                    Interrupted => "io_interrupted",
+                    Unsupported => "io_unsupported",
+                    OutOfMemory => "io_out_of_memory",
+                    Other => "io_other",
+
+                    // It's highly unlikely that any of these would actually be returned.
+                    NotADirectory => "io_not_a_directory",
+                    IsADirectory => "io_is_a_directory",
+                    DirectoryNotEmpty => "io_directory_not_empty",
+                    ReadOnlyFilesystem => "io_read_only_filesystem",
+                    StaleNetworkFileHandle => "io_stale_network_file_handle",
+                    StorageFull => "io_storage_full",
+                    NotSeekable => "io_not_seekable",
+                    FileTooLarge => "io_file_too_large",
+                    ExecutableFileBusy => "io_executable_file_busy",
+                    CrossesDevices => "io_crosses_devices",
+                    TooManyLinks => "io_too_many_links",
+                    InvalidFilename => "io_invalid_filename",
+                    ArgumentListTooLong => "io_argument_list_too_long",
+                    UnexpectedEof => "io_unexpected_eof",
+
+                    _ => "io_unknown",
+                }
+            }
+            #[cfg(target_os = "android")]
+            Self::Jni(_) => "jni",
+            Self::Timeout => "timeout",
+            #[cfg(feature = "__quic")]
+            Self::QuinnConnect(_) => "quic_connect",
+            #[cfg(feature = "__quic")]
+            Self::QuinnConnection(_) => "quic_connection",
+            #[cfg(feature = "__quic")]
+            Self::QuinnWriteError(_) => "quic_write",
+            #[cfg(feature = "__quic")]
+            Self::QuinnReadError(_) => "quic_read",
+            #[cfg(feature = "__quic")]
+            Self::QuinnStreamError(_) => "quic_stream",
+            #[cfg(feature = "__quic")]
+            Self::QuinnConfigError(_) => "quic_config",
+            #[cfg(feature = "__quic")]
+            Self::QuinnTlsConfigError(_) => "quic_tls_config_error",
+            #[cfg(feature = "__quic")]
+            Self::QuinnUnknownStreamError => "quic_unknown_stream",
+            #[cfg(feature = "__quic")]
+            Self::QuicMessageIdNot0(_) => "quic_message_id_not_0",
+            #[cfg(feature = "__tls")]
+            Self::RustlsError(_) => "tls",
+            Self::QueryCaseMismatch => "query_case_mismatch",
+
+            // Don't report these because the format is arbitrary, and in the case of Msg, dynamic.
+            Self::Message(_) | Self::Msg(_) => "message",
+        }
+    }
 }
 
 impl From<NoRecords> for NetError {
@@ -367,6 +459,37 @@ impl DnsError {
                 | NoError
                 | Unknown(_) => Ok(response),
             }
+    }
+
+    /// Returns the DNS error as a representative string for use as a metrics label.
+    pub fn as_metrics_label(&self) -> &'static str {
+        use hickory_proto::op::ResponseCode::*;
+        match self {
+            Self::ResponseCode(NoError) => "dns_response_code_noerror",
+            Self::ResponseCode(FormErr) => "dns_response_code_formerror",
+            Self::ResponseCode(ServFail) => "dns_response_code_servfail",
+            Self::ResponseCode(NXDomain) => "dns_response_code_nxdomain",
+            Self::ResponseCode(NotImp) => "dns_response_code_notimp",
+            Self::ResponseCode(Refused) => "dns_response_code_refused",
+            Self::ResponseCode(YXDomain) => "dns_response_code_yxdomain",
+            Self::ResponseCode(YXRRSet) => "dns_response_code_yxrrset",
+            Self::ResponseCode(NXRRSet) => "dns_response_code_nxrrset",
+            Self::ResponseCode(NotAuth) => "dns_response_code_notauth",
+            Self::ResponseCode(NotZone) => "dns_response_code_notzone",
+            Self::ResponseCode(BADVERS) => "dns_response_code_badvers",
+            Self::ResponseCode(BADSIG) => "dns_response_code_badsig",
+            Self::ResponseCode(BADKEY) => "dns_response_code_badkey",
+            Self::ResponseCode(BADTIME) => "dns_response_code_badtime",
+            Self::ResponseCode(BADMODE) => "dns_response_code_badmode",
+            Self::ResponseCode(BADNAME) => "dns_response_code_badname",
+            Self::ResponseCode(BADALG) => "dns_response_code_badalg",
+            Self::ResponseCode(BADTRUNC) => "dns_response_code_badtrunc",
+            Self::ResponseCode(BADCOOKIE) => "dns_response_code_badcookie",
+            Self::ResponseCode(Unknown(_)) => "dns_response_code_unknown",
+            Self::NoRecordsFound(_) => "dns_no_records",
+            #[cfg(feature = "__dnssec")]
+            Self::Nsec { .. } => "dns_nsec",
+        }
     }
 }
 

--- a/crates/net/src/xfer/mod.rs
+++ b/crates/net/src/xfer/mod.rs
@@ -445,11 +445,10 @@ impl Protocol {
             Self::H3 => true,
         }
     }
-}
 
-impl Display for Protocol {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
+    /// The string name of the protocol.
+    pub fn as_str(&self) -> &'static str {
+        match self {
             Self::Udp => "udp",
             Self::Tcp => "tcp",
             #[cfg(feature = "__tls")]
@@ -459,8 +458,14 @@ impl Display for Protocol {
             #[cfg(feature = "__quic")]
             Self::Quic => "quic",
             #[cfg(feature = "__h3")]
-            Self::H3 => "h3",
-        })
+            Self::H3 => "http3",
+        }
+    }
+}
+
+impl Display for Protocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -623,6 +623,14 @@ pub struct ResolverOpts {
         serde(default = "default_connect_timeout", with = "duration")
     )]
     pub connect_timeout: Duration,
+    /// Report the IP of the name server for query result metrics.
+    ///
+    /// When `false`, metrics are aggregated under a static "aggregate" address label to avoid
+    /// cardinality blowup. For this reason, you might want to leave this disabled when querying a
+    /// large or unbounded set of DNS servers.
+    #[cfg_attr(feature = "serde", serde(default))]
+    #[cfg(feature = "metrics")]
+    pub enable_per_name_server_metrics: bool,
 }
 
 impl ResolverOpts {
@@ -673,6 +681,8 @@ impl Default for ResolverOpts {
             deny_answers: vec![],
             edns_payload_len: default_edns_payload_len(),
             connect_timeout: default_connect_timeout(),
+            #[cfg(feature = "metrics")]
+            enable_per_name_server_metrics: false,
         }
     }
 }
@@ -1165,5 +1175,10 @@ mod tests {
         assert_eq!(code.case_randomization, json.case_randomization);
         assert_eq!(code.trust_anchor, json.trust_anchor);
         assert_eq!(code.connect_timeout, json.connect_timeout);
+        #[cfg(feature = "metrics")]
+        assert_eq!(
+            code.enable_per_name_server_metrics,
+            json.enable_per_name_server_metrics
+        );
     }
 }

--- a/crates/resolver/src/metrics.rs
+++ b/crates/resolver/src/metrics.rs
@@ -67,16 +67,16 @@ impl Default for ProtocolMetrics {
 
         let key = "protocol";
         Self {
-            udp: counter!(OUTGOING_QUERIES_TOTAL, key => "udp"),
-            tcp: counter!(OUTGOING_QUERIES_TOTAL, key => "tcp"),
+            udp: counter!(OUTGOING_QUERIES_TOTAL, key => Protocol::Udp.as_str()),
+            tcp: counter!(OUTGOING_QUERIES_TOTAL, key => Protocol::Tcp.as_str()),
             #[cfg(feature = "__tls")]
-            tls: counter!(OUTGOING_QUERIES_TOTAL, key => "tls"),
+            tls: counter!(OUTGOING_QUERIES_TOTAL, key => Protocol::Tls.as_str()),
             #[cfg(feature = "__https")]
-            https: counter!(OUTGOING_QUERIES_TOTAL, key => "https"),
+            https: counter!(OUTGOING_QUERIES_TOTAL, key => Protocol::Https.as_str()),
             #[cfg(feature = "__quic")]
-            quic: counter!(OUTGOING_QUERIES_TOTAL, key => "quic"),
+            quic: counter!(OUTGOING_QUERIES_TOTAL, key => Protocol::Quic.as_str()),
             #[cfg(feature = "__h3")]
-            h3: counter!(OUTGOING_QUERIES_TOTAL, key => "http3"),
+            h3: counter!(OUTGOING_QUERIES_TOTAL, key => Protocol::H3.as_str()),
         }
     }
 }

--- a/crates/resolver/src/metrics.rs
+++ b/crates/resolver/src/metrics.rs
@@ -7,21 +7,37 @@
 
 //! Metrics related to resolver and recursive resolver operations
 
+use std::net::IpAddr;
+
 use metrics::{
-    Counter, Gauge, Histogram, Unit, counter, describe_counter, describe_gauge, describe_histogram,
-    gauge, histogram,
+    Counter, Gauge, Histogram, Label, SharedString, Unit, counter, describe_counter,
+    describe_gauge, describe_histogram, gauge, histogram,
 };
 
+use hickory_net::NetError;
 use hickory_net::xfer::Protocol;
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub(crate) struct ResolverMetrics {
     outgoing_queries: ProtocolMetrics,
+    name_server_metrics: NameServerMetrics,
 }
 
 impl ResolverMetrics {
+    pub(crate) fn new(addr: NameServerAddr) -> Self {
+        Self {
+            outgoing_queries: ProtocolMetrics::default(),
+            name_server_metrics: NameServerMetrics::new(addr),
+        }
+    }
+
     pub(crate) fn increment_outgoing_query(&self, proto: &Protocol) {
         self.outgoing_queries.increment(proto);
+    }
+
+    pub(crate) fn increment_query_result(&self, proto: &Protocol, result: Result<(), &NetError>) {
+        self.name_server_metrics
+            .increment_query_result(proto, result);
     }
 }
 
@@ -78,6 +94,60 @@ impl Default for ProtocolMetrics {
             #[cfg(feature = "__h3")]
             h3: counter!(OUTGOING_QUERIES_TOTAL, key => Protocol::H3.as_str()),
         }
+    }
+}
+
+#[derive(Clone)]
+struct NameServerMetrics {
+    addr_label: Option<Label>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum NameServerAddr {
+    /// Track queries individually per nameserver IP address.
+    Individual(IpAddr),
+    /// Aggregate query metrics across all nameservers.
+    Aggregated,
+}
+
+impl NameServerMetrics {
+    fn new(addr: NameServerAddr) -> Self {
+        describe_counter!(
+            NAME_SERVER_QUERY_RESPONSES,
+            Unit::Count,
+            "Number of query responses by name server, protocol, and status"
+        );
+
+        Self {
+            addr_label: match addr {
+                NameServerAddr::Individual(ip) => {
+                    // Using an Arc lets us avoid an allocation in increment_query_result when cloning
+                    // the address string.
+                    Some(Label::new(
+                        "addr",
+                        SharedString::from_shared(ip.to_string().into()),
+                    ))
+                }
+                NameServerAddr::Aggregated => None,
+            },
+        }
+    }
+
+    pub(crate) fn increment_query_result(&self, proto: &Protocol, result: Result<(), &NetError>) {
+        let status = match result {
+            Ok(()) => "success",
+            Err(err) => err.as_metrics_label(),
+        };
+
+        let protocol_label = Label::new("protocol", proto.as_str());
+        let status_label = Label::new("status", status);
+
+        let labels = match self.addr_label.clone() {
+            Some(addr_label) => vec![addr_label, protocol_label, status_label],
+            None => vec![protocol_label, status_label],
+        };
+
+        counter!(NAME_SERVER_QUERY_RESPONSES, labels).increment(1);
     }
 }
 
@@ -146,6 +216,9 @@ pub const CACHE_MISS_DURATION: &str = "hickory_resolver_cache_miss_duration_seco
 
 /// Number of entries in the resolver response cache.
 pub const RESPONSE_CACHE_SIZE: &str = "hickory_resolver_response_cache_size";
+
+/// Number of queries responses by name server, protocol, and status.
+pub const NAME_SERVER_QUERY_RESPONSES: &str = "hickory_resolver_name_server_query_responses_total";
 
 /// Metrics for the optional recursive resolver feature
 #[cfg(feature = "recursor")]

--- a/crates/resolver/src/name_server.rs
+++ b/crates/resolver/src/name_server.rs
@@ -24,10 +24,10 @@ use parking_lot::Mutex as SyncMutex;
 use tokio::time::{Duration, Instant};
 use tracing::{debug, error, warn};
 
-#[cfg(feature = "metrics")]
-use crate::metrics::ResolverMetrics;
 #[cfg(all(feature = "metrics", any(feature = "__tls", feature = "__quic")))]
 use crate::metrics::opportunistic_encryption::ProbeMetrics;
+#[cfg(feature = "metrics")]
+use crate::metrics::{NameServerAddr, ResolverMetrics};
 use crate::{
     config::{
         ConnectionConfig, NameServerConfig, OpportunisticEncryption, ResolverOpts,
@@ -84,6 +84,12 @@ impl<P: ConnectionProvider> NameServer<P> {
             connections.sort_by_key(|ns| ns.protocol != Protocol::Udp);
         }
 
+        #[cfg(feature = "metrics")]
+        let resolver_metrics = ResolverMetrics::new(match options.enable_per_name_server_metrics {
+            true => NameServerAddr::Individual(config.ip),
+            false => NameServerAddr::Aggregated,
+        });
+
         Self {
             config,
             connections: AsyncMutex::new(connections),
@@ -91,7 +97,7 @@ impl<P: ConnectionProvider> NameServer<P> {
             #[cfg(all(feature = "metrics", any(feature = "__tls", feature = "__quic")))]
             opportunistic_probe_metrics: ProbeMetrics::default(),
             #[cfg(feature = "metrics")]
-            resolver_metrics: ResolverMetrics::default(),
+            resolver_metrics,
             connection_provider,
         }
     }
@@ -103,6 +109,22 @@ impl<P: ConnectionProvider> NameServer<P> {
         policy: ConnectionPolicy,
         cx: &Arc<PoolContext>,
     ) -> Result<DnsResponse, NetError> {
+        let (_protocol, result) = self.send_inner(request, policy, cx).await;
+        #[cfg(feature = "metrics")]
+        if let Some(protocol) = _protocol {
+            self.resolver_metrics
+                .increment_query_result(&protocol, result.as_ref().map(|_| ()));
+        }
+
+        result
+    }
+
+    async fn send_inner(
+        &self,
+        request: DnsRequest,
+        policy: ConnectionPolicy,
+        cx: &Arc<PoolContext>,
+    ) -> (Option<Protocol>, Result<DnsResponse, NetError>) {
         // Reconnect and retry once if a reused connection was closed mid-flight.
         // Caps total retries even when the pool holds several reusable connections.
         let mut reconnect_budget = 1u8;
@@ -112,7 +134,13 @@ impl<P: ConnectionProvider> NameServer<P> {
                 meta,
                 protocol,
                 reuse,
-            } = self.connected_mut_client(policy, cx).await?;
+            } = match self.connected_mut_client(policy, cx).await {
+                Ok(v) => v,
+                Err((err, protocol)) => {
+                    debug!(config = ?self.config, ?protocol, %err, "failed to establish connection to name server");
+                    return (protocol, Err(err));
+                }
+            };
             #[cfg(feature = "metrics")]
             self.resolver_metrics.increment_outgoing_query(&protocol);
             let now = Instant::now();
@@ -132,7 +160,7 @@ impl<P: ConnectionProvider> NameServer<P> {
                                     .await
                                     .response_received(self.config.ip, protocol);
                             }
-                            return Ok(response);
+                            return (Some(protocol), Ok(response));
                         }
                         Err(error) => error,
                     };
@@ -165,7 +193,7 @@ impl<P: ConnectionProvider> NameServer<P> {
                             .await
                             .error_received(self.config.ip, protocol, &err)
                     }
-                    return Err(err);
+                    return (Some(protocol), Err(err));
                 }
                 Err(error) => {
                     debug!(config = ?self.config, %error, "failed to connect to name server");
@@ -180,6 +208,10 @@ impl<P: ConnectionProvider> NameServer<P> {
                         && reconnect_budget > 0
                         && error.is_connection_closed()
                     {
+                        #[cfg(feature = "metrics")]
+                        // The increment in send() won't occur since we're retrying.
+                        self.resolver_metrics
+                            .increment_query_result(&protocol, Err(&error));
                         reconnect_budget -= 1;
                         continue;
                     }
@@ -215,7 +247,7 @@ impl<P: ConnectionProvider> NameServer<P> {
                     }
 
                     // These are connection failures, not lookup failures, that is handled in the resolver layer
-                    return Err(error);
+                    return (Some(protocol), Err(error));
                 }
             }
         }
@@ -229,7 +261,7 @@ impl<P: ConnectionProvider> NameServer<P> {
         &self,
         policy: ConnectionPolicy,
         cx: &Arc<PoolContext>,
-    ) -> Result<ConnectedClient<P>, NetError> {
+    ) -> Result<ConnectedClient<P>, (NetError, Option<Protocol>)> {
         // Check for an existing usable connection (short lock)
         {
             let mut connections = self.connections.lock().await;
@@ -259,7 +291,7 @@ impl<P: ConnectionProvider> NameServer<P> {
                 &cx.opportunistic_encryption,
                 &self.config.connections,
             )
-            .ok_or(NetError::NoConnections)?;
+            .ok_or((NetError::NoConnections, None))?;
 
         let protocol = config.protocol.to_protocol();
         if cx.opportunistic_encryption.is_enabled() && protocol.is_encrypted() {
@@ -271,12 +303,14 @@ impl<P: ConnectionProvider> NameServer<P> {
         }
 
         // Establish connection
-        let handle = Box::pin(self.connection_provider.new_connection(
-            self.config.ip,
-            config,
-            cx,
-        )?)
-        .await?;
+        let handle_fut = self
+            .connection_provider
+            .new_connection(self.config.ip, config, cx)
+            .map_err(|e| (e, Some(protocol)))?;
+
+        let handle = Box::pin(handle_fut)
+            .await
+            .map_err(|e| (e, Some(protocol)))?;
 
         if cx.opportunistic_encryption.is_enabled() && protocol.is_encrypted() {
             cx.transport_state()
@@ -1986,10 +2020,13 @@ mod opportunistic_enc_tests {
             provider.clone(),
         );
 
-        name_server
+        match name_server
             .connected_mut_client(ConnectionPolicy::default(), &cx)
             .await
-            .map(|_| ())
+        {
+            Ok(_) => Ok(()),
+            Err((e, _)) => Err(e),
+        }
     }
 }
 
@@ -2020,7 +2057,10 @@ mod resolver_metrics_tests {
                 .unwrap();
 
             runtime.block_on(async {
-                let options = ResolverOpts::default();
+                let options = ResolverOpts {
+                    enable_per_name_server_metrics: true,
+                    ..ResolverOpts::default()
+                };
                 let config = NameServerConfig::udp(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
                 let name_server = Arc::new(NameServer::new(
                     [],
@@ -2144,6 +2184,265 @@ mod resolver_metrics_tests {
         // We should have registered 1 TLS protocol query.
         let protocol = vec![Label::new("protocol", "tls")];
         assert_counter_eq(&map, OUTGOING_QUERIES_TOTAL, protocol, 1);
+    }
+
+    #[test]
+    fn test_name_server_query_success_metrics() {
+        subscribe();
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        with_local_recorder(&recorder, || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+
+            runtime.block_on(async {
+                let options = ResolverOpts {
+                    enable_per_name_server_metrics: true,
+                    ..ResolverOpts::default()
+                };
+                let config = NameServerConfig::udp(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
+                let mock_provider = MockProvider::default();
+                let name_server = Arc::new(NameServer::new([], config, &options, mock_provider));
+
+                let cx = Arc::new(PoolContext::new(options, TlsConfig::new().unwrap()));
+                let name = Name::parse("www.example.com.", None).unwrap();
+                let _ = name_server
+                    .send(
+                        DnsRequest::from_query(
+                            Query::new(name.clone(), RecordType::A),
+                            DnsRequestOptions::default(),
+                        ),
+                        ConnectionPolicy::default(),
+                        &cx,
+                    )
+                    .await;
+            });
+        });
+
+        #[allow(clippy::mutable_key_type)]
+        let map = snapshotter.snapshot().into_hashmap();
+
+        use crate::metrics::NAME_SERVER_QUERY_RESPONSES;
+        let labels = vec![
+            Label::new("addr", "8.8.8.8"),
+            Label::new("protocol", "udp"),
+            Label::new("status", "success"),
+        ];
+        assert_counter_eq(&map, NAME_SERVER_QUERY_RESPONSES, labels, 1);
+    }
+
+    #[test]
+    fn test_name_server_query_connection_failure_metrics() {
+        subscribe();
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        with_local_recorder(&recorder, || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+
+            runtime.block_on(async {
+                let options = ResolverOpts {
+                    enable_per_name_server_metrics: true,
+                    ..ResolverOpts::default()
+                };
+                let config = NameServerConfig::udp(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
+                let mock_provider = MockProvider {
+                    new_connection_error: Some(NetError::Io(Arc::new(std::io::Error::new(
+                        std::io::ErrorKind::ConnectionRefused,
+                        "connection refused",
+                    )))),
+                    ..MockProvider::default()
+                };
+                let name_server = Arc::new(NameServer::new([], config, &options, mock_provider));
+
+                let cx = Arc::new(PoolContext::new(options, TlsConfig::new().unwrap()));
+                let name = Name::parse("www.example.com.", None).unwrap();
+                let _ = name_server
+                    .send(
+                        DnsRequest::from_query(
+                            Query::new(name.clone(), RecordType::A),
+                            DnsRequestOptions::default(),
+                        ),
+                        ConnectionPolicy::default(),
+                        &cx,
+                    )
+                    .await;
+            });
+        });
+
+        #[allow(clippy::mutable_key_type)]
+        let map = snapshotter.snapshot().into_hashmap();
+
+        use crate::metrics::NAME_SERVER_QUERY_RESPONSES;
+        let labels = vec![
+            Label::new("addr", "8.8.8.8"),
+            Label::new("protocol", "udp"),
+            Label::new("status", "io_connection_refused"),
+        ];
+        assert_counter_eq(&map, NAME_SERVER_QUERY_RESPONSES, labels, 1);
+    }
+
+    #[test]
+    fn test_name_server_query_response_code_failure_metrics() {
+        subscribe();
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        with_local_recorder(&recorder, || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+
+            runtime.block_on(async {
+                let options = ResolverOpts {
+                    enable_per_name_server_metrics: true,
+                    ..ResolverOpts::default()
+                };
+                let config = NameServerConfig::udp(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
+                let mock_provider = MockProvider::default();
+                mock_provider
+                    .send_outcomes
+                    .lock()
+                    .push_back(Some(NetError::Dns(DnsError::ResponseCode(
+                        ResponseCode::ServFail,
+                    ))));
+                let name_server = Arc::new(NameServer::new([], config, &options, mock_provider));
+
+                let cx = Arc::new(PoolContext::new(options, TlsConfig::new().unwrap()));
+                let name = Name::parse("www.example.com.", None).unwrap();
+                let _ = name_server
+                    .send(
+                        DnsRequest::from_query(
+                            Query::new(name.clone(), RecordType::A),
+                            DnsRequestOptions::default(),
+                        ),
+                        ConnectionPolicy::default(),
+                        &cx,
+                    )
+                    .await;
+            });
+        });
+
+        #[allow(clippy::mutable_key_type)]
+        let map = snapshotter.snapshot().into_hashmap();
+
+        use crate::metrics::NAME_SERVER_QUERY_RESPONSES;
+        let labels = vec![
+            Label::new("addr", "8.8.8.8"),
+            Label::new("protocol", "udp"),
+            Label::new("status", "dns_response_code_servfail"),
+        ];
+        assert_counter_eq(&map, NAME_SERVER_QUERY_RESPONSES, labels, 1);
+    }
+
+    #[test]
+    fn test_name_server_query_no_records_success_metrics() {
+        subscribe();
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        with_local_recorder(&recorder, || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+
+            runtime.block_on(async {
+                let options = ResolverOpts {
+                    enable_per_name_server_metrics: true,
+                    ..ResolverOpts::default()
+                };
+                let config = NameServerConfig::udp(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
+                let name = Name::parse("www.example.com.", None).unwrap();
+                let query = Query::new(name.clone(), RecordType::A);
+                let mock_provider = MockProvider::default();
+                mock_provider
+                    .send_outcomes
+                    .lock()
+                    .push_back(Some(NetError::Dns(DnsError::NoRecordsFound(
+                        NoRecords::new(query, ResponseCode::NXDomain),
+                    ))));
+                let name_server = Arc::new(NameServer::new([], config, &options, mock_provider));
+
+                let cx = Arc::new(PoolContext::new(options, TlsConfig::new().unwrap()));
+                let _ = name_server
+                    .send(
+                        DnsRequest::from_query(
+                            Query::new(name.clone(), RecordType::A),
+                            DnsRequestOptions::default(),
+                        ),
+                        ConnectionPolicy::default(),
+                        &cx,
+                    )
+                    .await;
+            });
+        });
+
+        #[allow(clippy::mutable_key_type)]
+        let map = snapshotter.snapshot().into_hashmap();
+
+        use crate::metrics::NAME_SERVER_QUERY_RESPONSES;
+        let labels = vec![
+            Label::new("addr", "8.8.8.8"),
+            Label::new("protocol", "udp"),
+            Label::new("status", "dns_no_records"),
+        ];
+        assert_counter_eq(&map, NAME_SERVER_QUERY_RESPONSES, labels, 1);
+    }
+
+    #[test]
+    fn test_name_server_query_metrics_aggregation() {
+        subscribe();
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        with_local_recorder(&recorder, || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+
+            runtime.block_on(async {
+                let name = Name::parse("www.example.com.", None).unwrap();
+                let options = ResolverOpts {
+                    enable_per_name_server_metrics: false,
+                    ..Default::default()
+                };
+                let config = NameServerConfig::udp(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
+                let mock_provider = MockProvider::default();
+                let name_server = Arc::new(NameServer::new([], config, &options, mock_provider));
+
+                let cx = Arc::new(PoolContext::new(options, TlsConfig::new().unwrap()));
+                let _ = name_server
+                    .send(
+                        DnsRequest::from_query(
+                            Query::new(name.clone(), RecordType::A),
+                            DnsRequestOptions::default(),
+                        ),
+                        ConnectionPolicy::default(),
+                        &cx,
+                    )
+                    .await;
+            });
+        });
+
+        #[allow(clippy::mutable_key_type)]
+        let map = snapshotter.snapshot().into_hashmap();
+
+        use crate::metrics::NAME_SERVER_QUERY_RESPONSES;
+        let labels = vec![
+            // No address label.
+            Label::new("protocol", "udp"),
+            Label::new("status", "success"),
+        ];
+        assert_counter_eq(&map, NAME_SERVER_QUERY_RESPONSES, labels, 1);
     }
 }
 


### PR DESCRIPTION
Fixes: #3652 

This is useful for tracking the health of individual nameserver connections even if queries are coming back healthy from `NameserverPool` because at least one connection is functioning.

We want to keep the set of labels relatively bounded. To that end, everything except for the address is a compile-time-known string. We also avoid passing through the `Message(&'static str)` because that's not under the control of the metrics module and could contain anything. We also default the export to aggregate the addresses to avoid nasty surprises for anyone upgrading with metrics enabled.

Due to `#[non_exhaustive]` on a number of error enums, it's possible newly added error cases will not be collected in these metrics. We could attach the mappings to the enum definitions, but that would leak metrics-only implementation into those types. The strings don't seem generally-useful outside of metrics reporting.