### PR TITLE
Add simple constructor for ResolverConfig

### DIFF
--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -143,6 +143,13 @@ impl ResolverConfig {
         }
     }
 
+    /// Create a ResolverConfig from a list of name server configurations.
+    ///
+    /// No base domain for relative names will be set, and no additional search domains will be set.
+    pub fn from_name_servers(name_servers: Vec<NameServerConfig>) -> Self {
+        Self::from_parts(None, vec![], name_servers)
+    }
+
     /// Take the `domain`, `search`, and `name_servers` from the config.
     pub fn into_parts(self) -> (Option<Name>, Vec<Name>, Vec<NameServerConfig>) {
         (self.domain, self.search, self.name_servers)

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -44,7 +44,11 @@ use crate::proto::access_control::{AccessControlSet, AccessControlSetBuilder};
 use crate::proto::op::DEFAULT_MAX_PAYLOAD_LEN;
 use crate::proto::rr::Name;
 
-/// Configuration for the upstream nameservers to use for resolution
+/// Configuration for the upstream nameservers to use for resolution.
+///
+/// The `Default` implementation of this struct will be removed in a future version. Use
+/// [`Self::from_name_servers()`] instead. Note that a `ResolverConfig` with no name servers will
+/// produce a nonfunctional resolver.
 #[non_exhaustive]
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/crates/resolver/src/name_server_pool.rs
+++ b/crates/resolver/src/name_server_pool.rs
@@ -1005,9 +1005,7 @@ mod tests {
         config1.trust_negative_responses = false;
         let config2 = NameServerConfig::udp(IpAddr::from([8, 8, 8, 8]));
 
-        let mut resolver_config = ResolverConfig::default();
-        resolver_config.add_name_server(config1);
-        resolver_config.add_name_server(config2);
+        let resolver_config = ResolverConfig::from_name_servers(vec![config1, config2]);
 
         let io_loop = Runtime::new().unwrap();
         let pool = NameServerPool::from_config(


### PR DESCRIPTION
Partial backport of #3709.

Unfortunately we cannot mark a trait impl or its methods as deprecated. This currently produces a `useless_deprecated` warning.