### PR TITLE
server: avoid full-zone scans for negative in-memory lookups

### DIFF
--- a/crates/server/src/store/in_memory/inner.rs
+++ b/crates/server/src/store/in_memory/inner.rs
@@ -49,6 +49,32 @@ pub(super) struct InnerInMemory {
 }
 
 impl InnerInMemory {
+    /// Returns whether a name owns an RRset or is an empty non-terminal.
+    pub(super) fn name_exists(&self, name: &LowerName) -> bool {
+        // RrKey orders by canonical DNS name, then by numeric record type. Within
+        // each relative/FQDN partition, a name and its descendants are contiguous,
+        // with the name itself first. Only the first key at or after this lower
+        // bound can establish its existence.
+        let contains_name = |search_name| {
+            let start = RrKey::new(search_name, RecordType::Unknown(u16::MIN));
+            self.records
+                .range(start..)
+                .next()
+                .is_some_and(|(key, _)| name.zone_of(key.name()))
+        };
+
+        if contains_name(name.clone()) {
+            return true;
+        }
+
+        // Name ordering separates relative and fully qualified names, whereas
+        // zone_of ignores that distinction. Preserve that behavior even when the
+        // publicly mutable record map contains both forms.
+        let mut other: Name = name.into();
+        other.set_fqdn(!other.is_fqdn());
+        contains_name(other.into())
+    }
+
     #[cfg(feature = "__dnssec")]
     pub(super) fn proof(
         &self,
@@ -969,8 +995,258 @@ fn finish_nsec_record(
 mod tests {
     use std::str::FromStr;
 
+    use super::super::InMemoryZoneHandler;
     use super::*;
-    use crate::proto::rr::{Name, Record, rdata::NS};
+    use crate::{
+        proto::{
+            op::ResponseCode,
+            rr::{
+                Name, Record,
+                rdata::{A, NS},
+            },
+        },
+        zone_handler::{AxfrPolicy, LookupError, ZoneHandler, ZoneType},
+    };
+
+    fn lower_name(name: &str) -> LowerName {
+        Name::from_str(name).unwrap().into()
+    }
+
+    fn insert_rrset(inner: &mut InnerInMemory, name: Name, record_type: RecordType) -> RrKey {
+        let key = RrKey::new((&name).into(), record_type);
+        inner
+            .records
+            .insert(key.clone(), Arc::new(RecordSet::new(name, record_type, 0)));
+        key
+    }
+
+    #[test]
+    fn test_name_exists() {
+        let mut inner = InnerInMemory::default();
+        assert!(!inner.name_exists(&lower_name(".")));
+
+        for owner in [
+            "a.example.com.",
+            "leaf.branch.example.com.",
+            "prefix-other.example.com.",
+            "*.wild.example.com.",
+            "z.example.net.",
+        ] {
+            insert_rrset(&mut inner, Name::from_str(owner).unwrap(), RecordType::A);
+        }
+
+        for name in [
+            ".",
+            "com.",
+            "example.com.",
+            "A.EXAMPLE.COM.",
+            "branch.example.com.",
+            "leaf.branch.example.com.",
+            "wild.example.com.",
+            "*.wild.example.com.",
+        ] {
+            assert!(inner.name_exists(&lower_name(name)), "{name}");
+        }
+
+        for name in [
+            "0.example.com.",
+            "b.example.com.",
+            "bran.example.com.",
+            "child.a.example.com.",
+            "prefix.example.com.",
+            "host.wild.example.com.",
+            "zz.example.com.",
+            "example.org.",
+        ] {
+            assert!(!inner.name_exists(&lower_name(name)), "{name}");
+        }
+    }
+
+    #[test]
+    fn test_name_exists_record_type_boundaries() {
+        for record_type in [RecordType::Unknown(u16::MIN), RecordType::Unknown(u16::MAX)] {
+            let mut inner = InnerInMemory::default();
+            insert_rrset(
+                &mut inner,
+                Name::from_str("leaf.example.com.").unwrap(),
+                record_type,
+            );
+            assert!(inner.name_exists(&lower_name("leaf.example.com.")));
+            assert!(inner.name_exists(&lower_name("example.com.")));
+            assert!(!inner.name_exists(&lower_name("z.example.com.")));
+        }
+    }
+
+    #[test]
+    fn test_name_exists_matches_scan_after_mutation() {
+        let owners = [
+            "a.example.com.",
+            "leaf.branch.example.com.",
+            "branch-other.example.com.",
+            "*.wild.example.com.",
+            "z.example.com.",
+            "example.net.",
+        ];
+        let queries = [
+            ".",
+            "com.",
+            "example.com.",
+            "a.example.com.",
+            "b.example.com.",
+            "branch.example.com.",
+            "leaf.branch.example.com.",
+            "child.leaf.branch.example.com.",
+            "branch-other.example.com.",
+            "wild.example.com.",
+            "*.wild.example.com.",
+            "other.wild.example.com.",
+            "z.example.com.",
+            "zz.example.com.",
+            "example.net.",
+            "example.org.",
+        ];
+        let check = |inner: &InnerInMemory| {
+            for query in queries {
+                for fqdn in [false, true] {
+                    let mut name = Name::from_str(query).unwrap();
+                    name.set_fqdn(fqdn);
+                    let name = LowerName::from(name);
+                    let expected = inner
+                        .records
+                        .keys()
+                        .any(|key| key.name() == &name || name.zone_of(key.name()));
+                    assert_eq!(inner.name_exists(&name), expected, "{name:?}");
+                }
+            }
+        };
+
+        let mut inner = InnerInMemory::default();
+        let mut inserted = Vec::new();
+        check(&inner);
+        for (index, owner) in owners.into_iter().enumerate() {
+            // Interleave both ordering partitions, including numeric type 0 and 65535.
+            for fqdn in [index % 2 == 0, index % 2 != 0] {
+                let mut name = Name::from_str(owner).unwrap();
+                name.set_fqdn(fqdn);
+                let record_type = if fqdn {
+                    RecordType::Unknown(u16::MIN)
+                } else {
+                    RecordType::Unknown(u16::MAX)
+                };
+                inserted.push(insert_rrset(&mut inner, name, record_type));
+                check(&inner);
+            }
+        }
+        for key in inserted.into_iter().rev() {
+            assert!(inner.records.remove(&key).is_some());
+            check(&inner);
+        }
+    }
+
+    async fn lookup_aaaa_error(zone: &InMemoryZoneHandler, name: &str) -> LookupError {
+        zone.lookup(
+            &lower_name(name),
+            RecordType::AAAA,
+            None,
+            LookupOptions::default(),
+        )
+        .await
+        .unwrap_err()
+    }
+
+    #[tokio::test]
+    async fn test_negative_lookup_responses_after_mutation() {
+        let origin = Name::from_str("example.com.").unwrap();
+        let mut zone: InMemoryZoneHandler = InMemoryZoneHandler::empty(
+            origin.clone(),
+            ZoneType::Primary,
+            AxfrPolicy::Deny,
+            #[cfg(feature = "__dnssec")]
+            None,
+        );
+        assert!(zone.upsert_mut(
+            Record::from_rdata(
+                origin,
+                300,
+                RData::SOA(SOA::new(
+                    Name::from_str("ns.example.com.").unwrap(),
+                    Name::from_str("hostmaster.example.com.").unwrap(),
+                    1,
+                    3600,
+                    600,
+                    86400,
+                    300,
+                )),
+            ),
+            1,
+        ));
+        for owner in [
+            "a.example.com.",
+            "leaf.branch.example.com.",
+            "z.example.com.",
+        ] {
+            assert!(zone.upsert_mut(
+                Record::from_rdata(
+                    Name::from_str(owner).unwrap(),
+                    300,
+                    RData::A(A::new(192, 0, 2, 1)),
+                ),
+                1,
+            ));
+        }
+
+        for name in ["example.com.", "a.example.com.", "branch.example.com."] {
+            assert!(
+                matches!(
+                    lookup_aaaa_error(&zone, name).await,
+                    LookupError::NameExists
+                ),
+                "{name}"
+            );
+        }
+        for name in ["0.example.com.", "b.example.com.", "zz.example.com."] {
+            assert!(
+                lookup_aaaa_error(&zone, name).await.is_nx_domain(),
+                "{name}"
+            );
+        }
+        assert!(matches!(
+            lookup_aaaa_error(&zone, "example.net.").await,
+            LookupError::ResponseCode(ResponseCode::Refused)
+        ));
+        let answer = zone
+            .lookup(
+                &lower_name("a.example.com."),
+                RecordType::A,
+                None,
+                LookupOptions::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            answer.iter().next().unwrap().data,
+            RData::A(A::new(192, 0, 2, 1))
+        );
+
+        let key = RrKey::new(lower_name("leaf.branch.example.com."), RecordType::A);
+        let rrset = zone.records_mut().await.remove(&key).unwrap();
+        assert!(
+            lookup_aaaa_error(&zone, "branch.example.com.")
+                .await
+                .is_nx_domain()
+        );
+        zone.records_get_mut().insert(key, rrset);
+        assert!(matches!(
+            lookup_aaaa_error(&zone, "branch.example.com.").await,
+            LookupError::NameExists
+        ));
+        zone.clear();
+        assert!(
+            lookup_aaaa_error(&zone, "branch.example.com.")
+                .await
+                .is_nx_domain()
+        );
+    }
 
     #[test]
     fn test_inner_lookup_delegation() {

--- a/crates/server/src/store/in_memory/inner.rs
+++ b/crates/server/src/store/in_memory/inner.rs
@@ -25,15 +25,16 @@ use crate::{
             rdata::{DNSSECRData, NSEC, NSEC3, NSEC3PARAM, RRSIG},
         },
     },
-    zone_handler::{LookupError, Nsec3QueryInfo},
+    zone_handler::Nsec3QueryInfo,
 };
 
 use super::maybe_next_name;
 use crate::{
+    proto::op::ResponseCode,
     proto::rr::{
         DNSClass, LowerName, Name, RData, Record, RecordSet, RecordType, RrKey, rdata::SOA,
     },
-    zone_handler::LookupOptions,
+    zone_handler::{LookupError, LookupOptions},
 };
 
 #[derive(Default)]
@@ -49,32 +50,6 @@ pub(super) struct InnerInMemory {
 }
 
 impl InnerInMemory {
-    /// Returns whether a name owns an RRset or is an empty non-terminal.
-    pub(super) fn name_exists(&self, name: &LowerName) -> bool {
-        // RrKey orders by canonical DNS name, then by numeric record type. Within
-        // each relative/FQDN partition, a name and its descendants are contiguous,
-        // with the name itself first. Only the first key at or after this lower
-        // bound can establish its existence.
-        let contains_name = |search_name| {
-            let start = RrKey::new(search_name, RecordType::Unknown(u16::MIN));
-            self.records
-                .range(start..)
-                .next()
-                .is_some_and(|(key, _)| name.zone_of(key.name()))
-        };
-
-        if contains_name(name.clone()) {
-            return true;
-        }
-
-        // Name ordering separates relative and fully qualified names, whereas
-        // zone_of ignores that distinction. Preserve that behavior even when the
-        // publicly mutable record map contains both forms.
-        let mut other: Name = name.into();
-        other.set_fqdn(!other.is_fqdn());
-        contains_name(other.into())
-    }
-
     #[cfg(feature = "__dnssec")]
     pub(super) fn proof(
         &self,
@@ -220,12 +195,13 @@ impl InnerInMemory {
         }
     }
 
+    /// A miss retains whether the original name owns records or has descendants.
     pub(super) fn inner_lookup(
         &self,
         name: &LowerName,
         record_type: RecordType,
         lookup_options: LookupOptions,
-    ) -> Option<Arc<RecordSet>> {
+    ) -> Result<Arc<RecordSet>, LookupError> {
         // Check for delegation
         let mut search_name = name.clone();
         while !search_name.is_root() {
@@ -241,7 +217,7 @@ impl InnerInMemory {
                 // Don't return a referral, DS record resides in the parent zone.
                 (Some(_), false) if ds_exact => {}
                 // Return a delegation point: NS exists without SOA.
-                (Some(ns), false) => return Some(ns.clone()),
+                (Some(ns), false) => return Ok(ns.clone()),
                 // Zone apex: NS with SOA - we're at the top of the zone
                 (Some(_), true) => break,
                 // No NS, keep walking up.
@@ -251,18 +227,44 @@ impl InnerInMemory {
             search_name = search_name.base_name();
         }
 
-        // this range covers all the records for any of the RecordTypes at a given label.
+        let (lookup, name_exists) = self.lookup_records(name, record_type);
+        if let Some(rrset) = lookup {
+            return Ok(rrset.clone());
+        }
+        // Preserve wildcard selection even when the original name exists.
+        if let Some(rrset) = self.inner_lookup_wildcard(name, record_type, lookup_options) {
+            return Ok(rrset);
+        }
+        if name_exists {
+            Err(LookupError::NameExists)
+        } else {
+            Err(ResponseCode::NXDomain.into())
+        }
+    }
+
+    fn lookup_records(
+        &self,
+        name: &LowerName,
+        record_type: RecordType,
+    ) -> (Option<&Arc<RecordSet>>, bool) {
+        // Keep the first key from the answer lookup to also establish whether
+        // the name owns records or is an empty non-terminal. Canonical ordering
+        // places the owner before its descendants within each FQDN partition.
         let start_range_key = RrKey::new(name.clone(), RecordType::Unknown(u16::MIN));
         let end_range_key = RrKey::new(name.clone(), RecordType::Unknown(u16::MAX));
+        let mut records = self.records.range(&start_range_key..).peekable();
+        let name_exists = records
+            .peek()
+            .is_some_and(|(key, _)| name.zone_of(key.name()));
 
         fn aname_covers_type(key_type: RecordType, query_type: RecordType) -> bool {
             (query_type == RecordType::A || query_type == RecordType::AAAA)
                 && key_type == RecordType::ANAME
         }
 
-        let lookup = self
-            .records
-            .range(&start_range_key..&end_range_key)
+        let lookup = records
+            // Preserve the original exclusive record-type upper bound.
+            .take_while(|(key, _)| *key < &end_range_key)
             // remember CNAME can be the only record at a particular label
             .find(|(key, _)| {
                 key.record_type == record_type
@@ -271,11 +273,19 @@ impl InnerInMemory {
             })
             .map(|(_key, rr_set)| rr_set);
 
-        // TODO: maybe unwrap this recursion.
-        match lookup {
-            None => self.inner_lookup_wildcard(name, record_type, lookup_options),
-            l => l.cloned(),
-        }
+        (lookup, name_exists)
+    }
+
+    pub(super) fn name_exists_other_form(&self, name: &LowerName) -> bool {
+        // zone_of ignores the relative/FQDN distinction, unlike map ordering.
+        // Only a negative lookup lacking evidence above needs this other probe.
+        let mut other: Name = name.into();
+        other.set_fqdn(!other.is_fqdn());
+        let start = RrKey::new(other.into(), RecordType::Unknown(u16::MIN));
+        self.records
+            .range(start..)
+            .next()
+            .is_some_and(|(key, _)| name.zone_of(key.name()))
     }
 
     fn inner_lookup_wildcard(
@@ -291,7 +301,7 @@ impl InnerInMemory {
 
         let mut wildcard = name.clone().into_wildcard();
         loop {
-            let Some(rrset) = self.inner_lookup(&wildcard, record_type, lookup_options) else {
+            let Ok(rrset) = self.inner_lookup(&wildcard, record_type, lookup_options) else {
                 let parent = wildcard.base_name();
                 if parent.is_root() {
                     return None;
@@ -386,14 +396,14 @@ impl InnerInMemory {
 
             match self.inner_lookup(&next_name, query_type, lookup_options) {
                 // Intermediate CNAME — keep chasing.
-                Some(rr_set) if rr_set.record_type() == RecordType::CNAME => chain.push(rr_set),
+                Ok(rr_set) if rr_set.record_type() == RecordType::CNAME => chain.push(rr_set),
                 // Terminal record (A, AAAA, MX, etc.).
-                Some(rr_set) => {
+                Ok(rr_set) => {
                     chain.push(rr_set);
                     break;
                 }
                 // Target not in this zone.
-                None => break,
+                Err(_) => break,
             }
         }
 
@@ -451,7 +461,7 @@ impl InnerInMemory {
                 let additional = self.inner_lookup(&search, *query_type, lookup_options);
                 names.insert(search);
 
-                let Some(additional) = additional else {
+                let Ok(additional) = additional else {
                     continue;
                 };
 
@@ -1012,6 +1022,13 @@ mod tests {
         Name::from_str(name).unwrap().into()
     }
 
+    // Test the map lookup separately from delegation/wildcard traversal, which
+    // requires fully qualified query names.
+    fn name_exists(inner: &InnerInMemory, name: &LowerName) -> bool {
+        let (_, exists) = inner.lookup_records(name, RecordType::AAAA);
+        exists || inner.name_exists_other_form(name)
+    }
+
     fn insert_rrset(inner: &mut InnerInMemory, name: Name, record_type: RecordType) -> RrKey {
         let key = RrKey::new((&name).into(), record_type);
         inner
@@ -1021,9 +1038,71 @@ mod tests {
     }
 
     #[test]
+    fn test_lookup_records_keeps_first_answer_and_name_state() {
+        let mut inner = InnerInMemory::default();
+        let owner = Name::from_str("host.example.com.").unwrap();
+        insert_rrset(&mut inner, owner.clone(), RecordType::A);
+        insert_rrset(&mut inner, owner.clone(), RecordType::TXT);
+        let name = LowerName::from(owner);
+        for record_type in [RecordType::A, RecordType::TXT] {
+            let (answer, exists) = inner.lookup_records(&name, record_type);
+            assert!(exists);
+            assert_eq!(answer.unwrap().record_type(), record_type);
+        }
+        let (answer, exists) = inner.lookup_records(&name, RecordType::AAAA);
+        assert!(answer.is_none());
+        assert!(exists);
+        let (answer, exists) = inner.lookup_records(&lower_name("example.com."), RecordType::A);
+        assert!(answer.is_none());
+        assert!(exists);
+    }
+
+    #[test]
+    fn test_negative_state_preserves_wildcard_fallback() {
+        let mut inner = InnerInMemory::default();
+        insert_rrset(
+            &mut inner,
+            Name::from_str("*.example.com.").unwrap(),
+            RecordType::A,
+        );
+        insert_rrset(
+            &mut inner,
+            Name::from_str("host.example.com.").unwrap(),
+            RecordType::TXT,
+        );
+        for query in ["new.example.com.", "host.example.com."] {
+            let name = lower_name(query);
+            let answer = inner
+                .inner_lookup(&name, RecordType::A, LookupOptions::default())
+                .unwrap();
+            assert_eq!(answer.record_type(), RecordType::A);
+            assert_eq!(LowerName::from(answer.name()), name);
+        }
+        assert!(matches!(
+            inner.inner_lookup(
+                &lower_name("host.example.com."),
+                RecordType::AAAA,
+                LookupOptions::default()
+            ),
+            Err(LookupError::NameExists)
+        ));
+        // Preserve the existing wildcard NODATA behavior; changing it is separate.
+        assert!(
+            inner
+                .inner_lookup(
+                    &lower_name("new.example.com."),
+                    RecordType::AAAA,
+                    LookupOptions::default()
+                )
+                .unwrap_err()
+                .is_nx_domain()
+        );
+    }
+
+    #[test]
     fn test_name_exists() {
         let mut inner = InnerInMemory::default();
-        assert!(!inner.name_exists(&lower_name(".")));
+        assert!(!name_exists(&inner, &lower_name(".")));
 
         for owner in [
             "a.example.com.",
@@ -1045,7 +1124,7 @@ mod tests {
             "wild.example.com.",
             "*.wild.example.com.",
         ] {
-            assert!(inner.name_exists(&lower_name(name)), "{name}");
+            assert!(name_exists(&inner, &lower_name(name)), "{name}");
         }
 
         for name in [
@@ -1058,7 +1137,7 @@ mod tests {
             "zz.example.com.",
             "example.org.",
         ] {
-            assert!(!inner.name_exists(&lower_name(name)), "{name}");
+            assert!(!name_exists(&inner, &lower_name(name)), "{name}");
         }
     }
 
@@ -1071,9 +1150,9 @@ mod tests {
                 Name::from_str("leaf.example.com.").unwrap(),
                 record_type,
             );
-            assert!(inner.name_exists(&lower_name("leaf.example.com.")));
-            assert!(inner.name_exists(&lower_name("example.com.")));
-            assert!(!inner.name_exists(&lower_name("z.example.com.")));
+            assert!(name_exists(&inner, &lower_name("leaf.example.com.")));
+            assert!(name_exists(&inner, &lower_name("example.com.")));
+            assert!(!name_exists(&inner, &lower_name("z.example.com.")));
         }
     }
 
@@ -1115,7 +1194,7 @@ mod tests {
                         .records
                         .keys()
                         .any(|key| key.name() == &name || name.zone_of(key.name()));
-                    assert_eq!(inner.name_exists(&name), expected, "{name:?}");
+                    assert_eq!(name_exists(inner, &name), expected, "{name:?}");
                 }
             }
         };
@@ -1210,6 +1289,27 @@ mod tests {
                 "{name}"
             );
         }
+        // A fully qualified query must still see relative owners/descendants
+        // inserted directly into the publicly mutable record map.
+        let mut relative = Name::from_str("leaf.relative.example.com.").unwrap();
+        relative.set_fqdn(false);
+        let key = RrKey::new(LowerName::from(&relative), RecordType::A);
+        zone.records_get_mut().insert(
+            key.clone(),
+            Arc::new(RecordSet::new(relative, RecordType::A, 300)),
+        );
+        for name in ["leaf.relative.example.com.", "relative.example.com."] {
+            assert!(matches!(
+                lookup_aaaa_error(&zone, name).await,
+                LookupError::NameExists
+            ));
+        }
+        zone.records_get_mut().remove(&key);
+        assert!(
+            lookup_aaaa_error(&zone, "relative.example.com.")
+                .await
+                .is_nx_domain()
+        );
         assert!(matches!(
             lookup_aaaa_error(&zone, "example.net.").await,
             LookupError::ResponseCode(ResponseCode::Refused)
@@ -1280,7 +1380,7 @@ mod tests {
         let result =
             inner.inner_lookup(&query_name.into(), RecordType::A, LookupOptions::default());
 
-        assert!(result.is_some());
+        assert!(result.is_ok());
         let rrset = result.unwrap();
         assert_eq!(rrset.record_type(), RecordType::NS);
         assert_eq!(rrset.name(), &sub);
@@ -1291,7 +1391,7 @@ mod tests {
             RecordType::DS,
             LookupOptions::default(),
         );
-        assert!(result.is_none());
+        assert!(matches!(result, Err(LookupError::NameExists)));
 
         // Lookup NS record at delegation point (should return NS record)
         let result = inner.inner_lookup(
@@ -1299,7 +1399,7 @@ mod tests {
             RecordType::NS,
             LookupOptions::default(),
         );
-        assert!(result.is_some());
+        assert!(result.is_ok());
         let rrset = result.unwrap();
         assert_eq!(rrset.record_type(), RecordType::NS);
         assert_eq!(rrset.name(), &sub);

--- a/crates/server/src/store/in_memory/mod.rs
+++ b/crates/server/src/store/in_memory/mod.rs
@@ -449,11 +449,6 @@ impl<P: RuntimeProvider + Send + Sync> ZoneHandler for InMemoryZoneHandler<P> {
             (None, answer, _) => (None, answer),
         };
 
-        // This is annoying. The 1035 spec literally specifies that most DNS authorities would want to store
-        //   records in a list except when there are a lot of records. But this makes indexed lookups by name+type
-        //   always return empty sets. This is only important in the negative case, where other DNS authorities
-        //   generally return NoError and no results when other types exist at the same name. bah.
-        // TODO: can we get rid of this?
         use LookupControlFlow::*;
         let answers = match (cname_chain, answer) {
             // CNAME chase produced a chain — use it as the answer.
@@ -461,11 +456,8 @@ impl<P: RuntimeProvider + Send + Sync> ZoneHandler for InMemoryZoneHandler<P> {
             (None, Some(rr_set)) => LookupRecords::new(lookup_options, rr_set),
             (None, None) => {
                 return Continue(Err(
-                    if inner
-                        .records
-                        .keys()
-                        .any(|key| key.name() == name || name.zone_of(key.name()))
-                    {
+                    // An existing owner or empty non-terminal is NODATA, not NXDOMAIN.
+                    if inner.name_exists(name) {
                         LookupError::NameExists
                     } else {
                         LookupError::from(match self.origin().zone_of(name) {

--- a/crates/server/src/store/in_memory/mod.rs
+++ b/crates/server/src/store/in_memory/mod.rs
@@ -456,7 +456,9 @@ impl<P: RuntimeProvider + Send + Sync> ZoneHandler for InMemoryZoneHandler<P> {
             (None, Some(rr_set)) => LookupRecords::new(lookup_options, rr_set),
             (None, None) => {
                 return Continue(Err(
-                    // An existing owner or empty non-terminal is NODATA, not NXDOMAIN.
+                    // A name/type lookup miss does not imply the name is absent.
+                    // Existing owners and empty non-terminals yield NODATA, not NXDOMAIN
+                    // (RFC 2308 §2.2; RFC 4592 §2.2.2).
                     if inner.name_exists(name) {
                         LookupError::NameExists
                     } else {

--- a/crates/server/src/store/in_memory/mod.rs
+++ b/crates/server/src/store/in_memory/mod.rs
@@ -351,7 +351,26 @@ impl<P: RuntimeProvider + Send + Sync> ZoneHandler for InMemoryZoneHandler<P> {
             query_type = inner.replace_any(name);
         }
 
-        let answer = inner.inner_lookup(name, query_type, lookup_options);
+        let answer = match inner.inner_lookup(name, query_type, lookup_options) {
+            Ok(answer) => Some(answer),
+            Err(error) => {
+                // The answer lookup already checked the query's name partition.
+                // Only probe the other form for a miss lacking that evidence;
+                // recursive wildcard/additional lookups do not need this check.
+                let error = if error.is_nx_domain() {
+                    if inner.name_exists_other_form(name) {
+                        LookupError::NameExists
+                    } else if !self.origin().zone_of(name) {
+                        LookupError::from(ResponseCode::Refused)
+                    } else {
+                        error
+                    }
+                } else {
+                    error
+                };
+                return Continue(Err(error));
+            }
+        };
 
         // CNAME chasing: when the answer is a CNAME and the query was for a
         // different type, restart the lookup at the canonical name and collect
@@ -454,21 +473,7 @@ impl<P: RuntimeProvider + Send + Sync> ZoneHandler for InMemoryZoneHandler<P> {
             // CNAME chase produced a chain — use it as the answer.
             (Some(chain), _) => LookupRecords::many(lookup_options, chain),
             (None, Some(rr_set)) => LookupRecords::new(lookup_options, rr_set),
-            (None, None) => {
-                return Continue(Err(
-                    // A name/type lookup miss does not imply the name is absent.
-                    // Existing owners and empty non-terminals yield NODATA, not NXDOMAIN
-                    // (RFC 2308 §2.2; RFC 4592 §2.2.2).
-                    if inner.name_exists(name) {
-                        LookupError::NameExists
-                    } else {
-                        LookupError::from(match self.origin().zone_of(name) {
-                            true => ResponseCode::NXDomain,
-                            false => ResponseCode::Refused,
-                        })
-                    },
-                ));
-            }
+            (None, None) => unreachable!("lookup misses return before answer processing"),
         };
 
         Continue(Ok(AuthLookup::answers(


### PR DESCRIPTION
<h2>Summary</h2><p>Replace the full-zone scan used to distinguish NODATA from NXDOMAIN after an unsuccessful in-memory authoritative lookup.</p><p>The existing <code dir="ltr">BTreeMap</code> already orders records by canonical DNS name and record type. A lower-bound search can therefore determine whether a name or one of its descendants exists in O(log N). The implementation checks both relative and fully qualified name partitions to preserve the existing predicate’s behavior.</p><p>This adds no persistent index, dependency, or public API. It also remains correct after direct record-map mutation.</p><h2>Testing</h2><p>Added regression coverage for existing owners, empty non-terminals, missing names, record-type boundaries, mixed relative/FQDN names, and record insertion/removal. Tests also compare the new implementation against the previous scan.</p><p>Validated with Rust 1.95.0:</p><ul><li>Server library tests: 26 passed</li><li>Server library with <code dir="ltr">dnssec-ring,sqlite</code>: 28 passed</li><li>Binary integration tests without default features: 40 passed</li><li>Formatting and strict Clippy: passed</li></ul><h2>Performance</h2><p>A release-mode benchmark calls the public <code dir="ltr">ZoneHandler::lookup</code> API against synthetic zones containing one SOA and A-only owners.</p><div><div><div>
<table>
<tr><th>Owners</th><th>NXDOMAIN, before → after</th><th>AAAA NODATA, before → after</th></tr>
<tr><td>1,000</td><td>61.250 → 5.017 µs</td><td>69.398 → 5.185 µs</td></tr>
<tr><td>10,000</td><td>566.866 → 5.697 µs</td><td>667.812 → 6.067 µs</td></tr>
<tr><td>100,000</td><td>7,940.003 → 6.993 µs</td><td>8,684.727 → 7.440 µs</td></tr>
</table>

</div></div></div><p>Results are medians of nine warmed samples. The NODATA case deliberately exercises the old scan’s worst case. These are local microbenchmarks, not production or wire-level latency measurements.</p><h2>Scope</h2><p>This preserves existing response-code selection and does not address the separate wildcard NODATA behavior in #2905. It may overlap with the <code dir="ltr">name_exists</code> helper introduced by #3489; the range-based implementation could serve those checks as well.</p>