### PR TITLE
Remove error-prone coding patterns around `RecordDataDecodable`

### DIFF
--- a/crates/proto/src/dnssec/rdata/cdnskey.rs
+++ b/crates/proto/src/dnssec/rdata/cdnskey.rs
@@ -17,9 +17,7 @@ use crate::{
     dnssec::{Algorithm, PublicKeyBuf},
     error::ProtoResult,
     rr::{RData, RecordData, RecordDataDecodable, RecordType},
-    serialize::binary::{
-        BinDecoder, BinEncodable, BinEncoder, DecodeError, Restrict, RestrictedMath,
-    },
+    serialize::binary::{BinDecoder, BinEncodable, BinEncoder, DecodeError},
 };
 
 use super::DNSSECRData;
@@ -144,7 +142,7 @@ impl BinEncodable for CDNSKEY {
 }
 
 impl<'r> RecordDataDecodable<'r> for CDNSKEY {
-    fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError> {
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
         let flags = decoder.read_u16()?.unverified(/* used as a bitfield, this is safe */);
 
         // protocol is defined to only be '3' right now
@@ -159,14 +157,8 @@ impl<'r> RecordDataDecodable<'r> for CDNSKEY {
             _ => Some(Algorithm::from_u8(algorithm_value)),
         };
 
-        // The public key is the remaining bytes, excluding the first four bytes for the above
-        // fields. This subtraction is safe, as the first three fields must have been in the RDATA,
-        // otherwise there would have been an earlier return.
-        let key_len = length
-            .map(|u| u as usize)
-            .checked_sub(4)
-            .map_err(|len| DecodeError::IncorrectRDataLengthRead { read: 4, len })?
-            .unverified(/* used only as length safely */);
+        // The public key is the remaining bytes
+        let key_len = decoder.len();
         let public_key = decoder
             .read_vec(key_len)?
             .unverified(/* signature verification will fail if the public key is invalid */);
@@ -214,7 +206,7 @@ mod tests {
     use crate::{
         dnssec::Algorithm,
         rr::RecordDataDecodable,
-        serialize::binary::{BinDecoder, BinEncodable, BinEncoder, Restrict},
+        serialize::binary::{BinDecoder, BinEncodable, BinEncoder},
     };
 
     use super::CDNSKEY;
@@ -237,8 +229,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder = BinDecoder::new(bytes);
-        let read_rdata = CDNSKEY::read_data(&mut decoder, Restrict::new(bytes.len() as u16))
-            .expect("error decoding");
+        let read_rdata = CDNSKEY::read_data(&mut decoder).expect("error decoding");
 
         assert_eq!(rdata, read_rdata);
     }
@@ -255,8 +246,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder = BinDecoder::new(bytes);
-        let read_rdata = CDNSKEY::read_data(&mut decoder, Restrict::new(bytes.len() as u16))
-            .expect("error decoding");
+        let read_rdata = CDNSKEY::read_data(&mut decoder).expect("error decoding");
 
         assert_eq!(rdata, read_rdata);
     }

--- a/crates/proto/src/dnssec/rdata/cdnskey.rs
+++ b/crates/proto/src/dnssec/rdata/cdnskey.rs
@@ -157,10 +157,8 @@ impl<'r> RecordDataDecodable<'r> for CDNSKEY {
             _ => Some(Algorithm::from_u8(algorithm_value)),
         };
 
-        // The public key is the remaining bytes
-        let key_len = decoder.len();
         let public_key = decoder
-            .read_vec(key_len)?
+            .read_vec_to_end()
             .unverified(/* signature verification will fail if the public key is invalid */);
 
         Ok(Self::with_flags(flags, algorithm, public_key))

--- a/crates/proto/src/dnssec/rdata/cds.rs
+++ b/crates/proto/src/dnssec/rdata/cds.rs
@@ -17,9 +17,7 @@ use crate::{
     dnssec::{Algorithm, DigestType},
     error::ProtoResult,
     rr::{RData, RecordData, RecordDataDecodable, RecordType},
-    serialize::binary::{
-        BinDecoder, BinEncodable, BinEncoder, DecodeError, Restrict, RestrictedMath,
-    },
+    serialize::binary::{BinDecoder, BinEncodable, BinEncoder, DecodeError},
 };
 
 use super::DNSSECRData;
@@ -109,9 +107,7 @@ impl BinEncodable for CDS {
 }
 
 impl<'r> RecordDataDecodable<'r> for CDS {
-    fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError> {
-        let start_idx = decoder.index();
-
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
         let key_tag = decoder.read_u16()?.unverified(/* any u16 is a valid key_tag */);
 
         let algorithm_value = decoder.read_u8()?.unverified(/* no further validation required */);
@@ -123,12 +119,7 @@ impl<'r> RecordDataDecodable<'r> for CDS {
         let digest_type =
             DigestType::from(decoder.read_u8()?.unverified(/* DigestType is verified as safe */));
 
-        let bytes_read = decoder.index() - start_idx;
-        let left = length
-            .map(|u| u as usize)
-            .checked_sub(bytes_read)
-            .map_err(|len| DecodeError::IncorrectRDataLengthRead { read: bytes_read, len })?
-            .unverified(/* used only as length safely */);
+        let left = decoder.len();
         let digest =
             decoder.read_vec(left)?.unverified(/* this is only compared with other digests */);
 
@@ -176,7 +167,7 @@ mod tests {
     use crate::{
         dnssec::{Algorithm, DigestType},
         rr::RecordDataDecodable,
-        serialize::binary::{BinDecoder, BinEncodable, BinEncoder, Restrict},
+        serialize::binary::{BinDecoder, BinEncodable, BinEncoder},
     };
 
     use super::CDS;
@@ -198,8 +189,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder = BinDecoder::new(bytes);
-        let read_rdata = CDS::read_data(&mut decoder, Restrict::new(bytes.len() as u16))
-            .expect("error decoding");
+        let read_rdata = CDS::read_data(&mut decoder).expect("error decoding");
         assert_eq!(rdata, read_rdata);
     }
 
@@ -215,8 +205,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder = BinDecoder::new(bytes);
-        let read_rdata = CDS::read_data(&mut decoder, Restrict::new(bytes.len() as u16))
-            .expect("error decoding");
+        let read_rdata = CDS::read_data(&mut decoder).expect("error decoding");
         assert_eq!(rdata, read_rdata);
     }
 }

--- a/crates/proto/src/dnssec/rdata/cds.rs
+++ b/crates/proto/src/dnssec/rdata/cds.rs
@@ -119,9 +119,8 @@ impl<'r> RecordDataDecodable<'r> for CDS {
         let digest_type =
             DigestType::from(decoder.read_u8()?.unverified(/* DigestType is verified as safe */));
 
-        let left = decoder.len();
         let digest =
-            decoder.read_vec(left)?.unverified(/* this is only compared with other digests */);
+            decoder.read_vec_to_end().unverified(/* this is only compared with other digests */);
 
         Ok(Self::new(key_tag, algorithm, digest_type, digest))
     }

--- a/crates/proto/src/dnssec/rdata/dnskey.rs
+++ b/crates/proto/src/dnssec/rdata/dnskey.rs
@@ -21,10 +21,7 @@ use crate::{
     error::ProtoResult,
     rr::{Name, RecordData, RecordDataDecodable, RecordType, record_data::RData},
     serialize::{
-        binary::{
-            BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, NameEncoding,
-            Restrict, RestrictedMath,
-        },
+        binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, NameEncoding},
         txt::ParseError,
     },
 };
@@ -407,7 +404,7 @@ impl BinEncodable for DNSKEY {
 }
 
 impl<'r> RecordDataDecodable<'r> for DNSKEY {
-    fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError> {
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
         let flags: u16 = decoder.read_u16()?.unverified(/*used as a bitfield, this is safe*/);
 
         let _protocol: u8 = decoder
@@ -429,14 +426,8 @@ impl<'r> RecordDataDecodable<'r> for DNSKEY {
 
         let algorithm: Algorithm = Algorithm::read(decoder)?;
 
-        // the public key is the left-over bytes minus 4 for the first fields
-        //   this sub is safe, as the first 4 fields must have been in the rdata, otherwise there would have been
-        //   an earlier return.
-        let key_len = length
-        .map(|u| u as usize)
-        .checked_sub(4)
-        .map_err(|len| DecodeError::IncorrectRDataLengthRead { read: 4, len })?
-        .unverified(/*used only as length safely*/);
+        // the public key is the left-over bytes
+        let key_len = decoder.len();
         let public_key =
             decoder.read_vec(key_len)?.unverified(/*the byte array will fail in usage if invalid*/);
 
@@ -570,7 +561,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
-        let read_rdata = DNSKEY::read_data(&mut decoder, Restrict::new(bytes.len() as u16));
+        let read_rdata = DNSKEY::read_data(&mut decoder);
         let read_rdata = read_rdata.expect("error decoding");
 
         assert_eq!(rdata, read_rdata);
@@ -597,8 +588,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder = BinDecoder::new(bytes);
-        let read_rdata = DNSKEY::read_data(&mut decoder, Restrict::new(bytes.len() as u16))
-            .expect("error decoding");
+        let read_rdata = DNSKEY::read_data(&mut decoder).expect("error decoding");
 
         assert_eq!(rdata, read_rdata);
     }

--- a/crates/proto/src/dnssec/rdata/dnskey.rs
+++ b/crates/proto/src/dnssec/rdata/dnskey.rs
@@ -426,10 +426,8 @@ impl<'r> RecordDataDecodable<'r> for DNSKEY {
 
         let algorithm: Algorithm = Algorithm::read(decoder)?;
 
-        // the public key is the left-over bytes
-        let key_len = decoder.len();
         let public_key =
-            decoder.read_vec(key_len)?.unverified(/*the byte array will fail in usage if invalid*/);
+            decoder.read_vec_to_end().unverified(/*the byte array will fail in usage if invalid*/);
 
         Ok(Self::with_flags(
             flags,

--- a/crates/proto/src/dnssec/rdata/ds.rs
+++ b/crates/proto/src/dnssec/rdata/ds.rs
@@ -22,10 +22,7 @@ use crate::{
     error::ProtoResult,
     rr::{Name, RData, RecordData, RecordDataDecodable, RecordType},
     serialize::{
-        binary::{
-            BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, Restrict,
-            RestrictedMath,
-        },
+        binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError},
         txt::ParseError,
     },
 };
@@ -290,20 +287,13 @@ impl BinEncodable for DS {
 }
 
 impl<'r> RecordDataDecodable<'r> for DS {
-    fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError> {
-        let start_idx = decoder.index();
-
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
         let key_tag: u16 = decoder.read_u16()?.unverified(/*key_tag is valid as any u16*/);
         let algorithm: Algorithm = Algorithm::read(decoder)?;
         let digest_type =
             DigestType::from(decoder.read_u8()?.unverified(/*DigestType is verified as safe*/));
 
-        let bytes_read = decoder.index() - start_idx;
-        let left: usize = length
-        .map(|u| u as usize)
-        .checked_sub(bytes_read)
-        .map_err(|len| DecodeError::IncorrectRDataLengthRead { read: bytes_read, len })?
-        .unverified(/*used only as length safely*/);
+        let left = decoder.len();
         let digest =
             decoder.read_vec(left)?.unverified(/*the byte array will fail in usage if invalid*/);
 
@@ -478,8 +468,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
-        let restrict = Restrict::new(bytes.len() as u16);
-        let read_rdata = DS::read_data(&mut decoder, restrict).expect("Decoding error");
+        let read_rdata = DS::read_data(&mut decoder).expect("Decoding error");
         assert_eq!(rdata, read_rdata);
     }
 

--- a/crates/proto/src/dnssec/rdata/ds.rs
+++ b/crates/proto/src/dnssec/rdata/ds.rs
@@ -293,9 +293,8 @@ impl<'r> RecordDataDecodable<'r> for DS {
         let digest_type =
             DigestType::from(decoder.read_u8()?.unverified(/*DigestType is verified as safe*/));
 
-        let left = decoder.len();
         let digest =
-            decoder.read_vec(left)?.unverified(/*the byte array will fail in usage if invalid*/);
+            decoder.read_vec_to_end().unverified(/*the byte array will fail in usage if invalid*/);
 
         Ok(Self::new(key_tag, algorithm, digest_type, digest))
     }

--- a/crates/proto/src/dnssec/rdata/key.rs
+++ b/crates/proto/src/dnssec/rdata/key.rs
@@ -358,11 +358,9 @@ impl<'r> RecordDataDecodable<'r> for KEY {
 
         let algorithm: Algorithm = Algorithm::read(decoder)?;
 
-        // the public key is the left-over bytes minus 4 for the first fields
         // TODO: decode the key here?
-        let key_len = decoder.len();
-        let public_key: Vec<u8> =
-            decoder.read_vec(key_len)?.unverified(/*the byte array will fail in usage if invalid*/);
+        let public_key =
+            decoder.read_vec_to_end().unverified(/*the byte array will fail in usage if invalid*/);
 
         Ok(Self::new(
             key_trust, key_usage, signatory, protocol, algorithm, public_key,

--- a/crates/proto/src/dnssec/rdata/key.rs
+++ b/crates/proto/src/dnssec/rdata/key.rs
@@ -19,9 +19,7 @@ use crate::{
     dnssec::{Algorithm, PublicKey, Verifier, crypto::decode_public_key},
     error::ProtoResult,
     rr::{RecordData, RecordDataDecodable, RecordType, record_data::RData},
-    serialize::binary::{
-        BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, Restrict, RestrictedMath,
-    },
+    serialize::binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError},
 };
 
 /// [RFC 2535](https://tools.ietf.org/html/rfc2535#section-3), Domain Name System Security Extensions, March 1999
@@ -330,7 +328,7 @@ impl BinEncodable for KEY {
 }
 
 impl<'r> RecordDataDecodable<'r> for KEY {
-    fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError> {
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
         //      0   1   2   3   4   5   6   7   8   9   0   1   2   3   4   5
         //    +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
         //    |  A/C  | Z | XT| Z | Z | NAMTYP| Z | Z | Z | Z |      SIG      |
@@ -362,11 +360,7 @@ impl<'r> RecordDataDecodable<'r> for KEY {
 
         // the public key is the left-over bytes minus 4 for the first fields
         // TODO: decode the key here?
-        let key_len = length
-        .map(|u| u as usize)
-        .checked_sub(4)
-        .map_err(|len| DecodeError::IncorrectRDataLengthRead { read: 4, len })?
-        .unverified(/*used only as length safely*/);
+        let key_len = decoder.len();
         let public_key: Vec<u8> =
             decoder.read_vec(key_len)?.unverified(/*the byte array will fail in usage if invalid*/);
 
@@ -860,8 +854,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
-        let restrict = Restrict::new(bytes.len() as u16);
-        let read_rdata = KEY::read_data(&mut decoder, restrict).expect("Decoding error");
+        let read_rdata = KEY::read_data(&mut decoder).expect("Decoding error");
         assert_eq!(rdata, read_rdata);
         // assert!(rdata
         //             .to_digest(&Name::parse("www.example.com.", None).unwrap(),

--- a/crates/proto/src/dnssec/rdata/mod.rs
+++ b/crates/proto/src/dnssec/rdata/mod.rs
@@ -32,9 +32,7 @@ use tracing::trace;
 use crate::{
     error::*,
     rr::{RData, RecordDataDecodable, RecordType, rdata::NULL},
-    serialize::binary::{
-        BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, Restrict,
-    },
+    serialize::binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError},
 };
 
 pub use self::cdnskey::CDNSKEY;
@@ -458,36 +456,35 @@ impl DNSSECRData {
     pub(crate) fn read(
         decoder: &mut BinDecoder<'_>,
         record_type: RecordType,
-        rdata_length: Restrict<u16>,
     ) -> Result<Self, DecodeError> {
         match record_type {
             RecordType::CDNSKEY => {
                 trace!("reading CDNSKEY");
-                CDNSKEY::read_data(decoder, rdata_length).map(Self::CDNSKEY)
+                CDNSKEY::read_data(decoder).map(Self::CDNSKEY)
             }
             RecordType::CDS => {
                 trace!("reading CDS");
-                CDS::read_data(decoder, rdata_length).map(Self::CDS)
+                CDS::read_data(decoder).map(Self::CDS)
             }
             RecordType::DNSKEY => {
                 trace!("reading DNSKEY");
-                DNSKEY::read_data(decoder, rdata_length).map(Self::DNSKEY)
+                DNSKEY::read_data(decoder).map(Self::DNSKEY)
             }
             RecordType::DS => {
                 trace!("reading DS");
-                DS::read_data(decoder, rdata_length).map(Self::DS)
+                DS::read_data(decoder).map(Self::DS)
             }
             RecordType::KEY => {
                 trace!("reading KEY");
-                KEY::read_data(decoder, rdata_length).map(Self::KEY)
+                KEY::read_data(decoder).map(Self::KEY)
             }
             RecordType::NSEC => {
                 trace!("reading NSEC");
-                NSEC::read_data(decoder, rdata_length).map(Self::NSEC)
+                NSEC::read_data(decoder).map(Self::NSEC)
             }
             RecordType::NSEC3 => {
                 trace!("reading NSEC3");
-                NSEC3::read_data(decoder, rdata_length).map(Self::NSEC3)
+                NSEC3::read_data(decoder).map(Self::NSEC3)
             }
             RecordType::NSEC3PARAM => {
                 trace!("reading NSEC3PARAM");
@@ -495,11 +492,11 @@ impl DNSSECRData {
             }
             RecordType::RRSIG => {
                 trace!("reading RRSIG");
-                RRSIG::read_data(decoder, rdata_length).map(Self::RRSIG)
+                RRSIG::read_data(decoder).map(Self::RRSIG)
             }
             RecordType::SIG => {
                 trace!("reading SIG");
-                SIG::read_data(decoder, rdata_length).map(Self::SIG)
+                SIG::read_data(decoder).map(Self::SIG)
             }
             r => {
                 panic!("not a dnssec RecordType: {}", r);

--- a/crates/proto/src/dnssec/rdata/nsec.rs
+++ b/crates/proto/src/dnssec/rdata/nsec.rs
@@ -163,25 +163,9 @@ impl BinEncodable for NSEC {
 }
 
 impl<'r> RecordDataDecodable<'r> for NSEC {
-    fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError> {
-        let start_idx = decoder.index();
-
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
         let next_domain_name = Name::read(decoder)?;
-
-        let offset = u16::try_from(decoder.index() - start_idx).map_err(|_| {
-            DecodeError::IncorrectRDataLengthRead {
-                read: decoder.index() - start_idx,
-                len: u16::MAX as usize,
-            }
-        })?;
-        let bit_map_len =
-            length
-                .checked_sub(offset)
-                .map_err(|len| DecodeError::IncorrectRDataLengthRead {
-                    read: offset as usize,
-                    len: len as usize,
-                })?;
-        let type_bit_maps = RecordTypeSet::read_data(decoder, bit_map_len)?;
+        let type_bit_maps = RecordTypeSet::read_data(decoder)?;
 
         Ok(Self {
             next_domain_name,
@@ -285,8 +269,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
-        let restrict = Restrict::new(bytes.len() as u16);
-        let read_rdata = NSEC::read_data(&mut decoder, restrict).expect("Decoding error");
+        let read_rdata = NSEC::read_data(&mut decoder).expect("Decoding error");
         assert_eq!(rdata, read_rdata);
     }
 
@@ -318,8 +301,7 @@ mod tests {
         assert_eq!(encoder.into_bytes(), bytes);
 
         let mut decoder = BinDecoder::new(bytes);
-        let decoded = NSEC::read_data(&mut decoder, Restrict::new(bytes.len() as u16))
-            .expect("Decoding error");
+        let decoded = NSEC::read_data(&mut decoder).expect("Decoding error");
         assert_eq!(decoded, rdata);
     }
 }

--- a/crates/proto/src/dnssec/rdata/nsec3.rs
+++ b/crates/proto/src/dnssec/rdata/nsec3.rs
@@ -300,9 +300,7 @@ impl BinEncodable for NSEC3 {
 }
 
 impl<'r> RecordDataDecodable<'r> for NSEC3 {
-    fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError> {
-        let start_idx = decoder.index();
-
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
         let hash_algorithm = Nsec3HashAlgorithm::try_from(
             decoder.read_u8()?.unverified(/*Algorithm verified as safe*/),
         )?;
@@ -316,19 +314,11 @@ impl<'r> RecordDataDecodable<'r> for NSEC3 {
 
         // read the salt
         let salt_len = decoder.read_u8()?.map(|u| u as usize);
-        let salt_len_max = length
-            .map(|u| u as usize)
-            .checked_sub(decoder.index() - start_idx)
-            .map_err(|len| DecodeError::IncorrectRDataLengthRead {
-                read: decoder.index() - start_idx,
-                len,
-            })?;
+        let salt_len_max = decoder.len();
         let salt_len = salt_len
-            .verify_unwrap(|salt_len| {
-                *salt_len <= salt_len_max.unverified(/*safe in comparison usage*/)
-            })
+            .verify_unwrap(|salt_len| *salt_len <= salt_len_max)
             .map_err(|salt_len| DecodeError::IncorrectRDataLengthRead {
-                read: salt_len_max.unverified(/*safe in error context*/),
+                read: salt_len_max,
                 len: salt_len,
             })?;
         let salt: Vec<u8> =
@@ -336,39 +326,18 @@ impl<'r> RecordDataDecodable<'r> for NSEC3 {
 
         // read the hashed_owner_name
         let hash_len = decoder.read_u8()?.map(|u| u as usize);
-        let hash_len_max = length
-            .map(|u| u as usize)
-            .checked_sub(decoder.index() - start_idx)
-            .map_err(|len| DecodeError::IncorrectRDataLengthRead {
-                read: decoder.index() - start_idx,
-                len,
-            })?;
+        let hash_len_max = decoder.len();
         let hash_len = hash_len
-            .verify_unwrap(|hash_len| {
-                *hash_len <= hash_len_max.unverified(/*safe in comparison usage*/)
-            })
+            .verify_unwrap(|hash_len| *hash_len <= hash_len_max)
             .map_err(|hash_len| DecodeError::IncorrectRDataLengthRead {
-                read: hash_len_max.unverified(/*safe in error context*/),
+                read: hash_len_max,
                 len: hash_len,
             })?;
         let next_hashed_owner_name: Vec<u8> =
             decoder.read_vec(hash_len)?.unverified(/*will fail in usage if invalid*/);
 
         // read the bitmap
-        let offset = u16::try_from(decoder.index() - start_idx).map_err(|_| {
-            DecodeError::IncorrectRDataLengthRead {
-                read: decoder.index() - start_idx,
-                len: u16::MAX as usize,
-            }
-        })?;
-        let bit_map_len =
-            length
-                .checked_sub(offset)
-                .map_err(|len| DecodeError::IncorrectRDataLengthRead {
-                    read: offset as usize,
-                    len: len as usize,
-                })?;
-        let record_types = RecordTypeSet::read_data(decoder, bit_map_len)?;
+        let record_types = RecordTypeSet::read_data(decoder)?;
 
         Ok(Self::with_record_type_set(
             hash_algorithm,
@@ -534,8 +503,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
-        let restrict = Restrict::new(bytes.len() as u16);
-        let read_rdata = NSEC3::read_data(&mut decoder, restrict).expect("Decoding error");
+        let read_rdata = NSEC3::read_data(&mut decoder).expect("Decoding error");
         assert_eq!(rdata, read_rdata);
     }
 
@@ -578,8 +546,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
-        let restrict = Restrict::new(bytes.len() as u16);
-        let read_rdata = NSEC3::read_data(&mut decoder, restrict).expect("Decoding error");
+        let read_rdata = NSEC3::read_data(&mut decoder).expect("Decoding error");
         assert_eq!(rdata_wo, read_rdata);
     }
 }

--- a/crates/proto/src/dnssec/rdata/rrsig.rs
+++ b/crates/proto/src/dnssec/rdata/rrsig.rs
@@ -20,7 +20,7 @@ use crate::{
     dnssec::{DnssecSigner, TBS},
     error::ProtoResult,
     rr::{DNSClass, RData, Record, RecordData, RecordDataDecodable, RecordSet, RecordType},
-    serialize::binary::{BinDecoder, BinEncodable, BinEncoder, DecodeError, Restrict},
+    serialize::binary::{BinDecoder, BinEncodable, BinEncoder, DecodeError},
 };
 
 /// RRSIG is really a derivation of the original SIG record data. See SIG for more documentation
@@ -116,8 +116,8 @@ impl BinEncodable for RRSIG {
 }
 
 impl<'r> RecordDataDecodable<'r> for RRSIG {
-    fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError> {
-        SIG::read_data(decoder, length).map(Self)
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
+        SIG::read_data(decoder).map(Self)
     }
 }
 

--- a/crates/proto/src/dnssec/rdata/sig.rs
+++ b/crates/proto/src/dnssec/rdata/sig.rs
@@ -283,10 +283,9 @@ impl<'r> RecordDataDecodable<'r> for SIG {
         };
 
         // read the signature, this will vary by key size
-        let sig_len = decoder.len();
         let sig = decoder
-        .read_vec(sig_len)?
-        .unverified(/*will fail in usage if invalid*/);
+            .read_vec_to_end()
+            .unverified(/*will fail in usage if invalid*/);
         Ok(Self { input, sig })
     }
 }

--- a/crates/proto/src/dnssec/rdata/sig.rs
+++ b/crates/proto/src/dnssec/rdata/sig.rs
@@ -19,8 +19,7 @@ use crate::{
     error::{ProtoError, ProtoResult},
     rr::{Name, RData, RecordData, RecordDataDecodable, RecordSet, RecordType, SerialNumber},
     serialize::binary::{
-        BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, RDataEncoding, Restrict,
-        RestrictedMath,
+        BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, RDataEncoding,
     },
 };
 
@@ -257,9 +256,7 @@ impl BinEncodable for SIG {
 }
 
 impl<'r> RecordDataDecodable<'r> for SIG {
-    fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError> {
-        let start_idx = decoder.index();
-
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
         // TODO should we verify here? or elsewhere...
         let type_covered = RecordType::read(decoder)?;
         let algorithm = Algorithm::read(decoder)?;
@@ -285,12 +282,8 @@ impl<'r> RecordDataDecodable<'r> for SIG {
             signer_name,
         };
 
-        // read the signature, this will vary buy key size
-        let sig_len = length
-        .map(|u| u as usize)
-        .checked_sub(decoder.index() - start_idx)
-        .map_err(|len| DecodeError::IncorrectRDataLengthRead { read: decoder.index() - start_idx, len })?
-        .unverified(/*used only as length safely*/);
+        // read the signature, this will vary by key size
+        let sig_len = decoder.len();
         let sig = decoder
         .read_vec(sig_len)?
         .unverified(/*will fail in usage if invalid*/);
@@ -477,8 +470,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
-        let restrict = Restrict::new(bytes.len() as u16);
-        let read_rdata = SIG::read_data(&mut decoder, restrict).expect("Decoding error");
+        let read_rdata = SIG::read_data(&mut decoder).expect("Decoding error");
         assert_eq!(rdata, read_rdata);
     }
 }

--- a/crates/proto/src/rr/mod.rs
+++ b/crates/proto/src/rr/mod.rs
@@ -9,7 +9,7 @@
 
 use core::fmt::{Debug, Display};
 
-use crate::serialize::binary::{BinDecodable, BinDecoder, BinEncodable, DecodeError, Restrict};
+use crate::serialize::binary::{BinDecodable, BinDecoder, BinEncodable, DecodeError};
 
 pub(crate) mod dns_class;
 pub use dns_class::DNSClass;
@@ -72,20 +72,17 @@ pub trait RecordData: Clone + Sized + PartialEq + Eq + Display + Debug + BinEnco
 pub(crate) trait RecordDataDecodable<'r>: Sized {
     /// Read the RecordData from the data stream.
     ///
-    /// * `decoder` - data stream from which the RData will be read
-    /// * `record_type` - specifies the RecordType that has already been read from the stream
-    /// * `length` - the data length that should be read from the stream for this RecordData
-    fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError>;
+    /// The provided `decoder` should be clamped to the expected length of the data, because some
+    /// [RData] variants will otherwise consume all bytes in the stream. You may use
+    /// [BinDecoder::split_off] to obtain a decoder of the desired length.
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError>;
 }
 
 impl<'r, T> RecordDataDecodable<'r> for T
 where
     T: 'r + BinDecodable<'r> + Sized,
 {
-    fn read_data(
-        decoder: &mut BinDecoder<'r>,
-        _length: Restrict<u16>,
-    ) -> Result<Self, DecodeError> {
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
         T::read(decoder)
     }
 }

--- a/crates/proto/src/rr/rdata/caa.rs
+++ b/crates/proto/src/rr/rdata/caa.rs
@@ -699,8 +699,7 @@ impl<'r> RecordDataDecodable<'r> for CAA {
         let tag_len = decoder.read_u8()?;
         let tag = read_tag(decoder, tag_len)?;
 
-        let value_len = decoder.len();
-        let value = decoder.read_vec(value_len)?.unverified(/* stored as uninterpreted data */);
+        let value = decoder.read_vec_to_end().unverified(/* stored as uninterpreted data */);
 
         Ok(CAA {
             issuer_critical,

--- a/crates/proto/src/rr/rdata/caa.rs
+++ b/crates/proto/src/rr/rdata/caa.rs
@@ -690,26 +690,17 @@ impl<'r> RecordDataDecodable<'r> for CAA {
     /// The length of the Value field is specified implicitly as the
     /// remaining length of the enclosing RDATA section.
     /// ```
-    fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError> {
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
         let flags = decoder.read_u8()?.unverified(/*used as bitfield*/);
 
         let issuer_critical = (flags & 0b1000_0000) != 0;
         let reserved_flags = flags & 0b0111_1111;
 
         let tag_len = decoder.read_u8()?;
-        let value_len = length
-            .checked_sub(u16::from(tag_len.unverified(/*safe usage here*/)))
-            .checked_sub(2)
-            .map_err(|len| DecodeError::IncorrectRDataLengthRead {
-                read: len as usize,
-                len: u16::from(tag_len.unverified(/*safe usage here*/)) as usize + 2,
-            })?
-            .unverified(/* used only as length safely */);
-
         let tag = read_tag(decoder, tag_len)?;
 
-        let value =
-            decoder.read_vec(value_len as usize)?.unverified(/* stored as uninterpreted data */);
+        let value_len = decoder.len();
+        let value = decoder.read_vec(value_len)?.unverified(/* stored as uninterpreted data */);
 
         Ok(CAA {
             issuer_critical,
@@ -881,8 +872,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
-        let read_rdata = CAA::read_data(&mut decoder, Restrict::new(bytes.len() as u16))
-            .expect("failed to read back");
+        let read_rdata = CAA::read_data(&mut decoder).expect("failed to read back");
         assert_eq!(rdata, read_rdata);
     }
 
@@ -1086,7 +1076,7 @@ mod tests {
         ];
 
         let mut decoder = BinDecoder::new(MESSAGE);
-        let caa = CAA::read_data(&mut decoder, Restrict::new(MESSAGE.len() as u16)).unwrap();
+        let caa = CAA::read_data(&mut decoder).unwrap();
         assert!(!caa.issuer_critical);
         assert_eq!(caa.tag, "issue");
         match (caa.value_as_issue(), caa.value_as_iodef()) {
@@ -1099,20 +1089,12 @@ mod tests {
     #[test]
     fn test_name_non_ascii_character_escaped_dots_roundtrip() {
         const MESSAGE: &[u8] = b"\x00\x05issue\xe5\x85\x9edomain\\.\\.name";
-        let caa = CAA::read_data(
-            &mut BinDecoder::new(MESSAGE),
-            Restrict::new(u16::try_from(MESSAGE.len()).unwrap()),
-        )
-        .unwrap();
+        let caa = CAA::read_data(&mut BinDecoder::new(MESSAGE)).unwrap();
 
         let mut encoded = Vec::new();
         caa.emit(&mut BinEncoder::new(&mut encoded)).unwrap();
 
-        let caa_round_trip = CAA::read_data(
-            &mut BinDecoder::new(&encoded),
-            Restrict::new(u16::try_from(encoded.len()).unwrap()),
-        )
-        .unwrap();
+        let caa_round_trip = CAA::read_data(&mut BinDecoder::new(&encoded)).unwrap();
 
         assert_eq!(caa, caa_round_trip);
     }
@@ -1122,11 +1104,7 @@ mod tests {
         let mut original = *b"\x00\x05issueexample.com";
         for flags in 0..=u8::MAX {
             original[0] = flags;
-            let caa = CAA::read_data(
-                &mut BinDecoder::new(&original),
-                Restrict::new(u16::try_from(original.len()).unwrap()),
-            )
-            .unwrap();
+            let caa = CAA::read_data(&mut BinDecoder::new(&original)).unwrap();
 
             let mut encoded = Vec::new();
             caa.emit(&mut BinEncoder::new(&mut encoded)).unwrap();

--- a/crates/proto/src/rr/rdata/cert.rs
+++ b/crates/proto/src/rr/rdata/cert.rs
@@ -517,8 +517,7 @@ impl<'r> RecordDataDecodable<'r> for CERT {
         let key_tag = decoder.read_u16()?.unverified(/*valid as any u16*/);
         let algorithm = Algorithm::read(decoder)?;
 
-        let cert_len = decoder.len();
-        let cert_data = decoder.read_vec(cert_len)?.unverified(/*will fail in usage if invalid*/);
+        let cert_data = decoder.read_vec_to_end().unverified(/*will fail in usage if invalid*/);
 
         Ok(Self {
             cert_type,

--- a/crates/proto/src/rr/rdata/cert.rs
+++ b/crates/proto/src/rr/rdata/cert.rs
@@ -18,10 +18,7 @@ use crate::{
     error::ProtoResult,
     rr::{RData, RecordData, RecordDataDecodable, RecordType},
     serialize::{
-        binary::{
-            BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, RDataEncoding,
-            Restrict, RestrictedMath,
-        },
+        binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, RDataEncoding},
         txt::ParseError,
     },
 };
@@ -489,8 +486,7 @@ impl TryFrom<&[u8]> for CERT {
 
     fn try_from(cert_record: &[u8]) -> Result<Self, Self::Error> {
         let mut decoder = BinDecoder::new(cert_record);
-        let length = Restrict::new(cert_record.len() as u16); // You can use the full length here
-        Self::read_data(&mut decoder, length) // Reuse the read_data method for parsing
+        Self::read_data(&mut decoder) // Reuse the read_data method for parsing
     }
 }
 
@@ -507,9 +503,8 @@ impl BinEncodable for CERT {
 }
 
 impl<'r> RecordDataDecodable<'r> for CERT {
-    fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError> {
-        let rdata_length = length.map(|u| u as usize).unverified(/*used only as length safely*/);
-
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
+        let rdata_length = decoder.len();
         if rdata_length <= 5 {
             return Err(DecodeError::IncorrectRDataLengthRead {
                 read: rdata_length,
@@ -517,19 +512,12 @@ impl<'r> RecordDataDecodable<'r> for CERT {
             });
         }
 
-        let start_idx = decoder.index();
-
         // let cert_type = decoder.read_u16()?.unverified(/*valid as any u16*/);
         let cert_type = CertType::read(decoder)?;
         let key_tag = decoder.read_u16()?.unverified(/*valid as any u16*/);
         let algorithm = Algorithm::read(decoder)?;
 
-        let cert_len = length
-            .map(|u| u as usize)
-            .checked_sub(decoder.index() - start_idx)
-            .map_err(|len| DecodeError::IncorrectRDataLengthRead { read: decoder.index() - start_idx, len })?
-            .unverified(/*used only as length safely*/);
-
+        let cert_len = decoder.len();
         let cert_data = decoder.read_vec(cert_len)?.unverified(/*will fail in usage if invalid*/);
 
         Ok(Self {

--- a/crates/proto/src/rr/rdata/csync.rs
+++ b/crates/proto/src/rr/rdata/csync.rs
@@ -205,9 +205,7 @@ impl BinEncodable for CSYNC {
 }
 
 impl<'r> RecordDataDecodable<'r> for CSYNC {
-    fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError> {
-        let start_idx = decoder.index();
-
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
         let soa_serial = decoder.read_u32()?.unverified();
 
         let flags: u16 = decoder
@@ -218,21 +216,7 @@ impl<'r> RecordDataDecodable<'r> for CSYNC {
         let immediate: bool = flags & 0b0000_0001 == 0b0000_0001;
         let soa_minimum: bool = flags & 0b0000_0010 == 0b0000_0010;
         let reserved_flags = flags & 0b1111_1111_1111_1100;
-
-        let offset = u16::try_from(decoder.index() - start_idx).map_err(|_| {
-            DecodeError::IncorrectRDataLengthRead {
-                read: decoder.index() - start_idx,
-                len: u16::MAX as usize,
-            }
-        })?;
-        let bit_map_len =
-            length
-                .checked_sub(offset)
-                .map_err(|len| DecodeError::IncorrectRDataLengthRead {
-                    read: offset as usize,
-                    len: len as usize,
-                })?;
-        let type_bit_maps = RecordTypeSet::read_data(decoder, bit_map_len)?;
+        let type_bit_maps = RecordTypeSet::read_data(decoder)?;
 
         Ok(Self {
             soa_serial,
@@ -304,8 +288,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
-        let restrict = Restrict::new(bytes.len() as u16);
-        let read_rdata = CSYNC::read_data(&mut decoder, restrict).expect("Decoding error");
+        let read_rdata = CSYNC::read_data(&mut decoder).expect("Decoding error");
         assert_eq!(rdata, read_rdata);
     }
 

--- a/crates/proto/src/rr/rdata/https.rs
+++ b/crates/proto/src/rr/rdata/https.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     error::ProtoResult,
     rr::{RData, RecordData, RecordDataDecodable, RecordType},
-    serialize::binary::{BinDecoder, BinEncodable, BinEncoder, DecodeError, Restrict},
+    serialize::binary::{BinDecoder, BinEncodable, BinEncoder, DecodeError},
 };
 
 use super::SVCB;
@@ -40,8 +40,8 @@ impl BinEncodable for HTTPS {
 }
 
 impl<'r> RecordDataDecodable<'r> for HTTPS {
-    fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError> {
-        SVCB::read_data(decoder, length).map(Self)
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
+        SVCB::read_data(decoder).map(Self)
     }
 }
 

--- a/crates/proto/src/rr/rdata/null.rs
+++ b/crates/proto/src/rr/rdata/null.rs
@@ -68,12 +68,11 @@ impl BinEncodable for NULL {
 
 impl<'r> RecordDataDecodable<'r> for NULL {
     fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
-        let rdata_length = decoder.len();
-        if rdata_length > 0 {
-            let anything = decoder.read_vec(rdata_length)?.unverified(/*any byte array is good*/);
-            Ok(Self::with(anything))
-        } else {
+        if decoder.is_empty() {
             Ok(Self::new())
+        } else {
+            let anything = decoder.read_vec_to_end().unverified(/*any byte array is good*/);
+            Ok(Self::with(anything))
         }
     }
 }

--- a/crates/proto/src/rr/rdata/null.rs
+++ b/crates/proto/src/rr/rdata/null.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     error::ProtoResult,
     rr::{RData, RecordData, RecordDataDecodable, RecordType},
-    serialize::binary::{BinDecoder, BinEncodable, BinEncoder, DecodeError, Restrict},
+    serialize::binary::{BinDecoder, BinEncodable, BinEncoder, DecodeError},
 };
 
 /// [RFC 1035, DOMAIN NAMES - IMPLEMENTATION AND SPECIFICATION, November 1987](https://tools.ietf.org/html/rfc1035)
@@ -67,8 +67,8 @@ impl BinEncodable for NULL {
 }
 
 impl<'r> RecordDataDecodable<'r> for NULL {
-    fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError> {
-        let rdata_length = length.map(|u| u as usize).unverified(/*any u16 is valid*/);
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
+        let rdata_length = decoder.len();
         if rdata_length > 0 {
             let anything = decoder.read_vec(rdata_length)?.unverified(/*any byte array is good*/);
             Ok(Self::with(anything))
@@ -123,8 +123,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
-        let restrict = Restrict::new(bytes.len() as u16);
-        let read_rdata = NULL::read_data(&mut decoder, restrict).expect("Decoding error");
+        let read_rdata = NULL::read_data(&mut decoder).expect("Decoding error");
         assert_eq!(rdata, read_rdata);
     }
 }

--- a/crates/proto/src/rr/rdata/openpgpkey.rs
+++ b/crates/proto/src/rr/rdata/openpgpkey.rs
@@ -82,9 +82,8 @@ impl BinEncodable for OPENPGPKEY {
 
 impl<'r> RecordDataDecodable<'r> for OPENPGPKEY {
     fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
-        let length = decoder.len();
         let public_key =
-            decoder.read_vec(length)?.unverified(/*we do not enforce a specific format*/);
+            decoder.read_vec_to_end().unverified(/*we do not enforce a specific format*/);
         Ok(Self::new(public_key))
     }
 }

--- a/crates/proto/src/rr/rdata/openpgpkey.rs
+++ b/crates/proto/src/rr/rdata/openpgpkey.rs
@@ -16,7 +16,7 @@ use crate::{
     error::ProtoResult,
     rr::{RData, RecordData, RecordDataDecodable, RecordType},
     serialize::{
-        binary::{BinDecoder, BinEncodable, BinEncoder, DecodeError, Restrict},
+        binary::{BinDecoder, BinEncodable, BinEncoder, DecodeError},
         txt::ParseError,
     },
 };
@@ -81,10 +81,10 @@ impl BinEncodable for OPENPGPKEY {
 }
 
 impl<'r> RecordDataDecodable<'r> for OPENPGPKEY {
-    fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError> {
-        let rdata_length = length.map(usize::from).unverified();
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
+        let length = decoder.len();
         let public_key =
-            decoder.read_vec(rdata_length)?.unverified(/*we do not enforce a specific format*/);
+            decoder.read_vec(length)?.unverified(/*we do not enforce a specific format*/);
         Ok(Self::new(public_key))
     }
 }

--- a/crates/proto/src/rr/rdata/opt.rs
+++ b/crates/proto/src/rr/rdata/opt.rs
@@ -22,7 +22,7 @@ use crate::{
     error::{ProtoError, ProtoResult},
     rr::{RData, RecordData, RecordDataDecodable, RecordType},
     serialize::binary::{
-        BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, RDataEncoding, Restrict,
+        BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, RDataEncoding,
     },
 };
 
@@ -262,14 +262,12 @@ impl BinEncodable for OPT {
 }
 
 impl<'r> RecordDataDecodable<'r> for OPT {
-    fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError> {
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
         let mut state: OptReadState = OptReadState::ReadCode;
         let mut options: Vec<(EdnsCode, EdnsOption)> = Vec::new();
-        let start_idx = decoder.index();
 
-        // There is no unsafe direct use of the rdata length after this point
-        let rdata_length = length.map(|u| u as usize).unverified(/*rdata length usage is bounded*/);
-        while rdata_length > decoder.index() - start_idx {
+        let rdata_length = decoder.len();
+        while !decoder.is_empty() {
             match state {
                 OptReadState::ReadCode => {
                     state = OptReadState::Code {
@@ -871,8 +869,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
-        let restrict = Restrict::new(bytes.len() as u16);
-        let read_rdata = OPT::read_data(&mut decoder, restrict).expect("Decoding error");
+        let read_rdata = OPT::read_data(&mut decoder).expect("Decoding error");
         assert_eq!(rdata, read_rdata);
     }
 
@@ -884,7 +881,7 @@ mod tests {
         ];
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(&bytes);
-        let read_rdata = OPT::read_data(&mut decoder, Restrict::new(bytes.len() as u16));
+        let read_rdata = OPT::read_data(&mut decoder);
         assert!(
             read_rdata.is_ok(),
             "error decoding: {:?}",
@@ -915,7 +912,7 @@ mod tests {
         ];
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(&bytes);
-        let read_rdata = OPT::read_data(&mut decoder, Restrict::new(bytes.len() as u16));
+        let read_rdata = OPT::read_data(&mut decoder);
         assert!(
             read_rdata.is_ok(),
             "error decoding: {:?}",

--- a/crates/proto/src/rr/rdata/smimea.rs
+++ b/crates/proto/src/rr/rdata/smimea.rs
@@ -11,7 +11,7 @@ use crate::{
     error::ProtoResult,
     rr::{RData, RecordData, RecordDataDecodable, RecordType},
     serialize::{
-        binary::{BinDecoder, BinEncodable, BinEncoder, DecodeError, Restrict},
+        binary::{BinDecoder, BinEncodable, BinEncoder, DecodeError},
         txt::ParseError,
     },
 };
@@ -80,8 +80,8 @@ impl BinEncodable for SMIMEA {
 
 impl RecordDataDecodable<'_> for SMIMEA {
     #[inline]
-    fn read_data(decoder: &mut BinDecoder<'_>, length: Restrict<u16>) -> Result<Self, DecodeError> {
-        TLSA::read_data(decoder, length).map(Self)
+    fn read_data(decoder: &mut BinDecoder<'_>) -> Result<Self, DecodeError> {
+        TLSA::read_data(decoder).map(Self)
     }
 }
 

--- a/crates/proto/src/rr/rdata/soa.rs
+++ b/crates/proto/src/rr/rdata/soa.rs
@@ -368,7 +368,7 @@ mod tests {
     #[cfg(feature = "std")]
     use std::println;
 
-    use crate::{rr::RecordDataDecodable, serialize::binary::Restrict};
+    use crate::rr::RecordDataDecodable;
 
     use super::*;
 
@@ -390,13 +390,12 @@ mod tests {
         let mut encoder: BinEncoder<'_> = BinEncoder::new(&mut bytes);
         assert!(rdata.emit(&mut encoder).is_ok());
         let bytes = encoder.into_bytes();
-        let len = bytes.len() as u16;
 
         #[cfg(feature = "std")]
         println!("bytes: {bytes:?}");
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
-        let read_rdata = SOA::read_data(&mut decoder, Restrict::new(len)).expect("Decoding error");
+        let read_rdata = SOA::read_data(&mut decoder).expect("Decoding error");
         assert_eq!(rdata, read_rdata);
     }
 

--- a/crates/proto/src/rr/rdata/sshfp.rs
+++ b/crates/proto/src/rr/rdata/sshfp.rs
@@ -21,7 +21,7 @@ use crate::{
     error::ProtoResult,
     rr::{RData, RecordData, RecordDataDecodable, RecordType},
     serialize::{
-        binary::{BinDecoder, BinEncodable, BinEncoder, DecodeError, Restrict, RestrictedMath},
+        binary::{BinDecoder, BinEncodable, BinEncoder, DecodeError},
         txt::ParseError,
     },
 };
@@ -284,14 +284,10 @@ impl BinEncodable for SSHFP {
 }
 
 impl<'r> RecordDataDecodable<'r> for SSHFP {
-    fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError> {
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
         let algorithm = decoder.read_u8()?.unverified().into();
         let fingerprint_type = decoder.read_u8()?.unverified().into();
-        let fingerprint_len = length
-            .map(|l| l as usize)
-            .checked_sub(2)
-            .map_err(|len| DecodeError::IncorrectRDataLengthRead { read: 2, len })?
-            .unverified();
+        let fingerprint_len = decoder.len();
         let fingerprint = decoder.read_vec(fingerprint_len)?.unverified();
         Ok(SSHFP::new(algorithm, fingerprint_type, fingerprint))
     }
@@ -387,8 +383,7 @@ mod tests {
         assert_eq!(bytes, &result);
 
         let mut decoder = BinDecoder::new(result);
-        let read_rdata = SSHFP::read_data(&mut decoder, Restrict::new(result.len() as u16))
-            .expect("failed to read SSHFP");
+        let read_rdata = SSHFP::read_data(&mut decoder).expect("failed to read SSHFP");
         assert_eq!(read_rdata, rdata)
     }
 

--- a/crates/proto/src/rr/rdata/sshfp.rs
+++ b/crates/proto/src/rr/rdata/sshfp.rs
@@ -287,8 +287,7 @@ impl<'r> RecordDataDecodable<'r> for SSHFP {
     fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
         let algorithm = decoder.read_u8()?.unverified().into();
         let fingerprint_type = decoder.read_u8()?.unverified().into();
-        let fingerprint_len = decoder.len();
-        let fingerprint = decoder.read_vec(fingerprint_len)?.unverified();
+        let fingerprint = decoder.read_vec_to_end().unverified();
         Ok(SSHFP::new(algorithm, fingerprint_type, fingerprint))
     }
 }

--- a/crates/proto/src/rr/rdata/svcb.rs
+++ b/crates/proto/src/rr/rdata/svcb.rs
@@ -1176,8 +1176,7 @@ impl<'r> BinDecodable<'r> for EchConfigList {
     /// Base 64 is used here to simplify integration with TLS server software.
     /// To enable simpler parsing, this SvcParam MUST NOT contain escape sequences.
     fn read(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
-        let data =
-            decoder.read_vec(decoder.len())?.unverified(/*up to consumer to validate this data*/);
+        let data = decoder.read_vec_to_end().unverified(/*up to consumer to validate this data*/);
 
         Ok(Self(data))
     }

--- a/crates/proto/src/rr/rdata/svcb.rs
+++ b/crates/proto/src/rr/rdata/svcb.rs
@@ -29,10 +29,7 @@ use crate::{
         rdata::{A, AAAA},
     },
     serialize::{
-        binary::{
-            BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, RDataEncoding,
-            Restrict, RestrictedMath,
-        },
+        binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, RDataEncoding},
         txt::{Lexer, ParseError, Token},
     },
 };
@@ -1423,27 +1420,14 @@ impl RecordDataDecodable<'_> for SVCB {
     ///   If any RRs are malformed, the client MUST reject the entire RRSet and
     ///   fall back to non-SVCB connection establishment.
     /// ```
-    fn read_data(
-        decoder: &mut BinDecoder<'_>,
-        rdata_length: Restrict<u16>,
-    ) -> Result<Self, DecodeError> {
-        let start_index = decoder.index();
-
+    fn read_data(decoder: &mut BinDecoder<'_>) -> Result<Self, DecodeError> {
         let svc_priority = decoder.read_u16()?.unverified(/*any u16 is valid*/);
         let target_name = Name::read(decoder)?;
 
-        let mut remainder_len = rdata_length
-            .map(|len| len as usize)
-            .checked_sub(decoder.index() - start_index)
-            .map_err(|len| DecodeError::IncorrectRDataLengthRead {
-                read: decoder.index() - start_index,
-                len,
-            })?
-            .unverified(); // valid len
         let mut svc_params: Vec<(SvcParamKey, SvcParamValue)> = Vec::new();
 
         // must have at least 4 bytes left for the key and the length
-        while remainder_len >= 4 {
+        while decoder.len() >= 4 {
             // a 2 octet field containing the SvcParamKey as an integer in
             //      network byte order.  (See Section 14.3.2 for the defined values.)
             let key = SvcParamKey::read(decoder)?;
@@ -1460,14 +1444,6 @@ impl RecordDataDecodable<'_> for SVCB {
             }
 
             svc_params.push((key, value));
-            remainder_len = rdata_length
-                .map(|len| len as usize)
-                .checked_sub(decoder.index() - start_index)
-                .map_err(|len| DecodeError::IncorrectRDataLengthRead {
-                    read: decoder.index() - start_index,
-                    len,
-                })?
-                .unverified(); // valid len
         }
 
         Ok(Self {
@@ -1567,8 +1543,7 @@ mod tests {
         let bytes = encoder.into_bytes();
 
         let mut decoder = BinDecoder::new(bytes);
-        let read_rdata = SVCB::read_data(&mut decoder, Restrict::new(bytes.len() as u16))
-            .expect("failed to read back");
+        let read_rdata = SVCB::read_data(&mut decoder).expect("failed to read back");
         assert_eq!(rdata, read_rdata);
     }
 
@@ -1663,11 +1638,7 @@ mod tests {
         svcb.emit(&mut encoder).unwrap();
 
         let mut decoder = BinDecoder::new(&buf);
-        let decoded = SVCB::read_data(
-            &mut decoder,
-            Restrict::new(u16::try_from(buf.len()).unwrap()),
-        )
-        .unwrap();
+        let decoded = SVCB::read_data(&mut decoder).unwrap();
 
         assert_eq!(svcb, decoded);
     }

--- a/crates/proto/src/rr/rdata/tlsa.rs
+++ b/crates/proto/src/rr/rdata/tlsa.rs
@@ -18,7 +18,7 @@ use crate::{
     error::ProtoResult,
     rr::{RData, RecordData, RecordDataDecodable, RecordType},
     serialize::{
-        binary::{BinDecoder, BinEncodable, BinEncoder, DecodeError, Restrict, RestrictedMath},
+        binary::{BinDecoder, BinEncodable, BinEncoder, DecodeError},
         txt::ParseError,
     },
 };
@@ -452,20 +452,13 @@ impl RecordDataDecodable<'_> for TLSA {
     ///    /                                                               /
     ///    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     /// ```
-    fn read_data(
-        decoder: &mut BinDecoder<'_>,
-        rdata_length: Restrict<u16>,
-    ) -> Result<Self, DecodeError> {
+    fn read_data(decoder: &mut BinDecoder<'_>) -> Result<Self, DecodeError> {
         let cert_usage = decoder.read_u8()?.unverified(/*CertUsage is verified*/).into();
         let selector = decoder.read_u8()?.unverified(/*Selector is verified*/).into();
         let matching = decoder.read_u8()?.unverified(/*Matching is verified*/).into();
 
         // the remaining data is for the cert
-        let cert_len = rdata_length
-        .map(|u| u as usize)
-        .checked_sub(3)
-        .map_err(|len| DecodeError::IncorrectRDataLengthRead { read: 3, len })?
-        .unverified(/*used purely as length safely*/);
+        let cert_len = decoder.len();
         let cert_data = decoder.read_vec(cert_len)?.unverified(/*will fail in usage if invalid*/);
 
         Ok(Self {
@@ -629,8 +622,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
-        let read_rdata = TLSA::read_data(&mut decoder, Restrict::new(bytes.len() as u16))
-            .expect("failed to read back");
+        let read_rdata = TLSA::read_data(&mut decoder).expect("failed to read back");
         assert_eq!(rdata, read_rdata);
     }
 

--- a/crates/proto/src/rr/rdata/tlsa.rs
+++ b/crates/proto/src/rr/rdata/tlsa.rs
@@ -458,8 +458,7 @@ impl RecordDataDecodable<'_> for TLSA {
         let matching = decoder.read_u8()?.unverified(/*Matching is verified*/).into();
 
         // the remaining data is for the cert
-        let cert_len = decoder.len();
-        let cert_data = decoder.read_vec(cert_len)?.unverified(/*will fail in usage if invalid*/);
+        let cert_data = decoder.read_vec_to_end().unverified(/*will fail in usage if invalid*/);
 
         Ok(Self {
             cert_usage,

--- a/crates/proto/src/rr/rdata/tsig.rs
+++ b/crates/proto/src/rr/rdata/tsig.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     serialize::binary::{
         BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, NameEncoding,
-        RDataEncoding, Restrict, RestrictedMath,
+        RDataEncoding,
     },
 };
 
@@ -386,11 +386,13 @@ impl<'r> RecordDataDecodable<'r> for TSIG {
     ///  /                                                               /
     ///  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     /// ```
-    fn read_data(decoder: &mut BinDecoder<'r>, length: Restrict<u16>) -> Result<Self, DecodeError> {
-        let end_idx = length.map(|rdl| rdl as usize)
-        .checked_add(decoder.index())
-        .map_err(|len| DecodeError::IncorrectRDataLengthRead { read: decoder.index(), len })? // no legal message is long enough to trigger that
-        .unverified(/*used only as length safely*/);
+    fn read_data(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
+        let end_idx = decoder.len().checked_add(decoder.index()).ok_or_else(||
+            // no legal message is long enough to trigger this
+            DecodeError::IncorrectRDataLengthRead {
+                read: decoder.index(),
+                len: decoder.index(),
+            })?;
 
         let algorithm = TsigAlgorithm::read(decoder)?;
         let time_high = decoder.read_u16()?.unverified(/*valid as any u16*/) as u64;
@@ -852,8 +854,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
-        let read_rdata = TSIG::read_data(&mut decoder, Restrict::new(bytes.len() as u16))
-            .expect("failed to read back");
+        let read_rdata = TSIG::read_data(&mut decoder).expect("failed to read back");
         assert_eq!(rdata, read_rdata);
     }
 

--- a/crates/proto/src/rr/rdata/txt.rs
+++ b/crates/proto/src/rr/rdata/txt.rs
@@ -106,17 +106,10 @@ impl BinEncodable for TXT {
 }
 
 impl RecordDataDecodable<'_> for TXT {
-    fn read_data(
-        decoder: &mut BinDecoder<'_>,
-        rdata_length: Restrict<u16>,
-    ) -> Result<Self, DecodeError> {
-        let data_len = decoder.len();
+    fn read_data(decoder: &mut BinDecoder<'_>) -> Result<Self, DecodeError> {
         let mut strings = Vec::with_capacity(1);
 
-        // no unsafe usage of rdata length after this point
-        let rdata_length =
-            rdata_length.map(|u| u as usize).unverified(/*used as a higher bound, safely*/);
-        while data_len - decoder.len() < rdata_length {
+        while !decoder.is_empty() {
             let string = decoder.read_character_data()?.unverified(/*any data should be validate in TXT usage*/);
             strings.push(string.to_vec().into_boxed_slice());
         }
@@ -198,8 +191,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
-        let restrict = Restrict::new(bytes.len() as u16);
-        let read_rdata = TXT::read_data(&mut decoder, restrict).expect("Decoding error");
+        let read_rdata = TXT::read_data(&mut decoder).expect("Decoding error");
         assert_eq!(rdata, read_rdata);
     }
 
@@ -217,8 +209,7 @@ mod tests {
         println!("bytes: {bytes:?}");
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
-        let restrict = Restrict::new(bytes.len() as u16);
-        let read_rdata = TXT::read_data(&mut decoder, restrict).expect("Decoding error");
+        let read_rdata = TXT::read_data(&mut decoder).expect("Decoding error");
         assert_eq!(rdata, read_rdata);
     }
 }

--- a/crates/proto/src/rr/record.rs
+++ b/crates/proto/src/rr/record.rs
@@ -20,9 +20,7 @@ use crate::rr::rdata::A;
 use crate::{
     error::ProtoResult,
     rr::{Name, RData, RecordData, RecordType, dns_class::DNSClass},
-    serialize::binary::{
-        BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, Restrict,
-    },
+    serialize::binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError},
 };
 
 #[cfg(feature = "mdns")]
@@ -351,9 +349,8 @@ impl<'r> BinDecodable<'r> for Record<RData> {
             // RDATA           a variable length string of octets that describes the
             //                resource.  The format of this information varies
             //                according to the TYPE and CLASS of the resource record.
-            // Adding restrict to the rdata length because it's used for many calculations later
-            //  and must be validated before hand
-            RData::read(decoder, record_type, Restrict::new(rd_length))?
+            let decoder = decoder.split_off(rd_length as usize)?;
+            RData::read(decoder, record_type)?
         };
 
         Ok(Self {

--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -31,7 +31,7 @@ use crate::{
         record_type::RecordType,
     },
     serialize::{
-        binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, Restrict},
+        binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError},
         txt::{Lexer, ParseError, Token},
     },
 };
@@ -891,53 +891,54 @@ impl RData {
         }
     }
 
-    /// Read data from the decoder
-    pub fn read(
-        decoder: &mut BinDecoder<'_>,
-        record_type: RecordType,
-        length: Restrict<u16>,
-    ) -> Result<Self, DecodeError> {
+    /// Read data from the decoder.
+    ///
+    /// The provided `decoder` should be clamped to the expected length of the data, because some
+    /// [RData] variants will otherwise consume all bytes in the stream. You may use
+    /// [BinDecoder::split_off] to obtain an owned decoder of the desired length.
+    pub fn read(mut decoder: BinDecoder<'_>, record_type: RecordType) -> Result<Self, DecodeError> {
         let start_idx = decoder.index();
+        let length = decoder.len();
 
         let result = match record_type {
             RecordType::A => {
                 trace!("reading A");
-                A::read(decoder).map(Self::A)
+                A::read(&mut decoder).map(Self::A)
             }
             RecordType::AAAA => {
                 trace!("reading AAAA");
-                AAAA::read(decoder).map(Self::AAAA)
+                AAAA::read(&mut decoder).map(Self::AAAA)
             }
             RecordType::ANAME => {
                 trace!("reading ANAME");
-                ANAME::read(decoder).map(Self::ANAME)
+                ANAME::read(&mut decoder).map(Self::ANAME)
             }
             rt @ RecordType::ANY | rt @ RecordType::AXFR | rt @ RecordType::IXFR => {
                 return Err(DecodeError::UnknownRecordTypeValue(rt.into()));
             }
             RecordType::CAA => {
                 trace!("reading CAA");
-                CAA::read_data(decoder, length).map(Self::CAA)
+                CAA::read_data(&mut decoder).map(Self::CAA)
             }
             RecordType::CERT => {
                 trace!("reading CERT");
-                CERT::read_data(decoder, length).map(Self::CERT)
+                CERT::read_data(&mut decoder).map(Self::CERT)
             }
             RecordType::CNAME => {
                 trace!("reading CNAME");
-                CNAME::read(decoder).map(Self::CNAME)
+                CNAME::read(&mut decoder).map(Self::CNAME)
             }
             RecordType::CSYNC => {
                 trace!("reading CSYNC");
-                CSYNC::read_data(decoder, length).map(Self::CSYNC)
+                CSYNC::read_data(&mut decoder).map(Self::CSYNC)
             }
             RecordType::HINFO => {
                 trace!("reading HINFO");
-                HINFO::read_data(decoder, length).map(Self::HINFO)
+                HINFO::read_data(&mut decoder).map(Self::HINFO)
             }
             RecordType::HTTPS => {
                 trace!("reading HTTPS");
-                HTTPS::read_data(decoder, length).map(Self::HTTPS)
+                HTTPS::read_data(&mut decoder).map(Self::HTTPS)
             }
             RecordType::ZERO => {
                 trace!("reading EMPTY");
@@ -948,84 +949,79 @@ impl RData {
             }
             RecordType::MX => {
                 trace!("reading MX");
-                MX::read_data(decoder, length).map(Self::MX)
+                MX::read_data(&mut decoder).map(Self::MX)
             }
             RecordType::NAPTR => {
                 trace!("reading NAPTR");
-                NAPTR::read_data(decoder, length).map(Self::NAPTR)
+                NAPTR::read_data(&mut decoder).map(Self::NAPTR)
             }
             RecordType::NULL => {
                 trace!("reading NULL");
-                NULL::read_data(decoder, length).map(Self::NULL)
+                NULL::read_data(&mut decoder).map(Self::NULL)
             }
             RecordType::NS => {
                 trace!("reading NS");
-                NS::read(decoder).map(Self::NS)
+                NS::read(&mut decoder).map(Self::NS)
             }
             RecordType::OPENPGPKEY => {
                 trace!("reading OPENPGPKEY");
-                OPENPGPKEY::read_data(decoder, length).map(Self::OPENPGPKEY)
+                OPENPGPKEY::read_data(&mut decoder).map(Self::OPENPGPKEY)
             }
             RecordType::OPT => {
                 trace!("reading OPT");
-                OPT::read_data(decoder, length).map(Self::OPT)
+                OPT::read_data(&mut decoder).map(Self::OPT)
             }
             RecordType::PTR => {
                 trace!("reading PTR");
-                PTR::read(decoder).map(Self::PTR)
+                PTR::read(&mut decoder).map(Self::PTR)
             }
             RecordType::SMIMEA => {
                 trace!("reading SMIMEA");
-                SMIMEA::read_data(decoder, length).map(Self::SMIMEA)
+                SMIMEA::read_data(&mut decoder).map(Self::SMIMEA)
             }
             RecordType::SOA => {
                 trace!("reading SOA");
-                SOA::read_data(decoder, length).map(Self::SOA)
+                SOA::read_data(&mut decoder).map(Self::SOA)
             }
             RecordType::SRV => {
                 trace!("reading SRV");
-                SRV::read_data(decoder, length).map(Self::SRV)
+                SRV::read_data(&mut decoder).map(Self::SRV)
             }
             RecordType::SSHFP => {
                 trace!("reading SSHFP");
-                SSHFP::read_data(decoder, length).map(Self::SSHFP)
+                SSHFP::read_data(&mut decoder).map(Self::SSHFP)
             }
             RecordType::SVCB => {
                 trace!("reading SVCB");
-                SVCB::read_data(decoder, length).map(Self::SVCB)
+                SVCB::read_data(&mut decoder).map(Self::SVCB)
             }
             RecordType::TLSA => {
                 trace!("reading TLSA");
-                TLSA::read_data(decoder, length).map(Self::TLSA)
+                TLSA::read_data(&mut decoder).map(Self::TLSA)
             }
             RecordType::TSIG => {
                 trace!("reading TSIG");
-                TSIG::read_data(decoder, length).map(Self::TSIG)
+                TSIG::read_data(&mut decoder).map(Self::TSIG)
             }
             RecordType::TXT => {
                 trace!("reading TXT");
-                TXT::read_data(decoder, length).map(Self::TXT)
+                TXT::read_data(&mut decoder).map(Self::TXT)
             }
             #[cfg(feature = "__dnssec")]
-            r if r.is_dnssec() => DNSSECRData::read(decoder, record_type, length).map(Self::DNSSEC),
+            r if r.is_dnssec() => DNSSECRData::read(&mut decoder, record_type).map(Self::DNSSEC),
             record_type => {
                 trace!("reading Unknown record: {}", record_type);
-                NULL::read_data(decoder, length).map(|rdata| Self::Unknown {
+                NULL::read_data(&mut decoder).map(|rdata| Self::Unknown {
                     code: record_type,
                     rdata,
                 })
             }
         };
 
-        // we should have read rdata_length, but we did not
         let read = decoder.index() - start_idx;
-        length
-            .map(|u| u as usize)
-            .verify_unwrap(|rdata_length| read == *rdata_length)
-            .map_err(|rdata_length| DecodeError::IncorrectRDataLengthRead {
-                read,
-                len: rdata_length,
-            })?;
+        if !decoder.is_empty() {
+            return Err(DecodeError::IncorrectRDataLengthRead { read, len: length });
+        }
 
         result
     }
@@ -1513,16 +1509,10 @@ mod tests {
         for (_test_pass, (expect, binary)) in get_data().into_iter().enumerate() {
             #[cfg(feature = "std")]
             println!("test {_test_pass}: {binary:?}");
-            let length = binary.len() as u16; // pre exclusive borrow
-            let mut decoder = BinDecoder::new(&binary);
+            let decoder = BinDecoder::new(&binary);
 
             assert_eq!(
-                RData::read(
-                    &mut decoder,
-                    record_type_from_rdata(&expect),
-                    Restrict::new(length)
-                )
-                .unwrap(),
+                RData::read(decoder, record_type_from_rdata(&expect)).unwrap(),
                 expect
             );
         }

--- a/crates/proto/src/rr/record_type_set.rs
+++ b/crates/proto/src/rr/record_type_set.rs
@@ -117,7 +117,7 @@ impl BinEncodable for RecordTypeSet {
 }
 
 impl RecordDataDecodable<'_> for RecordTypeSet {
-    fn read_data(decoder: &mut BinDecoder<'_>, length: Restrict<u16>) -> Result<Self, DecodeError> {
+    fn read_data(decoder: &mut BinDecoder<'_>) -> Result<Self, DecodeError> {
         // 3.2.1.  Type Bit Maps Encoding
         //
         //  The encoding of the Type Bit Maps field is the same as that used by
@@ -167,8 +167,8 @@ impl RecordDataDecodable<'_> for RecordTypeSet {
         let mut state = BitMapReadState::Window;
 
         // loop through all the bytes in the bitmap
-        let bit_map_len = length.unverified();
-        let bytes = decoder.read_vec(bit_map_len as usize)?.unverified();
+        let bit_map_len = decoder.len();
+        let bytes = decoder.read_vec(bit_map_len)?.unverified();
         for current_byte in bytes.iter() {
             state = match state {
                 BitMapReadState::Window => BitMapReadState::Len {
@@ -277,9 +277,7 @@ mod tests {
         let bytes = encoder.into_bytes();
 
         let mut decoder: BinDecoder<'_> = BinDecoder::new(bytes);
-        let restrict = Restrict::new(bytes.len() as u16);
-        let read_bit_map =
-            RecordTypeSet::read_data(&mut decoder, restrict).expect("Decoding error");
+        let read_bit_map = RecordTypeSet::read_data(&mut decoder).expect("Decoding error");
         assert_eq!(types, read_bit_map);
     }
 }

--- a/crates/proto/src/rr/record_type_set.rs
+++ b/crates/proto/src/rr/record_type_set.rs
@@ -167,8 +167,7 @@ impl RecordDataDecodable<'_> for RecordTypeSet {
         let mut state = BitMapReadState::Window;
 
         // loop through all the bytes in the bitmap
-        let bit_map_len = decoder.len();
-        let bytes = decoder.read_vec(bit_map_len)?.unverified();
+        let bytes = decoder.read_vec_to_end().unverified();
         for current_byte in bytes.iter() {
             state = match state {
                 BitMapReadState::Window => BitMapReadState::Len {

--- a/crates/proto/src/serialize/binary/decoder.rs
+++ b/crates/proto/src/serialize/binary/decoder.rs
@@ -126,6 +126,13 @@ impl<'a> BinDecoder<'a> {
         self.read_slice(len).map(|s| s.map(ToOwned::to_owned))
     }
 
+    /// Reads a `Vec<u8>` out of the remaining bytes in the buffer
+    pub fn read_vec_to_end(&mut self) -> Restrict<Vec<u8>> {
+        let vec = self.remaining.to_owned();
+        self.remaining = &[];
+        Restrict::new(vec)
+    }
+
     /// Reads a slice out of the buffer, without allocating
     ///
     /// # Arguments

--- a/crates/proto/src/serialize/binary/decoder.rs
+++ b/crates/proto/src/serialize/binary/decoder.rs
@@ -144,6 +144,30 @@ impl<'a> BinDecoder<'a> {
         Ok(Restrict::new(read))
     }
 
+    /// Reads a [BinDecoder] out of the buffer, without allocating, and advances past it
+    ///
+    /// # Arguments
+    ///
+    /// * `length` - number of bytes to read from the buffer
+    ///
+    /// # Returns
+    ///
+    /// The [BinDecoder] of the specified length, otherwise an error
+    pub fn split_off(&mut self, length: usize) -> Result<Self, DecodeError> {
+        let Some((read, remaining)) = self.remaining.split_at_checked(length) else {
+            return Err(DecodeError::InsufficientBytes);
+        };
+
+        let decoder = Self {
+            buffer: &self.buffer[..self.index() + length],
+            remaining: read,
+        };
+
+        self.remaining = remaining;
+
+        Ok(decoder)
+    }
+
     /// Reads a slice from a previous index to the current
     pub fn slice_from(&self, index: usize) -> Result<&'a [u8], DecodeError> {
         if index > self.index() {


### PR DESCRIPTION
Closes https://github.com/hickory-dns/hickory-dns/issues/3743

Just in case it's useful information, I wrote pretty much all the code by hand instead of using LLMs. I expect an LLM could have generated good-enough code, but I wanted to become more familiar with the codebase and also wanted to feel any potential pain points derived from the API change. That's how I e.g., saw the opportunity for something like `BinDecoder::read_vec_to_end`.