### PR TITLE
Fix minor doc-comment typo in Message

### DIFF
--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -81,7 +81,7 @@ pub struct Message {
     pub queries: Vec<Query>,
     /// Records which directly answer the query
     pub answers: Vec<Record>,
-    /// Records with describe other authoritative servers
+    /// Records which describe other authoritative servers
     ///
     /// May optionally carry the SOA record for the authoritative data in the answer section.
     pub authorities: Vec<Record>,


### PR DESCRIPTION
i noticed a trivial typo in the documentation for one of `Message`'s fields.

this commit fixes this, replacing `with` with `which`.