### PR TITLE
backport r0.26: Limit non-EDNS UDP responses to 512

### DIFF
--- a/crates/server/src/zone_handler/message_response.rs
+++ b/crates/server/src/zone_handler/message_response.rs
@@ -8,7 +8,7 @@
 use tracing::{debug, error};
 
 use crate::{
-    net::{udp::MAX_RECEIVE_BUFFER_SIZE, xfer::Protocol},
+    net::xfer::Protocol,
     proto::{
         ProtoError,
         op::{
@@ -90,8 +90,9 @@ where
         encoder.set_max_size(match protocol {
             Protocol::Udp => match &self.edns {
                 Some(edns) => edns.max_payload(),
-                // No EDNS, use the recommended max from RFC 6891
-                None => MAX_RECEIVE_BUFFER_SIZE as u16,
+                // No EDNS, so the requestor advertised no buffer and RFC 1035 section 4.2.1
+                // restricts the message to 512 bytes
+                None => 512,
             },
             _ => u16::MAX,
         });
@@ -289,8 +290,8 @@ mod tests {
     use std::net::Ipv4Addr;
     use std::str::FromStr;
 
-    use crate::proto::op::{Header, Message, MessageType, Metadata, OpCode};
-    use crate::proto::rr::{DNSClass, Name, RData, Record};
+    use crate::proto::op::{Header, Message, MessageType, Metadata, OpCode, Query};
+    use crate::proto::rr::{DNSClass, Name, RData, Record, RecordType};
     use crate::proto::serialize::binary::{BinDecodable, BinDecoder, BinEncoder};
 
     use super::*;
@@ -366,6 +367,38 @@ mod tests {
         assert!(response.metadata.truncation);
         assert_eq!(response.answers.len(), 0);
         assert!(response.authorities.len() > 1);
+    }
+
+    /// A response with no OPT record answers a request that had none, so RFC 1035 section 4.2.1
+    /// applies and the message may not exceed 512 bytes.
+    #[test]
+    fn test_non_edns_udp_response_is_bounded_at_512() {
+        let answer = Record::from_rdata(
+            Name::from_str("www.example.com.").unwrap(),
+            0,
+            RData::A(Ipv4Addr::new(93, 184, 215, 14).into()),
+        );
+
+        let request = MessageRequest::mock(
+            Metadata::new(10, MessageType::Query, OpCode::Query),
+            Query::query(Name::root(), RecordType::A),
+        );
+        assert_eq!(request.max_payload(), 512);
+
+        let response = MessageResponseBuilder::from_message_request(&request).build(
+            Metadata::new(10, MessageType::Response, OpCode::Query),
+            iter::repeat(&answer),
+            [],
+            [],
+            [],
+        );
+
+        let (_info, buf) = response.encode(Protocol::Udp).expect("failed to encode");
+        assert!(buf.len() <= 512, "response was {} bytes", buf.len());
+
+        let response = Message::from_vec(&buf).expect("failed to decode");
+        assert!(response.metadata.truncation);
+        assert!(response.answers.len() > 1);
     }
 
     // https://github.com/hickory-dns/hickory-dns/issues/2210


### PR DESCRIPTION
Backport of #3815 

MessageResponse::encode sized the encoder from MAX_RECEIVE_BUFFER_SIZE (4096) whenever the response carried no OPT record. A response carries none exactly when the request carried none, so that is the non-EDNS case, where RFC 1035 section 4.2.1 restricts a UDP message to 512 bytes. RFC 6891's recommended payload size applies to a buffer that a requestor advertised, and there is none to honour here.

MessageRequest::max_payload() already returns 512 for such a request, so the two sides of the server disagreed on the same message.

Non-EDNS clients that received up to 4096 bytes now get 512 with the TC bit set and retry over TCP.

Fixes #3814

Backported to release/0.26, where Query::root() does not exist. The new test builds the query with Query::query(Name::root(), RecordType::A) and imports Query and RecordType, which the test module on main already had in scope. The fix itself is unchanged.

(cherry picked from commit c127a73b934db934eb227f3d3d9e122c765ef209)