### PR TITLE
docs: fix doubled words in dnskey and nsec3 rustdoc

### DIFF
--- a/crates/net/src/dnssec/nsec3.rs
+++ b/crates/net/src/dnssec/nsec3.rs
@@ -579,7 +579,7 @@ impl<'a> Context<'a> {
         }
     }
 
-    /// Hashes a name and returns both both the hash digest and the base32-encoded form.
+    /// Hashes a name and returns both the hash digest and the base32-encoded form.
     fn hash_and_label(&self, name: &Name) -> (Vec<u8>, Label) {
         let hash = self
             .hash_algorithm

--- a/crates/proto/src/dnssec/rdata/dnskey.rs
+++ b/crates/proto/src/dnssec/rdata/dnskey.rs
@@ -292,7 +292,7 @@ impl DNSKEY {
     ///
     /// # Arguments
     ///
-    /// * `name` - the label of of the DNSKEY record.
+    /// * `name` - the label of the DNSKEY record.
     /// * `digest_type` - the `DigestType` with which to create the message digest.
     pub fn to_digest(&self, name: &Name, digest_type: DigestType) -> ProtoResult<Digest> {
         let mut buf: Vec<u8> = Vec::new();


### PR DESCRIPTION
Two small doubled-word typos in rustdoc comments:

- `crates/proto/src/dnssec/rdata/dnskey.rs`: "the label of of the DNSKEY record" -> "the label of the DNSKEY record" (the `# Arguments` doc for `to_digest`).
- `crates/net/src/dnssec/nsec3.rs`: "returns both both the hash digest" -> "returns both the hash digest" (the doc for `hash_and_label`).

Documentation only.
