### PR TITLE
proto: Don't compile with once_cell/critical-section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ libc = "0.2"
 lru-cache = "0.1.2"
 moka = "0.12"
 ndk-context = "0.1.1"
-once_cell = { version = "1.20.0", default-features = false, features = ["critical-section"] }
+once_cell = { version = "1.20.0", default-features = false }
 prefix-trie = "0.9.2"
 rand = { version = "0.10.0", default-features = false, features = ["alloc"] }
 regex = { version = "1.3.4", default-features = false }

--- a/conformance/Cargo.lock
+++ b/conformance/Cargo.lock
@@ -176,12 +176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,10 +886,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
 
 [[package]]
 name = "ordered-float"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -91,12 +91,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,10 +442,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -464,12 +454,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"


### PR DESCRIPTION
Due to how workspaces work, having the top-level workspace `once_cell` definition include the feature `critical-section` means that all uses of `once_cell` will gain that feature, like in `hickory-proto` or `hickory-resolver`. From what I understand from #2878, the intention is to only enable `once_cell/critical-section` only when `hickory-proto` is compiled with `default-features: false` and with the feature `no-std-rand`, which this patch should fix.

Before this patch you can see that this feature is enabled by default by doing:

```
% cd crates/proto
% cargo tree -i once_cell -e features | grep "once_cell feature"
├── once_cell feature "alloc"
│   └── once_cell feature "std"
│       └── once_cell feature "default"
├── once_cell feature "critical-section"
├── once_cell feature "default" (*)
├── once_cell feature "portable-atomic"
│   └── once_cell feature "critical-section" (*)
├── once_cell feature "race"
│   └── once_cell feature "alloc" (*)
└── once_cell feature "std" (*)
```

Afterwards it should be:

```
├── once_cell feature "alloc"
│   └── once_cell feature "std"
│       └── once_cell feature "default"
├── once_cell feature "default" (*)
├── once_cell feature "race"
│   └── once_cell feature "alloc" (*)
└── once_cell feature "std" (*)
```