### PR TITLE
Add `drop_privileges` config option to skip privilege dropping

### DIFF
--- a/bin/src/config/mod.rs
+++ b/bin/src/config/mod.rs
@@ -142,6 +142,11 @@ pub(crate) struct Config {
     /// Only supported on Unix-like platforms. If the real or effective UID of the hickory process
     /// is root, we will attempt to change to this group (or to nobody if no group is specified here.)
     pub group: Option<String>,
+    /// Whether to drop privileges on startup. Defaults to true.
+    /// Set to false in container/namespace environments where
+    /// /etc/passwd is not available.
+    #[serde(default = "default_drop_privileges")]
+    pub(crate) drop_privileges: bool,
     /// List of configurations for zones
     #[serde(default)]
     #[serde(deserialize_with = "deserialize_with_file")]
@@ -240,6 +245,10 @@ impl Default for TcpSocketConfig {
             response_buffer_size: default_tcp_response_buffer_size(),
         }
     }
+}
+
+fn default_drop_privileges() -> bool {
+    true
 }
 
 fn default_tcp_listen_backlog() -> i32 {

--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -289,6 +289,7 @@ impl DnsServer {
             user,
             group,
             zones,
+            drop_privileges,
             #[cfg(feature = "__tls")]
             tls_cert,
             #[cfg(feature = "__https")]
@@ -415,12 +416,14 @@ impl DnsServer {
 
         // Drop privileges on Unix systems if running as root.
         #[cfg(target_family = "unix")]
-        check_drop_privs(
-            user.as_deref().unwrap_or(DEFAULT_USER),
-            group.as_deref().unwrap_or(DEFAULT_GROUP),
-        )?;
+        if drop_privileges {
+            check_drop_privs(
+                user.as_deref().unwrap_or(DEFAULT_USER),
+                group.as_deref().unwrap_or(DEFAULT_GROUP),
+            )?;
+        }
         #[cfg(not(target_family = "unix"))]
-        if user.is_some() || group.is_some() {
+        if drop_privileges && (user.is_some() || group.is_some()) {
             return Err("dropping privileges is only supported on Unix systems".to_string());
         }
 


### PR DESCRIPTION
Fixes #3094

When running hickory-dns inside a Linux namespace (like the Deckard test suite), 
the server crashes on startup because it tries to look up the user/group from `/etc/passwd` 
which isn't available inside the namespace.

This adds a new config option `drop_privileges` that defaults to true (so nothing changes for existing users). 
Setting it to false skips the privilege dropping step entirely, 
which is safe in namespaces where the process doesn't have real root access.

Usage:
```toml
drop_privileges = false
```
@djc 