### PR TITLE
Fix Clippy lints

### DIFF
--- a/bin/src/config/tests.rs
+++ b/bin/src/config/tests.rs
@@ -288,29 +288,26 @@ impl Iterator for TableMutator<'_> {
                     self.nested_array_mutator = None;
                 }
             }
-            if let Some(key) = self.key_iter.next() {
-                if key == "protocol" || key == "dnssec_policy" {
-                    // Skip the `protocol` key; apparently `deny_unknown_fields` does not work
-                    // on enum variants, so we just skip it here.
-                    // https://github.com/serde-rs/serde/issues/2294
-                    continue;
-                }
+            let key = self.key_iter.next()?;
+            if key == "protocol" || key == "dnssec_policy" {
+                // Skip the `protocol` key; apparently `deny_unknown_fields` does not work
+                // on enum variants, so we just skip it here.
+                // https://github.com/serde-rs/serde/issues/2294
+                continue;
+            }
 
-                match self.original.get(key).unwrap() {
-                    Value::String(_)
-                    | Value::Integer(_)
-                    | Value::Float(_)
-                    | Value::Boolean(_)
-                    | Value::Datetime(_) => {}
-                    Value::Array(array) => {
-                        self.nested_array_mutator = Some((key, Box::new(ArrayMutator::new(array))));
-                    }
-                    Value::Table(table) => {
-                        self.nested_table_mutator = Some((key, Box::new(TableMutator::new(table))));
-                    }
+            match self.original.get(key).unwrap() {
+                Value::String(_)
+                | Value::Integer(_)
+                | Value::Float(_)
+                | Value::Boolean(_)
+                | Value::Datetime(_) => {}
+                Value::Array(array) => {
+                    self.nested_array_mutator = Some((key, Box::new(ArrayMutator::new(array))));
                 }
-            } else {
-                return None;
+                Value::Table(table) => {
+                    self.nested_table_mutator = Some((key, Box::new(TableMutator::new(table))));
+                }
             }
         }
     }
@@ -359,24 +356,19 @@ impl Iterator for ArrayMutator<'_> {
                     self.nested_array_mutator = None;
                 }
             }
-            if let Some(index) = self.index_iter.next() {
-                match self.original.get(index).unwrap() {
-                    Value::String(_)
-                    | Value::Integer(_)
-                    | Value::Float(_)
-                    | Value::Boolean(_)
-                    | Value::Datetime(_) => {}
-                    Value::Array(array) => {
-                        self.nested_array_mutator =
-                            Some((index, Box::new(ArrayMutator::new(array))));
-                    }
-                    Value::Table(table) => {
-                        self.nested_table_mutator =
-                            Some((index, Box::new(TableMutator::new(table))));
-                    }
+            let index = self.index_iter.next()?;
+            match self.original.get(index).unwrap() {
+                Value::String(_)
+                | Value::Integer(_)
+                | Value::Float(_)
+                | Value::Boolean(_)
+                | Value::Datetime(_) => {}
+                Value::Array(array) => {
+                    self.nested_array_mutator = Some((index, Box::new(ArrayMutator::new(array))));
                 }
-            } else {
-                return None;
+                Value::Table(table) => {
+                    self.nested_table_mutator = Some((index, Box::new(TableMutator::new(table))));
+                }
             }
         }
     }

--- a/conformance/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
+++ b/conformance/conformance-tests/src/resolver/dnssec/scenarios/ede.rs
@@ -174,7 +174,7 @@ fn fixture(
         assert!(
             output.ede.iter().eq([&expected]),
             "output: {:?}, expected: {expected:?}",
-            &output.ede
+            output.ede
         );
     }
 

--- a/crates/proto/src/rr/rdata/caa.rs
+++ b/crates/proto/src/rr/rdata/caa.rs
@@ -734,7 +734,7 @@ impl fmt::Display for CAA {
             f,
             "{flags} {tag} \"{value}\"",
             flags = self.flags(),
-            tag = &self.tag,
+            tag = self.tag,
             value = String::from_utf8_lossy(&self.value)
         )
     }

--- a/crates/proto/src/rr/rdata/cert.rs
+++ b/crates/proto/src/rr/rdata/cert.rs
@@ -581,9 +581,9 @@ impl fmt::Display for CERT {
             f,
             "{cert_type} {key_tag} {algorithm} {cert_data}",
             cert_type = self.cert_type,
-            key_tag = &self.key_tag,
+            key_tag = self.key_tag,
             algorithm = self.algorithm,
-            cert_data = &cert_data
+            cert_data = cert_data
         )?;
 
         Ok(())

