### PR TITLE
resolver: reconnect once when a reused pooled connection was closed (backport to 0.26)

### DIFF
--- a/crates/net/src/error.rs
+++ b/crates/net/src/error.rs
@@ -161,6 +161,36 @@ impl NetError {
         matches!(self, Self::Dns(DnsError::NoRecordsFound { .. }))
     }
 
+    /// Returns true for a transport-level connection error: the connection was
+    /// closed, reset, or refused, as opposed to a timeout or a server-side (DNS)
+    /// error.
+    pub fn is_connection_closed(&self) -> bool {
+        match self {
+            #[cfg(feature = "__https")]
+            Self::H2(err) => {
+                err.is_io() || err.is_go_away() || err.reason() == Some(h2::Reason::REFUSED_STREAM)
+            }
+            #[cfg(feature = "__h3")]
+            Self::H3(err) => err.is_h3_no_error(),
+            Self::Io(err) => matches!(
+                err.kind(),
+                io::ErrorKind::ConnectionReset
+                    | io::ErrorKind::ConnectionAborted
+                    | io::ErrorKind::BrokenPipe
+                    | io::ErrorKind::NotConnected
+                    | io::ErrorKind::UnexpectedEof
+            ),
+            #[cfg(feature = "__quic")]
+            Self::QuinnConnection(err) => matches!(
+                err,
+                quinn::ConnectionError::ConnectionClosed(_)
+                    | quinn::ConnectionError::ApplicationClosed(_)
+                    | quinn::ConnectionError::Reset
+            ),
+            _ => false,
+        }
+    }
+
     /// Returns the SOA record, if the error contains one
     #[inline]
     pub fn into_soa(self) -> Option<Box<Record<SOA>>> {
@@ -375,4 +405,52 @@ pub struct ForwardNSData {
     pub ns: Record,
     /// Any glue records associated with the referant NS record.
     pub glue: Arc<[Record]>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_connection_closed_io_kinds() {
+        for kind in [
+            io::ErrorKind::ConnectionReset,
+            io::ErrorKind::ConnectionAborted,
+            io::ErrorKind::BrokenPipe,
+            io::ErrorKind::NotConnected,
+            io::ErrorKind::UnexpectedEof,
+        ] {
+            assert!(
+                NetError::from(io::Error::from(kind)).is_connection_closed(),
+                "{kind:?}"
+            );
+        }
+
+        assert!(
+            !NetError::from(io::Error::from(io::ErrorKind::PermissionDenied))
+                .is_connection_closed()
+        );
+        assert!(!NetError::Timeout.is_connection_closed());
+        assert!(!NetError::Message("server error").is_connection_closed());
+    }
+
+    #[cfg(feature = "__https")]
+    #[test]
+    fn is_connection_closed_h2() {
+        // REFUSED_STREAM: the server never processed the request, so it's safe to retry.
+        assert!(NetError::from(h2::Error::from(h2::Reason::REFUSED_STREAM)).is_connection_closed());
+        // A protocol error mid-exchange is not a clean connection-closed signal.
+        assert!(
+            !NetError::from(h2::Error::from(h2::Reason::INTERNAL_ERROR)).is_connection_closed()
+        );
+    }
+
+    #[cfg(feature = "__quic")]
+    #[test]
+    fn is_connection_closed_quic_excludes_timeout() {
+        assert!(NetError::QuinnConnection(quinn::ConnectionError::Reset).is_connection_closed());
+        assert!(
+            !NetError::QuinnConnection(quinn::ConnectionError::TimedOut).is_connection_closed()
+        );
+    }
 }

--- a/crates/net/src/h2.rs
+++ b/crates/net/src/h2.rs
@@ -313,13 +313,7 @@ async fn send(
     message: Bytes,
     cx: Arc<RequestContext>,
 ) -> Result<DnsResponse, NetError> {
-    let mut h2 = match h2.ready().await {
-        Ok(h2) => h2,
-        Err(err) => {
-            // TODO: make specific error
-            return Err(NetError::from(format!("h2 send_request error: {err}")));
-        }
-    };
+    let mut h2 = h2.ready().await?;
 
     // build up the http request
     let request = cx
@@ -329,17 +323,11 @@ async fn send(
     debug!("request: {:#?}", request);
 
     // Send the request
-    let (response_future, mut send_stream) = h2
-        .send_request(request, false)
-        .map_err(|err| NetError::from(format!("h2 send_request error: {err}")))?;
+    let (response_future, mut send_stream) = h2.send_request(request, false)?;
 
-    send_stream
-        .send_data(message, true)
-        .map_err(|e| NetError::from(format!("h2 send_data error: {e}")))?;
+    send_stream.send_data(message, true)?;
 
-    let mut response_stream = response_future
-        .await
-        .map_err(|err| NetError::from(format!("received a stream error: {err}")))?;
+    let mut response_stream = response_future.await?;
 
     debug!("got response: {:#?}", response_stream);
 

--- a/crates/net/src/h3/h3_client_stream.rs
+++ b/crates/net/src/h3/h3_client_stream.rs
@@ -75,25 +75,13 @@ impl H3ClientStream {
         debug!("request: {:#?}", request);
 
         // Send the request
-        let mut stream = h3
-            .send_request(request)
-            .await
-            .map_err(|err| NetError::from(format!("h3 send_request error: {err}")))?;
+        let mut stream = h3.send_request(request).await?;
 
-        stream
-            .send_data(message)
-            .await
-            .map_err(|e| NetError::from(format!("h3 send_data error: {e}")))?;
+        stream.send_data(message).await?;
 
-        stream
-            .finish()
-            .await
-            .map_err(|err| NetError::from(format!("received a stream error: {err}")))?;
+        stream.finish().await?;
 
-        let response = stream
-            .recv_response()
-            .await
-            .map_err(|err| NetError::from(format!("h3 recv_response error: {err}")))?;
+        let response = stream.recv_response().await?;
 
         debug!("got response: {:#?}", response);
 

--- a/crates/net/src/xfer/dns_multiplexer.rs
+++ b/crates/net/src/xfer/dns_multiplexer.rs
@@ -13,6 +13,7 @@ use core::{
     time::Duration,
 };
 use std::collections::{HashMap, hash_map::Entry};
+use std::io;
 
 use futures_channel::mpsc;
 use futures_util::{
@@ -340,7 +341,10 @@ impl<S: DnsClientStream> Stream for DnsMultiplexer<S> {
                 Poll::Ready(err) => {
                     let err = match err {
                         Some(Err(e)) => e,
-                        None => NetError::from("stream closed"),
+                        None => NetError::from(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "stream closed",
+                        )),
                         _ => unreachable!(),
                     };
 

--- a/crates/resolver/src/name_server.rs
+++ b/crates/resolver/src/name_server.rs
@@ -103,110 +103,128 @@ impl<P: ConnectionProvider> NameServer<P> {
         policy: ConnectionPolicy,
         cx: &Arc<PoolContext>,
     ) -> Result<DnsResponse, NetError> {
-        let ConnectedClient {
-            handle,
-            meta,
-            protocol,
-        } = self.connected_mut_client(policy, cx).await?;
-        #[cfg(feature = "metrics")]
-        self.resolver_metrics.increment_outgoing_query(&protocol);
-        let now = Instant::now();
-        let response = handle.send(request).first_answer().await;
-        let rtt = now.elapsed();
+        // Reconnect and retry once if a reused connection was closed mid-flight.
+        // Caps total retries even when the pool holds several reusable connections.
+        let mut reconnect_budget = 1u8;
+        loop {
+            let ConnectedClient {
+                handle,
+                meta,
+                protocol,
+                reuse,
+            } = self.connected_mut_client(policy, cx).await?;
+            #[cfg(feature = "metrics")]
+            self.resolver_metrics.increment_outgoing_query(&protocol);
+            let now = Instant::now();
+            let response = handle.send(request.clone()).first_answer().await;
+            let rtt = now.elapsed();
 
-        match response {
-            Ok(response) => {
-                meta.set_status(Status::Established);
-                let result = DnsError::from_response(response);
-                let error = match result {
-                    Ok(response) => {
-                        meta.srtt.record(rtt);
-                        self.server_srtt.record(rtt);
-                        if cx.opportunistic_encryption.is_enabled() && protocol.is_encrypted() {
-                            cx.transport_state()
-                                .await
-                                .response_received(self.config.ip, protocol);
+            match response {
+                Ok(response) => {
+                    meta.set_status(Status::Established);
+                    let result = DnsError::from_response(response);
+                    let error = match result {
+                        Ok(response) => {
+                            meta.srtt.record(rtt);
+                            self.server_srtt.record(rtt);
+                            if cx.opportunistic_encryption.is_enabled() && protocol.is_encrypted() {
+                                cx.transport_state()
+                                    .await
+                                    .response_received(self.config.ip, protocol);
+                            }
+                            return Ok(response);
                         }
-                        return Ok(response);
-                    }
-                    Err(error) => error,
-                };
+                        Err(error) => error,
+                    };
 
-                let update = match error {
-                    DnsError::NoRecordsFound(NoRecords {
-                        response_code: ResponseCode::ServFail,
-                        ..
-                    }) => Some(true),
-                    DnsError::NoRecordsFound(NoRecords { .. }) => Some(false),
-                    _ => None,
-                };
+                    let update = match error {
+                        DnsError::NoRecordsFound(NoRecords {
+                            response_code: ResponseCode::ServFail,
+                            ..
+                        }) => Some(true),
+                        DnsError::NoRecordsFound(NoRecords { .. }) => Some(false),
+                        _ => None,
+                    };
 
-                match update {
-                    Some(true) => {
-                        meta.srtt.record(rtt);
-                        self.server_srtt.record(rtt);
+                    match update {
+                        Some(true) => {
+                            meta.srtt.record(rtt);
+                            self.server_srtt.record(rtt);
+                        }
+                        Some(false) => {
+                            // record the failure
+                            meta.srtt.record_failure();
+                            self.server_srtt.record_failure();
+                        }
+                        None => {}
                     }
-                    Some(false) => {
-                        // record the failure
-                        meta.srtt.record_failure();
-                        self.server_srtt.record_failure();
+
+                    let err = NetError::from(error);
+                    if cx.opportunistic_encryption.is_enabled() && protocol.is_encrypted() {
+                        cx.transport_state()
+                            .await
+                            .error_received(self.config.ip, protocol, &err)
                     }
-                    None => {}
+                    return Err(err);
                 }
+                Err(error) => {
+                    debug!(config = ?self.config, %error, "failed to connect to name server");
 
-                let err = NetError::from(error);
-                if cx.opportunistic_encryption.is_enabled() && protocol.is_encrypted() {
-                    cx.transport_state()
-                        .await
-                        .error_received(self.config.ip, protocol, &err)
-                }
-                Err(err)
-            }
-            Err(error) => {
-                debug!(config = ?self.config, %error, "failed to connect to name server");
+                    // this transitions the state to failure, so the next acquire drops it
+                    meta.set_status(Status::Failed);
 
-                // this transitions the state to failure
-                meta.set_status(Status::Failed);
-
-                // record the failure on both the per-connection and server-level SRTTs.
-                // updating server_srtt ensures the server is deprioritized in pool
-                // ordering (decayed_srtt) so other servers get a chance to be tried.
-                match &error {
-                    NetError::Busy | NetError::Io(_) | NetError::Timeout => {
-                        meta.srtt.record_failure();
-                        self.server_srtt.record_failure();
+                    // A reused connection the peer had already closed isn't a server fault.
+                    // Reconnect and retry once without penalizing server selection. The resend
+                    // is at-least-once; the resolver only sends read-only queries through this pool.
+                    if reuse == ConnectionReuse::Reused
+                        && reconnect_budget > 0
+                        && error.is_connection_closed()
+                    {
+                        reconnect_budget -= 1;
+                        continue;
                     }
-                    #[cfg(feature = "__quic")]
-                    NetError::QuinnConfigError(_)
-                    | NetError::QuinnConnect(_)
-                    | NetError::QuinnConnection(_)
-                    | NetError::QuinnTlsConfigError(_) => {
-                        meta.srtt.record_failure();
-                        self.server_srtt.record_failure();
-                    }
-                    #[cfg(feature = "__tls")]
-                    NetError::RustlsError(_) => {
-                        meta.srtt.record_failure();
-                        self.server_srtt.record_failure();
-                    }
-                    _ => {}
-                }
 
-                if cx.opportunistic_encryption.is_enabled() && protocol.is_encrypted() {
-                    cx.transport_state()
-                        .await
-                        .error_received(self.config.ip, protocol, &error);
-                }
+                    // record the failure on both the per-connection and server-level SRTTs.
+                    // updating server_srtt ensures the server is deprioritized in pool
+                    // ordering (decayed_srtt) so other servers get a chance to be tried.
+                    match &error {
+                        NetError::Busy | NetError::Io(_) | NetError::Timeout => {
+                            meta.srtt.record_failure();
+                            self.server_srtt.record_failure();
+                        }
+                        #[cfg(feature = "__quic")]
+                        NetError::QuinnConfigError(_)
+                        | NetError::QuinnConnect(_)
+                        | NetError::QuinnConnection(_)
+                        | NetError::QuinnTlsConfigError(_) => {
+                            meta.srtt.record_failure();
+                            self.server_srtt.record_failure();
+                        }
+                        #[cfg(feature = "__tls")]
+                        NetError::RustlsError(_) => {
+                            meta.srtt.record_failure();
+                            self.server_srtt.record_failure();
+                        }
+                        _ => {}
+                    }
 
-                // These are connection failures, not lookup failures, that is handled in the resolver layer
-                Err(error)
+                    if cx.opportunistic_encryption.is_enabled() && protocol.is_encrypted() {
+                        cx.transport_state()
+                            .await
+                            .error_received(self.config.ip, protocol, &error);
+                    }
+
+                    // These are connection failures, not lookup failures, that is handled in the resolver layer
+                    return Err(error);
+                }
             }
         }
     }
 
     /// This will return a mutable client to allows for sending messages.
     ///
-    /// If the connection is in a failed state, then this will establish a new connection
+    /// If the connection is in a failed state, then this will establish a new connection.
+    ///
     async fn connected_mut_client(
         &self,
         policy: ConnectionPolicy,
@@ -227,6 +245,7 @@ impl<P: ConnectionProvider> NameServer<P> {
                     handle: conn.handle.clone(),
                     meta: conn.meta.clone(),
                     protocol: conn.protocol,
+                    reuse: ConnectionReuse::Reused,
                 });
             }
         }
@@ -273,6 +292,7 @@ impl<P: ConnectionProvider> NameServer<P> {
             handle,
             meta,
             protocol,
+            reuse: ConnectionReuse::Fresh,
         })
     }
 
@@ -518,11 +538,19 @@ impl<P: ConnectionProvider> ProbeRequest<P> {
     }
 }
 
+/// Whether `connected_mut_client` returned an existing pooled connection or established a new one.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ConnectionReuse {
+    Reused,
+    Fresh,
+}
+
 /// A connection selected by [`NameServer::connected_mut_client`] for sending a request.
 struct ConnectedClient<P: ConnectionProvider> {
     handle: P::Conn,
     meta: Arc<ConnectionMeta>,
     protocol: Protocol,
+    reuse: ConnectionReuse,
 }
 
 struct ConnectionState<P: ConnectionProvider> {
@@ -1721,7 +1749,7 @@ mod opportunistic_enc_tests {
     }
 
     fn mock_connection(protocol: Protocol) -> ConnectionState<MockProvider> {
-        ConnectionState::new(MockClientHandle, protocol)
+        ConnectionState::new(MockClientHandle::default(), protocol)
     }
 
     #[cfg(feature = "metrics")]
@@ -2123,7 +2151,100 @@ mod resolver_metrics_tests {
 }
 
 #[cfg(all(test, any(feature = "metrics", feature = "__tls")))]
+mod reconnect_tests {
+    use std::collections::VecDeque;
+    use std::io;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::Arc;
+
+    use parking_lot::Mutex as SyncMutex;
+    use test_support::subscribe;
+
+    use super::mock_provider::MockProvider;
+    use super::{ConnectionPolicy, NameServer};
+    use crate::config::{NameServerConfig, ResolverOpts};
+    use crate::connection_provider::TlsConfig;
+    use crate::name_server_pool::PoolContext;
+    use crate::net::NetError;
+    use crate::proto::op::{DnsRequest, DnsRequestOptions, Query};
+    use crate::proto::rr::{Name, RecordType};
+
+    fn connection_closed() -> NetError {
+        NetError::from(io::Error::from(io::ErrorKind::ConnectionReset))
+    }
+
+    fn query() -> DnsRequest {
+        DnsRequest::from_query(
+            Query::query(
+                Name::parse("www.example.com.", None).unwrap(),
+                RecordType::A,
+            ),
+            DnsRequestOptions::default(),
+        )
+    }
+
+    /// Build a name server whose connections replay `outcomes` across the sends they receive.
+    fn name_server_with(
+        outcomes: VecDeque<Option<NetError>>,
+    ) -> (
+        Arc<NameServer<MockProvider>>,
+        MockProvider,
+        Arc<PoolContext>,
+    ) {
+        let provider = MockProvider {
+            send_outcomes: Arc::new(SyncMutex::new(outcomes)),
+            ..MockProvider::default()
+        };
+        let options = ResolverOpts::default();
+        let config = NameServerConfig::udp(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
+        let ns = Arc::new(NameServer::new([], config, &options, provider.clone()));
+        let cx = Arc::new(PoolContext::new(options, TlsConfig::new().unwrap()));
+        (ns, provider, cx)
+    }
+
+    /// A reused pooled connection that the peer closed while idle should be
+    /// transparently reconnected rather than surfacing the error to the caller.
+    #[tokio::test]
+    async fn reconnects_once_when_reused_connection_was_closed() {
+        subscribe();
+
+        // Establish (ok), the reused send fails connection-closed, and the
+        // post-reconnect send succeeds (empty queue falls through to success).
+        let (ns, provider, cx) =
+            name_server_with(VecDeque::from([None, Some(connection_closed())]));
+
+        ns.clone()
+            .send(query(), ConnectionPolicy::default(), &cx)
+            .await
+            .expect("initial query establishes the connection");
+        ns.clone()
+            .send(query(), ConnectionPolicy::default(), &cx)
+            .await
+            .expect("stale reused connection is transparently reconnected");
+
+        // The initial connection plus the post-failure reconnect.
+        assert_eq!(provider.new_connection_calls().len(), 2);
+    }
+
+    /// A connection-closed error on a brand-new (non-reused) connection is a real
+    /// failure, not a stale-pool artifact: it must propagate without a retry.
+    #[tokio::test]
+    async fn does_not_retry_when_a_fresh_connection_fails_closed() {
+        subscribe();
+
+        let (ns, provider, cx) = name_server_with(VecDeque::from([Some(connection_closed())]));
+
+        ns.send(query(), ConnectionPolicy::default(), &cx)
+            .await
+            .expect_err("a fresh connection failure must not be retried");
+
+        assert_eq!(provider.new_connection_calls().len(), 1);
+    }
+}
+
+#[cfg(all(test, any(feature = "metrics", feature = "__tls")))]
 mod mock_provider {
+    use std::collections::VecDeque;
     use std::future::Future;
     use std::io;
     use std::pin::Pin;
@@ -2138,6 +2259,8 @@ mod mock_provider {
     use crate::net::runtime::TokioTime;
     use crate::net::runtime::iocompat::AsyncIoTokioAsStd;
     use crate::proto::op::Message;
+    use crate::proto::rr::rdata::NULL;
+    use crate::proto::rr::{RData, Record};
 
     /// `MockProvider` is a `ConnectionProvider` that uses a synchronous runtime provider.
     ///
@@ -2150,6 +2273,10 @@ mod mock_provider {
         pub(super) runtime: MockSyncRuntimeProvider,
         pub(super) new_connection_calls: Arc<SyncMutex<Vec<(IpAddr, ProtocolConfig)>>>,
         pub(super) new_connection_error: Option<NetError>,
+        /// Per-send outcomes, consumed front-to-back across all connections this
+        /// provider hands out: `Some(err)` fails that send, `None` (or an empty
+        /// queue) succeeds.
+        pub(super) send_outcomes: Arc<SyncMutex<VecDeque<Option<NetError>>>>,
     }
 
     impl MockProvider {
@@ -2175,7 +2302,9 @@ mod mock_provider {
 
             Ok(Box::pin(future::ready(match &self.new_connection_error {
                 Some(err) => Err(err.clone()),
-                None => Ok(MockClientHandle),
+                None => Ok(MockClientHandle {
+                    send_outcomes: self.send_outcomes.clone(),
+                }),
             })))
         }
 
@@ -2190,25 +2319,38 @@ mod mock_provider {
                 runtime: MockSyncRuntimeProvider,
                 new_connection_calls: Arc::new(SyncMutex::new(Vec::new())),
                 new_connection_error: None,
+                send_outcomes: Arc::new(SyncMutex::new(VecDeque::new())),
             }
         }
     }
 
     /// `MockClientHandle` is a `DnsHandle` that uses a synchronous runtime provider.
     ///
-    /// It's `send` method always returns a `NoError` response when polled, simulating a
-    /// successful DNS request exchange.
+    /// Its `send` method replays the provider's scripted `send_outcomes`: a `Some(err)`
+    /// entry fails that send, while `None` or an exhausted queue yields a `NoError` response.
     #[derive(Clone, Default)]
-    pub(super) struct MockClientHandle;
+    pub(super) struct MockClientHandle {
+        send_outcomes: Arc<SyncMutex<VecDeque<Option<NetError>>>>,
+    }
 
     impl DnsHandle for MockClientHandle {
         type Response = Pin<Box<dyn Stream<Item = Result<DnsResponse, NetError>> + Send>>;
         type Runtime = MockSyncRuntimeProvider;
 
         fn send(&self, request: DnsRequest) -> Self::Response {
+            if let Some(Some(err)) = self.send_outcomes.lock().pop_front() {
+                return Box::pin(once(future::ready(Err(err))));
+            }
             let mut response = Message::response(request.id, request.op_code);
             response.metadata.response_code = ResponseCode::NoError;
             response.add_queries(request.queries.clone());
+            if let Some(query) = request.queries.first() {
+                response.add_answer(Record::from_rdata(
+                    query.name.clone(),
+                    0,
+                    RData::NULL(NULL::with(vec![0])),
+                ));
+            }
             Box::pin(once(future::ready(Ok(
                 DnsResponse::from_message(response).unwrap()
             ))))

--- a/crates/resolver/src/name_server.rs
+++ b/crates/resolver/src/name_server.rs
@@ -103,7 +103,11 @@ impl<P: ConnectionProvider> NameServer<P> {
         policy: ConnectionPolicy,
         cx: &Arc<PoolContext>,
     ) -> Result<DnsResponse, NetError> {
-        let (handle, meta, protocol) = self.connected_mut_client(policy, cx).await?;
+        let ConnectedClient {
+            handle,
+            meta,
+            protocol,
+        } = self.connected_mut_client(policy, cx).await?;
         #[cfg(feature = "metrics")]
         self.resolver_metrics.increment_outgoing_query(&protocol);
         let now = Instant::now();
@@ -207,7 +211,7 @@ impl<P: ConnectionProvider> NameServer<P> {
         &self,
         policy: ConnectionPolicy,
         cx: &Arc<PoolContext>,
-    ) -> Result<(P::Conn, Arc<ConnectionMeta>, Protocol), NetError> {
+    ) -> Result<ConnectedClient<P>, NetError> {
         // Check for an existing usable connection (short lock)
         {
             let mut connections = self.connections.lock().await;
@@ -219,7 +223,11 @@ impl<P: ConnectionProvider> NameServer<P> {
                 &cx.opportunistic_encryption,
                 &connections,
             ) {
-                return Ok((conn.handle.clone(), conn.meta.clone(), conn.protocol));
+                return Ok(ConnectedClient {
+                    handle: conn.handle.clone(),
+                    meta: conn.meta.clone(),
+                    protocol: conn.protocol,
+                });
             }
         }
 
@@ -261,7 +269,11 @@ impl<P: ConnectionProvider> NameServer<P> {
         let state = ConnectionState::new(handle.clone(), protocol);
         let meta = state.meta.clone();
         self.connections.lock().await.push(state);
-        Ok((handle, meta, protocol))
+        Ok(ConnectedClient {
+            handle,
+            meta,
+            protocol,
+        })
     }
 
     pub(super) fn protocols(&self) -> impl Iterator<Item = Protocol> + '_ {
@@ -504,6 +516,13 @@ impl<P: ConnectionProvider> ProbeRequest<P> {
             metrics.record_probe_duration(proto, start.elapsed());
         }
     }
+}
+
+/// A connection selected by [`NameServer::connected_mut_client`] for sending a request.
+struct ConnectedClient<P: ConnectionProvider> {
+    handle: P::Conn,
+    meta: Arc<ConnectionMeta>,
+    protocol: Protocol,
 }
 
 struct ConnectionState<P: ConnectionProvider> {


### PR DESCRIPTION
Backport of #3711 to `release/0.26`.

When a connection-oriented transport (DoH/H2, DoT, DoH3, DoQ) keeps a pooled connection and reuses it, the first query after the peer closes that connection while idle fails instead of transparently reconnecting. `NameServer::send` reuses the dead connection, marks it `Failed`, and only re-establishes on the *next* query, so a single-shot caller sees a spurious failure. See #3712 / #3711 for the full write-up.

Three commits, cherry-picked from the `main` PR:

- **`net`: return typed transport errors instead of stringifying** — the h2/h3 send paths and the stream multiplexer's connection-closed signal return typed `NetError::{H2, H3, Io}` instead of `NetError::Msg`/`Message`.
- **`resolver`: return a named struct from `connected_mut_client`** — pure refactor, `(P::Conn, Arc<ConnectionMeta>, Protocol)` becomes a `ConnectedClient` struct.
- **`resolver`: reconnect once when a reused connection was closed** — adds `NetError::is_connection_closed` and a single bounded reconnect-and-retry when a *reused* connection failed connection-closed, without penalizing server selection.

The only adaptation from `main` is the test helper using `Query::query(..)` (0.26's two-arg constructor) instead of `Query::new(..)`.