### PR TITLE
Use SerialNumber for SOA serial field (addresses #3817)

### DIFF
--- a/bin/tests/integration/txt_tests.rs
+++ b/bin/tests/integration/txt_tests.rs
@@ -119,7 +119,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
             Name::from_str("action\\.domains.isi.edu.").unwrap(),
             soa.rname
         );
-        assert_eq!(20, soa.serial);
+        assert_eq!(SerialNumber::from(20), soa.serial);
         assert_eq!(7200, soa.refresh);
         assert_eq!(600, soa.retry);
         assert_eq!(3_600_000, soa.expire);
@@ -152,7 +152,7 @@ tech.   3600    in      soa     ns0.centralnic.net.     hostmaster.centralnic.ne
             Name::from_str("hostmaster.centralnic.net.").unwrap(),
             lower_soa.rname
         );
-        assert_eq!(271851, lower_soa.serial);
+        assert_eq!(SerialNumber::from(271851), lower_soa.serial);
         assert_eq!(900, lower_soa.refresh);
         assert_eq!(1800, lower_soa.retry);
         assert_eq!(6_048_000, lower_soa.expire);

--- a/bin/tests/integration/zone_handler_battery/basic.rs
+++ b/bin/tests/integration/zone_handler_battery/basic.rs
@@ -12,7 +12,7 @@ use hickory_net::{
 use hickory_proto::{
     op::{Message, MessageRequest, MessageType, Metadata, OpCode, Query, ResponseCode},
     rr::{
-        Name, RData, RecordType,
+        Name, RData, RecordType, SerialNumber,
         rdata::{A as A4, AAAA},
     },
 };
@@ -68,7 +68,7 @@ pub fn test_soa(handler: impl ZoneHandler) {
         RData::SOA(soa) => {
             assert_eq!(Name::from_str("hickory-dns.org.").unwrap(), soa.mname);
             assert_eq!(Name::from_str("root.hickory-dns.org.").unwrap(), soa.rname);
-            assert_eq!(199609203, soa.serial);
+            assert_eq!(SerialNumber::from(199609203), soa.serial);
             assert_eq!(28800, soa.refresh);
             assert_eq!(7200, soa.retry);
             assert_eq!(604800, soa.expire);

--- a/bin/tests/integration/zone_handler_battery/dnssec.rs
+++ b/bin/tests/integration/zone_handler_battery/dnssec.rs
@@ -74,7 +74,7 @@ pub fn test_soa(handler: impl ZoneHandler, keys: &[DNSKEY]) {
 
     assert_eq!(Name::from_str("hickory-dns.org.").unwrap(), soa.mname);
     assert_eq!(Name::from_str("root.hickory-dns.org.").unwrap(), soa.rname);
-    assert!(199609203 < soa.serial); // serial should be one or more b/c of the signing process
+    assert!(199609203 < soa.serial.get()); // serial should be one or more b/c of the signing process
     assert_eq!(28800, soa.refresh);
     assert_eq!(7200, soa.retry);
     assert_eq!(604800, soa.expire);

--- a/conformance/compatibility-tests/src/zone_transfer.rs
+++ b/conformance/compatibility-tests/src/zone_transfer.rs
@@ -17,7 +17,7 @@ use hickory_net::client::{Client, ClientHandle};
 use hickory_net::runtime::TokioRuntimeProvider;
 use hickory_net::tcp::TcpClientStream;
 use hickory_net::xfer::DnsMultiplexer;
-use hickory_proto::rr::{Name, RData, Record, RecordType, rdata::A};
+use hickory_proto::rr::{Name, RData, Record, RecordType, SerialNumber, rdata::A};
 use test_support::subscribe;
 
 use dns_test::{
@@ -140,5 +140,5 @@ fn assert_serial(r: &Record, expected: u32) {
     let RData::SOA(soa) = &r.data else {
         panic!("expected SOA record, got: {:?}", r.data)
     };
-    assert_eq!(soa.serial, expected);
+    assert_eq!(soa.serial, SerialNumber::from(expected));
 }

--- a/conformance/test-server/src/handlers.rs
+++ b/conformance/test-server/src/handlers.rs
@@ -14,7 +14,7 @@ use hickory_proto::{
         rdata::{DNSSECRData, NSEC3, NSEC3PARAM, RRSIG},
     },
     op::{DnsRequest, DnsRequestOptions, Message, MessageType, Query, ResponseCode},
-    rr::{RData, Record, RecordType, domain::Name, rdata},
+    rr::{RData, Record, RecordType, SerialNumber, domain::Name, rdata},
 };
 use std::{
     env,
@@ -571,7 +571,15 @@ pub(crate) fn nxdomain_with_ns_authority_handler(
     msg.metadata.recursion_desired = false;
     msg.metadata.response_code = ResponseCode::NXDomain;
 
-    let soa = rdata::SOA::new(ns_name.clone(), ns_name.clone(), 1, 3600, 600, 604800, 300);
+    let soa = rdata::SOA::new(
+        ns_name.clone(),
+        ns_name.clone(),
+        SerialNumber::from(1),
+        3600,
+        600,
+        604800,
+        300,
+    );
     msg.add_authority(Record::from_rdata(zone.clone(), 300, RData::SOA(soa)));
     msg.add_authority(Record::from_rdata(
         zone,

--- a/crates/net/src/client/mod.rs
+++ b/crates/net/src/client/mod.rs
@@ -37,7 +37,7 @@ use crate::{
             DEFAULT_MAX_PAYLOAD_LEN, DnsRequest, DnsRequestOptions, DnsResponse, Edns, Message,
             OpCode, Query, update_message,
         },
-        rr::{DNSClass, Name, RData, Record, RecordSet, RecordType, rdata::SOA},
+        rr::{DNSClass, Name, RData, Record, RecordSet, RecordType, SerialNumber, rdata::SOA},
     },
     runtime::RuntimeProvider,
     xfer::{
@@ -645,17 +645,17 @@ enum ClientStreamXfrState<R> {
     },
     Second {
         inner: R,
-        expected_serial: u32,
+        expected_serial: SerialNumber,
         maybe_incr: bool,
     },
     Axfr {
         inner: R,
-        expected_serial: u32,
+        expected_serial: SerialNumber,
     },
     Ixfr {
         inner: R,
         even: bool,
-        expected_serial: u32,
+        expected_serial: SerialNumber,
     },
     Ended,
     Invalid,
@@ -678,7 +678,7 @@ impl<R> ClientStreamXfrState<R> {
     // TODO: this is complex enough it should get its own tests
     fn process(&mut self, answers: &[Record]) -> Result<(), NetError> {
         use ClientStreamXfrState::*;
-        fn get_serial(r: &Record) -> Option<u32> {
+        fn get_serial(r: &Record) -> Option<SerialNumber> {
             match &r.data {
                 RData::SOA(soa) => Some(soa.serial),
                 _ => None,

--- a/crates/net/src/client/tests.rs
+++ b/crates/net/src/client/tests.rs
@@ -67,7 +67,7 @@ async fn readme_example() {
     assert!(!a_data.is_empty());
 }
 
-fn soa_record(serial: u32) -> Record {
+fn soa_record(serial: SerialNumber) -> Record {
     let soa = RData::SOA(SOA::new(
         Name::from_ascii("example.com.").unwrap(),
         Name::from_ascii("admin.example.com.").unwrap(),
@@ -102,10 +102,10 @@ fn get_stream_testcase(
 async fn test_stream_xfr_valid_axfr() {
     subscribe();
     let stream = get_stream_testcase(vec![vec![
-        soa_record(3),
+        soa_record(SerialNumber::from(3)),
         a_record(1),
         a_record(2),
-        soa_record(3),
+        soa_record(SerialNumber::from(3)),
     ]]);
     let mut stream = ClientStreamXfr::new(stream, false);
     assert!(matches!(stream.state, Start { .. }));
@@ -121,9 +121,9 @@ async fn test_stream_xfr_valid_axfr() {
 async fn test_stream_xfr_valid_axfr_multipart() {
     subscribe();
     let stream = get_stream_testcase(vec![
-        vec![soa_record(3)],
+        vec![soa_record(SerialNumber::from(3))],
         vec![a_record(1)],
-        vec![soa_record(3)],
+        vec![soa_record(SerialNumber::from(3))],
         vec![a_record(2)], // will be ignored as connection is dropped before reading this message
     ]);
     let mut stream = ClientStreamXfr::new(stream, false);
@@ -147,7 +147,10 @@ async fn test_stream_xfr_valid_axfr_multipart() {
 #[tokio::test]
 async fn test_stream_xfr_empty_axfr() {
     subscribe();
-    let stream = get_stream_testcase(vec![vec![soa_record(3)], vec![soa_record(3)]]);
+    let stream = get_stream_testcase(vec![
+        vec![soa_record(SerialNumber::from(3))],
+        vec![soa_record(SerialNumber::from(3))],
+    ]);
     let mut stream = ClientStreamXfr::new(stream, false);
     assert!(matches!(stream.state, Start { .. }));
 
@@ -166,12 +169,12 @@ async fn test_stream_xfr_empty_axfr() {
 async fn test_stream_xfr_axfr_with_ixfr_reply() {
     subscribe();
     let stream = get_stream_testcase(vec![vec![
-        soa_record(3),
-        soa_record(2),
+        soa_record(SerialNumber::from(3)),
+        soa_record(SerialNumber::from(2)),
         a_record(1),
-        soa_record(3),
+        soa_record(SerialNumber::from(3)),
         a_record(2),
-        soa_record(3),
+        soa_record(SerialNumber::from(3)),
     ]]);
     let mut stream = ClientStreamXfr::new(stream, false);
     assert!(matches!(stream.state, Start { .. }));
@@ -203,10 +206,10 @@ async fn test_stream_xfr_axfr_with_non_xfr_reply() {
 async fn test_stream_xfr_invalid_axfr_multipart() {
     subscribe();
     let stream = get_stream_testcase(vec![
-        vec![soa_record(3)],
+        vec![soa_record(SerialNumber::from(3))],
         vec![a_record(1)],
-        vec![soa_record(3), a_record(2)],
-        vec![soa_record(3)],
+        vec![soa_record(SerialNumber::from(3)), a_record(2)],
+        vec![soa_record(SerialNumber::from(3))],
     ]);
     let mut stream = ClientStreamXfr::new(stream, false);
     assert!(matches!(stream.state, Start { .. }));
@@ -229,12 +232,12 @@ async fn test_stream_xfr_invalid_axfr_multipart() {
 async fn test_stream_xfr_valid_ixfr() {
     subscribe();
     let stream = get_stream_testcase(vec![vec![
-        soa_record(3),
-        soa_record(2),
+        soa_record(SerialNumber::from(3)),
+        soa_record(SerialNumber::from(2)),
         a_record(1),
-        soa_record(3),
+        soa_record(SerialNumber::from(3)),
         a_record(2),
-        soa_record(3),
+        soa_record(SerialNumber::from(3)),
     ]]);
     let mut stream = ClientStreamXfr::new(stream, true);
     assert!(matches!(stream.state, Start { .. }));
@@ -250,12 +253,12 @@ async fn test_stream_xfr_valid_ixfr() {
 async fn test_stream_xfr_valid_ixfr_multipart() {
     subscribe();
     let stream = get_stream_testcase(vec![
-        vec![soa_record(3)],
-        vec![soa_record(2)],
+        vec![soa_record(SerialNumber::from(3))],
+        vec![soa_record(SerialNumber::from(2))],
         vec![a_record(1)],
-        vec![soa_record(3)],
+        vec![soa_record(SerialNumber::from(3))],
         vec![a_record(2)],
-        vec![soa_record(3)],
+        vec![soa_record(SerialNumber::from(3))],
         vec![a_record(3)], //
     ]);
     let mut stream = ClientStreamXfr::new(stream, true);

--- a/crates/net/src/xfer/dns_multiplexer.rs
+++ b/crates/net/src/xfer/dns_multiplexer.rs
@@ -391,7 +391,7 @@ mod test {
     use super::*;
     use crate::proto::op::{DnsRequestOptions, Message, Query};
     use crate::proto::rr::rdata::{NS, SOA};
-    use crate::proto::rr::{DNSClass, Name, RData, Record, RecordType};
+    use crate::proto::rr::{DNSClass, Name, RData, Record, RecordType, SerialNumber};
     use crate::proto::serialize::binary::BinEncodable;
     use crate::xfer::{DnsClientStream, StreamReceiver};
 
@@ -513,7 +513,7 @@ mod test {
             RData::SOA(SOA::new(
                 Name::parse("sns.dns.icann.org.", None).unwrap(),
                 Name::parse("noc.dns.icann.org.", None).unwrap(),
-                2015082403,
+                SerialNumber::from(2015082403),
                 7200,
                 3600,
                 1209600,

--- a/crates/proto/src/op/dns_response.rs
+++ b/crates/proto/src/op/dns_response.rs
@@ -210,7 +210,7 @@ mod tests {
     use crate::op::{Message, Query, ResponseCode};
     use crate::rr::RData;
     use crate::rr::rdata::{A, NS, SOA};
-    use crate::rr::{Name, Record, RecordType};
+    use crate::rr::{Name, Record, RecordType, SerialNumber};
 
     use super::*;
 
@@ -246,7 +246,15 @@ mod tests {
         Record::from_rdata(
             example(),
             88640,
-            RData::SOA(SOA::new(ns1(), hostmaster(), 1, 2, 3, 4, 5)),
+            RData::SOA(SOA::new(
+                ns1(),
+                hostmaster(),
+                SerialNumber::from(1),
+                2,
+                3,
+                4,
+                5,
+            )),
         )
     }
 

--- a/crates/proto/src/rr/rdata/soa.rs
+++ b/crates/proto/src/rr/rdata/soa.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     error::ProtoResult,
-    rr::{RData, RecordData, RecordType, domain::Name},
+    rr::{RData, RecordData, RecordType, domain::Name, serial_number::SerialNumber},
     serialize::{
         binary::{BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, RDataEncoding},
         txt::{ParseError, parse_ttl},
@@ -97,7 +97,7 @@ pub struct SOA {
     ///                 value wraps and should be compared using sequence space
     ///                 arithmetic.
     /// ```
-    pub serial: u32,
+    pub serial: SerialNumber,
 
     /// A 32 bit time interval before the zone should be refreshed, in seconds.
     ///
@@ -154,7 +154,7 @@ impl SOA {
     pub fn new(
         mname: Name,
         rname: Name,
-        serial: u32,
+        serial: SerialNumber,
         refresh: i32,
         retry: i32,
         expire: i32,
@@ -218,13 +218,19 @@ impl SOA {
             .and_then(parse_ttl)?;
 
         Ok(Self::new(
-            mname, rname, serial, refresh, retry, expire, minimum,
+            mname,
+            rname,
+            SerialNumber(serial),
+            refresh,
+            retry,
+            expire,
+            minimum,
         ))
     }
 
     /// Increments the serial number by one
     pub fn increment_serial(&mut self) {
-        self.serial += 1; // TODO: what to do on overflow?
+        self.serial += SerialNumber(1);
     }
 }
 
@@ -265,7 +271,7 @@ impl<'r> BinDecodable<'r> for SOA {
         Ok(Self {
             mname: Name::read(decoder)?,
             rname: Name::read(decoder)?,
-            serial: decoder.read_u32()?.unverified(/*any u32 is valid*/),
+            serial: SerialNumber::from(decoder.read_u32()?.unverified(/*any u32 is valid*/)),
             refresh: decoder.read_i32()?.unverified(/*any i32 is valid*/),
             retry: decoder.read_i32()?.unverified(/*any i32 is valid*/),
             expire: decoder.read_i32()?.unverified(/*any i32 is valid*/),
@@ -379,7 +385,7 @@ mod tests {
         let rdata = SOA::new(
             Name::from_str("m.example.com.").unwrap(),
             Name::from_str("r.example.com.").unwrap(),
-            1,
+            SerialNumber(1),
             2,
             3,
             4,
@@ -422,7 +428,7 @@ mod tests {
         let expected_soa = SOA::new(
             "hickory-dns.org.".parse().unwrap(),
             "root.hickory-dns.org.".parse().unwrap(),
-            199609203,
+            SerialNumber(199609203),
             28800,
             7200,
             604800,

--- a/crates/proto/src/rr/record_data.rs
+++ b/crates/proto/src/rr/record_data.rs
@@ -1355,7 +1355,10 @@ mod tests {
 
     use super::*;
     use crate::rr::domain::Name;
-    use crate::rr::rdata::{MX, SOA, SRV, TXT};
+    use crate::rr::{
+        SerialNumber,
+        rdata::{MX, SOA, SRV, TXT},
+    };
     use crate::serialize::binary::bin_tests::test_emit_data_set;
 
     fn get_data() -> Vec<(RData, Vec<u8>)> {
@@ -1389,7 +1392,7 @@ mod tests {
                 RData::SOA(SOA::new(
                     Name::from_str("www.example.com.").unwrap(),
                     Name::from_str("xxx.example.com.").unwrap(),
-                    u32::MAX,
+                    SerialNumber::from(u32::MAX),
                     -1,
                     -1,
                     -1,
@@ -1456,7 +1459,7 @@ mod tests {
             RData::SOA(SOA::new(
                 Name::from_str("www.example.com").unwrap(),
                 Name::from_str("xxx.example.com").unwrap(),
-                u32::MAX,
+                SerialNumber::from(u32::MAX),
                 -1,
                 -1,
                 -1,
@@ -1477,7 +1480,7 @@ mod tests {
             RData::SOA(SOA::new(
                 Name::from_str("www.example.com").unwrap(),
                 Name::from_str("xxx.example.com").unwrap(),
-                u32::MAX,
+                SerialNumber::from(u32::MAX),
                 -1,
                 -1,
                 -1,

--- a/crates/proto/src/rr/rr_set.rs
+++ b/crates/proto/src/rr/rr_set.rs
@@ -556,7 +556,7 @@ mod test {
             RData::SOA(SOA::new(
                 Name::from_str("sns.dns.icann.org.").unwrap(),
                 Name::from_str("noc.dns.icann.org.").unwrap(),
-                2015082403,
+                SerialNumber::from(2015082403),
                 7200,
                 3600,
                 1209600,
@@ -569,7 +569,7 @@ mod test {
             RData::SOA(SOA::new(
                 Name::from_str("sns.dns.icann.net.").unwrap(),
                 Name::from_str("noc.dns.icann.net.").unwrap(),
-                2015082403,
+                SerialNumber::from(2015082403),
                 7200,
                 3600,
                 1209600,
@@ -582,7 +582,7 @@ mod test {
             RData::SOA(SOA::new(
                 Name::from_str("sns.dns.icann.net.").unwrap(),
                 Name::from_str("noc.dns.icann.net.").unwrap(),
-                2015082404,
+                SerialNumber::from(2015082404),
                 7200,
                 3600,
                 1209600,
@@ -666,7 +666,7 @@ mod test {
             RData::SOA(SOA::new(
                 Name::from_str("sns.dns.icann.org.").unwrap(),
                 Name::from_str("noc.dns.icann.org.").unwrap(),
-                2015082403,
+                SerialNumber::from(2015082403),
                 7200,
                 3600,
                 1209600,

--- a/crates/proto/src/rr/serial_number.rs
+++ b/crates/proto/src/rr/serial_number.rs
@@ -1,6 +1,10 @@
 //! Number type to support Serial Number Arithmetics
 
-use core::{cmp::Ordering, ops::Add};
+use crate::{
+    error::ProtoResult,
+    serialize::binary::{BinEncodable, BinEncoder},
+};
+use core::{cmp::Ordering, fmt, num::ParseIntError, ops::Add, ops::AddAssign, str::FromStr};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -31,6 +35,14 @@ impl From<u32> for SerialNumber {
     }
 }
 
+impl FromStr for SerialNumber {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse::<u32>().map(Self::from)
+    }
+}
+
 /// Serial Number Addition, see RFC 1982, section 3.1
 ///
 /// The result is a wrapping add.
@@ -39,6 +51,13 @@ impl Add for SerialNumber {
 
     fn add(self, rhs: Self) -> Self::Output {
         Self(self.0.wrapping_add(rhs.0))
+    }
+}
+
+/// Serial Number Addition and assign.
+impl AddAssign for SerialNumber {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 = (*self + rhs).0;
     }
 }
 
@@ -63,5 +82,40 @@ impl PartialOrd for SerialNumber {
         } else {
             None
         }
+    }
+}
+
+impl fmt::Display for SerialNumber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl BinEncodable for SerialNumber {
+    fn emit(&self, encoder: &mut BinEncoder<'_>) -> ProtoResult<()> {
+        self.0.emit(encoder)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display() {
+        assert_eq!(format!("{}", SerialNumber::from(42)), "42");
+    }
+
+    #[test]
+    fn from_str() {
+        assert_eq!(
+            "42".parse::<SerialNumber>().unwrap(),
+            SerialNumber::from(42)
+        )
+    }
+
+    #[test]
+    fn from_str_error() {
+        assert!("abc".parse::<SerialNumber>().is_err());
     }
 }

--- a/crates/resolver/src/cache.rs
+++ b/crates/resolver/src/cache.rs
@@ -478,7 +478,7 @@ mod tests {
         time::{Duration, Instant},
     };
 
-    use hickory_proto::rr::rdata::CNAME;
+    use hickory_proto::rr::{SerialNumber, rdata::CNAME};
     #[cfg(feature = "serde")]
     use serde::Deserialize;
 
@@ -887,7 +887,15 @@ mod tests {
         norecs.soa = Some(Box::new(Record::from_rdata(
             zone_name.clone(),
             10,
-            SOA::new(name.base_name(), name.clone(), 1, 1, 1, 1, 1),
+            SOA::new(
+                name.base_name(),
+                name.clone(),
+                SerialNumber::from(1),
+                1,
+                1,
+                1,
+                1,
+            ),
         )));
         norecs.authorities = Some(Arc::new([Record::from_rdata(
             zone_name.clone(),

--- a/crates/server/src/store/in_memory/inner.rs
+++ b/crates/server/src/store/in_memory/inner.rs
@@ -31,7 +31,8 @@ use crate::{
 use super::maybe_next_name;
 use crate::{
     proto::rr::{
-        DNSClass, LowerName, Name, RData, Record, RecordSet, RecordType, RrKey, rdata::SOA,
+        DNSClass, LowerName, Name, RData, Record, RecordSet, RecordType, RrKey, SerialNumber,
+        rdata::SOA,
     },
     zone_handler::LookupOptions,
 };
@@ -184,12 +185,12 @@ impl InnerInMemory {
     }
 
     /// get the current serial number for the zone.
-    pub(super) fn serial(&self, origin: &LowerName) -> u32 {
+    pub(super) fn serial(&self, origin: &LowerName) -> SerialNumber {
         match self.inner_soa(origin) {
             Some(soa) => soa.serial,
             None => {
                 error!("could not lookup SOA for zone handler: {origin}");
-                0
+                SerialNumber::from(0)
             }
         }
     }
@@ -478,8 +479,8 @@ impl InnerInMemory {
             panic!("This was not an SOA record"); // valid panic, never should happen
         };
 
-        self.upsert(record, serial, dns_class);
-        serial
+        self.upsert(record, serial.get(), dns_class);
+        serial.get()
     }
 
     /// Inserts or updates a `Record` depending on its existence in the zone.
@@ -661,7 +662,7 @@ impl InnerInMemory {
 
         // insert all the nsec records
         for record in records {
-            let upserted = self.upsert(record, serial, dns_class);
+            let upserted = self.upsert(record, serial.get(), dns_class);
             debug_assert!(upserted);
         }
     }
@@ -790,7 +791,7 @@ impl InnerInMemory {
 
         // insert all the NSEC3 records.
         for record in records {
-            let upserted = self.upsert(record, serial, dns_class);
+            let upserted = self.upsert(record, serial.get(), dns_class);
             debug_assert!(upserted);
         }
 
@@ -986,7 +987,7 @@ mod tests {
             RData::SOA(SOA::new(
                 ns_name.clone(),
                 Name::from_str("hostmaster.example.com.").unwrap(),
-                1,
+                SerialNumber::from(1),
                 3600,
                 3600,
                 3600,

--- a/crates/server/src/store/in_memory/mod.rs
+++ b/crates/server/src/store/in_memory/mod.rs
@@ -104,7 +104,7 @@ impl<P: RuntimeProvider + Send + Sync> InMemoryZoneHandler<P> {
                 _ => None,
             })
             .ok_or_else(|| format!("SOA record must be present: {origin}"))?;
-        let serial = soa.serial;
+        let serial = soa.serial.get();
 
         let iter = records.into_values();
 
@@ -196,7 +196,7 @@ impl<P: RuntimeProvider + Send + Sync> InMemoryZoneHandler<P> {
 
     /// get the current serial number for the zone.
     pub async fn serial(&self) -> u32 {
-        self.inner.read().await.serial(self.origin())
+        self.inner.read().await.serial(self.origin()).get()
     }
 
     #[cfg(feature = "sqlite")]
@@ -253,7 +253,7 @@ impl<P: RuntimeProvider + Send + Sync> InMemoryZoneHandler<P> {
 
         // TODO: also generate the CDS and CDNSKEY
         let serial = inner.serial(origin);
-        inner.upsert(dnskey, serial, dns_class);
+        inner.upsert(dnskey, serial.get(), dns_class);
         inner.secure_keys.push(signer);
         Ok(())
     }

--- a/crates/server/src/zone_handler/catalog.rs
+++ b/crates/server/src/zone_handler/catalog.rs
@@ -1248,7 +1248,7 @@ mod tests {
     use crate::proto::{
         op::{MessageType, OpCode, Query},
         rr::{
-            Name, RData, Record, RecordType,
+            Name, RData, Record, RecordType, SerialNumber,
             rdata::{A, SOA},
         },
     };
@@ -1272,7 +1272,7 @@ mod tests {
             RData::SOA(SOA::new(
                 Name::from_str("ns.example.com.").unwrap(),
                 Name::from_str("admin.example.com.").unwrap(),
-                1,
+                SerialNumber::from(1),
                 3600,
                 1800,
                 604800,

--- a/tests/integration-tests/src/example_zone.rs
+++ b/tests/integration-tests/src/example_zone.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use hickory_proto::rr::rdata::{A, AAAA, CNAME, NS, SOA, TXT};
-use hickory_proto::rr::{Name, RData, Record};
+use hickory_proto::rr::{Name, RData, Record, SerialNumber};
 #[cfg(feature = "__dnssec")]
 use hickory_server::dnssec::NxProofKind;
 use hickory_server::store::in_memory::InMemoryZoneHandler;
@@ -25,7 +25,7 @@ pub fn create_example() -> InMemoryZoneHandler {
             RData::SOA(SOA::new(
                 Name::parse("sns.dns.icann.org.", None).unwrap(),
                 Name::parse("noc.dns.icann.org.", None).unwrap(),
-                2015082403,
+                SerialNumber::from(2015082403),
                 7200,
                 3600,
                 1209600,

--- a/tests/integration-tests/src/mock_client.rs
+++ b/tests/integration-tests/src/mock_client.rs
@@ -21,10 +21,14 @@ use futures::{
 use hickory_net::NetError;
 use hickory_net::runtime::{DnsTcpStream, DnsUdpSocket, RuntimeProvider, TokioHandle, TokioTime};
 use hickory_net::xfer::DnsHandle;
-use hickory_proto::ProtoError;
-use hickory_proto::op::{DnsRequest, DnsResponse, Message, Query};
-use hickory_proto::rr::rdata::{CNAME, NS, SOA};
-use hickory_proto::rr::{Name, RData, Record};
+use hickory_proto::{
+    ProtoError,
+    op::{DnsRequest, DnsResponse, Message, Query},
+    rr::{
+        Name, RData, Record, SerialNumber,
+        rdata::{CNAME, NS, SOA},
+    },
+};
 use hickory_resolver::config::ConnectionConfig;
 use hickory_resolver::{ConnectionProvider, PoolContext};
 
@@ -209,7 +213,15 @@ pub fn v4_record(name: Name, ip: Ipv4Addr) -> Record {
 }
 
 pub fn soa_record(name: Name, mname: Name) -> Record {
-    let soa = SOA::new(mname, Name::default(), 1, 3600, 60, 86400, 3600);
+    let soa = SOA::new(
+        mname,
+        Name::default(),
+        SerialNumber::from(1),
+        3600,
+        60,
+        86400,
+        3600,
+    );
     Record::from_rdata(name, 86400, RData::SOA(soa))
 }
 

--- a/tests/integration-tests/tests/integration/catalog_tests.rs
+++ b/tests/integration-tests/tests/integration/catalog_tests.rs
@@ -7,7 +7,7 @@ use hickory_net::{
 use hickory_proto::{
     op::{Edns, Message, MessageType, OpCode, Query, ResponseCode},
     rr::{
-        LowerName, Name, RData, Record, RecordType,
+        LowerName, Name, RData, Record, RecordType, SerialNumber,
         rdata::{
             A, AAAA, CNAME, NS, SOA,
             opt::{EdnsCode, EdnsOption, NSIDPayload},
@@ -41,7 +41,7 @@ fn create_records(records: &mut InMemoryZoneHandler) {
             RData::SOA(SOA::new(
                 Name::parse("sns.dns.icann.org.", None).unwrap(),
                 Name::parse("noc.dns.icann.org.", None).unwrap(),
-                2015082403,
+                SerialNumber::from(2015082403),
                 7200,
                 3600,
                 1209600,
@@ -255,7 +255,7 @@ async fn test_catalog_lookup_soa() {
         RData::SOA(SOA::new(
             Name::parse("sns.dns.icann.org.", None).unwrap(),
             Name::parse("noc.dns.icann.org.", None).unwrap(),
-            2015082403,
+            SerialNumber::from(2015082403),
             7200,
             3600,
             1209600,
@@ -327,7 +327,7 @@ async fn test_catalog_nx_soa() {
         RData::SOA(SOA::new(
             Name::parse("sns.dns.icann.org.", None).unwrap(),
             Name::parse("noc.dns.icann.org.", None).unwrap(),
-            2015082403,
+            SerialNumber::from(2015082403),
             7200,
             3600,
             1209600,
@@ -385,7 +385,7 @@ async fn test_catalog_soa_query_for_nx_name() {
         RData::SOA(SOA::new(
             Name::parse("sns.dns.icann.org.", None).unwrap(),
             Name::parse("noc.dns.icann.org.", None).unwrap(),
-            2015082403,
+            SerialNumber::from(2015082403),
             7200,
             3600,
             1209600,
@@ -452,7 +452,7 @@ async fn test_axfr_allow_all() {
         RData::SOA(SOA::new(
             Name::parse("sns.dns.icann.org.", None).unwrap(),
             Name::parse("noc.dns.icann.org.", None).unwrap(),
-            2015082403,
+            SerialNumber::from(2015082403),
             7200,
             3600,
             1209600,
@@ -501,7 +501,7 @@ async fn test_axfr_allow_all() {
             RData::SOA(SOA::new(
                 Name::parse("sns.dns.icann.org.", None).unwrap(),
                 Name::parse("noc.dns.icann.org.", None).unwrap(),
-                2015082403,
+                SerialNumber::from(2015082403),
                 7200,
                 3600,
                 1209600,
@@ -544,7 +544,7 @@ async fn test_axfr_allow_all() {
             RData::SOA(SOA::new(
                 Name::parse("sns.dns.icann.org.", None).unwrap(),
                 Name::parse("noc.dns.icann.org.", None).unwrap(),
-                2015082403,
+                SerialNumber::from(2015082403),
                 7200,
                 3600,
                 1209600,

--- a/tests/integration-tests/tests/integration/invalid_nsec3_tests.rs
+++ b/tests/integration-tests/tests/integration/invalid_nsec3_tests.rs
@@ -24,7 +24,7 @@ use hickory_proto::{
     },
     op::{DnsResponse, ResponseCode},
     rr::{
-        DNSClass, Name, RData, Record, RecordType,
+        DNSClass, Name, RData, Record, RecordType, SerialNumber,
         rdata::{A, AAAA, HINFO, MX, NS, SOA},
     },
 };
@@ -447,7 +447,7 @@ fn example_zone_handler(origin: Name, key: Box<dyn SigningKey>) -> InMemoryZoneH
             RData::SOA(SOA::new(
                 Name::parse("ns1", Some(&origin)).unwrap(),
                 Name::parse("bugs.x.w", Some(&origin)).unwrap(),
-                0,
+                SerialNumber::from(0),
                 3600,
                 300,
                 3600000,

--- a/tests/integration-tests/tests/integration/invalid_nsec_tests.rs
+++ b/tests/integration-tests/tests/integration/invalid_nsec_tests.rs
@@ -19,7 +19,7 @@ use hickory_proto::{
     },
     op::{DnsResponse, ResponseCode},
     rr::{
-        DNSClass, Name, RData, Record, RecordType,
+        DNSClass, Name, RData, Record, RecordType, SerialNumber,
         rdata::{A, AAAA, HINFO, MX, NS, SOA},
     },
 };
@@ -308,7 +308,7 @@ fn example_zone_handler(origin: Name, key: Box<dyn SigningKey>) -> InMemoryZoneH
             RData::SOA(SOA::new(
                 Name::parse("ns1", Some(&origin)).unwrap(),
                 Name::parse("bugs.x.w", Some(&origin)).unwrap(),
-                SERIAL,
+                SerialNumber::from(SERIAL),
                 3600,
                 300,
                 3600000,

--- a/tests/integration-tests/tests/integration/rfc4592_tests.rs
+++ b/tests/integration-tests/tests/integration/rfc4592_tests.rs
@@ -14,7 +14,7 @@ use hickory_net::{
 use hickory_proto::{
     op::ResponseCode,
     rr::{
-        DNSClass, Name, RData, Record, RecordType,
+        DNSClass, Name, RData, Record, RecordType, SerialNumber,
         rdata::{A, MX, NS, SOA, SRV, TXT},
     },
 };
@@ -277,7 +277,7 @@ async fn setup() -> (Client<TokioRuntimeProvider>, Server<Catalog>) {
             RData::SOA(SOA::new(
                 Name::parse("mname", Some(&origin)).unwrap(),
                 Name::parse("rname", Some(&origin)).unwrap(),
-                SERIAL,
+                SerialNumber::from(SERIAL),
                 3600,
                 300,
                 3600000,

--- a/tests/integration-tests/tests/integration/truncation_tests.rs
+++ b/tests/integration-tests/tests/integration/truncation_tests.rs
@@ -5,7 +5,9 @@ use hickory_net::udp::UdpClientStream;
 use hickory_net::xfer::FirstAnswer;
 use hickory_proto::op::{DnsRequest, Edns, Message, Query};
 use hickory_proto::rr::rdata::{A, SOA};
-use hickory_proto::rr::{DNSClass, Name, RData, Record, RecordSet, RecordType, RrKey};
+use hickory_proto::rr::{
+    DNSClass, Name, RData, Record, RecordSet, RecordType, RrKey, SerialNumber,
+};
 use hickory_server::Server;
 #[cfg(feature = "__dnssec")]
 use hickory_server::dnssec::NxProofKind;
@@ -84,7 +86,7 @@ fn new_large_catalog(num_records: u32) -> Catalog {
             RData::SOA(SOA::new(
                 n("sns.dns.icann.org."),
                 n("noc.dns.icann.org."),
-                2015082403,
+                SerialNumber::from(2015082403),
                 7200,
                 3600,
                 1209600,

--- a/tests/integration-tests/tests/integration/validating_forwarder_tests.rs
+++ b/tests/integration-tests/tests/integration/validating_forwarder_tests.rs
@@ -25,7 +25,7 @@ use hickory_proto::{
     },
     op::{DnsResponse, ResponseCode},
     rr::{
-        DNSClass, Name, RData, Record, RecordType,
+        DNSClass, Name, RData, Record, RecordType, SerialNumber,
         rdata::{A, SOA},
     },
 };
@@ -186,7 +186,7 @@ async fn setup_authoritative_server(
                 RData::SOA(SOA::new(
                     Name::parse("nameserver.", None).unwrap(),
                     Name::parse("admin.nameserver.", None).unwrap(),
-                    0,
+                    SerialNumber::from(0),
                     3600,
                     3600,
                     3600,

--- a/tests/test-support/src/lib.rs
+++ b/tests/test-support/src/lib.rs
@@ -20,7 +20,7 @@ use hickory_net::{
 use hickory_proto::{
     op::{Message, OpCode, Query, ResponseCode},
     rr::{
-        Name, RData, Record, RecordType,
+        Name, RData, Record, RecordType, SerialNumber,
         rdata::{A, NS, SOA},
     },
     serialize::binary::BinDecodable,
@@ -135,7 +135,15 @@ impl MockRecord {
             query_name: rr_name.clone(),
             query_type: RecordType::SOA,
             record_name: rr_name.clone(),
-            record_data: RData::SOA(SOA::new(mname.clone(), rname.clone(), 1, 1, 1, 1, 1)),
+            record_data: RData::SOA(SOA::new(
+                mname.clone(),
+                rname.clone(),
+                SerialNumber::from(1),
+                1,
+                1,
+                1,
+                1,
+            )),
             section: MockResponseSection::Authority,
         }
     }


### PR DESCRIPTION
Implements #3817: use `SerialNumber` for the SOA serial 
field so that wrap-around behaves correctly per RFC 1982.