### PR TITLE
fix(server): treat ECONNABORTED from accept() as recoverable (#3725)

### DIFF
--- a/crates/server/src/server/mod.rs
+++ b/crates/server/src/server/mod.rs
@@ -977,11 +977,12 @@ fn sanitize_src_address(src: SocketAddr) -> Result<(), String> {
     }
 }
 
+/// Determine whether an error returned from `accept()` indicates the listener
+/// itself is no longer usable. `ConnectionAborted` (ECONNABORTED) is a transient
+/// per-connection error — the inbound connection was aborted before it could be
+/// accepted — so it is recoverable and the accept loop should continue.
 fn is_unrecoverable_socket_error(err: &io::Error) -> bool {
-    matches!(
-        err.kind(),
-        io::ErrorKind::NotConnected | io::ErrorKind::ConnectionAborted
-    )
+    matches!(err.kind(), io::ErrorKind::NotConnected)
 }
 
 #[cfg(test)]
@@ -998,6 +999,16 @@ mod tests {
     use test_support::subscribe;
     use tokio::net::{TcpListener, UdpSocket};
     use tokio::time::timeout;
+
+    #[test]
+    fn econnaborted_is_recoverable() {
+        assert!(!is_unrecoverable_socket_error(&io::Error::from(
+            io::ErrorKind::ConnectionAborted
+        )));
+        assert!(is_unrecoverable_socket_error(&io::Error::from(
+            io::ErrorKind::NotConnected
+        )));
+    }
 
     #[tokio::test]
     async fn abort() {


### PR DESCRIPTION
ECONNABORTED is a transient per-connection error returned by accept() when an inbound connection is aborted before it could be accepted. is_unrecoverable_socket_error previously classified it as unrecoverable, so the TCP/TLS/HTTPS accept loops broke and the listener silently stopped accepting connections. This treats it as recoverable so the accept loop continues, and adds a unit test for the classification.

This is the release/0.26 companion to the main PR #3726. Fixes #3725.