### PR TITLE
fix(server): use string comparison for SQLite special paths in #3697

### DIFF
--- a/bin/tests/integration/named_tests.rs
+++ b/bin/tests/integration/named_tests.rs
@@ -353,6 +353,25 @@ async fn test_deny_networks_toml_startup() {
     query_a_refused(&mut client).await;
 }
 
+/// Test that the server starts successfully when a zone uses the SQLite store with
+/// `journal_path = ":memory:"`.
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn test_sqlite_memory_journal_startup() {
+    subscribe();
+    let provider = TokioRuntimeProvider::new();
+    let server = TestServer::start("example_sqlite_memory.toml");
+    let tcp_port = server.ports.get_v4(Protocol::Tcp);
+
+    let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, tcp_port.expect("no tcp_port")));
+    let (future, sender) = TcpClientStream::new(addr, None, None, provider.clone());
+    let stream = future.await.expect("failed to create tcp stream");
+    let (mut client, bg) = Client::<TokioRuntimeProvider>::new(stream, sender);
+    tokio::spawn(bg);
+
+    query_a(&mut client).await;
+}
+
 #[tokio::test]
 async fn test_deny_allow_networks_toml_startup() {
     subscribe();

--- a/bin/tests/integration/store_sqlite_tests.rs
+++ b/bin/tests/integration/store_sqlite_tests.rs
@@ -6,6 +6,7 @@ use std::{fs, path::Path};
 
 use futures_executor::block_on;
 
+use hickory_net::runtime::TokioRuntimeProvider;
 use hickory_proto::rr::Name;
 #[cfg(feature = "__dnssec")]
 use hickory_server::dnssec::NxProofKind;
@@ -82,3 +83,42 @@ basic_battery!(sqlite, crate::store_sqlite_tests::sqlite);
 dnssec_battery!(sqlite, crate::store_sqlite_tests::sqlite);
 #[cfg(feature = "__dnssec")]
 dynamic_update!(sqlite_update, crate::store_sqlite_tests::sqlite_update);
+
+/// Verify that `:memory:` is accepted as a journal path and that a root_dir prefix is
+/// not prepended to it.
+#[test]
+fn test_sqlite_memory_journal_path() {
+    use std::env::temp_dir;
+
+    let zone_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../tests/test-data/test_configs/example.com.zone");
+
+    // Pass a root_dir to simulate a real deployment (e.g., root_dir = /var/named).
+    // With the bug, this would produce "/tmp/:memory:" (or similar) and SQLite would fail.
+    let root_dir = temp_dir();
+
+    let config = SqliteConfig {
+        zone_path: zone_path.clone(),
+        journal_path: PathBuf::from(":memory:"),
+        allow_update: true,
+        #[cfg(feature = "__dnssec")]
+        tsig_keys: Vec::new(),
+    };
+
+    let result = block_on(SqliteZoneHandler::<TokioRuntimeProvider>::try_from_config(
+        Name::from_str("example.com.").unwrap(),
+        ZoneType::Primary,
+        AxfrPolicy::AllowAll,
+        false,
+        Some(root_dir.as_path()),
+        &config,
+        #[cfg(feature = "__dnssec")]
+        None,
+    ));
+
+    assert!(
+        result.is_ok(),
+        "loading zone with :memory: journal should succeed even with a root_dir, got: {:?}",
+        result.err()
+    );
+}

--- a/crates/server/src/store/sqlite/mod.rs
+++ b/crates/server/src/store/sqlite/mod.rs
@@ -127,12 +127,17 @@ impl<P: RuntimeProvider + Send + Sync> SqliteZoneHandler<P> {
         // to be compatible with previous versions, the extension might be zone, not jrnl
         let zone_path = rooted(&config.zone_path, root_dir);
 
-        let journal_path =
-            if config.journal_path.starts_with(":") || config.journal_path.starts_with("file:") {
-                config.journal_path.clone()
-            } else {
-                rooted(&config.journal_path, root_dir)
-            };
+        // Use string comparison (not Path::starts_with which does component matching)
+        // to detect SQLite special filenames like `:memory:` and URI filenames like `file:`.
+        let journal_path = if config
+            .journal_path
+            .to_str()
+            .is_some_and(|s| s.starts_with(':') || s.starts_with("file:"))
+        {
+            config.journal_path.clone()
+        } else {
+            rooted(&config.journal_path, root_dir)
+        };
 
         #[cfg_attr(not(feature = "__dnssec"), allow(unused_mut))]
         let mut handler = if journal_path.exists() {

--- a/tests/test-data/test_configs/example_sqlite_memory.toml
+++ b/tests/test-data/test_configs/example_sqlite_memory.toml
@@ -1,0 +1,36 @@
+## Test configuration for the SQLite zone store using an in-memory journal.
+
+[[zones]]
+zone = "localhost"
+zone_type = "Primary"
+file = "default/localhost.zone"
+
+[[zones]]
+zone = "0.0.127.in-addr.arpa"
+zone_type = "Primary"
+file = "default/127.0.0.1.zone"
+
+[[zones]]
+zone = "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa"
+zone_type = "Primary"
+file = "default/ipv6_1.zone"
+
+[[zones]]
+zone = "255.in-addr.arpa"
+zone_type = "Primary"
+file = "default/255.zone"
+
+[[zones]]
+zone = "0.in-addr.arpa"
+zone_type = "Primary"
+file = "default/0.zone"
+
+[[zones]]
+zone = "example.com"
+zone_type = "Primary"
+
+[zones.stores]
+type = "sqlite"
+zone_path = "example.com.zone"
+journal_path = ":memory:"
+allow_update = false


### PR DESCRIPTION
Sorry for the oversight in #3697. This PR fixes the bugs introduced in the previous patch.


PathBuf::starts_with uses path-component comparison, not string-prefix comparison. This meant :memory: (a single path component) did not match the component ":" and root_dir was still prepended, producing a path like /var/named/:memory: that SQLite cannot open.

Switch to to_str().map_or(false, |s| s.starts_with(':') || ...) for a correct string-prefix check.

Add tests:
- Unit test in hickory-server (try_from_config with :memory: and a non-None root_dir must succeed)
- Integration test in hickory-dns store_sqlite_tests verifying the same scenario via block_on
- Binary startup test (test_sqlite_memory_journal_startup) that boots the full hickory-dns binary with example_sqlite_memory.toml and performs a live DNS query against the in-memory SQLite zone