### PR TITLE
bin: skip configs with `dnssec_policy` when `__dnssec` is disabled

### DIFF
--- a/bin/src/config/tests.rs
+++ b/bin/src/config/tests.rs
@@ -461,6 +461,13 @@ fn test_reject_unknown_fields() {
                     skip = true;
                     break;
                 }
+
+                #[cfg(not(feature = "__dnssec"))]
+                if store.contains_key("dnssec_policy") {
+                    println!("skipping due to dnssec_policy setting");
+                    skip = true;
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #3811

The skip logic in test_reject_unknown_fields only looked at store types, so
example_recursor_dnssec.toml wasn't skipped in builds without __dnssec and the
test panicked parsing ValidateWithStaticKey.

Adds a check for the dnssec_policy field, same shape as the existing ones.