### PR TITLE
svcb: support SvcParamValue with interior whitespace, fix TODOs

### DIFF
--- a/crates/proto/src/rr/rdata/svcb.rs
+++ b/crates/proto/src/rr/rdata/svcb.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     serialize::{
         binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, RDataEncoding},
-        txt::{Lexer, ParseError, Token},
+        txt::{ParseError, decode_char_string, encode_char_string},
     },
 };
 
@@ -262,16 +262,17 @@ fn parse_value(key: SvcParamKey, value: Option<&str>) -> Result<SvcParamValue, P
     }
 }
 
-fn parse_char_data(value: &str) -> Result<String, ParseError> {
-    let mut lex = Lexer::new(value);
-    let ch_data = lex
-        .next_token()?
-        .ok_or(ParseError::Message("expected character data"))?;
-
-    match ch_data {
-        Token::CharData(data) => Ok(data),
-        _ => Err(ParseError::Message("expected character data")),
+/// Several SvcParamValues (mandatory, port, the IP hints, and ech which states
+/// "SvcParam") state: "To enable simpler parsing, this SvcParamValue MUST NOT
+/// contain escape sequences."
+fn deny_escapes(value: &str) -> Result<&str, ParseError> {
+    if value.contains('\\') {
+        return Err(ParseError::Message(
+            "this SvcParamValue MUST NOT contain escape sequences",
+        ));
     }
+
+    Ok(value)
 }
 
 /// [RFC 9460 SVCB and HTTPS Resource Records, Nov 2023](https://datatracker.ietf.org/doc/html/rfc9460#section-8)
@@ -296,7 +297,7 @@ fn parse_char_data(value: &str) -> Result<String, ParseError> {
 fn parse_mandatory(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
     let value = value.ok_or(ParseError::Message("expected at least one Mandatory field"))?;
 
-    let mandatories = parse_list::<SvcParamKey>(value)?;
+    let mandatories = parse_list::<SvcParamKey>(deny_escapes(value)?)?;
     Ok(SvcParamValue::Mandatory(Mandatory(mandatories)))
 }
 
@@ -316,7 +317,12 @@ fn parse_mandatory(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
 fn parse_alpn(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
     let value = value.ok_or(ParseError::Message("expected at least one ALPN code"))?;
 
-    let alpns = parse_list::<String>(value).expect("infallible");
+    // char-string decoding comes first (RFC 9460 §2.1)
+    let decoded = decode_char_string(value)?;
+    let decoded = String::from_utf8(decoded)
+        .map_err(|_| ParseError::Message("alpn-ids must be valid UTF-8"))?;
+
+    let alpns = parse_list::<String>(&decoded).expect("infallible");
     Ok(SvcParamValue::Alpn(Alpn(alpns)))
 }
 
@@ -347,8 +353,7 @@ fn parse_no_default_alpn(value: Option<&str>) -> Result<SvcParamValue, ParseErro
 fn parse_port(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
     let value = value.ok_or(ParseError::Message("a port number for the port option"))?;
 
-    let value = parse_char_data(value)?;
-    let port = u16::from_str(&value)?;
+    let port = u16::from_str(deny_escapes(value)?)?;
     Ok(SvcParamValue::Port(port))
 }
 
@@ -363,7 +368,7 @@ fn parse_port(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
 fn parse_ipv4_hint(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
     let value = value.ok_or(ParseError::Message("expected at least one ipv4 hint"))?;
 
-    let hints = parse_list::<A>(value)?;
+    let hints = parse_list::<A>(deny_escapes(value)?)?;
     Ok(SvcParamValue::Ipv4Hint(IpHint(hints)))
 }
 
@@ -378,7 +383,7 @@ fn parse_ipv4_hint(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
 fn parse_ipv6_hint(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
     let value = value.ok_or(ParseError::Message("expected at least one ipv6 hint"))?;
 
-    let hints = parse_list::<AAAA>(value)?;
+    let hints = parse_list::<AAAA>(deny_escapes(value)?)?;
     Ok(SvcParamValue::Ipv6Hint(IpHint(hints)))
 }
 
@@ -397,8 +402,7 @@ fn parse_ech_config(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
         "expected a base64 encoded string for EchConfig",
     ))?;
 
-    let value = parse_char_data(value)?;
-    let ech_config_bytes = data_encoding::BASE64.decode(value.as_bytes())?;
+    let ech_config_bytes = data_encoding::BASE64.decode(deny_escapes(value)?.as_bytes())?;
     Ok(SvcParamValue::EchConfigList(EchConfigList(
         ech_config_bytes,
     )))
@@ -420,10 +424,9 @@ fn parse_ech_config(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
 ///   MUST NOT be repeated.
 /// ```
 fn parse_unknown(value: Option<&str>) -> Result<SvcParamValue, ParseError> {
-    let unknown: Vec<u8> = if let Some(value) = value {
-        value.as_bytes().to_vec()
-    } else {
-        Vec::new()
+    let unknown = match value {
+        Some(value) => decode_char_string(value)?,
+        None => Vec::new(),
     };
 
     Ok(SvcParamValue::Unknown(Unknown(unknown)))
@@ -442,7 +445,7 @@ where
         match (c, escaping) {
             // End of value
             (',', false) => {
-                result.push(T::from_str(&parse_char_data(&current_value)?).map_err(Into::into)?);
+                result.push(T::from_str(&current_value).map_err(Into::into)?);
                 current_value.clear()
             }
             // Start of escape sequence
@@ -464,7 +467,7 @@ where
 
     // Push the remaining value if there's any
     if !current_value.is_empty() {
-        result.push(T::from_str(&parse_char_data(&current_value)?).map_err(Into::into)?);
+        result.push(T::from_str(&current_value).map_err(Into::into)?);
     }
 
     Ok(result)
@@ -934,11 +937,13 @@ impl BinEncodable for Mandatory {
     /// ```
     fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
         if self.0.is_empty() {
-            return Err(ProtoError::from("Alpn expects at least one value"));
+            return Err(ProtoError::from("Mandatory expects at least one value"));
         }
 
-        // TODO: order by key value
-        for key in self.0.iter() {
+        let mut keys = self.0.clone();
+        keys.sort_unstable();
+
+        for key in keys {
             key.emit(encoder)?
         }
 
@@ -963,9 +968,11 @@ impl fmt::Display for Mandatory {
     ///
     ///    ipv6hint=... key65333=ex1 key65444=ex2 mandatory=key65444,ipv6hint
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        for key in self.0.iter() {
-            // TODO: confirm in the RFC that trailing commas are ok
-            write!(f, "{key},")?;
+        for (index, key) in self.0.iter().enumerate() {
+            if index != 0 {
+                write!(f, ",")?;
+            }
+            write!(f, "{key}")?;
         }
 
         Ok(())
@@ -1134,12 +1141,22 @@ impl fmt::Display for Alpn {
     ///   The presentation value SHALL be a comma-separated list
     ///   (Appendix A.1) of one or more "alpn-id"s.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        for alpn in self.0.iter() {
-            // TODO: confirm in the RFC that trailing commas are ok
-            write!(f, "{alpn},")?;
+        // commas and backslashes within an alpn-id are escaped first (Appendix A.1),
+        // then the joined list is encoded as a char-string (RFC 9460 §2.1)
+        let mut joined = Vec::new();
+        for (index, alpn) in self.0.iter().enumerate() {
+            if index != 0 {
+                joined.push(b',');
+            }
+            for byte in alpn.bytes() {
+                if byte == b',' || byte == b'\\' {
+                    joined.push(b'\\');
+                }
+                joined.push(byte);
+            }
         }
 
-        Ok(())
+        encode_char_string(&joined, f)
     }
 }
 
@@ -1312,8 +1329,11 @@ where
     ///   in standard textual format [RFC 5952](https://tools.ietf.org/html/rfc5952).  To enable simpler parsing,
     ///   this SvcParamValue MUST NOT contain escape sequences.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        for ip in self.0.iter() {
-            write!(f, "{ip},")?;
+        for (index, ip) in self.0.iter().enumerate() {
+            if index != 0 {
+                write!(f, ",")?;
+            }
+            write!(f, "{ip}")?;
         }
 
         Ok(())
@@ -1363,10 +1383,7 @@ impl BinEncodable for Unknown {
 
 impl fmt::Display for Unknown {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        // TODO: this needs to be properly encoded
-        write!(f, "\"{}\"", String::from_utf8_lossy(&self.0))?;
-
-        Ok(())
+        encode_char_string(&self.0, f)
     }
 }
 
@@ -1638,6 +1655,18 @@ mod tests {
     }
 
     #[test]
+    fn test_encode_decode_svcb_value_with_escapes() {
+        test_encode_decode(SVCB::new(
+            1,
+            Name::from_utf8(".").unwrap(),
+            vec![(
+                SvcParamKey::Key(65367),
+                SvcParamValue::Unknown(Unknown(b"a\"b\\c \x00\x7f\xff".to_vec())),
+            )],
+        ));
+    }
+
+    #[test]
     fn test_no_panic() {
         const BUF: &[u8] = &[
             255, 121, 0, 0, 0, 0, 40, 255, 255, 160, 160, 0, 0, 0, 64, 0, 1, 255, 158, 0, 0, 0, 8,
@@ -1797,7 +1826,7 @@ mod tests {
 
         // NOTE: In each case the test vector from the RFC was augmented with a TTL (42 in each
         //       case). The parser requires this but the test vectors do not include it.
-        let vectors: [TestVector; 9] = [
+        let vectors = [
             // https://datatracker.ietf.org/doc/html/rfc9460#appendix-D.1
             // Figure 2: AliasMode
             TestVector {
@@ -1843,7 +1872,7 @@ mod tests {
                 priority: 1,
                 params: vec![(
                     SvcParamKey::Key(667),
-                    SvcParamValue::Unknown(Unknown(b"hello\\210qoo".into())),
+                    SvcParamValue::Unknown(Unknown(b"hello\xd2qoo".into())),
                 )],
             },
             // Figure 7: Two Quoted IPv6 Hints
@@ -1899,29 +1928,25 @@ mod tests {
             },
             // Figure 10: An "alpn" Value with an Escaped Comma and an Escaped Backslash in Two Presentation Formats
             TestVector {
-                record: r#"example.com.  42  SVCB   16 foo.example.org. alpn="f\\\\oo\,bar,h2""#,
+                record: r#"example.com.  42  SVCB   16 foo.example.org. alpn="f\\\\oo\\,bar,h2""#,
                 record_type: RecordType::SVCB,
                 target_name: Name::from_str("foo.example.org.").unwrap(),
                 priority: 16,
                 params: vec![(
                     SvcParamKey::Alpn,
-                    SvcParamValue::Alpn(Alpn(vec![r#"f\\oo,bar"#.to_owned(), "h2".to_owned()])),
+                    SvcParamValue::Alpn(Alpn(vec![r#"f\oo,bar"#.to_owned(), "h2".to_owned()])),
                 )],
             },
-            /*
-             * TODO(XXX): Parser does not replace escaped characters, does not see "\092," as
-             *            an escaped delim.
             TestVector {
-                record: r#"example.com.  42  SVCB   116 foo.example.org. alpn=f\\\092oo\092,bar,h2""#,
+                record: r#"example.com.  42  SVCB   16 foo.example.org. alpn=f\\\092oo\092,bar,h2"#,
                 record_type: RecordType::SVCB,
                 target_name: Name::from_str("foo.example.org.").unwrap(),
                 priority: 16,
                 params: vec![(
                     SvcParamKey::Alpn,
-                    SvcParamValue::Alpn(Alpn(vec![r#"f\\oo,bar"#.to_owned(), "h2".to_owned()])),
+                    SvcParamValue::Alpn(Alpn(vec![r#"f\oo,bar"#.to_owned(), "h2".to_owned()])),
                 )],
             },
-            */
         ];
 
         for record in vectors {

--- a/crates/proto/src/rr/rdata/svcb.rs
+++ b/crates/proto/src/rr/rdata/svcb.rs
@@ -175,7 +175,7 @@ impl SVCB {
     ///   strings.  Key names should contain 1-63 characters from the ranges
     ///   "a"-"z", "0"-"9", and "-".  In ABNF [RFC5234],
     ///
-    ///   alpha-lc      = %x61-7A   ;  a-z
+    ///   alpha-lc      = %x61-7A   ; a-z
     ///   SvcParamKey   = 1*63(alpha-lc / DIGIT / "-")
     ///   SvcParam      = SvcParamKey ["=" SvcParamValue]
     ///   SvcParamValue = char-string ; See Appendix A.
@@ -220,19 +220,14 @@ impl SVCB {
         // Loop over all of the service parameters
         let mut svc_params = Vec::new();
         for token in tokens {
-            // first need to split the key and (optional) value
             let mut key_value = token.splitn(2, '=');
+
             let key = key_value
                 .next()
                 .ok_or_else(|| ParseError::MissingToken("SVCB SvcbParams missing".to_string()))?;
 
-            // get the value, and remove any quotes
-            let mut value = key_value.next();
-            if let Some(value) = value.as_mut() {
-                if value.starts_with('"') && value.ends_with('"') {
-                    *value = &value[1..value.len() - 1];
-                }
-            }
+            let value = key_value.next();
+
             svc_params.push(into_svc_param(key, value)?);
         }
 
@@ -1369,7 +1364,7 @@ impl BinEncodable for Unknown {
 impl fmt::Display for Unknown {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         // TODO: this needs to be properly encoded
-        write!(f, "\"{}\",", String::from_utf8_lossy(&self.0))?;
+        write!(f, "\"{}\"", String::from_utf8_lossy(&self.0))?;
 
         Ok(())
     }
@@ -1536,6 +1531,7 @@ mod tests {
 
     #[track_caller]
     fn test_encode_decode(rdata: SVCB) {
+        // wire-format round-trip
         let mut bytes = Vec::new();
         let mut encoder = BinEncoder::new(&mut bytes);
         rdata.emit(&mut encoder).expect("failed to emit SVCB");
@@ -1544,6 +1540,10 @@ mod tests {
         let mut decoder = BinDecoder::new(bytes);
         let read_rdata = SVCB::read_data(&mut decoder).expect("failed to read back");
         assert_eq!(rdata, read_rdata);
+
+        // presentation-format round-trip
+        let parsed_rdata: SVCB = parse_record(&format!("example.com. 42 IN SVCB {rdata}"));
+        assert_eq!(rdata, parsed_rdata);
     }
 
     #[test]
@@ -1593,6 +1593,47 @@ mod tests {
                     SvcParamValue::Mandatory(Mandatory(vec![SvcParamKey::Alpn])),
                 ),
             ],
+        ));
+    }
+
+    /// [RFC 9460 §2.1, SVCB and HTTPS Resource Records, Nov 2023](https://datatracker.ietf.org/doc/html/rfc9460#section-2.1)
+    ///
+    /// ```text
+    /// 2.1.  Zone-File Presentation Format
+    ///
+    ///   alpha-lc      = %x61-7A   ; a-z
+    ///   SvcParamKey   = 1*63(alpha-lc / DIGIT / "-")
+    ///   SvcParam      = SvcParamKey ["=" SvcParamValue]
+    ///   SvcParamValue = char-string ; See Appendix A.
+    ///   value         = *OCTET ; Value before key-specific parsing
+    /// ```
+    ///
+    /// [RFC 9460 Appendix A, SVCB and HTTPS Resource Records, Nov 2023](https://datatracker.ietf.org/doc/html/rfc9460#appendix-A)
+    ///
+    /// ```text
+    /// Appendix A.  Decoding Text in Zone Files
+    ///
+    ///   ; non-special is VCHAR minus DQUOTE, ";", "(", ")", and "\".
+    ///   non-special = %x21 / %x23-27 / %x2A-3A / %x3C-5B / %x5D-7E
+    ///   ; non-digit is VCHAR minus DIGIT.
+    ///   non-digit   = %x21-2F / %x3A-7E
+    ///   ; dec-octet is a number 0-255 as a three-digit decimal number.
+    ///   dec-octet   = ( "0" / "1" ) 2DIGIT /
+    ///                 "2" ( ( %x30-34 DIGIT ) / ( "5" %x30-35 ) )
+    ///   escaped     = "\" ( non-digit / dec-octet )
+    ///   contiguous  = 1*( non-special / escaped )
+    ///   quoted      = DQUOTE *( contiguous / ( ["\"] WSP ) ) DQUOTE
+    ///   char-string = contiguous / quoted
+    /// ```
+    #[test]
+    fn test_encode_decode_svcb_value_with_space() {
+        test_encode_decode(SVCB::new(
+            1,
+            Name::from_utf8(".").unwrap(),
+            vec![(
+                SvcParamKey::Key(65367),
+                SvcParamValue::Unknown(Unknown(b"fizz, buzz".to_vec())),
+            )],
         ));
     }
 

--- a/crates/proto/src/serialize/txt/mod.rs
+++ b/crates/proto/src/serialize/txt/mod.rs
@@ -16,8 +16,11 @@
 
 //! Text serialization types
 
-use alloc::string::ToString;
-use core::str::FromStr;
+use alloc::{string::ToString, vec::Vec};
+use core::{
+    fmt::{self, Write},
+    str::FromStr,
+};
 
 mod errors;
 pub use errors::{LexerError, ParseError, ParseResult};
@@ -33,6 +36,78 @@ pub use zone::Parser;
 mod zone_lex;
 pub(crate) use zone_lex::Lexer;
 pub use zone_lex::Token;
+
+/// Decodes a `char-string` into the octets it represents.
+///
+/// [RFC 9460 Appendix A, SVCB and HTTPS Resource Records, Nov 2023](https://datatracker.ietf.org/doc/html/rfc9460#appendix-A)
+///
+/// ```text
+///   ; non-digit is VCHAR minus DIGIT.
+///   non-digit   = %x21-2F / %x3A-7E
+///   ; dec-octet is a number 0-255 as a three-digit decimal number.
+///   dec-octet   = ( "0" / "1" ) 2DIGIT /
+///                 "2" ( ( %x30-34 DIGIT ) / ( "5" %x30-35 ) )
+///   escaped     = "\" ( non-digit / dec-octet )
+/// ```
+pub fn decode_char_string(value: &str) -> Result<Vec<u8>, ParseError> {
+    let mut bytes = value.bytes();
+    let mut value = Vec::with_capacity(value.len());
+
+    while let Some(byte) = bytes.next() {
+        let b'\\' = byte else {
+            value.push(byte);
+            continue;
+        };
+
+        match bytes.next() {
+            Some(d1 @ b'0'..=b'9') => {
+                let (Some(d2 @ b'0'..=b'9'), Some(d3 @ b'0'..=b'9')) = (bytes.next(), bytes.next())
+                else {
+                    return Err(ParseError::Message(
+                        "expected three decimal digits after '\\'",
+                    ));
+                };
+
+                #[allow(clippy::identity_op)]
+                let octet = 100 * u16::from(d1 - b'0')
+                    + 10 * u16::from(d2 - b'0')
+                    + 1 * u16::from(d3 - b'0');
+
+                if octet > 255 {
+                    return Err(ParseError::Message("dec-octet must be in range 0-255"));
+                }
+
+                value.push(octet as u8);
+            }
+            Some(byte) => value.push(byte),
+            None => return Err(ParseError::Message("unterminated escape sequence")),
+        }
+    }
+
+    Ok(value)
+}
+
+/// Encodes octets as a quoted `char-string`.
+pub fn encode_char_string<W: Write>(value: &[u8], f: &mut W) -> Result<(), fmt::Error> {
+    f.write_char('"')?;
+    for byte in value.iter().copied() {
+        match byte {
+            b'"' | b'\\' => {
+                f.write_char('\\')?;
+                f.write_char(byte as char)?;
+            }
+            b' '..=b'~' => f.write_char(byte as char)?,
+            #[expect(clippy::identity_op)]
+            _ => {
+                f.write_char('\\')?;
+                f.write_char(char::from(b'0' + byte / 100 % 10))?;
+                f.write_char(char::from(b'0' + byte / 10 % 10))?;
+                f.write_char(char::from(b'0' + byte / 1 % 10))?;
+            }
+        }
+    }
+    f.write_char('"')
+}
 
 /// parses the string following the rules from:
 ///  <https://tools.ietf.org/html/rfc2308> (NXCaching RFC) and
@@ -118,4 +193,139 @@ pub fn parse_ttl(ttl_str: &str) -> ParseResult<u32> {
     }
 
     Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{string::String, vec::Vec};
+
+    use super::*;
+
+    fn encode(bytes: &[u8]) -> String {
+        let mut string = String::new();
+        encode_char_string(bytes, &mut string).unwrap();
+        string
+    }
+
+    #[test]
+    fn decode_passthrough() {
+        assert_eq!(decode_char_string("").unwrap(), b"");
+        assert_eq!(decode_char_string("hello").unwrap(), b"hello");
+        assert_eq!(decode_char_string("fizz, buzz").unwrap(), b"fizz, buzz");
+        // non-ASCII octets pass through unchanged
+        assert_eq!(decode_char_string("héllo").unwrap(), "héllo".as_bytes());
+    }
+
+    /// [RFC 9460 Appendix A, SVCB and HTTPS Resource Records, Nov 2023](https://datatracker.ietf.org/doc/html/rfc9460#appendix-A)
+    ///
+    /// ```text
+    ///   escaped     = "\" ( non-digit / dec-octet )
+    /// ```
+    #[test]
+    fn decode_escaped() {
+        // "\" non-digit
+        assert_eq!(decode_char_string(r#"\\"#).unwrap(), b"\\");
+        assert_eq!(decode_char_string(r#"\""#).unwrap(), b"\"");
+        assert_eq!(decode_char_string(r#"a\;b"#).unwrap(), b"a;b");
+        // "\" dec-octet, full range
+        assert_eq!(decode_char_string(r#"\000"#).unwrap(), b"\x00");
+        assert_eq!(decode_char_string(r#"\255"#).unwrap(), b"\xff");
+        // RFC 4343 §2.1: '.' can be expressed as \046 or \.
+        assert_eq!(decode_char_string(r#"\046"#).unwrap(), b".");
+        assert_eq!(decode_char_string(r#"\."#).unwrap(), b".");
+    }
+
+    /// [RFC 9460 Appendix D, SVCB and HTTPS Resource Records, Nov 2023](https://datatracker.ietf.org/doc/html/rfc9460#appendix-D)
+    ///
+    /// Figure 6: A Generic Key and Quoted Value with a Decimal Escape, and
+    /// Figure 10: An "alpn" Value with an Escaped Comma and an Escaped
+    /// Backslash in Two Presentation Formats
+    #[test]
+    fn decode_rfc9460_appendix_d_vectors() {
+        // Figure 6: \210 is the single octet 0xD2
+        assert_eq!(
+            decode_char_string(r#"hello\210qoo"#).unwrap(),
+            b"hello\xd2qoo"
+        );
+
+        // Figure 10: the quoted and contiguous forms decode to the same value
+        assert_eq!(
+            decode_char_string(r#"f\\\\oo\\,bar,h2"#).unwrap(),
+            b"f\\\\oo\\,bar,h2"
+        );
+        assert_eq!(
+            decode_char_string(r#"f\\\092oo\092,bar,h2"#).unwrap(),
+            b"f\\\\oo\\,bar,h2"
+        );
+    }
+
+    /// [RFC 9460 Appendix A.1, SVCB and HTTPS Resource Records, Nov 2023](https://datatracker.ietf.org/doc/html/rfc9460#appendix-A.1)
+    ///
+    /// ```text
+    ///   Decoding of value-lists happens after character-string decoding.  For
+    ///   example, consider these char-string SvcParamValues:
+    ///
+    ///   "part1,part2,part3\\,part4\\\\"
+    ///   part1\,\p\a\r\t2\044part3\092,part4\092\\
+    ///
+    ///   These inputs are equivalent: character-string decoding either of them
+    ///   would produce the same value:
+    ///
+    ///   part1,part2,part3\,part4\\
+    /// ```
+    #[test]
+    fn decode_rfc9460_appendix_a1_equivalence() {
+        let expected = b"part1,part2,part3\\,part4\\\\";
+
+        assert_eq!(
+            decode_char_string(r#"part1,part2,part3\\,part4\\\\"#).unwrap(),
+            expected
+        );
+        assert_eq!(
+            decode_char_string(r#"part1\,\p\a\r\t2\044part3\092,part4\092\\"#).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn decode_invalid() {
+        // dangling escape
+        assert!(decode_char_string(r#"\"#).is_err());
+        // a digit after '\' must be followed by exactly two more digits
+        assert!(decode_char_string(r#"\2"#).is_err());
+        assert!(decode_char_string(r#"\26"#).is_err());
+        assert!(decode_char_string(r#"\2a6"#).is_err());
+        // dec-octet must be 0-255
+        assert!(decode_char_string(r#"\256"#).is_err());
+        assert!(decode_char_string(r#"\999"#).is_err());
+    }
+
+    #[test]
+    fn encode_basics() {
+        assert_eq!(encode(b""), r#""""#);
+        assert_eq!(encode(b"hello"), r#""hello""#);
+        // whitespace needs no escaping inside the quotes
+        assert_eq!(encode(b"fizz, buzz"), r#""fizz, buzz""#);
+        // '"' and '\' are escaped as \X
+        assert_eq!(encode(b"a\"b"), r#""a\"b""#);
+        assert_eq!(encode(b"a\\b"), r#""a\\b""#);
+        // octets outside %x20-7E are escaped as \DDD
+        assert_eq!(encode(b"\x00\x09\x7f\xff"), r#""\000\009\127\255""#);
+        // Figure 6's value encodes back to its quoted presentation
+        assert_eq!(encode(b"hello\xd2qoo"), r#""hello\210qoo""#);
+    }
+
+    #[test]
+    fn round_trip_all_octets() {
+        let decoded = (0..=255).collect::<Vec<u8>>();
+
+        let encoded = encode(&decoded);
+        let encoded = encoded
+            .strip_prefix('"')
+            .unwrap()
+            .strip_suffix('"')
+            .unwrap();
+
+        assert_eq!(decode_char_string(encoded).unwrap(), decoded);
+    }
 }

--- a/crates/proto/src/serialize/txt/zone_lex.rs
+++ b/crates/proto/src/serialize/txt/zone_lex.rs
@@ -196,7 +196,7 @@ impl<'a> Lexer<'a> {
                         Some(ch @ ')') if !is_list => {
                             return Err(LexerError::IllegalCharacter(ch));
                         }
-                        Some(ch) if ch.is_whitespace() || ch == ')' || ch == ';' => {
+                        Some(ch) if Self::ends_char_data(ch) => {
                             if is_list {
                                 char_data_vec
                                     .as_mut()
@@ -255,6 +255,13 @@ impl<'a> Lexer<'a> {
                     match ch {
                         Some('"') => {
                             self.txt.next();
+                            // a char-string is either contiguous or quoted, so nothing
+                            // may follow the closing quote (RFC 9460 appendix A: char-string = contiguous / quoted)
+                            if let Some(ch) = self.peek() {
+                                if !Self::ends_char_data(ch) {
+                                    return Err(LexerError::IllegalCharacter(ch));
+                                }
+                            }
                             self.state = State::CharData { is_list };
                             // we don't return a Token as this is supposed
                             // to be a subset of the surrounding CharData.
@@ -315,6 +322,10 @@ impl<'a> Lexer<'a> {
 
         s.push(ch);
         Ok(())
+    }
+
+    fn ends_char_data(ch: char) -> bool {
+        ch.is_whitespace() || ch == ')' || ch == ';'
     }
 
     fn escape_seq(&mut self) -> LexerResult<char> {
@@ -508,6 +519,22 @@ mod lex_test {
             Lexer::new("a\\077").next_token().unwrap().unwrap(),
             Token::CharData("a\\077".to_string())
         );
+    }
+
+    #[test]
+    fn quoted_char_data_must_end_the_token() {
+        // a quoted section can contain whitespace
+        assert_eq!(
+            Lexer::new(r#"key="fizz, buzz""#)
+                .next_token()
+                .unwrap()
+                .unwrap(),
+            Token::CharData("key=fizz, buzz".to_string())
+        );
+
+        // char-string = contiguous / quoted: nothing may follow the closing quote
+        assert!(Lexer::new(r#"foo="bar"baz"#).next_token().is_err());
+        assert!(Lexer::new(r#"foo="bar""baz""#).next_token().is_err());
     }
 
     #[test]

--- a/crates/proto/src/serialize/txt/zone_lex.rs
+++ b/crates/proto/src/serialize/txt/zone_lex.rs
@@ -218,8 +218,25 @@ impl<'a> Lexer<'a> {
                                 };
                             }
                         }
-                        // TODO: this next one can be removed, but will keep unescaping for quoted strings
-                        //Some('\\') => { try!(Self::push_to_str(&mut char_data, try!(self.escape_seq()))); },
+                        Some('\\') => {
+                            self.txt.next();
+                            // keep the escape intact (unescaping happens in Name::from_str) so \" is not interpreted as a delimiter.
+                            Self::push_to_str(&mut char_data, '\\')?;
+                            match self.peek() {
+                                // only %x21-7E permitted after a backslash, other octets must be escaped as \DDD instead (RFC 9460 appendix A `escaped`, RFC 4343 §2.1)
+                                Some(ch) if ch.is_ascii_graphic() => {
+                                    self.txt.next();
+                                    Self::push_to_str(&mut char_data, ch)?;
+                                }
+                                Some(ch) => return Err(LexerError::IllegalCharacter(ch)),
+                                None => return Err(LexerError::EOF),
+                            }
+                        }
+                        // a quoted section mid-token, e.g. the SvcParamValue in key65367="fizz, buzz" (RFC 9460 §2.1)
+                        Some('"') => {
+                            self.txt.next();
+                            self.state = State::CharDataQuote { is_list };
+                        }
                         Some(ch) if !ch.is_control() && !ch.is_whitespace() => {
                             self.txt.next();
                             Self::push_to_str(&mut char_data, ch)?;
@@ -232,6 +249,35 @@ impl<'a> Lexer<'a> {
                                 .ok_or(LexerError::IllegalState("char_data is None"))
                                 .map(|s| Some(Token::CharData(s)));
                         }
+                    }
+                }
+                State::CharDataQuote { is_list } => {
+                    match ch {
+                        Some('"') => {
+                            self.txt.next();
+                            self.state = State::CharData { is_list };
+                            // we don't return a Token as this is supposed
+                            // to be a subset of the surrounding CharData.
+                        }
+                        Some('\\') => {
+                            self.txt.next();
+                            // keep the escape intact
+                            Self::push_to_str(&mut char_data, '\\')?;
+                            match self.peek() {
+                                // inside quotes the grammar also allows "\" WSP (RFC 9460 appendix A: ["\"] WSP)
+                                Some(ch) if ch.is_ascii_graphic() || ch == ' ' || ch == '\t' => {
+                                    self.txt.next();
+                                    Self::push_to_str(&mut char_data, ch)?;
+                                }
+                                Some(ch) => return Err(LexerError::IllegalCharacter(ch)),
+                                None => return Err(LexerError::UnclosedQuotedString),
+                            }
+                        }
+                        Some(ch) => {
+                            self.txt.next();
+                            Self::push_to_str(&mut char_data, ch)?;
+                        }
+                        None => return Err(LexerError::UnclosedQuotedString),
                     }
                 }
                 State::At => {
@@ -339,9 +385,10 @@ impl Iterator for CowChars<'_> {
 pub(crate) enum State {
     StartLine,
     RestOfLine,
-    Blank,                      // only if the first part of the line
-    List,                       // (..)
-    CharData { is_list: bool }, // [a-zA-Z, non-control utf8]+
+    Blank,                           // only if the first part of the line
+    List,                            // (..)
+    CharData { is_list: bool },      // [a-zA-Z, non-control utf8]+
+    CharDataQuote { is_list: bool }, // a ".*" section within a CharData token
     //  Name,              // CharData + '.' + CharData
     Comment { is_list: bool }, // ;.*
     At,                        // @


### PR DESCRIPTION
3 commits, all individually reviewable:

---

svcb: support SvcParamValue with interior whitespace

Adds a presentation round trip test to the SVCB test
function and a test case for key values with spaces in them:

    example.com. 42 IN SVCB 1 . key65267="fizz, buzz",

Also fixes said case.

---

Add decode_char_string and encode_char_string helpers to serialize/txt

No implementation of this algorithm exists in the codebase, other places
incorrectly reuse the lexer which silently swallows ;()@$ for char-string
parsing.

---

svcb: use decode_char_string and deny escapes per RFCs

As mentioned in the previous commit, using the lexer to decode char-strings
is wrong as it is a toplevel solution which consumes comments, and does not
unescape properly.

Also adheres to the spec in denying escapes in certain fields.