### PR TITLE
release/0.26 backport: recursor: add config for qname minimization with relaxed mode.

### DIFF
--- a/conformance/e2e-tests/src/recursor.rs
+++ b/conformance/e2e-tests/src/recursor.rs
@@ -3,5 +3,6 @@ mod cname;
 mod config;
 mod delegation;
 mod dnssec;
+mod qmin_relaxed;
 mod rfc9539;
 mod security;

--- a/conformance/e2e-tests/src/recursor/qmin_relaxed.rs
+++ b/conformance/e2e-tests/src/recursor/qmin_relaxed.rs
@@ -1,0 +1,1 @@
+mod scenarios;

--- a/conformance/e2e-tests/src/recursor/qmin_relaxed/scenarios.rs
+++ b/conformance/e2e-tests/src/recursor/qmin_relaxed/scenarios.rs
@@ -1,0 +1,253 @@
+//! These scenarios use a single test network with the following records:
+//!
+//! example.testing:
+//!  sub.example.testing IN A 192.0.2.1
+//!  sub.ent.example.testing IN A 192.0.3.1
+//!  host1.ent.example.testing IN A 192.0.4.1
+//!  host2.ent.sub.example.testing IN A 192.0.5.1
+//!  host3.sub.ent.example.testing IN A 192.0.6.1
+//!  host4.ent.ent.example.testing IN A 192.0.7.1
+use std::{net::Ipv4Addr, thread, time::Duration};
+
+use dns_test::{
+    Error, FQDN, Implementation, Network, Resolver,
+    client::{Client, DigOutput, DigSettings},
+    name_server::{NameServer, Running},
+    record::{Record, RecordType},
+    zone_file::Root,
+};
+
+/// qname minimization relaxed mode error code tests
+///
+/// Querying IN A sub.example.testing yields NOERROR and 1 answer record
+/// Querying IN A sub.ent.example.testing yields NOERROR and 1 answer record
+/// Querying IN A host1.ent.example.testing yields NOERROR and 1 answer record
+/// Querying IN A host2.ent.sub.example.testing yields NOERROR and 1 answer record
+/// Querying IN A host3.sub.ent.example.testing yields NOERROR and 1 answer record
+/// Querying IN A host4.ent.ent.example.testing yields NOERROR and 1 answer record
+///
+/// Querying IN A ent.example.testing yields NOERROR and 1 authority record
+/// Querying IN A ent.sub.example.testing yields NOERROR and 1 authority record
+/// Querying IN A ent.ent.example.testing yields NOERROR and 1 authority record
+///
+/// Querying IN A host5.example.testing yields NXDOMAIN and 1 authority record
+/// Querying IN A host6.ent.example.testing yields NXDOMAIN and 1 authority record
+#[test]
+fn qmin_relaxed_error_code_tests() -> Result<(), Error> {
+    let sub1_fqdn = FQDN("sub.example.testing.")?;
+    let sub1_ipv4_addr = Ipv4Addr::new(192, 0, 2, 1);
+    let sub2_fqdn = FQDN("sub.ent.example.testing.")?;
+    let sub2_ipv4_addr = Ipv4Addr::new(192, 0, 3, 1);
+    let host1_fqdn = FQDN("host1.ent.example.testing.")?;
+    let host1_ipv4_addr = Ipv4Addr::new(192, 0, 4, 1);
+    let host2_fqdn = FQDN("host2.ent.sub.example.testing.")?;
+    let host2_ipv4_addr = Ipv4Addr::new(192, 0, 5, 1);
+    let host3_fqdn = FQDN("host3.sub.ent.example.testing.")?;
+    let host3_ipv4_addr = Ipv4Addr::new(192, 0, 6, 1);
+    let host4_fqdn = FQDN("host4.ent.ent.example.testing.")?;
+    let host4_ipv4_addr = Ipv4Addr::new(192, 0, 7, 1);
+
+    let test = TestNetwork::new()?;
+
+    let res = test.dig(RecordType::A, &sub1_fqdn)?;
+    assert!(res.status.is_noerror());
+    assert_eq!(res.answer.len(), 1);
+    if let Record::A(rec) = res.answer.first().unwrap() {
+        assert_eq!(rec.fqdn, sub1_fqdn);
+        assert_eq!(rec.ipv4_addr, sub1_ipv4_addr);
+    } else {
+        panic!("error");
+    }
+
+    let res = test.dig(RecordType::A, &sub2_fqdn)?;
+    assert!(res.status.is_noerror());
+    assert_eq!(res.answer.len(), 1);
+    if let Record::A(rec) = res.answer.first().unwrap() {
+        assert_eq!(rec.fqdn, sub2_fqdn);
+        assert_eq!(rec.ipv4_addr, sub2_ipv4_addr);
+    } else {
+        panic!("error");
+    }
+
+    let res = test.dig(RecordType::A, &host1_fqdn)?;
+    assert!(res.status.is_noerror());
+    assert_eq!(res.answer.len(), 1);
+    if let Record::A(rec) = res.answer.first().unwrap() {
+        assert_eq!(rec.fqdn, host1_fqdn);
+        assert_eq!(rec.ipv4_addr, host1_ipv4_addr);
+    } else {
+        panic!("error");
+    }
+
+    let res = test.dig(RecordType::A, &host2_fqdn)?;
+    assert!(res.status.is_noerror());
+    assert_eq!(res.answer.len(), 1);
+    if let Record::A(rec) = res.answer.first().unwrap() {
+        assert_eq!(rec.fqdn, host2_fqdn);
+        assert_eq!(rec.ipv4_addr, host2_ipv4_addr);
+    } else {
+        panic!("error");
+    }
+
+    let res = test.dig(RecordType::A, &host3_fqdn)?;
+    assert!(res.status.is_noerror());
+    assert_eq!(res.answer.len(), 1);
+    if let Record::A(rec) = res.answer.first().unwrap() {
+        assert_eq!(rec.fqdn, host3_fqdn);
+        assert_eq!(rec.ipv4_addr, host3_ipv4_addr);
+    } else {
+        panic!("error");
+    }
+
+    let res = test.dig(RecordType::A, &host4_fqdn)?;
+    assert!(res.status.is_noerror());
+    assert_eq!(res.answer.len(), 1);
+    if let Record::A(rec) = res.answer.first().unwrap() {
+        assert_eq!(rec.fqdn, host4_fqdn);
+        assert_eq!(rec.ipv4_addr, host4_ipv4_addr);
+    } else {
+        panic!("error");
+    }
+
+    let res = test.dig(RecordType::A, &FQDN("ent.example.testing.")?)?;
+    assert!(res.status.is_noerror());
+    assert_eq!(res.answer.len(), 0);
+    assert_eq!(res.authority.len(), 1);
+    if let Record::SOA(rec) = res.authority.first().unwrap() {
+        assert_eq!(rec.zone, FQDN("example.testing.")?);
+    } else {
+        panic!("error");
+    }
+
+    let res = test.dig(RecordType::A, &FQDN("ent.sub.example.testing.")?)?;
+    assert!(res.status.is_noerror());
+    assert_eq!(res.answer.len(), 0);
+    assert_eq!(res.authority.len(), 1);
+    if let Record::SOA(rec) = res.authority.first().unwrap() {
+        assert_eq!(rec.zone, FQDN("example.testing.")?);
+    } else {
+        panic!("error");
+    }
+
+    let res = test.dig(RecordType::A, &FQDN("ent.ent.example.testing.")?)?;
+    assert!(res.status.is_noerror());
+    assert_eq!(res.answer.len(), 0);
+    assert_eq!(res.authority.len(), 1);
+    if let Record::SOA(rec) = res.authority.first().unwrap() {
+        assert_eq!(rec.zone, FQDN("example.testing.")?);
+    } else {
+        panic!("error");
+    }
+
+    let res = test.dig(RecordType::A, &FQDN("host5.example.testing.")?)?;
+    assert!(res.status.is_nxdomain());
+    assert_eq!(res.answer.len(), 0);
+    assert_eq!(res.authority.len(), 1);
+    if let Record::SOA(rec) = res.authority.first().unwrap() {
+        assert_eq!(rec.zone, FQDN("example.testing.")?);
+    } else {
+        panic!("error");
+    }
+
+    let res = test.dig(RecordType::A, &FQDN("host6.ent.example.testing.")?)?;
+    assert!(res.status.is_nxdomain());
+    assert_eq!(res.answer.len(), 0);
+    assert_eq!(res.authority.len(), 1);
+    if let Record::SOA(rec) = res.authority.first().unwrap() {
+        assert_eq!(rec.zone, FQDN("example.testing.")?);
+    } else {
+        panic!("error");
+    }
+
+    Ok(())
+}
+
+struct TestNetwork {
+    _network: Network,
+    _root_ns: NameServer<Running>,
+    _tld_ns: NameServer<Running>,
+    _example_ns: NameServer<Running>,
+    resolver: Resolver,
+    client: Client,
+}
+
+impl TestNetwork {
+    fn new() -> Result<Self, Error> {
+        let sub1_fqdn = FQDN("sub.example.testing.")?;
+        let sub1_ipv4_addr = Ipv4Addr::new(192, 0, 2, 1);
+        let sub2_fqdn = FQDN("sub.ent.example.testing.")?;
+        let sub2_ipv4_addr = Ipv4Addr::new(192, 0, 3, 1);
+        let host1_fqdn = FQDN("host1.ent.example.testing.")?;
+        let host1_ipv4_addr = Ipv4Addr::new(192, 0, 4, 1);
+        let host2_fqdn = FQDN("host2.ent.sub.example.testing.")?;
+        let host2_ipv4_addr = Ipv4Addr::new(192, 0, 5, 1);
+        let host3_fqdn = FQDN("host3.sub.ent.example.testing.")?;
+        let host3_ipv4_addr = Ipv4Addr::new(192, 0, 6, 1);
+        let host4_fqdn = FQDN("host4.ent.ent.example.testing.")?;
+        let host4_ipv4_addr = Ipv4Addr::new(192, 0, 7, 1);
+
+        let network = Network::new()?;
+
+        let mut root_ns = NameServer::new(&Implementation::test_peer(), FQDN::ROOT, &network)?;
+        let mut tld_ns = NameServer::new(&Implementation::test_peer(), FQDN::TEST_TLD, &network)?;
+
+        let mut example_ns = NameServer::new(
+            &Implementation::test_peer(),
+            FQDN("example.testing.")?,
+            &network,
+        )?;
+
+        example_ns.add(Record::a(sub1_fqdn, sub1_ipv4_addr));
+        example_ns.add(Record::a(sub2_fqdn, sub2_ipv4_addr));
+        example_ns.add(Record::a(host1_fqdn, host1_ipv4_addr));
+        example_ns.add(Record::a(host2_fqdn, host2_ipv4_addr));
+        example_ns.add(Record::a(host3_fqdn, host3_ipv4_addr));
+        example_ns.add(Record::a(host4_fqdn, host4_ipv4_addr));
+
+        root_ns.referral_nameserver(&tld_ns);
+        tld_ns.referral_nameserver(&example_ns);
+
+        let root_hint: Root = root_ns.root_hint();
+
+        let resolver = Resolver::new(&network, root_hint)
+            .custom_config(HICKORY_RECURSOR_QMIN_RELAXED_CONFIG.to_string())
+            .start_with_subject(&Implementation::hickory())?;
+
+        let client = Client::new(resolver.network())?;
+
+        let ret = Self {
+            _network: network,
+            _root_ns: root_ns.start()?,
+            _tld_ns: tld_ns.start()?,
+            _example_ns: example_ns.start()?,
+            resolver,
+            client,
+        };
+
+        thread::sleep(Duration::from_secs(2));
+
+        Ok(ret)
+    }
+
+    fn dig(&self, r_type: RecordType, q_name: &FQDN) -> Result<DigOutput, Error> {
+        let a_settings = *DigSettings::default().recurse().authentic_data();
+        self.client
+            .dig(a_settings, self.resolver.ipv4_addr(), r_type, q_name)
+    }
+}
+
+static HICKORY_RECURSOR_QMIN_RELAXED_CONFIG: &str = r#"
+user = "nobody"
+group = "nogroup"
+
+[[zones]]
+zone = "."
+zone_type = "External"
+
+[zones.stores]
+type = "recursor"
+roots = "/etc/root.hints"
+dnssec_policy = "ValidationDisabled"
+allow_server = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+qname_minimization = "Relaxed"
+"#;

