### PR TITLE
fix(recursor): short-circuit on NXDOMAIN responses with NS records

### DIFF
--- a/conformance/conformance-tests/src/resolver/dns.rs
+++ b/conformance/conformance-tests/src/resolver/dns.rs
@@ -3,6 +3,7 @@
 mod regression;
 mod rfc1035;
 mod rfc3597;
+mod rfc8020;
 mod rfc8906;
 mod rfc9156;
 mod scenarios;

--- a/conformance/conformance-tests/src/resolver/dns/rfc8020.rs
+++ b/conformance/conformance-tests/src/resolver/dns/rfc8020.rs
@@ -1,0 +1,46 @@
+use dns_test::{
+    Error, FQDN, Implementation, Network, PEER, Resolver,
+    client::{Client, DigSettings, DigStatus},
+    name_server::NameServer,
+    record::RecordType,
+};
+
+/// See RFC 8020, "NXDOMAIN: There Really Is Nothing Underneath".
+///
+/// An NXDOMAIN response can carry NS records in its authority section. Those NS records are not a
+/// referral to follow: nothing exists below a name that does not exist, so the resolver has to
+/// answer NXDOMAIN.
+///
+/// Regression test for https://github.com/hickory-dns/hickory-dns/issues/3565
+#[test]
+fn nxdomain_with_ns_in_authority() -> Result<(), Error> {
+    let cut = FQDN("nxcut.example.testing.")?;
+    let needle_fqdn = FQDN("a.b.nxcut.example.testing.")?;
+
+    let network = Network::new()?;
+
+    let mut root_ns = NameServer::new(&PEER, FQDN::ROOT, &network)?;
+
+    let cut_ns = NameServer::new(
+        &Implementation::test_server("nxdomain_with_ns_authority", Vec::new(), "udp"),
+        cut.clone(),
+        &network,
+    )?;
+
+    root_ns.referral(cut, FQDN("ns.external.testing.")?, cut_ns.ipv4_addr());
+
+    let root_hint = root_ns.root_hint();
+
+    let _root_ns = root_ns.start()?;
+    let _cut_ns = cut_ns.start()?;
+
+    let resolver = Resolver::new(&network, root_hint).start()?;
+
+    let client = Client::new(&network)?;
+    let settings = *DigSettings::default().recurse();
+    let output = client.dig(settings, resolver.ipv4_addr(), RecordType::A, &needle_fqdn)?;
+
+    assert_eq!(output.status, DigStatus::NXDOMAIN);
+
+    Ok(())
+}

--- a/conformance/test-server/src/handlers.rs
+++ b/conformance/test-server/src/handlers.rs
@@ -552,6 +552,41 @@ pub(crate) fn parent_ns_in_authority_handler(
     Ok(msg)
 }
 
