### PR TITLE
resolver: Accept "udp" and "tcp" as plain strings in protocol config

### DIFF
--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -22,7 +22,10 @@ use std::{fs, io};
 
 use ipnet::IpNet;
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
+use serde::{
+    Deserialize, Serialize,
+    de::{self, Visitor, value::MapAccessDeserializer},
+};
 use tracing::warn;
 #[cfg(all(
     feature = "toml",
@@ -396,6 +399,37 @@ impl ConnectionConfig {
 }
 
 #[cfg(feature = "serde")]
+fn connection_config_protocol_parser<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<ProtocolConfig, D::Error> {
+    struct ProtocolConfigVisitor;
+
+    impl<'de> Visitor<'de> for ProtocolConfigVisitor {
+        type Value = ProtocolConfig;
+
+        fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(r#"a string ("udp" | "tcp") or a protocol table"#)
+        }
+
+        fn visit_str<E: de::Error>(self, s: &str) -> Result<Self::Value, E> {
+            match s {
+                "tcp" => Ok(ProtocolConfig::Tcp),
+                "udp" => Ok(ProtocolConfig::Udp),
+                _ => Err(E::custom(
+                    r#"only "tcp" and "udp" are allowed in string form!"#,
+                )),
+            }
+        }
+
+        fn visit_map<A: de::MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {
+            ProtocolConfig::deserialize(MapAccessDeserializer::new(map))
+        }
+    }
+
+    deserializer.deserialize_any(ProtocolConfigVisitor)
+}
+
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for ConnectionConfig {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         #[derive(Deserialize)]
@@ -403,6 +437,7 @@ impl<'de> Deserialize<'de> for ConnectionConfig {
         struct OptionalParts {
             #[serde(default)]
             port: Option<u16>,
+            #[serde(deserialize_with = "connection_config_protocol_parser")]
             protocol: ProtocolConfig,
             #[serde(default)]
             bind_addr: Option<SocketAddr>,
@@ -1180,5 +1215,36 @@ mod tests {
             code.enable_per_name_server_metrics,
             json.enable_per_name_server_metrics
         );
+    }
+
+    #[test]
+    fn connection_config_protocol_forms() {
+        let config = toml::from_str::<ConnectionConfig>(r#"protocol = "udp""#).unwrap();
+        assert_eq!(config.protocol, ProtocolConfig::Udp);
+
+        let config = toml::from_str::<ConnectionConfig>(r#"protocol = "tcp""#).unwrap();
+        assert_eq!(config.protocol, ProtocolConfig::Tcp);
+
+        // The table form still works.
+        let config = toml::from_str::<ConnectionConfig>(r#"protocol = { type = "tcp" }"#).unwrap();
+        assert_eq!(config.protocol, ProtocolConfig::Tcp);
+
+        #[cfg(feature = "__tls")]
+        {
+            let config = toml::from_str::<ConnectionConfig>(
+                r#"protocol = { type = "tls", server_name = "example.com" }"#,
+            )
+            .unwrap();
+            assert_eq!(
+                config.protocol,
+                ProtocolConfig::Tls {
+                    server_name: Arc::from("example.com")
+                }
+            );
+            assert_eq!(config.port, 853);
+        }
+
+        // Only protocols without additional fields have a string form.
+        assert!(toml::from_str::<ConnectionConfig>(r#"protocol = "quic""#).is_err());
     }
 }

--- a/tests/test-data/test_configs/example_forwarder.toml
+++ b/tests/test-data/test_configs/example_forwarder.toml
@@ -43,8 +43,9 @@ type = "forward"
 [[zones.stores.name_servers]]
 ip = "8.8.8.8"
 trust_negative_responses = false
+## protocol is either a plain string ("udp" or "tcp") or a table, e.g. { type = "tls", server_name = "..." }
 connections = [
-    { protocol = { type = "udp" } },
+    { protocol = "udp" },
     { protocol = { type = "tcp" } },
 ]
 


### PR DESCRIPTION
Partially addresses #3303

# Summary
Allow passing "udp" and "tcp" as plain strings in protocol config.

```toml
# before
connections = [{ protocol = { type = "udp" } }]
# after
connections = [{ protocol = "udp" }]
```

- This is a purely additive change. The existing table format is still accepted for both "udp" and "tcp".
- Serialization isn't affected. It still outputs the table format.

# Changes:
- Add custom deserializer for `ConnectionConfig.protocol` which only allows the two string literals "udp" and "tcp" mapping to `ProtocolConfig::Udp` and `ProtocolConfig::Tcp` respectively, and defaults to table format for all the other enum variants.
- Add basic tests for `ConnectionConfig` deserialization in both formats.
- Add plain string example to the `example_forwarder.toml` example config.
