### PR TITLE
Order CNAME chain records in recursor answers

### DIFF
--- a/crates/resolver/src/recursor/handle.rs
+++ b/crates/resolver/src/recursor/handle.rs
@@ -317,16 +317,18 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
     ) -> Result<Message, RecursorError> {
         let query_type = query.query_type;
 
-        // Don't resolve CNAME lookups for a CNAME (or ANY) query
-        if query_type == RecordType::CNAME || query_type == RecordType::ANY {
-            return Ok(response);
-        }
-
         // Return early if there aren't any CNAME in the response.
         let has_cname = response
             .all_sections()
             .any(|rec| matches!(rec.data, CNAME(_)));
         if !has_cname {
+            return Ok(response);
+        }
+
+        // Don't resolve CNAME lookups for a CNAME (or ANY) query, but still order the chain
+        // the upstream returned.
+        if query_type == RecordType::CNAME || query_type == RecordType::ANY {
+            order_cname_chain(&mut response.answers, &query.name);
             return Ok(response);
         }
 
@@ -398,6 +400,8 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
         if !cname_chain.is_empty() {
             response.answers.extend(cname_chain);
         }
+
+        order_cname_chain(&mut response.answers, &query.name);
 
         Ok(response)
     }
@@ -919,6 +923,35 @@ fn name_server_config(
         OpportunisticEncryption::Enabled { .. } => NameServerConfig::opportunistic_encryption(ip),
         _ => NameServerConfig::udp_and_tcp(ip),
     }
+}
+
+/// Sort `answers` so a CNAME chain unrolls from `query_name`, the order clients such as glibc
+/// need to follow it.
+fn order_cname_chain(answers: &mut Vec<Record>, query_name: &Name) {
+    let mut ordered = Vec::with_capacity(answers.len());
+    let mut name = query_name.clone();
+
+    // Bounded by the same hop limit as the lookups above. Records left over, including any
+    // past that limit, keep their relative order at the end.
+    for _ in 0..MAX_CNAME_LOOKUPS {
+        let (matched, rest): (Vec<Record>, Vec<Record>) =
+            answers.drain(..).partition(|record| record.name == name);
+        *answers = rest;
+
+        let target = matched.iter().find_map(|record| match &record.data {
+            CNAME(cname) => Some(cname.0.clone()),
+            _ => None,
+        });
+        ordered.extend(matched);
+
+        match target {
+            Some(next) => name = next,
+            None => break,
+        }
+    }
+
+    ordered.append(answers);
+    *answers = ordered;
 }
 
 /// Maximum number of cname records to look up in a CNAME chain, regardless of the recursion

--- a/crates/resolver/src/recursor/tests.rs
+++ b/crates/resolver/src/recursor/tests.rs
@@ -1157,6 +1157,143 @@ enabled = {}
     }
 }
 
