### PR TITLE
Fix validation with multiple RRSIGs

### DIFF
--- a/crates/net/src/dnssec/mod.rs
+++ b/crates/net/src/dnssec/mod.rs
@@ -986,18 +986,28 @@ impl<H: DnsHandle> DnssecDnsHandle<H> {
                         .first_answer()
                         .map(move |result| match result {
                             Ok(message) => {
-                                let verdict_opt = verify_rrsig_with_keys(
+                                // Report a failed signature as an error, so that select_ok()
+                                // below tries the remaining RRSIGs.
+                                match verify_rrsig_with_keys(
                                     message,
                                     &rrsig,
                                     key,
                                     rrset,
                                     current_time,
-                                );
-                                Ok(verdict_opt.map(|(proof, adjusted_ttl)| RrsetProof {
-                                    proof,
-                                    adjusted_ttl,
-                                    rrsig_index: Some(i),
-                                }))
+                                ) {
+                                    Some((proof, adjusted_ttl)) => Ok(RrsetProof {
+                                        proof,
+                                        adjusted_ttl,
+                                        rrsig_index: Some(i),
+                                    }),
+                                    None => Err(ProofError::new(
+                                        Proof::Bogus,
+                                        ProofErrorKind::RrsigsUnverified {
+                                            name: Name::from(&key.name),
+                                            record_type: key.record_type,
+                                        },
+                                    )),
+                                }
                             }
                             Err(net) => Err(ProofError::new(
                                 Proof::Bogus,
@@ -1020,19 +1030,10 @@ impl<H: DnsHandle> DnssecDnsHandle<H> {
         }
 
         // as long as any of the verifications is good, then the RRSET is valid.
-        let select = future::select_ok(verifications);
-
-        // this will return either a good result or the errors
-        let (proof, rest) = select.await?;
+        let (proof, rest) = future::select_ok(verifications).await?;
         drop(rest);
 
-        proof.ok_or_else(||
-            // we are in a bogus state, DS records were available (see beginning of function), but RRSIGs couldn't be verified
-            ProofError::new(Proof::Bogus, ProofErrorKind::RrsigsUnverified {
-                name: Name::from(&key.name),
-                record_type: key.record_type,
-            }
-        ))
+        Ok(proof)
     }
 
     /// An internal function used to clone the handle, but maintain some information back to the

--- a/crates/proto/src/dnssec/mod.rs
+++ b/crates/proto/src/dnssec/mod.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 
 use crate::dnssec::crypto::Digest;
 use crate::error::ProtoError;
-use crate::rr::{Name, RData, Record, rdata::tsig::TsigAlgorithm};
+use crate::rr::{Name, RData, Record, RecordType, rdata::tsig::TsigAlgorithm};
 use crate::serialize::binary::{BinEncodable, BinEncoder, DecodeError, NameEncoding};
 
 mod algorithm;
@@ -384,7 +384,7 @@ impl Clone for DnsSecError {
 }
 
 /// DNSSEC status of an answer
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum DnssecSummary {
     /// All records have been DNSSEC validated
     Secure,
@@ -396,9 +396,15 @@ pub enum DnssecSummary {
 
 impl DnssecSummary {
     /// Whether the records have been DNSSEC validated or not
+    ///
+    /// RRSIGs are skipped, since only the RRSIG used for verification carries the RRset's proof.
     pub fn from_records<'a>(records: impl Iterator<Item = &'a Record>) -> Self {
         let mut all_secure = None;
         for record in records {
+            if record.record_type() == RecordType::RRSIG {
+                continue;
+            }
+
             match &record.proof {
                 Proof::Secure => {
                     all_secure.get_or_insert(true);
@@ -523,6 +529,120 @@ mod test_utils {
             neg_dns_key.verify(tbs.as_ref(), &sig).is_err(),
             "algorithm: {:?} (dnskey, neg)",
             neg_pub_key.algorithm(),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+    use core::net::Ipv4Addr;
+
+    use super::rdata::{DNSSECRData, RRSIG, SigInput};
+    use super::*;
+    use crate::rr::SerialNumber;
+
+    fn a_record(name: &Name, proof: Proof) -> Record {
+        let mut record = Record::from_rdata(
+            name.clone(),
+            3600,
+            RData::A(Ipv4Addr::new(192, 0, 2, 1).into()),
+        );
+        record.proof = proof;
+        record
+    }
+
+    fn rrsig_record(name: &Name, algorithm: Algorithm, proof: Proof) -> Record {
+        let input = SigInput {
+            type_covered: RecordType::A,
+            algorithm,
+            num_labels: 2,
+            original_ttl: 3600,
+            sig_expiration: SerialNumber(0),
+            sig_inception: SerialNumber(0),
+            key_tag: 0,
+            signer_name: Name::root(),
+        };
+        let mut record = Record::from_rdata(
+            name.clone(),
+            3600,
+            RData::DNSSEC(DNSSECRData::RRSIG(RRSIG::from_sig(input, vec![]))),
+        );
+        record.proof = proof;
+        record
+    }
+
+    /// Only the RRSIG used for verification is marked, the other one stays Indeterminate.
+    #[test]
+    fn summary_ignores_unused_rrsig() {
+        let name = Name::from_ascii("www.example.").unwrap();
+        let records = [
+            a_record(&name, Proof::Secure),
+            rrsig_record(&name, Algorithm::ECDSAP256SHA256, Proof::Secure),
+            rrsig_record(&name, Algorithm::RSASHA256, Proof::Indeterminate),
+        ];
+
+        assert_eq!(
+            DnssecSummary::from_records(records.iter()),
+            DnssecSummary::Secure
+        );
+    }
+
+    #[test]
+    fn summary_follows_rrset_proof() {
+        let name = Name::from_ascii("www.example.").unwrap();
+        for (proof, expected) in [
+            (Proof::Secure, DnssecSummary::Secure),
+            (Proof::Insecure, DnssecSummary::Insecure),
+            (Proof::Indeterminate, DnssecSummary::Insecure),
+            (Proof::Bogus, DnssecSummary::Bogus),
+        ] {
+            let records = [
+                a_record(&name, proof),
+                rrsig_record(&name, Algorithm::ECDSAP256SHA256, proof),
+            ];
+            assert_eq!(DnssecSummary::from_records(records.iter()), expected);
+        }
+    }
+
+    /// The proof of an RRSIG must not override the proof of the records it covers.
+    #[test]
+    fn summary_ignores_rrsig_proof() {
+        let name = Name::from_ascii("www.example.").unwrap();
+        let records = [
+            a_record(&name, Proof::Bogus),
+            rrsig_record(&name, Algorithm::ECDSAP256SHA256, Proof::Secure),
+        ];
+        assert_eq!(
+            DnssecSummary::from_records(records.iter()),
+            DnssecSummary::Bogus
+        );
+
+        let records = [
+            a_record(&name, Proof::Insecure),
+            rrsig_record(&name, Algorithm::ECDSAP256SHA256, Proof::Secure),
+        ];
+        assert_eq!(
+            DnssecSummary::from_records(records.iter()),
+            DnssecSummary::Insecure
+        );
+    }
+
+    #[test]
+    fn summary_of_rrsigs_only_is_insecure() {
+        let name = Name::from_ascii("www.example.").unwrap();
+        let records = [rrsig_record(
+            &name,
+            Algorithm::ECDSAP256SHA256,
+            Proof::Secure,
+        )];
+        assert_eq!(
+            DnssecSummary::from_records(records.iter()),
+            DnssecSummary::Insecure
+        );
+        assert_eq!(
+            DnssecSummary::from_records([].iter()),
+            DnssecSummary::Insecure
         );
     }
 }

--- a/tests/integration-tests/tests/integration/main.rs
+++ b/tests/integration-tests/tests/integration/main.rs
@@ -6,6 +6,7 @@ mod dnssec_client_handle_tests;
 mod invalid_nsec3_tests;
 mod invalid_nsec_tests;
 mod lookup_tests;
+mod multiple_rrsig_tests;
 mod name_server_pool_tests;
 mod retry_dns_handle_tests;
 mod rfc4592_tests;

--- a/tests/integration-tests/tests/integration/multiple_rrsig_tests.rs
+++ b/tests/integration-tests/tests/integration/multiple_rrsig_tests.rs
@@ -1,0 +1,288 @@
+#![cfg(feature = "__dnssec")]
+
+//! These tests confirm that an RRset with more than one RRSIG validates if any one of them can be
+//! verified, regardless of the order of the RRSIGs in the response.
+
+use std::{sync::Arc, time::Duration};
+
+use hickory_integration::{
+    generate_key,
+    mock_request_handler::{MockHandler, fetch_dnskey},
+    print_response, setup_dnssec_client_server,
+};
+use hickory_net::client::ClientHandle;
+use hickory_proto::{
+    dnssec::{
+        Algorithm, DnssecSigner, Proof, SigningKey,
+        rdata::{DNSKEY, DNSSECRData, RRSIG},
+    },
+    op::{DnsResponse, ResponseCode},
+    rr::{
+        DNSClass, Name, RData, Record, RecordType,
+        rdata::{A, NS, SOA},
+    },
+};
+use hickory_server::{
+    dnssec::NxProofKind,
+    store::in_memory::InMemoryZoneHandler,
+    zone_handler::{AxfrPolicy, Catalog, ZoneType},
+};
+use test_support::subscribe;
+
+/// How to derive an RRSIG that can't be verified from a genuine one.
+#[derive(Clone, Copy, Debug)]
+enum BadRrsig {
+    /// Algorithm not supported by hickory (ED448).
+    UnsupportedAlgorithm,
+    /// Key tag not present in the DNSKEY RRset.
+    UnknownKeyTag,
+    /// Signature does not match the RRset.
+    CorruptSignature,
+}
+
+/// Position of the bad RRSIG relative to the genuine one.
+#[derive(Clone, Copy, Debug)]
+enum Position {
+    Before,
+    After,
+}
+
+#[tokio::test]
+async fn unsupported_algorithm_rrsig_before_valid_rrsig() {
+    test_extra_rrsig(BadRrsig::UnsupportedAlgorithm, Position::Before).await;
+}
+
+#[tokio::test]
+async fn unsupported_algorithm_rrsig_after_valid_rrsig() {
+    test_extra_rrsig(BadRrsig::UnsupportedAlgorithm, Position::After).await;
+}
+
+#[tokio::test]
+async fn unknown_key_tag_rrsig_before_valid_rrsig() {
+    test_extra_rrsig(BadRrsig::UnknownKeyTag, Position::Before).await;
+}
+
+#[tokio::test]
+async fn unknown_key_tag_rrsig_after_valid_rrsig() {
+    test_extra_rrsig(BadRrsig::UnknownKeyTag, Position::After).await;
+}
+
+#[tokio::test]
+async fn corrupt_rrsig_before_valid_rrsig() {
+    test_extra_rrsig(BadRrsig::CorruptSignature, Position::Before).await;
+}
+
+#[tokio::test]
+async fn corrupt_rrsig_after_valid_rrsig() {
+    test_extra_rrsig(BadRrsig::CorruptSignature, Position::After).await;
+}
+
+#[tokio::test]
+async fn only_unverifiable_rrsigs() {
+    subscribe();
+
+    let (response, dnskey_response, genuine_rrsig) = honest_response().await;
+
+    let mut modified_response = response.clone();
+    modified_response
+        .answers
+        .retain(|record| record.record_type() != RecordType::RRSIG);
+    modified_response.answers.push(derive_bad_rrsig(
+        &genuine_rrsig,
+        BadRrsig::UnsupportedAlgorithm,
+    ));
+    modified_response
+        .answers
+        .push(derive_bad_rrsig(&genuine_rrsig, BadRrsig::CorruptSignature));
+
+    let response = query_mock(modified_response, dnskey_response).await;
+    assert_proof(&response, Proof::Bogus);
+}
+
+async fn test_extra_rrsig(bad_rrsig: BadRrsig, position: Position) {
+    subscribe();
+
+    let (response, dnskey_response, genuine_rrsig) = honest_response().await;
+
+    let mut modified_response = response.clone();
+    let bad_rrsig = derive_bad_rrsig(&genuine_rrsig, bad_rrsig);
+    let genuine_index = modified_response
+        .answers
+        .iter()
+        .position(|record| record.record_type() == RecordType::RRSIG)
+        .expect("genuine RRSIG not found in response");
+    match position {
+        Position::Before => modified_response.answers.insert(genuine_index, bad_rrsig),
+        Position::After => modified_response
+            .answers
+            .insert(genuine_index + 1, bad_rrsig),
+    }
+
+    let response = query_mock(modified_response, dnskey_response).await;
+    assert_proof(&response, Proof::Secure);
+}
+
+/// Queries the honest server for `www.example. IN A`, returning the response, the DNSKEY
+/// response, and the RRSIG covering the A RRset.
+async fn honest_response() -> (DnsResponse, DnsResponse, Record<RRSIG>) {
+    let (key, public_key) = generate_key();
+    let catalog = example_zone_catalog(key);
+    let (mut client, _honest_server) =
+        setup_dnssec_client_server(catalog, &public_key, zone_name().into()).await;
+
+    let response = client
+        .query(query_name(), DNSClass::IN, RecordType::A)
+        .await
+        .unwrap();
+    print_response(&response);
+    assert_eq!(response.metadata.response_code, ResponseCode::NoError);
+    assert_proof(&response, Proof::Secure);
+
+    let rrsigs = response
+        .answers
+        .iter()
+        .filter_map(|record| {
+            record.clone().map(|data| match data {
+                RData::DNSSEC(DNSSECRData::RRSIG(rrsig)) => Some(rrsig),
+                _ => None,
+            })
+        })
+        .collect::<Vec<_>>();
+    let [genuine_rrsig] = rrsigs.as_slice() else {
+        panic!("expected exactly one RRSIG in the honest response: {rrsigs:?}");
+    };
+
+    let dnskey_response = fetch_dnskey(&mut client).await;
+    (response, dnskey_response, genuine_rrsig.clone())
+}
+
+/// Serves `response` from a mock server and returns the validated response.
+async fn query_mock(response: DnsResponse, dnskey_response: DnsResponse) -> DnsResponse {
+    let RData::DNSSEC(DNSSECRData::DNSKEY(dnskey)) = &dnskey_response.answers[0].data else {
+        panic!("expected DNSKEY in DNSKEY response: {dnskey_response:#?}");
+    };
+
+    let mock = MockHandler::new(
+        query_name().into(),
+        RecordType::A,
+        response,
+        dnskey_response.clone(),
+    );
+    let (mut client, _mock_server) =
+        setup_dnssec_client_server(mock, dnskey.public_key(), zone_name().into()).await;
+
+    let response = client
+        .query(query_name(), DNSClass::IN, RecordType::A)
+        .await
+        .unwrap();
+    print_response(&response);
+    response
+}
+
+fn derive_bad_rrsig(genuine: &Record<RRSIG>, kind: BadRrsig) -> Record {
+    let mut input = genuine.data.input().clone();
+    let mut sig = genuine.data.sig().to_vec();
+    match kind {
+        BadRrsig::UnsupportedAlgorithm => input.algorithm = Algorithm::Unknown(16),
+        BadRrsig::UnknownKeyTag => input.key_tag = input.key_tag.wrapping_add(1),
+        BadRrsig::CorruptSignature => sig[0] = !sig[0],
+    }
+
+    Record::from_rdata(
+        genuine.name.clone(),
+        genuine.ttl,
+        RData::DNSSEC(DNSSECRData::RRSIG(RRSIG::from_sig(input, sig))),
+    )
+}
+
+fn assert_proof(response: &DnsResponse, expected: Proof) {
+    let a_records = response
+        .answers
+        .iter()
+        .filter(|record| record.record_type() == RecordType::A)
+        .collect::<Vec<_>>();
+    assert!(
+        !a_records.is_empty(),
+        "no A records in response: {response:#?}"
+    );
+    for record in a_records {
+        assert_eq!(record.proof, expected, "unexpected proof for {record}");
+    }
+}
+
+fn query_name() -> Name {
+    Name::parse("www.example.", None).unwrap()
+}
+
+fn zone_name() -> Name {
+    Name::parse("example.", None).unwrap()
+}
+
+/// Constructs a catalog with a minimal signed `example.` zone.
+fn example_zone_catalog(key: Box<dyn SigningKey>) -> Catalog {
+    let origin = zone_name();
+    let mut handler: InMemoryZoneHandler = InMemoryZoneHandler::empty(
+        origin.clone(),
+        ZoneType::Primary,
+        AxfrPolicy::Deny,
+        Some(NxProofKind::Nsec),
+    );
+
+    const SERIAL: u32 = 1;
+    const TTL: u32 = 3600;
+
+    handler.upsert_mut(
+        Record::from_rdata(
+            origin.clone(),
+            TTL,
+            RData::SOA(SOA::new(
+                Name::parse("ns1", Some(&origin)).unwrap(),
+                Name::parse("hostmaster", Some(&origin)).unwrap(),
+                SERIAL,
+                3600,
+                300,
+                3600000,
+                TTL,
+            )),
+        ),
+        SERIAL,
+    );
+    handler.upsert_mut(
+        Record::from_rdata(
+            origin.clone(),
+            TTL,
+            RData::NS(NS(Name::parse("ns1", Some(&origin)).unwrap())),
+        ),
+        SERIAL,
+    );
+    handler.upsert_mut(
+        Record::from_rdata(
+            Name::parse("ns1", Some(&origin)).unwrap(),
+            TTL,
+            RData::A(A::new(192, 0, 2, 1)),
+        ),
+        SERIAL,
+    );
+    handler.upsert_mut(
+        Record::from_rdata(
+            Name::parse("www", Some(&origin)).unwrap(),
+            TTL,
+            RData::A(A::new(192, 0, 2, 2)),
+        ),
+        SERIAL,
+    );
+
+    handler
+        .add_zone_signing_key_mut(DnssecSigner::new(
+            DNSKEY::from_key(&key.to_public_key().unwrap()),
+            key,
+            origin.clone(),
+            Duration::from_secs(86400),
+        ))
+        .unwrap();
+    handler.secure_zone_mut().unwrap();
+
+    let mut catalog = Catalog::new();
+    catalog.upsert(origin.into(), vec![Arc::new(handler)]);
+    catalog
+}


### PR DESCRIPTION
`verify_default_rrset()` races the RRSIG verifications with `select_ok()`, but a
signature that failed to verify was reported as `Ok(None)`, which `select_ok()`
takes as success. The first RRSIG to complete decided the result, so an RRset
with a valid second signature could come back Bogus depending on the order of
the RRSIGs in the response.

This is visible for zones signed with two algorithms, e.g. mailbox.org
(RSASHA1-NSEC3-SHA1 + ECDSAP256SHA256): on 0.26.1, `mailbox.org. MX` is Bogus
whenever the alg 7 RRSIG comes first. #3690 fixed the alg 7 verification, which
hides the problem for that zone, but the same thing happens for any RRset where
one signature is stale, corrupt, or uses an unsupported algorithm.

The second commit makes `DnssecSummary::from_records()` skip RRSIGs. Since
56abc2e8d only the RRSIG used for verification gets the RRset's proof, the
unused one stays Indeterminate and the server never set AD for such zones.

Adds integration tests for RRsets with multiple RRSIGs (unsupported algorithm,
unknown key tag, corrupt signature, in either order). The "bad RRSIG first"
cases fail without these changes.

Related: #3690. A backport for `release/0.26` is on https://github.com/MartB/hickory-dns/tree/fix/multi-rrsig-validation-0.26