### PR TITLE
hickory-resolver's `toml` depends on `serde` feature

### DIFF
--- a/crates/resolver/Cargo.toml
+++ b/crates/resolver/Cargo.toml
@@ -49,7 +49,7 @@ recursor = ["dep:async-recursion", "dep:lru-cache"]
 serde = ["dep:serde", "hickory-proto/serde"]
 system-config = ["dep:ipconfig", "dep:resolv-conf", "dep:jni", "dep:ndk-context", "dep:system-configuration"]
 
-toml = ["dep:toml"]
+toml = ["dep:toml", "serde"]
 
 tokio = ["dep:tokio", "tokio/rt", "hickory-net/tokio"]
 


### PR DESCRIPTION
This fixes compilation of:

```
cargo check \
  --package hickory-resolver \
  --no-default-features \
  --features h3-aws-lc-rs,toml
```