### PR TITLE
fix(resolver): parse scoped link-local nameservers on macOS

### DIFF
--- a/crates/resolver/src/system_conf/apple.rs
+++ b/crates/resolver/src/system_conf/apple.rs
@@ -35,7 +35,14 @@ pub fn read_system_conf() -> Result<(ResolverConfig, ResolverOpts), ProtoError> 
     let mut nameservers = Vec::with_capacity(nameservers_cf.len() as usize);
     for n in &*nameservers_cf {
         let s = Cow::from(&*n);
-        let addr = match IpAddr::from_str(&s) {
+        // macOS reports link-local nameservers with a zone id (e.g. `fe80::1%en0`),
+        // which `IpAddr::from_str` cannot parse. Strip the zone and keep the base
+        // address, matching the `resolv.conf` path (see `resolv_conf::ScopedIp`).
+        let stripped = match s.split_once('%') {
+            Some((addr, _zone)) => addr,
+            None => &*s,
+        };
+        let addr = match IpAddr::from_str(stripped) {
             Ok(addr) => addr,
             Err(e) => {
                 warn!(


### PR DESCRIPTION
## Summary

On Apple targets, `read_system_conf()` drops scoped link-local IPv6 nameservers such as `fe80::1%en0`, which macOS commonly advertises. `std::net::IpAddr::from_str` has no zone-id support, so `fe80::1%en0` fails to parse. Since #3667 the entry is skipped with a warning instead of aborting the whole read — but if such an address is the host's *only* nameserver, the resolver is left with no nameservers at all (see #3764).

This strips the zone id and keeps the base address before parsing, so the nameserver is retained rather than discarded. It matches the behavior of the `resolv.conf` path (`resolv_conf::ScopedIp`, which drops the scope and keeps the address), and mirrors the pre-0.26 macOS behavior that went through `unix.rs`.

## Notes

- A scope-dropped link-local address may still hit #2081 when matching responses. If you'd prefer to keep *skipping* such entries rather than retaining them, I'm happy to adjust — I filed #3764 to discuss the direction; this PR implements the "strip and keep" option.

## Test plan

- [x] `cargo build -p hickory-resolver` on macOS (compiles the `apple.rs` path)
- [x] `cargo fmt --check`

Refs #3764