+fn chain_delegation() -> Result<Vec<MockRecord>, NetError> {
+    let tld_zone = Name::from_ascii("testing.")?;
+    let tld_ns = Name::from_ascii("testing.testing.")?;
+    let leaf_zone = Name::from_ascii("hickory-dns.testing.")?;
+    let leaf_ns = Name::from_ascii("ns.hickory-dns.testing.")?;
+
+    Ok(vec![
+        MockRecord::ns(ROOT_IP, &tld_zone, &tld_ns),
+        MockRecord::a(ROOT_IP, &tld_ns, TLD_IP)
+            .with_query_name(&tld_zone)
+            .with_query_type(RecordType::NS)
+            .with_section(MockResponseSection::Additional),
+        MockRecord::ns(TLD_IP, &leaf_zone, &leaf_ns),
+        MockRecord::a(TLD_IP, &leaf_ns, LEAF_IP)
+            .with_query_name(&leaf_zone)
+            .with_query_type(RecordType::NS)
+            .with_section(MockResponseSection::Additional),
+    ])
+}
+
+#[tokio::test]
+async fn cname_chain_answer_order() -> Result<(), NetError> {
+    subscribe();
+
+    let alias = Name::from_ascii("alias.hickory-dns.testing.")?;
+    let intermediate = Name::from_ascii("intermediate.hickory-dns.testing.")?;
+    let canonical = Name::from_ascii("canonical.hickory-dns.testing.")?;
+
+    let delegation = chain_delegation()?;
+
+    let alias_cname = MockRecord::cname(LEAF_IP, &alias, &intermediate).with_query_name(&alias);
+    let intermediate_cname =
+        MockRecord::cname(LEAF_IP, &intermediate, &canonical).with_query_name(&alias);
+    let canonical_a = MockRecord::a(LEAF_IP, &canonical, LEAF_IP).with_query_name(&alias);
+
+    // The authoritative server returns the whole chain in all three cases: the address record
+    // ahead of the aliases that lead to it, the aliases themselves reversed, and already
+    // unrolled.
+    let answer_orders = [
+        vec![
+            canonical_a.clone(),
+            alias_cname.clone(),
+            intermediate_cname.clone(),
+        ],
+        vec![
+            intermediate_cname.clone(),
+            alias_cname.clone(),
+            canonical_a.clone(),
+        ],
+        vec![alias_cname, intermediate_cname, canonical_a],
+    ];
+
+    for answers in answer_orders {
+        let mut responses = delegation.clone();
+        responses.extend(answers);
+
+        let recursor = Recursor::with_options(
+            &[ROOT_IP],
+            RecursorOptions {
+                deny_server: Vec::new(),
+                ..RecursorOptions::default()
+            },
+            MockProvider::new(MockNetworkHandler::new(responses)),
+        )?;
+
+        let response = recursor
+            .resolve(
+                Query::new(alias.clone(), RecordType::A),
+                Instant::now(),
+                false,
+            )
+            .await?;
+
+        let chain = response
+            .answers
+            .iter()
+            .map(|record| (record.name.clone(), record.record_type()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            chain,
+            vec![
+                (alias.clone(), RecordType::CNAME),
+                (intermediate.clone(), RecordType::CNAME),
+                (canonical.clone(), RecordType::A),
+            ]
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn cname_chain_answer_order_for_cname_query() -> Result<(), NetError> {
+    subscribe();
+
+    let alias = Name::from_ascii("alias.hickory-dns.testing.")?;
+    let intermediate = Name::from_ascii("intermediate.hickory-dns.testing.")?;
+    let canonical = Name::from_ascii("canonical.hickory-dns.testing.")?;
+
+    // A CNAME query does not resolve the chain, so the upstream order is all there is.
+    let mut responses = chain_delegation()?;
+    responses.extend([
+        MockRecord::cname(LEAF_IP, &intermediate, &canonical)
+            .with_query_name(&alias)
+            .with_query_type(RecordType::CNAME),
+        MockRecord::cname(LEAF_IP, &alias, &intermediate)
+            .with_query_name(&alias)
+            .with_query_type(RecordType::CNAME),
+    ]);
+
+    let recursor = Recursor::with_options(
+        &[ROOT_IP],
+        RecursorOptions {
+            deny_server: Vec::new(),
+            ..RecursorOptions::default()
+        },
+        MockProvider::new(MockNetworkHandler::new(responses)),
+    )?;
+
+    let response = recursor
+        .resolve(
+            Query::new(alias.clone(), RecordType::CNAME),
+            Instant::now(),
+            false,
+        )
+        .await?;
+
+    let names = response
+        .answers
+        .iter()
+        .map(|record| record.name.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec![alias, intermediate]);
+
+    Ok(())
+}
+
 const ROOT_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
 const TLD_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
 const LEAF_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 0, 3, 1));

--- a/tests/test-support/src/lib.rs
+++ b/tests/test-support/src/lib.rs
@@ -21,7 +21,7 @@ use hickory_proto::{
     op::{Message, OpCode, Query, ResponseCode},
     rr::{
         Name, RData, Record, RecordType,
-        rdata::{A, NS, SOA},
+        rdata::{A, CNAME, NS, SOA},
     },
     serialize::binary::BinDecodable,
 };
@@ -112,6 +112,18 @@ impl MockRecord {
             query_type: RecordType::A,
             record_name: rr_name.clone(),
             record_data: RData::A(A(v4)),
+            section: MockResponseSection::Answer,
+        }
+    }
+
+    pub fn cname(server: IpAddr, rr_name: &Name, target: &Name) -> Self {
+        Self {
+            ns: server,
+            ttl: 3600,
+            query_name: rr_name.clone(),
+            query_type: RecordType::A,
+            record_name: rr_name.clone(),
+            record_data: RData::CNAME(CNAME(target.clone())),
             section: MockResponseSection::Answer,
         }
     }


### PR DESCRIPTION
Refs #3641

The recursor hands back the answer section in whatever order the upstream sent it. `resolve_cnames` appends only the hops it resolves itself, and skips any hop whose target is already in the answer. So a response carrying the whole chain passes straight through.

glibc walks the chain from the query name. Put the `A` record ahead of its `CNAME`s and the lookup fails, even though every record is there.

`order_cname_chain` sorts the answer so the chain unrolls from the query name. Records outside the chain keep their relative order at the end, and the walk is bounded by `MAX_CNAME_LOOKUPS`.

I checked this against a local authoritative server that returns the chain address-record-first. 0.26.1 and main both forward the bad order. The patched build unrolls it, and does the same for a five-hop chain that arrived out of order.

This covers the recursor only. A `forward` zone takes a different path and still passes the upstream order through.

#3647 touches the same function. Nothing here depends on it, but this will want a rebase if that lands first.
