### PR TITLE
resolver: Implement provider and IP family diversity

### DIFF
--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -475,6 +475,21 @@ impl ProtocolConfig {
         }
     }
 
+    /// Returns the TLS server name, if the protocol uses TLS.
+    pub fn server_name(&self) -> Option<&Arc<str>> {
+        match self {
+            ProtocolConfig::Udp | ProtocolConfig::Tcp => None,
+            #[cfg(feature = "__tls")]
+            ProtocolConfig::Tls { server_name } => Some(server_name),
+            #[cfg(feature = "__https")]
+            ProtocolConfig::Https { server_name, .. } => Some(server_name),
+            #[cfg(feature = "__quic")]
+            ProtocolConfig::Quic { server_name } => Some(server_name),
+            #[cfg(feature = "__h3")]
+            ProtocolConfig::H3 { server_name, .. } => Some(server_name),
+        }
+    }
+
     /// Default port for the protocol.
     pub fn default_port(&self) -> u16 {
         match self {

--- a/crates/resolver/src/name_server.rs
+++ b/crates/resolver/src/name_server.rs
@@ -307,6 +307,14 @@ impl<P: ConnectionProvider> NameServer<P> {
         self.config.ip
     }
 
+    /// Returns the TLS server name identifying this server's provider, if any.
+    pub(super) fn provider(&self) -> Option<&Arc<str>> {
+        self.config
+            .connections
+            .iter()
+            .find_map(|conn| conn.protocol.server_name())
+    }
+
     pub(crate) fn decayed_srtt(&self) -> f64 {
         self.server_srtt.current()
     }

--- a/crates/resolver/src/name_server_pool.rs
+++ b/crates/resolver/src/name_server_pool.rs
@@ -276,6 +276,12 @@ impl<P: ConnectionProvider> PoolState<P> {
             }
         }
 
+        // Spread the leading servers across distinct providers so a single
+        // provider outage doesn't consume the entire parallel batch.
+        if self.cx.options.num_concurrent_reqs > 1 {
+            diversify_batch(&mut servers, self.cx.options.num_concurrent_reqs);
+        }
+
         // If the name server we're trying is giving us backpressure by returning NetErrorKind::Busy,
         // we will first try the other name servers (as for other error types). However, if the other
         // servers are also busy, we're going to wait for a little while and then retry each server that
@@ -447,6 +453,30 @@ pub(crate) fn sort_servers_by_query_statistics<P: ConnectionProvider>(
     // Positive f64 bit patterns sort in the same order as their float values,
     // so to_bits() is a valid u64 ordering key for non-negative SRTT values.
     servers.sort_by_cached_key(|s| s.decayed_srtt().to_bits());
+}
+
+/// Reorders the first `count` entries of `servers` so they come from distinct
+/// providers where possible, preserving the existing order otherwise.
+///
+/// For each leading slot, the next server whose provider (identified by TLS
+/// server name) is not already among the preceding servers is rotated forward.
+/// Servers without a server name (plain UDP/TCP) never conflict. The rest of
+/// the list is left untouched.
+fn diversify_batch<P: ConnectionProvider>(servers: &mut [Arc<NameServer<P>>], count: usize) {
+    for slot in 1..count.min(servers.len()) {
+        let (picked, rest) = servers.split_at(slot);
+        let Some(found) = rest.iter().position(|server| {
+            server.provider().is_none_or(|name| {
+                !picked.iter().any(|seen| {
+                    seen.provider()
+                        .is_some_and(|other| other.eq_ignore_ascii_case(name))
+                })
+            })
+        }) else {
+            break;
+        };
+        servers[slot..=slot + found].rotate_right(1);
+    }
 }
 
 /// Context for a [`NameServerPool`]
@@ -993,6 +1023,34 @@ mod tests {
     use crate::net::xfer::{DnsHandle, FirstAnswer};
     use crate::proto::op::{DnsRequestOptions, Query};
     use crate::proto::rr::{Name, RecordType};
+
+    /// Servers sharing a TLS server name are pushed apart so the parallel batch
+    /// (the leading `num_concurrent_reqs` servers) spans distinct providers.
+    #[cfg(feature = "__tls")]
+    #[test]
+    fn diversify_across_providers() {
+        subscribe();
+
+        let a1 = IpAddr::from([10, 0, 0, 1]);
+        let a2 = IpAddr::from([10, 0, 0, 2]);
+        let b1 = IpAddr::from([10, 0, 1, 1]);
+        let provider = MockProvider::new(MockNetworkHandler::new(Vec::new()));
+        let mut servers = [(a1, "a.example"), (a2, "a.example"), (b1, "b.example")]
+            .map(|(ip, name)| {
+                Arc::new(NameServer::new(
+                    [],
+                    NameServerConfig::tls(ip, Arc::from(name)),
+                    &ResolverOpts::default(),
+                    provider.clone(),
+                ))
+            })
+            .to_vec();
+        diversify_batch(&mut servers, 2);
+        assert_eq!(
+            servers.iter().map(|s| s.ip()).collect::<Vec<_>>(),
+            [a1, b1, a2]
+        );
+    }
 
     #[ignore]
     // because of there is a real connection that needs a reasonable timeout

--- a/crates/resolver/src/name_server_pool.rs
+++ b/crates/resolver/src/name_server_pool.rs
@@ -276,8 +276,9 @@ impl<P: ConnectionProvider> PoolState<P> {
             }
         }
 
-        // Spread the leading servers across distinct providers so a single
-        // provider outage doesn't consume the entire parallel batch.
+        // Spread the leading servers across distinct providers and address
+        // families so a single provider outage or a broken path for one IP
+        // family doesn't consume the entire parallel batch.
         if self.cx.options.num_concurrent_reqs > 1 {
             diversify_batch(&mut servers, self.cx.options.num_concurrent_reqs);
         }
@@ -455,24 +456,37 @@ pub(crate) fn sort_servers_by_query_statistics<P: ConnectionProvider>(
     servers.sort_by_cached_key(|s| s.decayed_srtt().to_bits());
 }
 
-/// Reorders the first `count` entries of `servers` so they come from distinct
-/// providers where possible, preserving the existing order otherwise.
+/// Reorders the first `count` entries of `servers` so they span distinct
+/// providers and address families where possible, preserving the existing
+/// order otherwise.
 ///
-/// For each leading slot, the next server whose provider (identified by TLS
-/// server name) is not already among the preceding servers is rotated forward.
-/// Servers without a server name (plain UDP/TCP) never conflict. The rest of
-/// the list is left untouched.
+/// For each leading slot, the next server that introduces both a provider
+/// (identified by TLS server name) and an address family not already among the
+/// preceding servers is rotated forward; failing that, one with a new provider,
+/// then one with a new address family. Servers without a server name (plain
+/// UDP/TCP) never conflict on provider. The rest of the list is left untouched.
 fn diversify_batch<P: ConnectionProvider>(servers: &mut [Arc<NameServer<P>>], count: usize) {
     for slot in 1..count.min(servers.len()) {
         let (picked, rest) = servers.split_at(slot);
-        let Some(found) = rest.iter().position(|server| {
+        let new_provider = |server: &Arc<NameServer<P>>| {
             server.provider().is_none_or(|name| {
                 !picked.iter().any(|seen| {
                     seen.provider()
                         .is_some_and(|other| other.eq_ignore_ascii_case(name))
                 })
             })
-        }) else {
+        };
+        let new_family = |server: &Arc<NameServer<P>>| {
+            !picked
+                .iter()
+                .any(|seen| seen.ip().is_ipv6() == server.ip().is_ipv6())
+        };
+        let Some(found) = rest
+            .iter()
+            .position(|server| new_provider(server) && new_family(server))
+            .or_else(|| rest.iter().position(new_provider))
+            .or_else(|| rest.iter().position(new_family))
+        else {
             break;
         };
         servers[slot..=slot + found].rotate_right(1);
@@ -1049,6 +1063,33 @@ mod tests {
         assert_eq!(
             servers.iter().map(|s| s.ip()).collect::<Vec<_>>(),
             [a1, b1, a2]
+        );
+    }
+
+    /// Servers sharing an address family are pushed apart so the parallel batch
+    /// spans both IPv4 and IPv6 when possible.
+    #[test]
+    fn diversify_across_ip_families() {
+        subscribe();
+
+        let v4a = IpAddr::from([10, 0, 0, 1]);
+        let v4b = IpAddr::from([10, 0, 0, 2]);
+        let v6 = IpAddr::from([0x2001, 0xdb8, 0, 0, 0, 0, 0, 1]);
+        let provider = MockProvider::new(MockNetworkHandler::new(Vec::new()));
+        let mut servers = [v4a, v4b, v6]
+            .map(|ip| {
+                Arc::new(NameServer::new(
+                    [],
+                    NameServerConfig::udp(ip),
+                    &ResolverOpts::default(),
+                    provider.clone(),
+                ))
+            })
+            .to_vec();
+        diversify_batch(&mut servers, 2);
+        assert_eq!(
+            servers.iter().map(|s| s.ip()).collect::<Vec<_>>(),
+            [v4a, v6, v4b]
         );
     }
 


### PR DESCRIPTION
This change makes Hickory's name server selection more defensive by selecting from its pool a nameserver from both distinct providers and IP families for DoT/DoH/DoQ upstreams for the parallel requests.

Most user's would have favourable connections to a set of upstream servers such as, say, Cloudflare/whichever provider, through their ISPs peering connections and SRTT would mean that their nameservers would/could end up being used most of the time. Then a network blip would occur causing the lookups to fail over to the next best provider. Instead; preemptively make it so the requests go to different providers by their TLS server name.

The second commit takes this and also sends the requests across different IP versions. Currently, there's a bug in Hickory in which if a server has a valid IPv6 GUA and for whichever reason - one's ISP decides to yank the IPv6 routing but keep the address - Hickory goes into a death spiral constantly retrying different v6 upstreams.