### PR TITLE
Narrow use of `once_cell/critical-section` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,9 +538,29 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6a127ecbb3c4632e1525380e04c0c3fcf8dcb44d32a79ea290d8a36906edcd8"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
+dependencies = [
+ "data-encoding",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "deranged"
@@ -1032,6 +1052,7 @@ dependencies = [
  "bitflags",
  "critical-section",
  "data-encoding",
+ "data-encoding-macro",
  "idna",
  "ipnet",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ cfg-if = "1"
 clap = { version = "4.0", default-features = false }
 console = "0.16"
 data-encoding = { version = "2.2.0", default-features = false }
+data-encoding-macro = "0.1.21"
 hex = "0.4"
 hostname = "0.4"
 idna = { version = "1.0.3", default-features = false, features = ["alloc", "compiled_data"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ libc = "0.2"
 lru-cache = "0.1.2"
 moka = "0.12"
 ndk-context = "0.1.1"
-once_cell = { version = "1.20.0", default-features = false, features = ["critical-section"] }
+once_cell = { version = "1.20.0", default-features = false }
 prefix-trie = "0.9.2"
 rand = { version = "0.10.0", default-features = false, features = ["alloc"] }
 regex = { version = "1.3.4", default-features = false }

--- a/conformance/Cargo.lock
+++ b/conformance/Cargo.lock
@@ -176,12 +176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,10 +907,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
 
 [[package]]
 name = "ordered-float"

--- a/conformance/Cargo.lock
+++ b/conformance/Cargo.lock
@@ -209,9 +209,29 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6a127ecbb3c4632e1525380e04c0c3fcf8dcb44d32a79ea290d8a36906edcd8"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
+dependencies = [
+ "data-encoding",
+ "syn",
+]
 
 [[package]]
 name = "der-parser"
@@ -526,6 +546,7 @@ version = "0.27.0-alpha.1"
 dependencies = [
  "bitflags",
  "data-encoding",
+ "data-encoding-macro",
  "idna",
  "ipnet",
  "once_cell",

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -23,6 +23,7 @@ license.workspace = true
 std = [
     "data-encoding/std",
     "ipnet/std",
+    "once_cell/std",
     "rand/std",
     "rand/thread_rng",
     "ring?/std",

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -55,6 +55,7 @@ aws-lc-rs = { workspace = true, optional = true }
 bitflags = { workspace = true, optional = true }
 critical-section = { workspace = true, optional = true }
 data-encoding = { workspace = true, features = ["alloc"] }
+data-encoding-macro.workspace = true
 idna.workspace = true
 ipnet.workspace = true
 js-sys = { workspace = true, optional = true }

--- a/crates/proto/src/rr/domain/mod.rs
+++ b/crates/proto/src/rr/domain/mod.rs
@@ -9,6 +9,7 @@
 
 mod label;
 mod name;
+#[cfg(feature = "std")]
 pub mod usage;
 
 pub use self::label::{IntoLabel, Label, LabelCmp};

--- a/crates/proto/src/rr/domain/name.rs
+++ b/crates/proto/src/rr/domain/name.rs
@@ -23,7 +23,6 @@ use tinyvec::TinyVec;
 
 use crate::error::{ProtoError, ProtoResult};
 use crate::rr::domain::label::{CaseInsensitive, CaseSensitive, IntoLabel, Label, LabelCmp};
-use crate::rr::domain::usage::LOCALHOST as LOCALHOST_usage;
 use crate::serialize::binary::{
     BinDecodable, BinDecoder, BinEncodable, BinEncoder, DecodeError, NameEncoding, Restrict,
 };
@@ -878,7 +877,9 @@ impl Name {
     /// assert!(name.is_localhost());
     /// ```
     pub fn is_localhost(&self) -> bool {
-        LOCALHOST_usage.zone_of(self)
+        self.iter()
+            .next_back()
+            .is_some_and(|label| label.eq_ignore_ascii_case(b"localhost"))
     }
 
     /// True if the first label of this name is the wildcard, i.e. '*'

--- a/crates/proto/src/rr/rdata/sshfp.rs
+++ b/crates/proto/src/rr/rdata/sshfp.rs
@@ -14,8 +14,7 @@ use core::fmt;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use data_encoding::{Encoding, Specification};
-use once_cell::sync::Lazy;
+use data_encoding::Encoding;
 
 use crate::{
     error::ProtoResult,
@@ -27,14 +26,12 @@ use crate::{
 };
 
 /// HEX formatting specific to TLSA, SMIMEA and SSHFP encodings
-pub static HEX: Lazy<Encoding> = Lazy::new(|| {
-    let mut spec = Specification::new();
-    spec.symbols.push_str("0123456789abcdef");
-    spec.ignore.push_str(" \t\r\n");
-    spec.translate.from.push_str("ABCDEF");
-    spec.translate.to.push_str("abcdef");
-    spec.encoding().expect("error in sshfp HEX encoding")
-});
+pub static HEX: Encoding = data_encoding_macro::new_encoding! {
+    symbols: "0123456789abcdef",
+    ignore: " \t\r\n",
+    translate_from: "ABCDEF",
+    translate_to: "abcdef",
+};
 
 /// [RFC 4255](https://tools.ietf.org/html/rfc4255#section-3.1)
 ///

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -98,9 +98,29 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6a127ecbb3c4632e1525380e04c0c3fcf8dcb44d32a79ea290d8a36906edcd8"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
+dependencies = [
+ "data-encoding",
+ "syn",
+]
 
 [[package]]
 name = "deranged"
@@ -232,6 +252,7 @@ dependencies = [
  "aws-lc-rs",
  "bitflags",
  "data-encoding",
+ "data-encoding-macro",
  "idna",
  "ipnet",
  "once_cell",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -91,12 +91,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "data-encoding"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,10 +463,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -485,12 +475,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"


### PR DESCRIPTION
This disables `once_cell/critical-section` by default, only re-enabling it for `hickory-proto/no-std-rand`. I gated `ZoneUsage` behind `hickory-proto/std` since it relies on `once_cell` as well, but is only used for easy access to some lazy `Name` statics. I made `hickory-proto/std` enable `once_cell/std`, since `once_cell` prioritizes standard library mutexes over those from `critical_section`. I also replaced another `once_cell::Lazy` use with a compile-time macro, in order to set up a decoder from `data_encoding`.

This is intended to replace #3848.