### PR TITLE
Add opt-in features for platform-specific `read_system_conf` sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -100,7 +100,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -609,7 +609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2316,7 +2316,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2375,7 +2375,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2588,7 +2588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3296,7 +3296,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -47,7 +47,17 @@ __dnssec = []
 recursor = ["dep:async-recursion", "dep:lru-cache"]
 
 serde = ["dep:serde", "hickory-proto/serde"]
-system-config = ["dep:ipconfig", "dep:resolv-conf", "dep:jni", "dep:ndk-context", "dep:system-configuration"]
+
+system-config = [
+  "dep:ipconfig",
+  "dep:system-configuration",
+  "dep:jni",
+  "dep:ndk-context",
+]
+
+system-config-resolv-conf = [
+  "system-config",
+]
 
 toml = ["dep:toml"]
 
@@ -72,7 +82,7 @@ quinn = { workspace = true, optional = true, features = [
     "runtime-tokio",
 ] }
 rand.workspace = true
-resolv-conf = { workspace = true, optional = true, features = ["system"] }
+resolv-conf = { workspace = true }
 rustls = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
 smallvec.workspace = true
@@ -138,4 +148,11 @@ workspace = true
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true
 max_combination_size = 2
-denylist = ["__tls", "__https", "__quic", "__h3", "__dnssec"]
+denylist = [
+  "__tls",
+  "__https",
+  "__quic",
+  "__h3",
+  "__dnssec",
+  "system-config-resolv-conf",
+]

--- a/crates/resolver/src/system_conf/mod.rs
+++ b/crates/resolver/src/system_conf/mod.rs
@@ -8,38 +8,71 @@
 //! System configuration loading
 //!
 //! This module is responsible for parsing and returning the configuration from
-//!  the host system. It will read from the default location on each operating
-//!  system, e.g. most Unixes have this written to `/etc/resolv.conf`
+//! the host system. It will read from the default location on each operating
+//! system, e.g. most Unixes have this written to `/etc/resolv.conf`
 #![allow(missing_docs)]
 
-#[cfg(all(unix, not(any(target_os = "android", target_vendor = "apple"))))]
-#[cfg(feature = "system-config")]
-mod unix;
+mod resolv_conf;
 
-#[cfg(all(unix, not(any(target_os = "android", target_vendor = "apple"))))]
-#[cfg(feature = "system-config")]
-pub use self::unix::{parse_resolv_conf, read_system_conf};
+// `read_resolv_conf` `parse_resolv_conf` are simply utility functions for
+// parsing a `resolv.conf` file, so it can be available on all platforms
+pub use self::resolv_conf::{parse_resolv_conf, read_resolv_conf};
 
-#[cfg(windows)]
-#[cfg(feature = "system-config")]
+#[cfg(any(
+    // If the user has explicitly opted into resolv.conf as their primary
+    // "default system config", then compile it regardless of target platform
+    feature = "system-config-resolv-conf",
+
+    // Otherwise, if they have not explicitly opted into `resolv.conf`, but
+    // have activated the general `system-config` feature, then choose platforms
+    // where `resolv.conf` is typically the primary system configuration for
+    // DNS.
+    all(
+        feature = "system-config",
+        unix,
+        not(any(target_vendor = "apple", target_os = "android")),
+    )
+))]
+pub use self::resolv_conf::read_system_conf;
+
+#[cfg(all(
+    windows,
+    feature = "system-config",
+    not(feature = "system-config-resolv-conf"),
+))]
 mod windows;
 
-#[cfg(target_os = "windows")]
-#[cfg(feature = "system-config")]
+#[cfg(all(
+    windows,
+    feature = "system-config",
+    not(feature = "system-config-resolv-conf"),
+))]
 pub use self::windows::read_system_conf;
 
-#[cfg(target_os = "android")]
-#[cfg(feature = "system-config")]
+#[cfg(all(
+    feature = "system-config",
+    target_os = "android",
+    not(feature = "system-config-resolv-conf"),
+))]
 mod android;
 
-#[cfg(target_os = "android")]
-#[cfg(feature = "system-config")]
+#[cfg(all(
+    feature = "system-config",
+    target_os = "android",
+    not(feature = "system-config-resolv-conf"),
+))]
 pub use self::android::read_system_conf;
 
-#[cfg(target_vendor = "apple")]
-#[cfg(feature = "system-config")]
+#[cfg(all(
+    feature = "system-config",
+    target_vendor = "apple",
+    not(feature = "system-config-resolv-conf"),
+))]
 mod apple;
 
-#[cfg(target_vendor = "apple")]
-#[cfg(feature = "system-config")]
+#[cfg(all(
+    feature = "system-config",
+    target_vendor = "apple",
+    not(feature = "system-config-resolv-conf"),
+))]
 pub use self::apple::read_system_conf;

--- a/crates/resolver/src/system_conf/resolv_conf.rs
+++ b/crates/resolver/src/system_conf/resolv_conf.rs
@@ -21,14 +21,27 @@ use crate::config::{NameServerConfig, ResolverConfig, ResolverOpts};
 use crate::net::NetError;
 use crate::proto::rr::Name;
 
+#[cfg(any(
+    feature = "system-config-resolv-conf",
+    all(
+        feature = "system-config",
+        unix,
+        not(any(target_vendor = "apple", target_os = "android")),
+    )
+))]
 pub fn read_system_conf() -> Result<(ResolverConfig, ResolverOpts), NetError> {
     read_resolv_conf("/etc/resolv.conf")
 }
 
-fn read_resolv_conf<P: AsRef<Path>>(path: P) -> Result<(ResolverConfig, ResolverOpts), NetError> {
+/// Read the given file as a `resolv.conf` file and parse it into hickory
+/// config.
+pub fn read_resolv_conf<P: AsRef<Path>>(
+    path: P,
+) -> Result<(ResolverConfig, ResolverOpts), NetError> {
     parse_resolv_conf(fs::read(path)?)
 }
 
+/// Parse the given bytes as a `resolv.conf` file into hickory config.
 pub fn parse_resolv_conf<T: AsRef<[u8]>>(
     data: T,
 ) -> Result<(ResolverConfig, ResolverOpts), NetError> {


### PR DESCRIPTION
This adds a new feature for each of the platform-specific methods for retrieving the target host's "system DNS config" which is provided via the `read_system_conf` function.

This allows the crate consumer to choose which specific method they wish the `read_system_conf` function to use, in case they would like it to use a different method than the typical default for that system.

For example, in the general case, if the target platform is Android, the default choice is to use the Android NDK to fetch the system's DNS config; however, in special cases, such as Termux, the target host *is* Android, but the NDK is not available to binaries that run in this environment.

For further examples, Apple uses their own `SystemConfiguration` framework, so this is the default method chosen for `read_system_conf`; but `/etc/resolv.conf` is still typically available on MacOS, so the `system-config-resolv-conf` feature allows the crate consumer to choose to read that instead as the default system DNS config. Likewise, Windows has its own subsystems for DNS config, but WSL makes a `/etc/resolv.conf` file available which reflects the Windows DNS config.

These feature flags let the user choose which behavior they would prefer `read_system_conf` to have.

Fixes #3625
