### PR TITLE
Add tests for SerialNumber arithmetic (RFC 1982)

### DIFF
--- a/crates/proto/src/rr/serial_number.rs
+++ b/crates/proto/src/rr/serial_number.rs
@@ -65,3 +65,57 @@ impl PartialOrd for SerialNumber {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn equal() {
+        let a = SerialNumber(42);
+        let b = SerialNumber(42);
+        assert_eq!(a.partial_cmp(&b), Some(Ordering::Equal));
+    }
+
+    #[test]
+    fn none() {
+        let a = SerialNumber(0);
+        let b = SerialNumber(1 << 31);
+        assert_eq!(a.partial_cmp(&b), None);
+    }
+
+    #[test]
+    fn less() {
+        let a = SerialNumber(40);
+        let b = SerialNumber(42);
+        assert_eq!(a.partial_cmp(&b), Some(Ordering::Less));
+    }
+
+    #[test]
+    fn less_wrap() {
+        let a = SerialNumber(u32::MAX);
+        let b = SerialNumber(0);
+        assert_eq!(a.partial_cmp(&b), Some(Ordering::Less));
+    }
+
+    #[test]
+    fn greater() {
+        let a = SerialNumber(42);
+        let b = SerialNumber(40);
+        assert_eq!(a.partial_cmp(&b), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn greater_wrap() {
+        let a = SerialNumber(0);
+        let b = SerialNumber(u32::MAX);
+        assert_eq!(a.partial_cmp(&b), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn add_wrapping() {
+        let a = SerialNumber(1);
+        let b = SerialNumber(u32::MAX);
+        assert_eq!(a + b, SerialNumber(0));
+    }
+}

--- a/crates/proto/src/rr/serial_number.rs
+++ b/crates/proto/src/rr/serial_number.rs
@@ -65,3 +65,58 @@ impl PartialOrd for SerialNumber {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_equal() {
+       let a = SerialNumber (42);
+       let b = SerialNumber (42);
+       assert_eq!(a.partial_cmp(&b), Some(Ordering::Equal));
+    }
+
+    #[test]
+    fn test_none() {
+        let a = SerialNumber(0);
+        let b = SerialNumber (1 << 31);
+        assert_eq!(a.partial_cmp(&b), None);    
+    }
+
+    #[test]
+    fn test_less() {
+        let a = SerialNumber(40);
+        let b = SerialNumber (42);
+        assert_eq!(a.partial_cmp(&b), Some(Ordering::Less));    
+    }
+
+    #[test]
+    fn test_less_wrap() {
+        let a = SerialNumber(u32::MAX);
+        let b = SerialNumber (0);
+        assert_eq!(a.partial_cmp(&b), Some(Ordering::Less));    
+    }
+
+    #[test]
+    fn test_greater() {
+        let a = SerialNumber(42);
+        let b = SerialNumber (40);
+        assert_eq!(a.partial_cmp(&b), Some(Ordering::Greater));    
+    }
+
+    #[test]
+    fn test_greater_wrap() {
+        let a = SerialNumber(0);
+        let b = SerialNumber (u32::MAX);
+        assert_eq!(a.partial_cmp(&b), Some(Ordering::Greater));    
+    }
+
+    #[test]
+    fn test_add_wrapping() {
+        let a = SerialNumber(1);
+        let b = SerialNumber (u32::MAX);
+        assert_eq!(a+b ,SerialNumber(0));    
+    }
+
+}

--- a/crates/proto/src/rr/serial_number.rs
+++ b/crates/proto/src/rr/serial_number.rs
@@ -72,51 +72,50 @@ mod tests {
 
     #[test]
     fn test_equal() {
-       let a = SerialNumber (42);
-       let b = SerialNumber (42);
-       assert_eq!(a.partial_cmp(&b), Some(Ordering::Equal));
+        let a = SerialNumber(42);
+        let b = SerialNumber(42);
+        assert_eq!(a.partial_cmp(&b), Some(Ordering::Equal));
     }
 
     #[test]
     fn test_none() {
         let a = SerialNumber(0);
-        let b = SerialNumber (1 << 31);
-        assert_eq!(a.partial_cmp(&b), None);    
+        let b = SerialNumber(1 << 31);
+        assert_eq!(a.partial_cmp(&b), None);
     }
 
     #[test]
     fn test_less() {
         let a = SerialNumber(40);
-        let b = SerialNumber (42);
-        assert_eq!(a.partial_cmp(&b), Some(Ordering::Less));    
+        let b = SerialNumber(42);
+        assert_eq!(a.partial_cmp(&b), Some(Ordering::Less));
     }
 
     #[test]
     fn test_less_wrap() {
         let a = SerialNumber(u32::MAX);
-        let b = SerialNumber (0);
-        assert_eq!(a.partial_cmp(&b), Some(Ordering::Less));    
+        let b = SerialNumber(0);
+        assert_eq!(a.partial_cmp(&b), Some(Ordering::Less));
     }
 
     #[test]
     fn test_greater() {
         let a = SerialNumber(42);
-        let b = SerialNumber (40);
-        assert_eq!(a.partial_cmp(&b), Some(Ordering::Greater));    
+        let b = SerialNumber(40);
+        assert_eq!(a.partial_cmp(&b), Some(Ordering::Greater));
     }
 
     #[test]
     fn test_greater_wrap() {
         let a = SerialNumber(0);
-        let b = SerialNumber (u32::MAX);
-        assert_eq!(a.partial_cmp(&b), Some(Ordering::Greater));    
+        let b = SerialNumber(u32::MAX);
+        assert_eq!(a.partial_cmp(&b), Some(Ordering::Greater));
     }
 
     #[test]
     fn test_add_wrapping() {
         let a = SerialNumber(1);
-        let b = SerialNumber (u32::MAX);
-        assert_eq!(a+b ,SerialNumber(0));    
+        let b = SerialNumber(u32::MAX);
+        assert_eq!(a + b, SerialNumber(0));
     }
-
 }


### PR DESCRIPTION
serial_number.rs had no test coverage (0%). This PR adds unit tests for SerialNumber arithmetic as defined in RFC 1982.

 Test covering:
- Equality
- Addition with wrapping (u32 overflow)
- Less than: normal case and wrap-around case
- Greater than: normal case and wrap-around case
- Undefined case (None) when distance equals 2^31