--- a/crates/resolver/src/recursor/handle.rs
+++ b/crates/resolver/src/recursor/handle.rs
@@ -14,7 +14,10 @@ use lru_cache::LruCache;
 use parking_lot::Mutex;
 use tracing::{debug, trace, warn};
 
-use super::{DnssecPolicy, RecursorError, RecursorOptions, error::AuthorityData, is_subzone};
+use super::{
+    DnssecPolicy, QNameMinimization, RecursorError, RecursorOptions, error::AuthorityData,
+    is_subzone,
+};
 #[cfg(feature = "metrics")]
 use crate::metrics::recursor::RecursorMetrics;
 #[cfg(feature = "__dnssec")]
@@ -53,6 +56,7 @@ pub(crate) struct RecursorDnsHandle<P: ConnectionProvider> {
     connection_cache: Arc<Mutex<LruCache<IpAddr, Arc<NameServer<P>>>>>,
     request_options: DnsRequestOptions,
     ttl_config: TtlConfig,
+    qname_minimization: QNameMinimization,
 }
 
 impl<P: ConnectionProvider> RecursorDnsHandle<P> {
@@ -85,6 +89,7 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
             case_randomization,
             opportunistic_encryption,
             edns_payload_len,
+            qname_minimization,
         } = options;
 
         let avoid_local_udp_ports = Arc::new(avoid_local_udp_ports);
