### PR TITLE
fix(server): treat ECONNABORTED from accept() as recoverable (#3725)

### DIFF
--- a/crates/server/src/server/mod.rs
+++ b/crates/server/src/server/mod.rs
@@ -1009,11 +1009,9 @@ fn sanitize_src_address(src: SocketAddr) -> Result<(), String> {
     }
 }
 
+/// Returns `true` if an `accept()` error means the listener itself is no longer usable.
 fn is_unrecoverable_socket_error(err: &io::Error) -> bool {
-    matches!(
-        err.kind(),
-        io::ErrorKind::NotConnected | io::ErrorKind::ConnectionAborted
-    )
+    matches!(err.kind(), io::ErrorKind::NotConnected)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
ECONNABORTED is a transient per-connection error returned by accept() when an inbound connection is aborted before it could be accepted. is_unrecoverable_socket_error previously classified it as unrecoverable, so the TCP/TLS/HTTPS accept loops broke and the listener silently stopped accepting connections. This treats it as recoverable so the accept loop continues, and adds a unit test for the classification.

A companion PR targets release/0.26. Fixes #3725.