### PR TITLE
resolver: Fix 'unused method' with features `blocklist,tls-ring`

### DIFF
--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -14,6 +14,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 #[cfg(all(
+    feature = "recursor",
     feature = "toml",
     feature = "serde",
     any(feature = "__tls", feature = "__quic")
@@ -25,6 +26,7 @@ use ipnet::IpNet;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 #[cfg(all(
+    feature = "recursor",
     feature = "toml",
     feature = "serde",
     any(feature = "__tls", feature = "__quic")
@@ -32,6 +34,7 @@ use tracing::warn;
 use tracing::{debug, info};
 
 #[cfg(all(
+    feature = "recursor",
     feature = "toml",
     feature = "serde",
     any(feature = "__tls", feature = "__quic")
@@ -804,6 +807,7 @@ pub enum OpportunisticEncryption {
 
 impl OpportunisticEncryption {
     #[cfg(all(
+        feature = "recursor",
         feature = "toml",
         feature = "serde",
         any(feature = "__tls", feature = "__quic")


### PR DESCRIPTION
This silences a warning if you run `cargo test --package hickory-dns --features blocklist,tls-ring`.