### PR TITLE
resolver: tolerate malformed system search domains

### DIFF
--- a/crates/resolver/src/system_conf/apple.rs
+++ b/crates/resolver/src/system_conf/apple.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, net::IpAddr, str::FromStr};
 
-use hickory_proto::{ProtoError, rr::Name};
+use hickory_proto::ProtoError;
 use system_configuration::{
     core_foundation::{
         array::CFArray,
@@ -12,6 +12,7 @@ use system_configuration::{
 };
 use tracing::warn;
 
+use super::sanitize::parse_search_domains;
 use crate::config::{NameServerConfig, ResolverConfig, ResolverOpts};
 
 pub fn read_system_conf() -> Result<(ResolverConfig, ResolverOpts), ProtoError> {
@@ -67,7 +68,9 @@ pub fn read_system_conf() -> Result<(ResolverConfig, ResolverOpts), ProtoError> 
 
         let mut search_domains = Vec::with_capacity(search_domains_cf.len() as usize);
         for s in &*search_domains_cf {
-            search_domains.push(Name::from_str(&Cow::from(&*s))?);
+            for domain in parse_search_domains(&Cow::from(&*s)) {
+                search_domains.push(domain?);
+            }
         }
         search_domains
     } else {

--- a/crates/resolver/src/system_conf/mod.rs
+++ b/crates/resolver/src/system_conf/mod.rs
@@ -43,3 +43,61 @@ mod apple;
 #[cfg(target_vendor = "apple")]
 #[cfg(feature = "system-config")]
 pub use self::apple::read_system_conf;
+
+#[cfg(all(feature = "system-config", any(windows, target_vendor = "apple")))]
+mod sanitize {
+    use std::str::FromStr;
+
+    use crate::proto::{ProtoError, rr::Name};
+
+    pub(super) fn parse_search_domains(
+        raw: &str,
+    ) -> impl Iterator<Item = Result<Name, ProtoError>> + '_ {
+        raw.split(|c: char| c.is_whitespace() || c == '\0')
+            .filter(|domain| !domain.is_empty())
+            .map(Name::from_str)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::str::FromStr;
+
+        use crate::proto::rr::Name;
+
+        use super::parse_search_domains;
+
+        fn names(domains: &[&str]) -> Vec<Name> {
+            domains
+                .iter()
+                .map(|d| Name::from_str(d).expect("test domain must parse"))
+                .collect()
+        }
+
+        #[test]
+        fn test_parse_search_domains() {
+            let cases: &[(&str, &[&str])] = &[
+                ("example.com", &["example.com"]),
+                ("example.com. example.net", &["example.com.", "example.net"]),
+                ("a.com\tb.com\r\nc.com", &["a.com", "b.com", "c.com"]),
+                ("test.com\0something.net", &["test.com", "something.net"]),
+                ("", &[]),
+            ];
+            for (input, expected) in cases {
+                assert_eq!(
+                    parse_search_domains(input)
+                        .collect::<Result<Vec<_>, _>>()
+                        .expect("test domains must parse"),
+                    names(expected),
+                    "input: {input:?}"
+                );
+            }
+
+            let invalid = format!("{}.com valid.com", "a".repeat(64));
+            assert!(
+                parse_search_domains(&invalid)
+                    .collect::<Result<Vec<_>, _>>()
+                    .is_err()
+            );
+        }
+    }
+}

--- a/crates/resolver/src/system_conf/windows.rs
+++ b/crates/resolver/src/system_conf/windows.rs
@@ -13,6 +13,7 @@ use std::str::FromStr;
 use ipconfig::computer::{get_domain, get_search_list};
 use ipconfig::get_adapters;
 
+use super::sanitize::parse_search_domains;
 use crate::config::{NameServerConfig, ResolverConfig, ResolverOpts};
 use crate::proto::ProtoError;
 use crate::proto::rr::Name;
@@ -40,7 +41,7 @@ pub fn read_system_conf() -> Result<(ResolverConfig, ResolverOpts), ProtoError> 
     let search_list = get_search_list()
         .map_err(|e| format!("ipconfig::get_search_list() failed: {e}"))?
         .iter()
-        .map(|x| Name::from_str(x))
+        .flat_map(|x| parse_search_domains(x))
         .collect::<Result<Vec<_>, _>>()?;
 
     let domain = match get_domain().map_err(|e| format!("ipconfig::get_domain() failed: {e}"))? {


### PR DESCRIPTION
## Problem

The macOS and Windows system-configuration readers treated every value returned in the OS search list as one domain name. System configuration can provide several search domains in a single value separated by whitespace or embedded NUL bytes. Parsing that combined value with `Name::from_str(...)?` rejects it and discards the entire resolver configuration.

## Fix

Parse search-list values with a shared helper that treats whitespace and NUL as separators, removes empty segments, and parses each resulting domain separately. Parse errors for any other malformed name still propagate, so the change is limited to these separator forms.

This applies only to search-list entries. The Windows primary `Domain` remains on its existing strict `Name::from_str` path.

Covered by unit tests for ordinary entries, packed whitespace-separated domains, NUL-separated domains, empty input, and propagation of other malformed names.