### PR TITLE
fix(server): skip root_dir prefix for SQLite special paths in journal path

### DIFF
--- a/crates/server/src/store/sqlite/mod.rs
+++ b/crates/server/src/store/sqlite/mod.rs
@@ -126,7 +126,13 @@ impl<P: RuntimeProvider + Send + Sync> SqliteZoneHandler<P> {
 
         // to be compatible with previous versions, the extension might be zone, not jrnl
         let zone_path = rooted(&config.zone_path, root_dir);
-        let journal_path = rooted(&config.journal_path, root_dir);
+
+        let journal_path =
+            if config.journal_path.starts_with(":") || config.journal_path.starts_with("file:") {
+                config.journal_path.clone()
+            } else {
+                rooted(&config.journal_path, root_dir)
+            };
 
         #[cfg_attr(not(feature = "__dnssec"), allow(unused_mut))]
         let mut handler = if journal_path.exists() {


### PR DESCRIPTION
## Summary

When `journal_path` is set to a SQLite special path like `:memory:` or
`file::memory:?cache=shared`, the `rooted()` call prepends `directory`
to it, producing an invalid path (e.g. `/var/named/:memory:`).

This patch skips `rooted()` when `journal_path` starts with `:` or
`file:`, passing it directly to `Connection::open()` so SQLite can
handle it with its own semantics.

## Use Case

Embedded / containerized deployments (e.g. OpenWrt) where a persistent
journal is unnecessary and an in-memory database is preferred.