### PR TITLE
Fix name parsing doc comments

### DIFF
--- a/crates/proto/src/rr/domain/name.rs
+++ b/crates/proto/src/rr/domain/name.rs
@@ -1224,10 +1224,9 @@ impl BinEncodable for Name {
 const COMPRESSED_NAME_LIMIT: usize = 120;
 
 impl<'r> BinDecodable<'r> for Name {
-    /// parses the chain of labels
-    ///  this has a max of 255 octets, with each label being less than 63.
-    ///  all names will be stored lowercase internally.
-    /// This will consume the portions of the `Vec` which it is reading...
+    /// Parses a domain name.
+    ///
+    /// The maximum length of a name is 255 octets, and the maximum length of each label is 63.
     fn read(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
         let mut name = Self::default();
         read_inner(decoder, &mut name)?;

--- a/crates/proto/src/rr/lower_name.rs
+++ b/crates/proto/src/rr/lower_name.rs
@@ -270,10 +270,9 @@ impl Deref for LowerName {
 }
 
 impl<'r> BinDecodable<'r> for LowerName {
-    /// parses the chain of labels
-    ///  this has a max of 255 octets, with each label being less than 63.
-    ///  all names will be stored lowercase internally.
-    /// This will consume the portions of the Vec which it is reading...
+    /// Parses a domain name and converts it to lowercase.
+    ///
+    /// The maximum length of a name is 255 octets, and the maximum length of each label is 63.
     fn read(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
         let name = Name::read(decoder)?;
         Ok(Self(name.to_lowercase()))


### PR DESCRIPTION
This fixes two doc comments on `<Name as BinDecodable>::read()` and `<LowerName as BinDecodable>::read()` that are out of date and incorrect. These date back to 8b7facb69ef0e513174c8f8332605b9e6200da7e. I noticed this in the context of reviewing #3741.