### PR TITLE
fix(server): backport CNAME answer section fix to 0.26

### DIFF
--- a/bin/tests/integration/in_memory.rs
+++ b/bin/tests/integration/in_memory.rs
@@ -102,24 +102,24 @@ async fn test_cname_loop() {
         .unwrap();
 
     let records = lookup.iter().collect::<Vec<_>>();
-    assert_eq!(records.len(), 1);
+    // bar -> foo (self-referencing): both CNAMEs in the answer section
+    assert_eq!(records.len(), 2);
     let record = records[0];
     assert_eq!(record.name, Name::from_str("bar.example.com.").unwrap());
     assert_eq!(
         record.data,
         RData::CNAME(CNAME(Name::from_str("foo.example.com.").unwrap()))
     );
-
-    let additionals = lookup
-        .additionals()
-        .expect("Should be additional records")
-        .collect::<Vec<_>>();
-    assert_eq!(additionals.len(), 1);
-    let record = additionals[0];
+    let record = records[1];
     assert_eq!(record.name, Name::from_str("foo.example.com.").unwrap());
     assert_eq!(
         record.data,
         RData::CNAME(CNAME(Name::from_str("foo.example.com.").unwrap()))
+    );
+
+    assert!(
+        lookup.additionals().is_none(),
+        "Should be no additional records."
     );
 
     let lookup = auth
@@ -133,29 +133,29 @@ async fn test_cname_loop() {
         .unwrap();
 
     let records = lookup.iter().collect::<Vec<_>>();
-    assert_eq!(records.len(), 1);
+    // baz -> boz -> biz -> baz (loop): full chain in the answer section
+    assert_eq!(records.len(), 3);
     let record = records[0];
     assert_eq!(record.name, Name::from_str("baz.example.com.").unwrap());
     assert_eq!(
         record.data,
         RData::CNAME(CNAME(Name::from_str("boz.example.com.").unwrap()))
     );
-
-    let additionals = lookup
-        .additionals()
-        .expect("Should be additional records")
-        .collect::<Vec<_>>();
-    assert_eq!(additionals.len(), 2);
-    let record = additionals[0];
+    let record = records[1];
     assert_eq!(record.name, Name::from_str("boz.example.com.").unwrap());
     assert_eq!(
         record.data,
         RData::CNAME(CNAME(Name::from_str("biz.example.com.").unwrap()))
     );
-    let record = additionals[1];
+    let record = records[2];
     assert_eq!(record.name, Name::from_str("biz.example.com.").unwrap());
     assert_eq!(
         record.data,
         RData::CNAME(CNAME(Name::from_str("baz.example.com.").unwrap()))
+    );
+
+    assert!(
+        lookup.additionals().is_none(),
+        "Should be no additional records."
     );
 }

--- a/bin/tests/integration/zone_handler_battery/basic.rs
+++ b/bin/tests/integration/zone_handler_battery/basic.rs
@@ -254,14 +254,18 @@ pub fn test_cname_alias(handler: impl ZoneHandler) {
         .0
         .unwrap();
 
-    let additionals = lookup.additionals().expect("no additionals in response");
+    // CNAME chasing should place both the CNAME and the target A record in the
+    // answer section, with no additionals.
+    assert!(
+        lookup.additionals().is_none(),
+        "CNAME chase should not produce additionals"
+    );
 
-    // for cname lookups, we have a cname returned in the answer, the catalog will perform additional lookups
-    let cname = lookup
-        .into_iter()
+    let mut answers = lookup.into_iter();
+
+    let cname = answers
         .next()
         .expect("CNAME record not found in zone handler");
-
     match &cname.data {
         RData::CNAME(cname) => {
             assert_eq!(Name::from_str("www.example.com.").unwrap(), cname.0)
@@ -269,8 +273,7 @@ pub fn test_cname_alias(handler: impl ZoneHandler) {
         _ => panic!("wrong rdata type returned"),
     }
 
-    // assert the A record is in the additionals section
-    let a = additionals.into_iter().next().expect("A record not found");
+    let a = answers.next().expect("A record not found in answer");
     match a.data {
         RData::A(a) => assert_eq!(A4::new(127, 0, 0, 1), a),
         _ => panic!("wrong rdata type returned"),
@@ -295,14 +298,19 @@ pub fn test_cname_chain(handler: impl ZoneHandler) {
         .0
         .unwrap();
 
-    let additionals = lookup.additionals().expect("no additionals in response");
+    // CNAME chasing should place the full chain in the answer section, with no
+    // additionals.
+    assert!(
+        lookup.additionals().is_none(),
+        "CNAME chase should not produce additionals"
+    );
 
-    // for cname lookups, we have a cname returned in the answer, the catalog will perform additional lookups
-    let cname = lookup
-        .into_iter()
+    let mut answers = lookup.into_iter();
+
+    // first CNAME: alias-chain -> alias
+    let cname = answers
         .next()
         .expect("CNAME record not found in zone handler");
-
     match &cname.data {
         RData::CNAME(cname) => {
             assert_eq!(Name::from_str("alias.example.com.").unwrap(), cname.0);
@@ -310,10 +318,8 @@ pub fn test_cname_chain(handler: impl ZoneHandler) {
         _ => panic!("wrong rdata type returned"),
     }
 
-    // assert the A record is in the additionals section
-    let mut additionals = additionals.into_iter();
-
-    let cname = additionals.next().expect("CNAME record not found");
+    // second CNAME: alias -> www
+    let cname = answers.next().expect("second CNAME record not found");
     match &cname.data {
         RData::CNAME(cname) => {
             assert_eq!(Name::from_str("www.example.com.").unwrap(), cname.0);
@@ -321,7 +327,8 @@ pub fn test_cname_chain(handler: impl ZoneHandler) {
         _ => panic!("wrong rdata type returned"),
     }
 
-    let a = additionals.next().expect("A record not found");
+    // terminal A record
+    let a = answers.next().expect("A record not found");
     match a.data {
         RData::A(a) => assert_eq!(A4::new(127, 0, 0, 1), a),
         _ => panic!("wrong rdata type returned"),
@@ -715,14 +722,17 @@ pub fn test_wildcard_chain(handler: impl ZoneHandler) {
         .0
         .expect("lookup of www.wildcard.example.com. failed");
 
-    // the name should match the lookup, not the A records
-    let additionals = lookup.additionals().expect("no additionals");
+    // CNAME chasing puts the full chain in the answer section
+    assert!(
+        lookup.additionals().is_none(),
+        "CNAME chase should not produce additionals"
+    );
 
-    let record = lookup
-        .into_iter()
+    let mut answers = lookup.into_iter();
+
+    let record = answers
         .next()
         .expect("CNAME record not found in zone handler");
-
     match &record.data {
         RData::CNAME(cname) => {
             assert_eq!(Name::from_str("www.example.com.").unwrap(), cname.0);
@@ -730,8 +740,7 @@ pub fn test_wildcard_chain(handler: impl ZoneHandler) {
         _ => panic!("wrong rdata type returned"),
     }
 
-    let mut additionals = additionals.into_iter();
-    let a = additionals.next().expect("A record not found");
+    let a = answers.next().expect("A record not found in answer");
     match a.data {
         RData::A(a) => assert_eq!(A4::new(127, 0, 0, 1), a),
         _ => panic!("wrong rdata type returned"),

--- a/crates/server/src/store/in_memory/inner.rs
+++ b/crates/server/src/store/in_memory/inner.rs
@@ -314,14 +314,74 @@ impl InnerInMemory {
         }
     }
 
+    /// Chase a CNAME chain to its terminal record (RFC 1034 §3.6.2).
+    ///
+    /// Starting from a CNAME answer, follows the canonical name until a
+    /// non-CNAME record matching `query_type` is found, the target is
+    /// out-of-zone, a loop is detected, or the chain exceeds
+    /// `MAX_CNAME_DEPTH`.
+    ///
+    /// Returns the chain of CNAME record sets followed during the chase.
+    /// The terminal (non-CNAME) record, if found, is the last element.
+    pub(super) fn chase_cnames(
+        &self,
+        name: &LowerName,
+        first_cname: Arc<RecordSet>,
+        query_type: RecordType,
+        lookup_options: LookupOptions,
+    ) -> Vec<Arc<RecordSet>> {
+        /// Safety bound on chain depth to prevent excessive work on
+        /// pathological zones.  Cycle detection also terminates loops.
+        const MAX_CNAME_DEPTH: usize = 8;
+
+        let mut chain = vec![first_cname];
+        let mut seen = HashSet::new();
+        seen.insert(name.clone());
+
+        loop {
+            if chain.len() >= MAX_CNAME_DEPTH {
+                break;
+            }
+
+            // Extract the canonical name from the last record in the chain.
+            // Unwrap safety: `chain` is initialized to be non-empty, and is only appended to.
+            let Some(cname_rdata) = chain.last().unwrap().records_without_rrsigs().next() else {
+                break;
+            };
+            let RData::CNAME(cname) = &cname_rdata.data else {
+                // Last record is the terminal (non-CNAME) — we're done.
+                break;
+            };
+            let next_name = LowerName::from(&cname.0);
+
+            if !seen.insert(next_name.clone()) {
+                break; // loop detected
+            }
+
+            match self.inner_lookup(&next_name, query_type, lookup_options) {
+                // Intermediate CNAME — keep chasing.
+                Some(rr_set) if rr_set.record_type() == RecordType::CNAME => chain.push(rr_set),
+                // Terminal record (A, AAAA, MX, etc.).
+                Some(rr_set) => {
+                    chain.push(rr_set);
+                    break;
+                }
+                // Target not in this zone.
+                None => break,
+            }
+        }
+
+        chain
+    }
+
     /// Search for additional records to include in the response
     ///
     /// # Arguments
     ///
     /// * original_name - the original name that was being looked up
     /// * original_query_type - original type in the request query
-    /// * next_name - the name from the CNAME, ANAME, MX, etc. record that is being searched
-    /// * search_type - the root search type, ANAME, CNAME, MX, i.e. the beginning of the chain
+    /// * next_name - the name from the ANAME, MX, NS, or SRV record that is being searched
+    /// * search_type - the root search type, ANAME, MX, i.e. the beginning of the chain
     /// * lookup_options - Query-related lookup options (e.g., DNSSEC DO bit, supported hash
     ///   algorithms, etc.)
     pub(super) fn additional_search(
@@ -334,7 +394,7 @@ impl InnerInMemory {
     ) -> Option<Vec<Arc<RecordSet>>> {
         let mut additionals: Vec<Arc<RecordSet>> = vec![];
 
-        // if it's a CNAME or other forwarding record, we'll be adding additional records based on the query_type
+        // if it's an ANAME or other forwarding record, we'll be adding additional records based on the query_type
         let mut query_types_arr = [original_query_type; 2];
         let query_types: &[RecordType] = match original_query_type {
             RecordType::ANAME | RecordType::NS | RecordType::MX | RecordType::SRV => {
@@ -371,8 +431,19 @@ impl InnerInMemory {
                         additionals.push(additional.clone());
                     }
 
-                    next_name =
-                        maybe_next_name(&additional, *query_type).map(|(name, _search_type)| name);
+                    // Follow CNAME chains within additional processing
+                    // (e.g. ANAME → CNAME → A).
+                    next_name = if additional.record_type() == RecordType::CNAME {
+                        additional
+                            .records_without_rrsigs()
+                            .next()
+                            .and_then(|r| match &r.data {
+                                RData::CNAME(cname) => Some(LowerName::from(&cname.0)),
+                                _ => None,
+                            })
+                    } else {
+                        maybe_next_name(&additional, *query_type).map(|(name, _search_type)| name)
+                    };
                 }
             }
         }

--- a/crates/server/src/store/in_memory/mod.rs
+++ b/crates/server/src/store/in_memory/mod.rs
@@ -353,7 +353,27 @@ impl<P: RuntimeProvider + Send + Sync> ZoneHandler for InMemoryZoneHandler<P> {
 
         let answer = inner.inner_lookup(name, query_type, lookup_options);
 
-        // evaluate any cnames for additional inclusion
+        // CNAME chasing: when the answer is a CNAME and the query was for a
+        // different type, restart the lookup at the canonical name and collect
+        // the full chain into the ANSWER section (RFC 1034 §3.6.2).
+        let (answer, cname_chain) = match answer {
+            Some(a) if a.record_type() == RecordType::CNAME && query_type != RecordType::CNAME => {
+                let chain = inner.chase_cnames(name, a, query_type, lookup_options);
+                // The terminal record drives additional section processing.
+                // If the chain ends in a non-CNAME record, use it; otherwise
+                // there is no terminal record to process.
+                let terminal = chain
+                    .last()
+                    .filter(|rr| rr.record_type() != RecordType::CNAME)
+                    .cloned();
+                (terminal, Some(chain))
+            }
+            _ => (answer, None),
+        };
+
+        // Evaluate additional section records for the answer (ANAME, MX,
+        // SRV, NS).  For CNAME-chased queries this processes the terminal
+        // record; for direct answers it processes the original answer.
         let additionals_root_chain_type: Option<(_, _)> = answer
             .as_ref()
             .and_then(|a| maybe_next_name(a, query_type))
@@ -435,9 +455,11 @@ impl<P: RuntimeProvider + Send + Sync> ZoneHandler for InMemoryZoneHandler<P> {
         //   generally return NoError and no results when other types exist at the same name. bah.
         // TODO: can we get rid of this?
         use LookupControlFlow::*;
-        let answers = match answer {
-            Some(rr_set) => LookupRecords::new(lookup_options, rr_set),
-            None => {
+        let answers = match (cname_chain, answer) {
+            // CNAME chase produced a chain — use it as the answer.
+            (Some(chain), _) => LookupRecords::many(lookup_options, chain),
+            (None, Some(rr_set)) => LookupRecords::new(lookup_options, rr_set),
+            (None, None) => {
                 return Continue(Err(
                     if inner
                         .records
@@ -687,18 +709,15 @@ fn maybe_next_name(
         | (t @ RecordType::ANAME, RecordType::AAAA)
         | (t @ RecordType::ANAME, RecordType::ANAME) => t,
         (t @ RecordType::NS, RecordType::NS) => t,
-        // CNAME will continue to additional processing for any query type
-        (t @ RecordType::CNAME, _) => t,
         (t @ RecordType::MX, RecordType::MX) => t,
         (t @ RecordType::SRV, RecordType::SRV) => t,
-        // other additional collectors can be added here can be added here
+        // other additional collectors can be added here
         _ => return None,
     };
 
     let name = match (&record_set.records_without_rrsigs().next()?.data, t) {
         (RData::ANAME(name), RecordType::ANAME) => name,
         (RData::NS(ns), RecordType::NS) => &ns.0,
-        (RData::CNAME(name), RecordType::CNAME) => name,
         (RData::MX(mx), RecordType::MX) => &mx.exchange,
         (RData::SRV(srv), RecordType::SRV) => &srv.target,
         _ => return None,

--- a/tests/integration-tests/tests/integration/catalog_tests.rs
+++ b/tests/integration-tests/tests/integration/catalog_tests.rs
@@ -871,9 +871,8 @@ fn test_edns_request(origin: LowerName, edns: Edns) -> Request {
 
 // }
 
-// TODO: these should be moved to the battery tests
 #[tokio::test]
-async fn test_cname_additionals() {
+async fn test_cname_alias() {
     subscribe();
 
     let example = create_example();
@@ -910,24 +909,20 @@ async fn test_cname_additionals() {
     assert_eq!(result.metadata.response_code, ResponseCode::NoError);
 
     let answers = result.answers;
-    assert_eq!(answers.len(), 1);
-    assert_eq!(answers.first().unwrap().record_type(), RecordType::CNAME);
+    assert_eq!(answers.len(), 2);
+    assert_eq!(answers[0].record_type(), RecordType::CNAME);
     assert_eq!(
-        answers.first().unwrap().data,
+        answers[0].data,
         RData::CNAME(CNAME(Name::from_str("www.example.com.").unwrap()))
     );
+    assert_eq!(answers[1].record_type(), RecordType::A);
+    assert_eq!(answers[1].data, RData::A(A::new(93, 184, 215, 14)));
 
-    let additionals = result.additionals;
-    assert!(!additionals.is_empty());
-    assert_eq!(additionals.first().unwrap().record_type(), RecordType::A);
-    assert_eq!(
-        additionals.first().unwrap().data,
-        RData::A(A::new(93, 184, 215, 14))
-    );
+    assert!(result.additionals.is_empty());
 }
 
 #[tokio::test]
-async fn test_multiple_cname_additionals() {
+async fn test_cname_chain() {
     subscribe();
 
     let example = create_example();
@@ -964,32 +959,22 @@ async fn test_multiple_cname_additionals() {
     assert_eq!(result.metadata.response_code, ResponseCode::NoError);
 
     let answers = result.answers;
-    assert_eq!(answers.len(), 1);
-    assert_eq!(answers.first().unwrap().record_type(), RecordType::CNAME);
+    // alias2 -> alias -> www: full CNAME chain + terminal A in ANSWER
+    assert_eq!(answers.len(), 3);
+    assert_eq!(answers[0].record_type(), RecordType::CNAME);
     assert_eq!(
-        answers.first().unwrap().data,
+        answers[0].data,
         RData::CNAME(CNAME(Name::from_str("alias.example.com.").unwrap()))
     );
-
-    // we should have the intermediate record
-    let additionals = result.additionals;
-    assert!(!additionals.is_empty());
+    assert_eq!(answers[1].record_type(), RecordType::CNAME);
     assert_eq!(
-        additionals.first().unwrap().record_type(),
-        RecordType::CNAME
-    );
-    assert_eq!(
-        additionals.first().unwrap().data,
+        answers[1].data,
         RData::CNAME(CNAME(Name::from_str("www.example.com.").unwrap()))
     );
+    assert_eq!(answers[2].record_type(), RecordType::A);
+    assert_eq!(answers[2].data, RData::A(A::new(93, 184, 215, 14)));
 
-    // final record should be the actual
-    assert!(!additionals.is_empty());
-    assert_eq!(additionals.last().unwrap().record_type(), RecordType::A);
-    assert_eq!(
-        additionals.last().unwrap().data,
-        RData::A(A::new(93, 184, 215, 14))
-    );
+    assert!(result.additionals.is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Cherry-pick of #3706 onto `release/0.26`.

When a query hits a CNAME and the requested type is not CNAME, the authoritative server now restarts the lookup at the canonical name and returns the full chain — including the terminal record — in the ANSWER section (RFC 1034 §3.6.2).