### PR TITLE
Add failing test for wildcard expansion with NSEC

### DIFF
--- a/conformance/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
+++ b/conformance/conformance-tests/src/resolver/dnssec/scenarios/secure.rs
@@ -382,13 +382,24 @@ fn no_root_ds_query() -> Result<(), Error> {
 }
 
 #[test]
-fn nsec_wildcard_expanded_positive_response() -> Result<(), Error> {
+fn nsec_wildcard_expanded_positive_response_four_labels() -> Result<(), Error> {
+    nsec_wildcard_expanded_positive_response(
+        FQDN::EXAMPLE_SUBDOMAIN
+            .push_label("a")
+            .push_label("b")
+            .push_label("c")
+            .push_label("d"),
+    )
+}
+
+#[ignore = "hickory wildcard validation is incorrect"]
+#[test]
+fn nsec_wildcard_expanded_positive_response_one_label() -> Result<(), Error> {
+    nsec_wildcard_expanded_positive_response(FQDN::EXAMPLE_SUBDOMAIN.push_label("www"))
+}
+
+fn nsec_wildcard_expanded_positive_response(needle_fqdn: FQDN) -> Result<(), Error> {
     let expected_ipv4_addr = Ipv4Addr::new(1, 2, 3, 4);
-    let needle_fqdn = FQDN::EXAMPLE_SUBDOMAIN
-        .push_label("a")
-        .push_label("b")
-        .push_label("c")
-        .push_label("d");
     let network = Network::new()?;
 
     let mut leaf_ns = NameServer::new(&PEER, FQDN::TEST_DOMAIN, &network)?;


### PR DESCRIPTION
This adds a failing test for validation of positive responses with wildcard expansion when using NSEC records. There are two things wrong with the existing validation code. First, it assembles `wildcard_name` by removing labels from candidate names taken from NSEC records, picking one that satisfies some conditions, and adding a `*` label. For some cases, this produces the wrong result. Second, it looks for an NSEC record that covers `wildcard_name`, when we would expect positive responses to have an NSEC record that matches the wildcard name. These two issues cancel out for the existing test, where the query name is `d.c.b.a.example.hickory-dns.testing.` and `wildcard_name` is `*.c.b.a.example.hickory-dns.testing.`, instead of `*.example.hickory-dns.testing.` For this new test, `wildcard_name` is correct as a consequence of the query name being shorter, and the validation logic fails because of the matching vs. covering issue.

We could vastly simplify the validation logic for positive responses by instead looking at the `labels` field of the RRSIG for the responsive RRset, truncating the RRset's name to that many lables, and then adding a `*` label. (see also #3659) We will still need some logic relying on NSEC records alone for NODATA/NXDOMAIN response wildcard proofs. We'll need to revisit the related logic for that case. I think we first need to identify the closest enclosing name that is proven to exist, check that the next closer name is proven to not exist, and then append the `*` label. Generally, I think untangling the positive and negative response logic from each other could help with code readability as well.