@@ -151,6 +156,7 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
             connection_cache: Arc::new(Mutex::new(LruCache::new(ns_cache_size))),
             request_options,
             ttl_config: cache_policy.clone(),
+            qname_minimization,
         })
     }
 
@@ -534,7 +540,12 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
             let response = match lookup_res {
                 Ok(response) => response,
                 // Short-circuit on NXDOMAIN, per RFC 8020.
-                Err(e) if e.is_nx_domain() => return Err(e),
+                // RFC 9156 also describes a relaxed mode where RFC 8020 is not enforced.
+                Err(e)
+                    if e.is_nx_domain() && self.qname_minimization == QNameMinimization::Strict =>
+                {
+                    return Err(e);
+                }
                 // Short-circuit on timeouts. Requesting a longer name from the same pool would likely
                 // encounter them again.
                 Err(e) if e.is_timeout() => return Err(e),

--- a/crates/resolver/src/recursor/mod.rs
+++ b/crates/resolver/src/recursor/mod.rs
@@ -634,6 +634,10 @@ pub struct RecursorOptions {
     /// See [DnsRequestOptions::edns_payload_len][crate::proto::op::DnsRequestOptions::edns_payload_len].
     #[cfg_attr(feature = "serde", serde(default = "default_edns_payload_len"))]
     pub edns_payload_len: u16,
+
+    /// Configure QNAME minimization.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub qname_minimization: QNameMinimization,
 }
 
 impl Default for RecursorOptions {
@@ -652,6 +656,7 @@ impl Default for RecursorOptions {
             case_randomization: false,
             opportunistic_encryption: OpportunisticEncryption::default(),
             edns_payload_len: default_edns_payload_len(),
+            qname_minimization: QNameMinimization::default(),
         }
     }
 }
