### PR TITLE
Delete two TODOs in KEY RDATA decoding

### DIFF
--- a/crates/proto/src/dnssec/rdata/key.rs
+++ b/crates/proto/src/dnssec/rdata/key.rs
@@ -352,13 +352,11 @@ impl<'r> RecordDataDecodable<'r> for KEY {
             return Err(DecodeError::ExtendedKeyFlagsUnsupported(flags));
         }
 
-        // TODO: protocol my be infallible
         let protocol =
             Protocol::from(decoder.read_u8()?.unverified(/*Protocol is verified as safe*/));
 
         let algorithm: Algorithm = Algorithm::read(decoder)?;
 
-        // TODO: decode the key here?
         let public_key =
             decoder.read_vec_to_end().unverified(/*the byte array will fail in usage if invalid*/);
 


### PR DESCRIPTION
This deletes two TODO comments we don't need anymore. The first comment is incorrect, as `Protocol::from()` is indeed infallible. The second comment is not needed, because we'll always need to hang on to the raw bytes of keys, even for unsupported algorithms. This is necessary for forwards compatibility and for DNSSEC verification of RRsets containing keys with multiple algorithms.