### PR TITLE
Remove Default implementation on ResolverConfig

### DIFF
--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -46,7 +46,7 @@ use crate::proto::rr::Name;
 
 /// Configuration for the upstream nameservers to use for resolution
 #[non_exhaustive]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ResolverConfig {
     /// Base search domain

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -143,6 +143,13 @@ impl ResolverConfig {
         }
     }
 
+    /// Create a ResolverConfig from a list of name server configurations.
+    ///
+    /// No base domain for relative names will be set, and no additional search domains will be set.
+    pub fn from_name_servers(name_servers: Vec<NameServerConfig>) -> Self {
+        Self::from_parts(None, vec![], name_servers)
+    }
+
     /// Take the `domain`, `search`, and `name_servers` from the config.
     pub fn into_parts(self) -> (Option<Name>, Vec<Name>, Vec<NameServerConfig>) {
         (self.domain, self.search, self.name_servers)

--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -101,12 +101,12 @@
 //! # use tokio::runtime::Runtime;
 //! # use hickory_resolver::Resolver;
 //! # use hickory_resolver::net::runtime::TokioRuntimeProvider;
-//! # use hickory_resolver::config::ResolverConfig;
+//! # use hickory_resolver::config::{ResolverConfig, GOOGLE};
 //! #
 //! # let mut io_loop = Runtime::new().unwrap();
 //! #
 //! # let resolver = Resolver::builder_with_config(
-//! #     ResolverConfig::default(),
+//! #     ResolverConfig::udp_and_tcp(&GOOGLE),
 //! #     TokioRuntimeProvider::default()
 //! # ).build().unwrap();
 //! # io_loop.block_on(async {

--- a/crates/resolver/src/name_server_pool.rs
+++ b/crates/resolver/src/name_server_pool.rs
@@ -1005,9 +1005,7 @@ mod tests {
         config1.trust_negative_responses = false;
         let config2 = NameServerConfig::udp(IpAddr::from([8, 8, 8, 8]));
 
-        let mut resolver_config = ResolverConfig::default();
-        resolver_config.add_name_server(config1);
-        resolver_config.add_name_server(config2);
+        let resolver_config = ResolverConfig::from_name_servers(vec![config1, config2]);
 
         let io_loop = Runtime::new().unwrap();
         let pool = NameServerPool::from_config(

--- a/util/src/bin/resolve.rs
+++ b/util/src/bin/resolve.rs
@@ -291,7 +291,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         });
     }
 
-    let mut config = sys_config.unwrap_or_default();
+    let mut config = sys_config.unwrap_or_else(|| ResolverConfig::from_name_servers(vec![]));
 
     for ns in name_servers.iter() {
         config.add_name_server(ns.clone());


### PR DESCRIPTION
This removes the `Default` implementation on `ResolverConfig`, as suggested in https://github.com/hickory-dns/hickory-dns/issues/3605#issuecomment-4553049143. To replace its use cases in a more ergonomic manner, I added a `ResolverConfig::from_name_servers()` constructor.