+/// This handler answers every query with NXDOMAIN, and puts an SOA plus an NS record (with A glue)
+/// in the authority section. It is the authoritative server from
+/// <https://github.com/hickory-dns/hickory-dns/issues/3565>. An NXDOMAIN response that also
+/// carries NS records is a valid but uncommon shape, and per RFC 8020 the NS records are not a
+/// referral to follow. The glue address is unrouteable TEST-NET-1, so following the referral would
+/// surface as a query to an unreachable server.
+pub(crate) fn nxdomain_with_ns_authority_handler(
+    request: Message,
+    _transport: Transport,
+) -> Result<Message> {
+    let mut msg = request.into_response();
+
+    let zone = Name::from_ascii("nxcut.example.testing.")?;
+    let ns_name = Name::from_ascii("ns.nxcut.example.testing.")?;
+
+    msg.metadata.authoritative = true;
+    msg.metadata.recursion_desired = false;
+    msg.metadata.response_code = ResponseCode::NXDomain;
+
+    let soa = rdata::SOA::new(ns_name.clone(), ns_name.clone(), 1, 3600, 600, 604800, 300);
+    msg.add_authority(Record::from_rdata(zone.clone(), 300, RData::SOA(soa)));
+    msg.add_authority(Record::from_rdata(
+        zone,
+        300,
+        RData::NS(rdata::NS(ns_name.clone())),
+    ));
+    msg.add_additional(Record::from_rdata(
+        ns_name,
+        300,
+        RData::A(rdata::A([192, 0, 2, 254].into())),
+    ));
+
+    Ok(msg)
+}
+
 /// This handler generates a response with QR=0 (Query type instead of Response type).
 /// Such responses should be rejected by resolvers as invalid.
 pub(crate) fn qr_not_response_handler(request: Message, _transport: Transport) -> Result<Message> {

--- a/conformance/test-server/src/main.rs
+++ b/conformance/test-server/src/main.rs
@@ -20,8 +20,9 @@ mod handlers;
 use handlers::{
     BogusNoDataInsteadOfCname, DropRrsetHandler, bad_case_handler, bad_txid_handler,
     bailiwick_handler, base_handler, cname_loop_handler, empty_response_handler,
-    nsec3_nocover_handler, packet_loss_handler, parent_ns_in_authority_handler,
-    qr_not_response_force_tcp_handler, qr_not_response_handler, truncated_response_handler,
+    nsec3_nocover_handler, nxdomain_with_ns_authority_handler, packet_loss_handler,
+    parent_ns_in_authority_handler, qr_not_response_force_tcp_handler, qr_not_response_handler,
+    truncated_response_handler,
 };
 mod zone_file;
 
@@ -75,6 +76,7 @@ enum HandlerArg {
     CnameLoop,
     EmptyResponse,
     Nsec3Nocover,
+    NxdomainWithNsAuthority,
     ParentNsInAuthority,
     PacketLoss,
     TruncatedResponse,
@@ -100,6 +102,9 @@ impl HandlerArg {
             Self::CnameLoop => &(cname_loop_handler as HandlerMessageFnPtr),
             Self::EmptyResponse => &(empty_response_handler as HandlerMessageFnPtr),
             Self::Nsec3Nocover => &(nsec3_nocover_handler as HandlerMessageFnPtr),
+            Self::NxdomainWithNsAuthority => {
+                &(nxdomain_with_ns_authority_handler as HandlerMessageFnPtr)
+            }
             Self::ParentNsInAuthority => &(parent_ns_in_authority_handler as HandlerMessageFnPtr),
             Self::PacketLoss => &(packet_loss_handler as HandlerBytesFnPtr),
             Self::TruncatedResponse => &(truncated_response_handler as HandlerMessageFnPtr),

--- a/crates/resolver/src/recursor/error.rs
+++ b/crates/resolver/src/recursor/error.rs
@@ -130,16 +130,18 @@ impl From<NetError> for RecursorError {
             return Self::Net(e);
         };
 
-        if let Some(ns) = no_records.ns {
-            Self::ForwardNS(ns)
-        } else {
-            Self::Negative(AuthorityData {
+        // An NXDOMAIN answer denies the whole subtree below the queried name (RFC 8020), so NS
+        // records in its authority section are not a referral to follow.
+        let nx_domain = matches!(no_records.response_code, ResponseCode::NXDomain);
+        match no_records.ns {
+            Some(ns) if !nx_domain => Self::ForwardNS(ns),
+            _ => Self::Negative(AuthorityData {
                 query: no_records.query,
                 soa: no_records.soa,
                 no_records_found: true,
-                nx_domain: matches!(no_records.response_code, ResponseCode::NXDomain),
+                nx_domain,
                 authorities: no_records.authorities,
-            })
+            }),
         }
     }
 }

--- a/crates/resolver/src/recursor/tests.rs
+++ b/crates/resolver/src/recursor/tests.rs
@@ -535,6 +535,84 @@ async fn cache_negative_responses() -> Result<(), NetError> {
     Ok(())
 }
 
+#[tokio::test]
+async fn nxdomain_with_ns_records_short_circuits() -> Result<(), NetError> {
+    subscribe();
+
+    let no_exist_name = Name::from_ascii("www.doesnotexist.hickory-dns.testing.")?;
+    let no_exist_cut = Name::from_ascii("doesnotexist.hickory-dns.testing.")?;
+
+    let tld_zone = Name::from_ascii("testing.")?;
+    let tld_ns = Name::from_ascii("testing.testing.")?;
+    let leaf_zone = Name::from_ascii("hickory-dns.testing.")?;
+    let leaf_ns = Name::from_ascii("ns.hickory-dns.testing.")?;
+    let bogus_ns = Name::from_ascii("ns.doesnotexist.hickory-dns.testing.")?;
+
+    let responses = vec![
+        MockRecord::ns(ROOT_IP, &tld_zone, &tld_ns),
+        MockRecord::a(ROOT_IP, &tld_ns, TLD_IP)
+            .with_query_name(&tld_zone)
+            .with_query_type(RecordType::NS)
+            .with_section(MockResponseSection::Additional),
+        MockRecord::ns(TLD_IP, &leaf_zone, &leaf_ns),
+        MockRecord::a(TLD_IP, &leaf_ns, LEAF_IP)
+            .with_query_name(&leaf_zone)
+            .with_query_type(RecordType::NS)
+            .with_section(MockResponseSection::Additional),
+        // The zone cut probe gets an NXDOMAIN whose authority section carries NS records
+        // alongside the SOA.
+        MockRecord::soa(LEAF_IP, &leaf_ns, &leaf_zone, &leaf_ns)
+            .with_query_name(&no_exist_cut)
+            .with_query_type(RecordType::NS)
+            .with_ttl(3600),
+        MockRecord::ns(LEAF_IP, &leaf_zone, &bogus_ns)
+            .with_query_name(&no_exist_cut)
+            .with_query_type(RecordType::NS)
+            .with_section(MockResponseSection::Authority),
+    ];
+
+    let cut = no_exist_cut.clone();
+    let handler = MockNetworkHandler::new(responses).with_mutation(Box::new(
+        move |_destination: IpAddr, _protocol: Protocol, message: &mut Message| {
+            if message.queries[0].name == cut {
+                message.metadata.response_code = ResponseCode::NXDomain;
+            }
+        },
+    ));
+
+    let provider = MockProvider::new(handler);
+    let recursor = Recursor::with_options(
+        &[ROOT_IP],
+        RecursorOptions {
+            deny_server: Vec::new(), // We use addresses in the default deny filters.
+            ..RecursorOptions::default()
+        },
+        provider.clone(),
+    )?;
+
+    let error = recursor
+        .resolve(
+            Query::new(no_exist_name.clone(), RecordType::A),
+            Instant::now(),
+            false,
+        )
+        .await
+        .unwrap_err();
+    assert!(error.is_nx_domain());
+
+    // Per RFC 8020 nothing below the NXDOMAIN name exists, so no further probe is made.
+    assert_eq!(
+        provider
+            .queries(&LEAF_IP)
+            .iter()
+            .filter(|x| x.name == no_exist_name)
+            .count(),
+        0,
+    );
+
+    Ok(())
+}
+
 #[test]
 fn is_subzone_test() {
     use core::str::FromStr;


### PR DESCRIPTION
Fixes #3565.

When an authoritative server answers a QNAME minimization probe with NXDOMAIN and puts NS records in the authority section, `RecursorError::from(NetError)` picked `ForwardNS` because it tested `no_records.ns` before `response_code`. `is_nx_domain()` is false for that variant, so the RFC 8020 short-circuit in `ns_pool_for_name()` never fired. The recursor kept probing sub-labels and the client got SERVFAIL, where BIND, Unbound, PowerDNS and Knot all return NXDOMAIN.

Checking the response code first means an NXDOMAIN takes the `Negative` arm even when NS records are present. The records stay in `AuthorityData::authorities`, they just no longer count as a referral to follow.

The conformance test adds a `nxdomain_with_ns_authority` handler modeled on the reporter's server and drives a real recursor through it. Before the fix the client gets SERVFAIL. After it, NXDOMAIN, and bind and unbound answer the same. A unit test covers the error conversion and asserts the probe loop stops at the first label.
