### PR TITLE
Implement DerefMut on Message and Header

### DIFF
--- a/crates/proto/src/op/header.rs
+++ b/crates/proto/src/op/header.rs
@@ -9,7 +9,11 @@
 
 #[cfg(test)]
 use alloc::vec::Vec;
-use core::{convert::From, fmt, ops::Deref};
+use core::{
+    convert::From,
+    fmt,
+    ops::{Deref, DerefMut},
+};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -166,6 +170,12 @@ impl Deref for Header {
 
     fn deref(&self) -> &Self::Target {
         &self.metadata
+    }
+}
+
+impl DerefMut for Header {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.metadata
     }
 }
 

--- a/crates/proto/src/op/message.rs
+++ b/crates/proto/src/op/message.rs
@@ -8,7 +8,10 @@
 //! Basic protocol message for DNS
 
 use alloc::{boxed::Box, fmt, vec::Vec};
-use core::{mem, ops::Deref};
+use core::{
+    mem,
+    ops::{Deref, DerefMut},
+};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -532,6 +535,12 @@ impl Deref for Message {
 
     fn deref(&self) -> &Self::Target {
         &self.metadata
+    }
+}
+
+impl DerefMut for Message {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.metadata
     }
 }
 


### PR DESCRIPTION
This implements `DerefMut` on two structs that already `Deref` to `Metadata`. When I do "Find All References" on the `metadata` field of `Message`, I see hundreds of field accesses from construction of requests or responses in tests. Adding these impls improves the ergonomics of crafting messages, as `message.response_code` etc. will now work for both reading and writing.