### PR TITLE
RFC 9539 test: filter out priming queries

### DIFF
--- a/conformance/e2e-tests/src/server/dot/scenarios.rs
+++ b/conformance/e2e-tests/src/server/dot/scenarios.rs
@@ -94,11 +94,15 @@ fn pdns_opportunistic_dot_success() -> Result<(), Error> {
         Duration::from_secs(10),
     )?;
 
-    // Partition the captured incoming queries based on their dest port.
+    // Partition the captured incoming queries based on their dest port. Filter out any priming
+    // queries for ". IN NS".
     let (dot_queries, udp_queries) = tshark
         .terminate()?
         .into_iter()
-        .filter(|c| matches!(c.direction, Direction::Incoming { .. }))
+        .filter(|c| {
+            matches!(c.direction, Direction::Incoming { .. })
+                && query_name_and_type(c) != ("<Root>", record_types::NS)
+        })
         .partition::<Vec<_>, _>(|m| m.dst_port == DOT_PORT);
 
     // We should have received 2 UDP queries:
@@ -177,6 +181,7 @@ const DOT_PORT: u16 = 853;
 /// on hickory-proto just for matching to expected.
 mod record_types {
     pub(super) const A: u16 = 1;
+    pub(super) const NS: u16 = 2;
     pub(super) const AAAA: u16 = 28;
     pub(super) const MX: u16 = 15;
 }


### PR DESCRIPTION
I've seen frequent test flakes locally, but not in CI, from the end-to-end test `server::dot::scenarios::pdns_opportunistic_dot_success`. One of the checks was failing due to seeing an extra UDP query to the root zone name server. This extra query was for the root zone's NS RRset, and it was triggered by pdns-resolver's own priming query logic (see RFC 9609). This PR filters that query out from the packet captures to fix the issue. I suspect that the priming query is always made, and there's a race condition between the priming query being sent and `tshark` being started. Given that this doesn't happen in CI, perhaps the priming query always wins the race due to the restricted CI runner resources.