### PR TITLE
Make regexes for deleting DNSKEY RRSIG more strict

### DIFF
--- a/conformance/dns-test/src/docker/ede-dot-com/configure_child.sh
+++ b/conformance/dns-test/src/docker/ede-dot-com/configure_child.sh
@@ -232,7 +232,7 @@ for subdomain in ${subdomains[@]}; do
         # Find the ID of the key signing key
         ksk_id=$(grep "KSK;" $output_dir/db.$zone.signed | awk -F' = ' '{print $NF}')
         # Find the line containing the signature over KSK DNSKEY as well as where it starts and ends
-        line_rrsig_middle=$(grep  -n "$ksk_id.*no-rrsig-ksk.*" $output_dir/db.$zone.signed | cut -f1 -d:)
+        line_rrsig_middle=$(grep  -n "$ksk_id no-rrsig-ksk.*" $output_dir/db.$zone.signed | cut -f1 -d:)
         line_rrsig_start_num=$((line_rrsig_middle-1))
         line_rrsig_end=$(tail -n +$line_rrsig_start_num $output_dir/db.$zone.signed | grep -m 1 ")")
         line_rrsig_end_num=$(grep -n "$line_rrsig_end" $output_dir/db.$zone.signed | cut -f1 -d:)
@@ -242,7 +242,7 @@ for subdomain in ${subdomains[@]}; do
         # First delete the signature over the KSK
         ksk_id=$(grep "KSK;" $output_dir/db.$zone.signed | awk -F' = ' '{print $NF}')
         # Find the line containing the signature over KSK DNSKEY as well as where it starts and ends
-        line_rrsig_middle=$(grep  -n "$ksk_id.*no-rrsig-dnskey.*" $output_dir/db.$zone.signed | cut -f1 -d:)
+        line_rrsig_middle=$(grep  -n "$ksk_id no-rrsig-dnskey.*" $output_dir/db.$zone.signed | cut -f1 -d:)
         line_rrsig_start_num=$((line_rrsig_middle-1))
         line_rrsig_end=$(tail -n +$line_rrsig_start_num $output_dir/db.$zone.signed | grep -m 1 ")")
         line_rrsig_end_num=$(grep -n "$line_rrsig_end" $output_dir/db.$zone.signed | cut -f1 -d:)


### PR DESCRIPTION
I spotted a flaky test failure in CI where an ede-dot-com test printed the following:

```
/configure_child.sh: line 246: 11
24
37
50
86
98
111
124
139
154: syntax error in expression (error token is "24
37
50
86
98
111
124
139
154")
```

My hypothesis is that a key's ID happened to be 20260 or 20270. We search for the regex `$ksk_id.*no-rrsig-dnskey.*`, so if the key ID were one of these values, it could have matched the signature inception or expiration of many RRSIGs, causing this `grep -n` command to return multiple line numbers. The script expects to match only one RRSIG, and get only one line number, so getting multiple line numbers breaks the subsequent bash arithmetic expression. Changing the regex to expect a space would avoid this scenario. We have pinned our version of dnssec-signzone used by this script, so we shouldn't need any more flexibility in the presentation format of these RRSIGs.