--- a/crates/proto/src/rr/rdata/csync.rs
+++ b/crates/proto/src/rr/rdata/csync.rs
@@ -250,8 +250,8 @@ impl fmt::Display for CSYNC {
         write!(
             f,
             "{soa_serial} {flags}",
-            soa_serial = &self.soa_serial,
-            flags = &self.flags(),
+            soa_serial = self.soa_serial,
+            flags = self.flags(),
         )?;
 
         for ty in self.type_bit_maps.iter() {

--- a/crates/proto/src/rr/rdata/hinfo.rs
+++ b/crates/proto/src/rr/rdata/hinfo.rs
@@ -181,8 +181,8 @@ impl fmt::Display for HINFO {
         write!(
             f,
             "{cpu} {os}",
-            cpu = &String::from_utf8_lossy(&self.cpu),
-            os = &String::from_utf8_lossy(&self.os)
+            cpu = String::from_utf8_lossy(&self.cpu),
+            os = String::from_utf8_lossy(&self.os)
         )?;
         Ok(())
     }

--- a/crates/proto/src/rr/rdata/mx.rs
+++ b/crates/proto/src/rr/rdata/mx.rs
@@ -168,12 +168,7 @@ impl RecordData for MX {
 ///   anything in FOO.COM, but that it won't match a plain FOO.COM.
 impl fmt::Display for MX {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(
-            f,
-            "{pref} {ex}",
-            pref = &self.preference,
-            ex = self.exchange
-        )
+        write!(f, "{pref} {ex}", pref = self.preference, ex = self.exchange)
     }
 }
 

--- a/crates/proto/src/rr/rdata/naptr.rs
+++ b/crates/proto/src/rr/rdata/naptr.rs
@@ -325,9 +325,9 @@ impl fmt::Display for NAPTR {
             "{order} {pref} \"{flags}\" \"{service}\" \"{regexp}\" {replace}",
             order = self.order,
             pref = self.preference,
-            flags = &String::from_utf8_lossy(&self.flags),
-            service = &String::from_utf8_lossy(&self.services),
-            regexp = &String::from_utf8_lossy(&self.regexp),
+            flags = String::from_utf8_lossy(&self.flags),
+            service = String::from_utf8_lossy(&self.services),
+            regexp = String::from_utf8_lossy(&self.regexp),
             replace = self.replacement
         )
     }

--- a/crates/proto/src/rr/rdata/openpgpkey.rs
+++ b/crates/proto/src/rr/rdata/openpgpkey.rs
@@ -68,9 +68,10 @@ impl OPENPGPKEY {
             "OPENPGPKEY public key field is missing",
         ))?;
         let public_key = data_encoding::BASE64.decode(encoded_public_key.as_bytes())?;
-        Some(Self::new(public_key))
-            .filter(|_| tokens.next().is_none())
-            .ok_or(ParseError::Message("too many fields for OPENPGPKEY"))
+        if tokens.next().is_some() {
+            return Err(ParseError::Message("too many fields for OPENPGPKEY"));
+        }
+        Ok(Self::new(public_key))
     }
 }
 

--- a/crates/proto/src/rr/rdata/sshfp.rs
+++ b/crates/proto/src/rr/rdata/sshfp.rs
@@ -136,9 +136,10 @@ impl SSHFP {
                 .ok_or_else(|| missing_field::<ParseError>("fingerprint"))?
                 .as_bytes(),
         )?;
-        Some(Self::new(algorithm, fingerprint_type, fingerprint))
-            .filter(|_| tokens.next().is_none())
-            .ok_or(ParseError::Message("too many fields for SSHFP"))
+        if tokens.next().is_some() {
+            return Err(ParseError::Message("too many fields for SSHFP"));
+        }
+        Ok(Self::new(algorithm, fingerprint_type, fingerprint))
     }
 }
 

--- a/crates/server/src/zone_handler/message_response.rs
+++ b/crates/server/src/zone_handler/message_response.rs
@@ -434,7 +434,7 @@ mod tests {
         let header = Header::read(&mut decoder).unwrap();
         let msg = MessageRequest::read(&mut decoder, header).unwrap();
 
-        eprintln!("query: {:?}", &*msg.queries);
+        eprintln!("query: {:?}", *msg.queries);
 
         MessageResponseBuilder::new(&msg.queries, None)
             .build_no_records(Metadata::response_from_request(&msg.metadata))

--- a/fuzz/fuzz_targets/preserve_rdata.rs
+++ b/fuzz/fuzz_targets/preserve_rdata.rs
@@ -93,8 +93,8 @@ fn compare(original: &[u8], message: &Message, reencoded: &[u8]) {
         };
         println!("Parsed message: {message:?}");
         println!("Record type: {}", original_rr.r#type);
-        println!("Original:   {:02x?}", &original_rr.rdata);
-        println!("Re-encoded: {:02x?}", &reencoded_rr.rdata);
+        println!("Original:   {:02x?}", original_rr.rdata);
+        println!("Re-encoded: {:02x?}", reencoded_rr.rdata);
         panic!("record RDATA was not preserved when decoding and re-encoding: {error_message}");
     }
 }


### PR DESCRIPTION
This fixes some new Clippy lints that show up with the 1.97 toolchain. There are three code patterns that got flagged: extra references in formatting macros, manual implementation of `?` on `Option`, and `Some(_).filter(_)`.