### PR TITLE
net: report dropped requests as closed connections

### DIFF
--- a/crates/net/src/error.rs
+++ b/crates/net/src/error.rs
@@ -40,6 +40,10 @@ pub enum NetError {
     #[error("resource too busy")]
     Busy,
 
+    /// The connection carrying a request went away before it could be answered.
+    #[error("connection closed before a response was received")]
+    ConnectionClosed,
+
     /// Unable to decode HTTP header value to string
     #[cfg(any(feature = "__https", feature = "__h3"))]
     #[error("header decode error: {0}")]
@@ -179,6 +183,7 @@ impl NetError {
             }
             #[cfg(feature = "__h3")]
             Self::H3(err) => err.is_h3_no_error(),
+            Self::ConnectionClosed => true,
             Self::Io(err) => matches!(
                 err.kind(),
                 io::ErrorKind::ConnectionReset
@@ -211,6 +216,7 @@ impl NetError {
     pub fn as_metrics_label(&self) -> &'static str {
         match self {
             Self::Busy => "busy",
+            Self::ConnectionClosed => "connection_closed",
             #[cfg(any(feature = "__https", feature = "__h3"))]
             Self::Decode(_) => "http_header_decode",
             Self::Dns(dns_err) => dns_err.as_metrics_label(),

--- a/crates/net/src/xfer/mod.rs
+++ b/crates/net/src/xfer/mod.rs
@@ -265,9 +265,12 @@ impl<P: RuntimeProvider> DnsHandle for BufDnsRequestStreamHandle<P> {
 
         let (request, oneshot) = OneshotDnsRequest::oneshot(request);
         let mut sender = self.sender.clone();
-        let try_send = sender.try_send(request).map_err(|_| {
+        let try_send = sender.try_send(request).map_err(|error| {
             debug!("unable to enqueue message");
-            NetError::Busy
+            match error.is_disconnected() {
+                true => NetError::ConnectionClosed,
+                false => NetError::Busy,
+            }
         });
 
         match try_send {
@@ -333,11 +336,7 @@ impl Stream for DnsResponseReceiver {
             *self = match &mut *self {
                 Self::Receiver(receiver) => {
                     let receiver = Pin::new(receiver);
-                    let future = ready!(
-                        receiver
-                            .poll(cx)
-                            .map_err(|_| NetError::from("receiver was canceled"))
-                    )?;
+                    let future = ready!(receiver.poll(cx).map_err(|_| NetError::ConnectionClosed))?;
                     Self::Received(future)
                 }
                 Self::Received(stream) => {
@@ -483,3 +482,46 @@ pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 ///
 /// Under high load, a larger buffer prevents messages from being dropped due to backpressure.
 const DEFAULT_STREAM_BUFFER_SIZE: usize = 32;
+
+#[cfg(test)]
+mod tests {
+    use futures_util::StreamExt;
+
+    use crate::proto::op::Message;
+    use crate::runtime::TokioRuntimeProvider;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn a_dropped_request_reports_a_closed_connection() {
+        let (sender, receiver) = oneshot::channel();
+        let mut response = DnsResponseReceiver::Receiver(receiver);
+        drop(sender);
+
+        let err = response
+            .next()
+            .await
+            .expect("the receiver yields the failure")
+            .expect_err("a dropped request cannot produce a response");
+        assert!(matches!(&err, NetError::ConnectionClosed));
+        assert!(err.is_connection_closed());
+    }
+
+    #[tokio::test]
+    async fn a_request_sent_to_a_closed_exchange_reports_a_closed_connection() {
+        let (sender, receiver) = mpsc::channel(1);
+        drop(receiver);
+        let handle = BufDnsRequestStreamHandle::<TokioRuntimeProvider> {
+            sender,
+            _phantom: PhantomData,
+        };
+
+        let err = handle
+            .send(DnsRequest::from(Message::query()))
+            .next()
+            .await
+            .expect("the response stream yields the send failure")
+            .expect_err("a closed exchange cannot accept a request");
+        assert!(matches!(err, NetError::ConnectionClosed));
+    }
+}

--- a/crates/resolver/src/name_server.rs
+++ b/crates/resolver/src/name_server.rs
@@ -138,6 +138,9 @@ impl<P: ConnectionProvider> NameServer<P> {
                 Ok(v) => v,
                 Err((err, protocol)) => {
                     debug!(config = ?self.config, ?protocol, %err, "failed to establish connection to name server");
+                    if err.is_connection_closed() {
+                        self.server_srtt.record_failure();
+                    }
                     return (protocol, Err(err));
                 }
             };

--- a/crates/resolver/src/name_server_pool.rs
+++ b/crates/resolver/src/name_server_pool.rs
@@ -390,7 +390,10 @@ impl<P: ConnectionProvider> PoolState<P> {
                     // If the server is busy, try it again later if necessary.
                     NetError::Busy => busy.push(server),
                     // If the connection failed or timed out, try another one.
-                    NetError::Io(_) | NetError::NoConnections | NetError::Timeout => {}
+                    NetError::ConnectionClosed
+                    | NetError::Io(_)
+                    | NetError::NoConnections
+                    | NetError::Timeout => {}
                     // If we got an `NXDomain` response from a server whose negative responses we
                     // don't trust, we should try another server.
                     NetError::Dns(DnsError::NoRecordsFound(NoRecords {
@@ -408,6 +411,12 @@ impl<P: ConnectionProvider> PoolState<P> {
 
 /// Compare two errors to see if one contains a server response.
 fn most_specific(previous: NetError, current: NetError) -> NetError {
+    match (&previous, &current) {
+        (NetError::NoConnections, NetError::ConnectionClosed) => return current,
+        (NetError::ConnectionClosed, NetError::NoConnections) => return previous,
+        _ => (),
+    }
+
     match (&previous, &current) {
         (
             NetError::Dns(DnsError::NoRecordsFound { .. }),
@@ -988,7 +997,10 @@ mod tests {
     use tokio::runtime::Runtime;
 
     use super::*;
-    use crate::config::{NameServerConfig, ResolverConfig, ServerOrderingStrategy};
+    use crate::config::{
+        ConnectionConfig, NameServerConfig, ResolverConfig, ServerOrderingStrategy,
+    };
+    use crate::connection_provider::ConnectionProvider;
     use crate::net::runtime::{RuntimeProvider, TokioHandle, TokioRuntimeProvider, TokioTime};
     use crate::net::xfer::{DnsHandle, FirstAnswer};
     use crate::proto::op::{DnsRequestOptions, Query};
@@ -1169,6 +1181,98 @@ mod tests {
             !response.answers.is_empty(),
             "expected A record in response"
         );
+    }
+
+    #[tokio::test]
+    async fn test_pool_retries_on_connection_closed() {
+        subscribe();
+
+        let closed_ip = IpAddr::from([192, 0, 2, 1]);
+        let good_ip = IpAddr::from([192, 0, 2, 2]);
+        let query_name = Name::from_str("example.com.").expect("query name should be valid");
+
+        let handler = MockNetworkHandler::new(vec![MockRecord::a(good_ip, &query_name, good_ip)]);
+        let provider = ConnectionClosedProvider {
+            inner: MockProvider::new(handler),
+            closed_ip,
+        };
+        let opts = ResolverOpts {
+            num_concurrent_reqs: 1,
+            server_ordering_strategy: ServerOrderingStrategy::UserProvidedOrder,
+            ..ResolverOpts::default()
+        };
+        let closed_server = Arc::new(NameServer::new(
+            [],
+            NameServerConfig::udp(closed_ip),
+            &opts,
+            provider.clone(),
+        ));
+        let good_server = Arc::new(NameServer::new(
+            [],
+            NameServerConfig::udp(good_ip),
+            &opts,
+            provider,
+        ));
+        let initial_srtt = closed_server.decayed_srtt();
+        let pool = NameServerPool::from_nameservers(
+            vec![closed_server.clone(), good_server],
+            Arc::new(PoolContext::new(
+                opts,
+                TlsConfig::new().expect("TLS configuration should be valid"),
+            )),
+        );
+
+        let response = pool
+            .lookup(
+                Query::new(query_name, RecordType::A),
+                DnsRequestOptions::default(),
+            )
+            .first_answer()
+            .await
+            .expect("pool should try the second server after the first connection closes");
+
+        assert_eq!(response.answers.len(), 1);
+        assert!(closed_server.decayed_srtt() > initial_srtt);
+    }
+
+    #[test]
+    fn test_connection_closed_is_more_specific_than_no_connections() {
+        for error in [
+            most_specific(NetError::NoConnections, NetError::ConnectionClosed),
+            most_specific(NetError::ConnectionClosed, NetError::NoConnections),
+        ] {
+            assert!(matches!(&error, NetError::ConnectionClosed));
+            assert!(error.is_connection_closed());
+        }
+    }
+
+    #[derive(Clone)]
+    struct ConnectionClosedProvider {
+        inner: MockProvider,
+        closed_ip: IpAddr,
+    }
+
+    impl ConnectionProvider for ConnectionClosedProvider {
+        type Conn = <MockProvider as ConnectionProvider>::Conn;
+        type FutureConn = Pin<Box<dyn Future<Output = Result<Self::Conn, NetError>> + Send>>;
+        type RuntimeProvider = MockProvider;
+
+        fn new_connection(
+            &self,
+            ip: IpAddr,
+            config: &ConnectionConfig,
+            cx: &PoolContext,
+        ) -> Result<Self::FutureConn, NetError> {
+            if ip == self.closed_ip {
+                return Ok(Box::pin(future::ready(Err(NetError::ConnectionClosed))));
+            }
+
+            self.inner.new_connection(ip, config, cx)
+        }
+
+        fn runtime_provider(&self) -> &Self::RuntimeProvider {
+            &self.inner
+        }
     }
 
     /// Regression test: when a server times out, its server-level SRTT should be penalized


### PR DESCRIPTION
Fixes #3851.

When a connection task terminates, it drops the requests it was carrying and their response senders. The waiting caller previously received a string-based cancellation error that no connection retry path recognized, so pool failover stopped even when another server could answer. Sending to an already-closed exchange had the same problem.

Both paths now report `NetError::ConnectionClosed`. The resolver pool preserves that specific error, continues to another server, and penalizes the failed server's SRTT. `NetError` is `#[non_exhaustive]`, so the added variant is semver-compatible.

Focused tests cover dropped and disconnected exchanges, pool failover, error specificity, and SRTT ordering.
