### PR TITLE
Expose nameserver send

### DIFF
--- a/crates/resolver/src/lib.rs
+++ b/crates/resolver/src/lib.rs
@@ -188,6 +188,7 @@ pub use hosts::Hosts;
 pub mod lookup;
 pub mod lookup_ip;
 mod name_server;
+pub use name_server::ConnectionPolicy;
 pub use name_server::NameServer;
 mod name_server_pool;
 #[cfg(all(feature = "toml", any(feature = "__tls", feature = "__quic")))]

--- a/crates/resolver/src/name_server.rs
+++ b/crates/resolver/src/name_server.rs
@@ -97,7 +97,8 @@ impl<P: ConnectionProvider> NameServer<P> {
     }
 
     // TODO: there needs to be some way of customizing the connection based on EDNS options from the server side...
-    pub(crate) async fn send(
+    /// Send a DNS request with the given connection policy and pool context.
+    pub async fn send(
         self: Arc<Self>,
         request: DnsRequest,
         policy: ConnectionPolicy,
@@ -774,8 +775,11 @@ impl From<u8> for Status {
 }
 
 #[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
-pub(crate) struct ConnectionPolicy {
-    pub(crate) disable_udp: bool,
+#[non_exhaustive]
+/// Rules for what connections are considered in the selection process
+pub struct ConnectionPolicy {
+    /// Remove UDP when selecting connection
+    pub disable_udp: bool,
 }
 
 impl ConnectionPolicy {

--- a/crates/resolver/src/name_server.rs
+++ b/crates/resolver/src/name_server.rs
@@ -778,11 +778,20 @@ impl From<u8> for Status {
 #[non_exhaustive]
 /// Rules for what connections are considered in the selection process
 pub struct ConnectionPolicy {
-    /// Remove UDP when selecting connection
-    pub disable_udp: bool,
+    pub(crate) disable_udp: bool,
 }
 
 impl ConnectionPolicy {
+    /// Whether this connection policy allows UDP connections
+    pub fn disable_udp(&self) -> bool {
+        self.disable_udp
+    }
+
+    /// Set whether this connection policy allows UDP connections
+    pub fn set_disable_udp(&mut self, disable_udp: bool) {
+        self.disable_udp = disable_udp;
+    }
+
     /// Checks if the given server has any protocols compatible with current policy.
     pub(crate) fn allows_server<P: ConnectionProvider>(&self, server: &NameServer<P>) -> bool {
         server.protocols().any(|p| self.allows_protocol(p))


### PR DESCRIPTION
NameServer's send method was previously accessible in hickory 0.25 but became private in 0.26. It would be helpful for use cases where only one name server is necessary.