### PR TITLE
Switch from cargo-all-features to cargo-hack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,29 +134,29 @@ jobs:
         run: just ${{ matrix.feature }}
 
   check-all-features-matrix:
-    name: cargo-all-features
+    name: cargo-hack / ${{ matrix.partition }}
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
       matrix:
-        chunk:
-          - 1
-          - 2
-          - 3
-          - 4
+        partition:
+          - 1/4
+          - 2/4
+          - 3/4
+          - 4/4
     steps:
       - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - name: cargo install cargo-all-features
+      - name: cargo install cargo-hack
         uses: baptiste0928/cargo-install@v3
         with:
-          crate: cargo-all-features
-          version: 1.12.0
+          crate: cargo-hack
+          version: 0.6.45
 
-      - name: cargo check-all-features
-        run: cargo check-all-features --n-chunks 4 --chunk ${{ matrix.chunk }}
+      - name: cargo hack check (workspace)
+        run: cargo hack check --workspace --feature-powerset --depth 2 --skip __tls,__https,__quic,__h3,__dnssec --partition ${{ matrix.partition }}
 
   ## Check past and future versions
   ##   this enforces the minimum version of rust this project works with

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -122,8 +122,3 @@ prometheus-parse = { workspace = true }
 
 [lints]
 workspace = true
-
-[package.metadata.cargo-all-features]
-skip_optional_dependencies = true
-max_combination_size = 2
-denylist = ["__tls", "__https", "__quic", "__h3", "__dnssec", "systemd"]

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -103,8 +103,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true
-
-[package.metadata.cargo-all-features]
-skip_optional_dependencies = true
-max_combination_size = 2
-denylist = ["__tls", "__https", "__quic", "__h3", "__dnssec"]

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -23,6 +23,7 @@ license.workspace = true
 std = [
     "data-encoding/std",
     "ipnet/std",
+    "once_cell/std",
     "rand/std",
     "rand/thread_rng",
     "ring?/std",
@@ -82,8 +83,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true
-
-[package.metadata.cargo-all-features]
-skip_optional_dependencies = true
-max_combination_size = 2
-denylist = ["__tls", "__https", "__quic", "__h3", "__dnssec"]

--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -134,8 +134,3 @@ required-features = ["tokio", "system-config"]
 
 [lints]
 workspace = true
-
-[package.metadata.cargo-all-features]
-skip_optional_dependencies = true
-max_combination_size = 2
-denylist = ["__tls", "__https", "__quic", "__h3", "__dnssec"]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -136,8 +136,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true
-
-[package.metadata.cargo-all-features]
-skip_optional_dependencies = true
-max_combination_size = 2
-denylist = ["__tls", "__https", "__quic", "__h3", "__dnssec"]

--- a/tests/integration-tests/Cargo.toml
+++ b/tests/integration-tests/Cargo.toml
@@ -110,10 +110,5 @@ tokio = { workspace = true, features = ["macros", "rt"] }
 test-support.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "std"] }
 
-[package.metadata.cargo-all-features]
-skip_optional_dependencies = true
-max_combination_size = 2
-denylist = ["__tls", "__https", "__quic", "__h3", "__dnssec"]
-
 [lints]
 workspace = true

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -101,10 +101,5 @@ hickory-net = { workspace = true, features = ["tokio"] }
 hickory-resolver = { workspace = true, features = ["recursor", "system-config", "tokio"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 
-[package.metadata.cargo-all-features]
-skip_optional_dependencies = true
-max_combination_size = 2
-denylist = ["__tls", "__https", "__quic", "__h3", "__dnssec"]
-
 [lints]
 workspace = true


### PR DESCRIPTION
In #3848, we're trying to avoid hickory-proto always requiring `once_cell`'s `critical-section` feature. That means though that `cargo build --package hickory-proto --no-default-features` will no longer compile. Instead you'll need:

```
cargo build \
  --package hickory-proto \
  --no-default-features \
  --features no-std-rand
```

Unfortunately `cargo-all-features` cannot exclude just the `--no-default-features` test. Instead, this patch switches over to using `cargo-hack`, which does support that functionality.

Note that this was assisted with an LLM, but I've reviewed and manually modified it as well.