### PR TITLE
bin: use SO_REUSEADDR for udp sockets too

### DIFF
--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -713,6 +713,8 @@ fn build_tcp_listener(
     };
 
     sock.set_reuse_address(true)?;
+    #[cfg(unix)]
+    sock.set_reuse_port(true)?;
     sock.set_nonblocking(true)?;
 
     let s_addr = SocketAddr::new(ip, port);
@@ -738,6 +740,8 @@ fn build_udp_socket(
     };
 
     sock.set_reuse_address(true)?;
+    #[cfg(unix)]
+    sock.set_reuse_port(true)?;
     sock.set_nonblocking(true)?;
 
     #[cfg(unix)]

--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -737,6 +737,7 @@ fn build_udp_socket(
         s
     };
 
+    sock.set_reuse_address(true)?;
     sock.set_nonblocking(true)?;
 
     #[cfg(unix)]


### PR DESCRIPTION
Other than making the binding behavior consistent,
SO_REUSEADDR is useful if you want to run a local
resolver and an authoritative nameserver on the same
machine.

Your authoritative nameserver would bind ::, and
the local resolver would bind ::1 (or a ULA
address, such as fd43:9c36:3507::1)

And since the kernel routes packets to the most
specific address, the local resolver wins for its
specific addresses. And the authoritative
nameserver serves on the machine's public address.