### PR TITLE
Remove DerefMut impl on LowerName

### DIFF
--- a/crates/proto/src/rr/lower_name.rs
+++ b/crates/proto/src/rr/lower_name.rs
@@ -12,7 +12,7 @@ use alloc::string::{String, ToString};
 use core::cmp::{Ordering, PartialEq};
 use core::fmt;
 use core::hash::{Hash, Hasher};
-use core::ops::{Deref, DerefMut};
+use core::ops::Deref;
 use core::str::FromStr;
 
 use crate::error::*;
@@ -266,12 +266,6 @@ impl Deref for LowerName {
 
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-
-impl DerefMut for LowerName {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 

--- a/crates/server/src/store/blocklist.rs
+++ b/crates/server/src/store/blocklist.rs
@@ -239,16 +239,17 @@ impl BlocklistZoneHandler {
                 None => entry,
             };
 
-            let Ok(mut name) = LowerName::from_str(name) else {
-                warn!("unable to derive LowerName for blocklist entry '{name}'; skipping entry");
+            let Ok(mut name) = Name::from_str(name) else {
+                warn!("unable to parse Name for blocklist entry '{name}'; skipping entry");
                 continue;
             };
 
             trace!("inserting blocklist entry {name}");
 
-            // The boolean value is not significant; only the key is used.
             name.set_fqdn(true);
-            self.blocklist.insert(name, true);
+            let lower_name = LowerName::from(name);
+            // The boolean value is not significant; only the key is used.
+            self.blocklist.insert(lower_name, true);
         }
 
         Ok(())


### PR DESCRIPTION
I noticed that we have a `DerefMut` impl on `LowerName`. This is an issue because it would allow users to accidentally break the invariant that the `LowerName`'s field is represented in lowercase, i.e. via `Name::extend_name()` with uppercase ASCII characters. This would then lead to unexpected results when comparing or hashing the `LowerName`. This PR deletes the `DerefMut` impl, and fixes one innocuous modification of the FQDN flag through `LowerName` elsewhere. This was the only mutable access to `LowerName`'s field.