@@ -783,6 +788,18 @@ pub enum DnssecPolicyConfig {
         /// set to control the size of the DNSSEC validation cache.  Set to none to use the default
         validation_cache_size: Option<usize>,
     },
+}
+
+/// Configuration for QNAME minimization (RFC 9156).
+#[cfg_attr(feature = "serde", derive(Deserialize))]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum QNameMinimization {
+    /// Enforce RFC 8020: short-circuit on NXDOMAIN.
+    #[default]
+    Strict,
+
+    /// Relax RFC 8020: continue on NXDOMAIN.
+    Relaxed,
 }
 
 /// Bailiwick/sub zone checking.

--- a/crates/resolver/src/recursor/tests.rs
+++ b/crates/resolver/src/recursor/tests.rs
@@ -19,6 +19,7 @@ use crate::{
         op::{Message, Query, ResponseCode},
         rr::{Name, Record, RecordType},
     },
+    recursor::QNameMinimization,
 };
 
 #[tokio::test]
@@ -443,6 +444,94 @@ async fn ns_pool_zone_name_test() -> Result<(), NetError> {
             ttl_lookup(&recursor, &ent_delegated_query_name).await?,
             &ent_delegated_query_name,
             ENT_DELEGATED_LEAF_IP
+        ));
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn ns_pool_zone_name_nxdomain_at_ent() -> Result<(), NetError> {
+    subscribe();
+
+    let query_name = Name::from_ascii("host.ent.hickory-dns.testing.")?;
+    let ent_name = Name::from_ascii("ent.hickory-dns.testing.")?;
+
+    let tld_zone = Name::from_ascii("testing.")?;
+    let tld_ns = Name::from_ascii("testing.testing.")?;
+    let leaf_zone = Name::from_ascii("hickory-dns.testing.")?;
+    let leaf_ns = Name::from_ascii("ns.hickory-dns.testing.")?;
+
+    let responses = vec![
+        MockRecord::ns(ROOT_IP, &tld_zone, &tld_ns),
+        MockRecord::a(ROOT_IP, &tld_ns, TLD_IP)
+            .with_query_name(&tld_zone)
+            .with_query_type(RecordType::NS)
+            .with_section(MockResponseSection::Additional),
+        MockRecord::ns(TLD_IP, &leaf_zone, &leaf_ns),
+        MockRecord::a(TLD_IP, &leaf_ns, LEAF_IP)
+            .with_query_name(&leaf_zone)
+            .with_query_type(RecordType::NS)
+            .with_section(MockResponseSection::Additional),
+        MockRecord::soa(LEAF_IP, &leaf_zone, &leaf_ns, &leaf_ns)
+            .with_query_name(&ent_name)
+            .with_query_type(RecordType::NS)
+            .with_section(MockResponseSection::Authority),
+        MockRecord::soa(LEAF_IP, &leaf_zone, &leaf_ns, &leaf_ns)
+            .with_query_name(&query_name)
+            .with_query_type(RecordType::NS)
+            .with_section(MockResponseSection::Authority),
+        MockRecord::a(LEAF_IP, &query_name, LEAF_IP),
+    ];
+
+    let nxdomain_at_ent = Box::new(move |_, _, message: &mut Message| {
+        if let Some(query) = message.queries.first() {
+            if query.name == ent_name && query.query_type == RecordType::NS {
+                let mut error_message =
+                    Message::error_msg(message.id, message.op_code, ResponseCode::NXDomain);
+                error_message.add_authorities(message.authorities.drain(..));
+                *message = error_message;
+            }
+        }
+    });
+
+    let recursor_no_cache = Recursor::with_options(
+        &[ROOT_IP],
+        RecursorOptions {
+            deny_server: Vec::new(),
+            ns_cache_size: 1,
+            qname_minimization: QNameMinimization::Relaxed,
+            ..RecursorOptions::default()
+        },
+        MockProvider::new(
+            MockNetworkHandler::new(responses.clone()).with_mutation(nxdomain_at_ent.clone()),
+        ),
+    )?;
+
+    let recursor_cache = Recursor::with_options(
+        &[ROOT_IP],
+        RecursorOptions {
+            deny_server: Vec::new(),
+            ns_cache_size: 1024,
+            qname_minimization: QNameMinimization::Relaxed,
+            ..RecursorOptions::default()
+        },
+        MockProvider::new(
+            MockNetworkHandler::new(responses.clone()).with_mutation(nxdomain_at_ent),
+        ),
+    )?;
+
+    for recursor in [recursor_no_cache, recursor_cache] {
+        assert_eq!(
+            get_zone_name(&recursor, &query_name).await?,
+            Some(leaf_zone.clone())
+        );
+
+        // Sanity check - IPs are correct
+        assert!(validate_response(
+            ttl_lookup(&recursor, &query_name).await?,
+            &query_name,
+            LEAF_IP
         ));
     }
 

--- a/tests/test-data/test_configs/example_recursor.toml
+++ b/tests/test-data/test_configs/example_recursor.toml
@@ -118,6 +118,10 @@ allow_server = ["127.0.0.254/32"]
 ## you can override these default entries by adding exceptions to allow_server.
 deny_server = ["0.0.0.0/8", "127.0.0.0/8", "::/128", "::1/128"]
 
+## qname_minimization: "Relaxed" or "Strict", defaults to "Strict".
+## When set to "Relaxed", queries continue when receiving NXDOMAIN on empty non-terminal labels.
+qname_minimization = "Strict"
+
 ## cache_policy: set the minimum/maximum TTL for positive/negative responses.
 ## This can be set for all queries and for specific query types.
 [zones.stores.cache_policy.default]


### PR DESCRIPTION
backport to the release/0.26 branch of https://github.com/hickory-dns/hickory-dns/pull/3759:

My continue for https://github.com/hickory-dns/hickory-dns/pull/3629.

Problem: recursor fails to resolve when NXDOMAIN returned at empty non terminal domain label.

This add an enum QnameMinimization with two variants: Strict and Relaxed. The default Strict mode has the same behavior as prior. Relaxed mode not enforce RFC8020 i.e. continue even when the intermediate returns NXDOMAIN.