### PR TITLE
server: return NXDOMAIN for SOA queries on non-existent names (backport to 0.26)

### DIFF
--- a/crates/server/src/store/in_memory/mod.rs
+++ b/crates/server/src/store/in_memory/mod.rs
@@ -477,16 +477,6 @@ impl<P: RuntimeProvider + Send + Sync> ZoneHandler for InMemoryZoneHandler<P> {
 
         // perform the actual lookup
         match record_type {
-            RecordType::SOA => (
-                self.lookup(
-                    self.origin(),
-                    record_type,
-                    Some(&request_info),
-                    lookup_options,
-                )
-                .await,
-                None,
-            ),
             RecordType::AXFR => (
                 LookupControlFlow::Break(Err(LookupError::NetError(
                     "AXFR must be handled with ZoneHandler::zone_transfer()".into(),

--- a/tests/integration-tests/tests/integration/catalog_tests.rs
+++ b/tests/integration-tests/tests/integration/catalog_tests.rs
@@ -337,6 +337,64 @@ async fn test_catalog_nx_soa() {
 }
 
 #[tokio::test]
+#[allow(clippy::unreadable_literal)]
+async fn test_catalog_soa_query_for_nx_name() {
+    subscribe();
+
+    let example = create_example();
+    let origin = example.origin().clone();
+
+    let mut catalog = Catalog::new();
+    catalog.upsert(origin, vec![Arc::new(example)]);
+
+    let mut question = Message::query();
+
+    let mut query = Query::new();
+    query.set_name(Name::parse("nx.example.com.", None).unwrap());
+    query.set_query_type(RecordType::SOA);
+
+    question.add_query(query);
+
+    // temp request
+    let question_bytes = question.to_bytes().unwrap();
+    let question_req =
+        Request::from_bytes(question_bytes, ([127, 0, 0, 1], 5553).into(), Protocol::Udp).unwrap();
+
+    let response_handler = TestResponseHandler::new();
+    catalog
+        .lookup(
+            &question_req,
+            None,
+            TokioTime::current_time(),
+            response_handler.clone(),
+        )
+        .await;
+    let result = response_handler.into_message().await;
+
+    assert_eq!(result.metadata.response_code, ResponseCode::NXDomain);
+    assert_eq!(result.metadata.message_type, MessageType::Response);
+    assert!(result.metadata.authoritative);
+    assert!(result.answers.is_empty());
+
+    let authorities = result.authorities;
+
+    assert_eq!(authorities.len(), 1);
+    assert_eq!(authorities.first().unwrap().record_type(), RecordType::SOA);
+    assert_eq!(
+        authorities.first().unwrap().data,
+        RData::SOA(SOA::new(
+            Name::parse("sns.dns.icann.org.", None).unwrap(),
+            Name::parse("noc.dns.icann.org.", None).unwrap(),
+            2015082403,
+            7200,
+            3600,
+            1209600,
+            3600,
+        ))
+    );
+}
+
+#[tokio::test]
 async fn test_non_authoritive_nx_refused() {
     subscribe();
 


### PR DESCRIPTION
Backport of #3685 to `release/0.26`, per @djc's request.

Cherry-picks cleanly apart from one API difference. The added test called `Query::root()`, which doesn't exist on 0.26, so it now uses `Query::new()` like the other tests in `catalog_tests.rs`. The `set_name` call right after it makes the two identical.

`cargo test -p hickory-integration --test integration catalog` passes 16/16 here including `test_catalog_soa_query_for_nx_name`. `cargo fmt --check` and `cargo clippy -p hickory-server --all-features` are clean.
