### PR TITLE
Allow absolute blocklist paths (0.26 backport)

### DIFF
--- a/crates/server/src/store/blocklist.rs
+++ b/crates/server/src/store/blocklist.rs
@@ -14,7 +14,7 @@ use std::{
     fs::File,
     io::{self, Read},
     net::{Ipv4Addr, Ipv6Addr},
-    path::Path,
+    path::{Path, PathBuf},
     str::FromStr,
     time::{Duration, Instant},
 };
@@ -113,20 +113,22 @@ impl BlocklistZoneHandler {
 
         // Load block lists into the block table cache for this zone handler.
         for bl in &config.lists {
-            info!("adding blocklist {bl}");
+            info!("adding blocklist {}", bl.display());
 
-            let file = match File::open(format!("{base_dir}/{bl}")) {
+            let file = match File::open(format!("{base_dir}/{}", bl.display())) {
                 Ok(file) => file,
                 Err(e) => {
                     return Err(format!(
-                        "unable to open blocklist file {base_dir}/{bl}: {e:?}"
+                        "unable to open blocklist file {base_dir}/{}: {e:?}",
+                        bl.display()
                     ));
                 }
             };
 
             if let Err(e) = handler.add(file) {
                 return Err(format!(
-                    "unable to add data from blocklist {base_dir}/{bl}: {e:?}"
+                    "unable to add data from blocklist {base_dir}/{}: {e:?}",
+                    bl.display()
                 ));
             }
         }
@@ -167,7 +169,7 @@ impl BlocklistZoneHandler {
     ///
     /// # Example
     /// ```
-    /// use std::{fs::File, net::{Ipv4Addr, Ipv6Addr}, path::Path, str::FromStr, sync::Arc};
+    /// use std::{fs::File, net::{Ipv4Addr, Ipv6Addr}, path::{Path, PathBuf}, str::FromStr, sync::Arc};
     /// use hickory_proto::rr::{LowerName, RecordType, Name};
     /// use hickory_server::{
     ///     store::blocklist::*,
@@ -179,7 +181,7 @@ impl BlocklistZoneHandler {
     ///     let config = BlocklistConfig {
     ///         wildcard_match: true,
     ///         min_wildcard_depth: 2,
-    ///         lists: vec!["default/blocklist.txt".to_string()],
+    ///         lists: vec![PathBuf::from("default/blocklist.txt")],
     ///         sinkhole_ipv4: None,
     ///         sinkhole_ipv6: None,
     ///         block_message: None,
@@ -523,7 +525,7 @@ pub struct BlocklistConfig {
 
     /// Block lists to load.  These should be specified as relative (to the server zone directory)
     /// paths in the config file.
-    pub lists: Vec<String>,
+    pub lists: Vec<PathBuf>,
 
     /// IPv4 sinkhole IP. This is the IP that is returned when a blocklist entry is matched for an
     /// A query. If unspecified, an implementation-provided default will be used.
@@ -594,7 +596,7 @@ mod test {
         let config = BlocklistConfig {
             wildcard_match: true,
             min_wildcard_depth: 2,
-            lists: vec!["default/blocklist.txt".to_string()],
+            lists: vec![PathBuf::from("default/blocklist.txt")],
             sinkhole_ipv4: None,
             sinkhole_ipv6: None,
             block_message: None,
@@ -640,7 +642,7 @@ mod test {
         let config = BlocklistConfig {
             min_wildcard_depth: 2,
             wildcard_match: false,
-            lists: vec!["default/blocklist.txt".to_string()],
+            lists: vec![PathBuf::from("default/blocklist.txt")],
             sinkhole_ipv4: Some(Ipv4Addr::new(192, 0, 2, 1)),
             sinkhole_ipv6: Some(Ipv6Addr::new(0, 0, 0, 0, 0xc0, 0, 2, 1)),
             block_message: Some(String::from("blocked")),
@@ -675,7 +677,7 @@ mod test {
         let config = BlocklistConfig {
             min_wildcard_depth: 2,
             wildcard_match: false,
-            lists: vec!["default/blocklist.txt".to_string()],
+            lists: vec![PathBuf::from("default/blocklist.txt")],
             sinkhole_ipv4: Some(Ipv4Addr::new(192, 0, 2, 1)),
             sinkhole_ipv6: Some(Ipv6Addr::new(0, 0, 0, 0, 0xc0, 0, 2, 1)),
             block_message: Some(String::from("blocked")),
@@ -707,7 +709,7 @@ mod test {
         let config = BlocklistConfig {
             min_wildcard_depth: 2,
             wildcard_match: true,
-            lists: vec!["default/blocklist3.txt".to_string()],
+            lists: vec![PathBuf::from("default/blocklist3.txt")],
             sinkhole_ipv4: Some(Ipv4Addr::new(192, 0, 2, 1)),
             sinkhole_ipv6: Some(Ipv6Addr::new(0, 0, 0, 0, 0xc0, 0, 2, 1)),
             block_message: Some(String::from("blocked")),
@@ -765,7 +767,7 @@ mod test {
         let config = BlocklistConfig {
             wildcard_match: true,
             min_wildcard_depth: 2,
-            lists: vec!["default/blocklist.txt".to_string()],
+            lists: vec![PathBuf::from("default/blocklist.txt")],
             sinkhole_ipv4: None,
             sinkhole_ipv6: None,
             block_message: None,

--- a/crates/server/src/store/blocklist.rs
+++ b/crates/server/src/store/blocklist.rs
@@ -36,6 +36,7 @@ use crate::{
     },
     resolver::lookup::Lookup,
     server::{Request, RequestInfo},
+    store::rooted,
     zone_handler::{
         AuthLookup, AxfrPolicy, LookupControlFlow, LookupError, LookupOptions, ZoneHandler,
         ZoneTransfer, ZoneType,
@@ -102,24 +103,15 @@ impl BlocklistZoneHandler {
             metrics: BlocklistMetrics::new(),
         };
 
-        let base_dir = match base_dir {
-            Some(dir) => dir.display(),
-            None => {
-                return Err(format!(
-                    "invalid blocklist (zone directory) base path specified: '{base_dir:?}'"
-                ));
-            }
-        };
-
         // Load block lists into the block table cache for this zone handler.
         for bl in &config.lists {
             info!("adding blocklist {}", bl.display());
-
-            let file = match File::open(format!("{base_dir}/{}", bl.display())) {
+            let bl = rooted(bl, base_dir);
+            let file = match File::open(&bl) {
                 Ok(file) => file,
                 Err(e) => {
                     return Err(format!(
-                        "unable to open blocklist file {base_dir}/{}: {e:?}",
+                        "unable to open blocklist file {}: {e:?}",
                         bl.display()
                     ));
                 }
@@ -127,7 +119,7 @@ impl BlocklistZoneHandler {
 
             if let Err(e) = handler.add(file) {
                 return Err(format!(
-                    "unable to add data from blocklist {base_dir}/{}: {e:?}",
+                    "unable to add data from blocklist {}: {e:?}",
                     bl.display()
                 ));
             }
@@ -523,8 +515,7 @@ pub struct BlocklistConfig {
     /// or *.com that might block many more hosts than intended.
     pub min_wildcard_depth: u8,
 
-    /// Block lists to load.  These should be specified as relative (to the server zone directory)
-    /// paths in the config file.
+    /// Block lists to load.  A relative path is relative to the server zone directory.
     pub lists: Vec<PathBuf>,
 
     /// IPv4 sinkhole IP. This is the IP that is returned when a blocklist entry is matched for an
@@ -574,7 +565,7 @@ impl Default for BlocklistConfig {
 mod test {
     use std::{
         net::{Ipv4Addr, Ipv6Addr},
-        path::Path,
+        path::{Path, PathBuf},
         str::FromStr,
         sync::Arc,
     };
@@ -799,6 +790,27 @@ mod test {
         .expect("unable to create config");
 
         assert_eq!(zh.entry_count(), 0);
+    }
+
+    #[test]
+    fn test_blocklist_file_absolute_path() {
+        subscribe();
+
+        let mut abs_blocklist_path =
+            PathBuf::from_str(env!("CARGO_MANIFEST_DIR")).expect("valid path");
+        abs_blocklist_path.push("../../tests/test-data/test_configs/default/blocklist.txt");
+
+        let config = BlocklistConfig {
+            lists: vec![abs_blocklist_path],
+            ..Default::default()
+        };
+
+        BlocklistZoneHandler::try_from_config(
+            Name::root(),
+            config,
+            Some(Path::new("/some/where/non-existent")),
+        )
+        .expect("configuration is valid");
     }
 
     async fn basic_test(

--- a/crates/server/src/store/file.rs
+++ b/crates/server/src/store/file.rs
@@ -24,6 +24,7 @@ use crate::{
     proto::rr::{LowerName, Name, RecordType},
     server::{Request, RequestInfo},
     store::in_memory::{InMemoryZoneHandler, zone_from_path},
+    store::rooted,
     zone_handler::{
         AuthLookup, AxfrPolicy, LookupControlFlow, LookupError, LookupOptions, ZoneHandler,
         ZoneTransfer, ZoneType,
@@ -251,13 +252,6 @@ impl DnssecZoneHandler for FileZoneHandler {
 pub struct FileConfig {
     /// path to the zone file
     pub zone_path: PathBuf,
-}
-
-pub(crate) fn rooted(zone_file: &Path, root_dir: Option<&Path>) -> PathBuf {
-    match root_dir {
-        Some(root) => root.join(zone_file),
-        None => zone_file.to_owned(),
-    }
 }
 
 #[cfg(test)]

--- a/crates/server/src/store/mod.rs
+++ b/crates/server/src/store/mod.rs
@@ -7,6 +7,8 @@
 
 //! All persistent store implementations
 
+use std::path::{Path, PathBuf};
+
 pub mod blocklist;
 pub mod file;
 pub mod forwarder;
@@ -14,3 +16,10 @@ pub mod in_memory;
 pub mod recursor;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
+
+pub(crate) fn rooted(file: &Path, root_dir: Option<&Path>) -> PathBuf {
+    match root_dir {
+        Some(root) => root.join(file),
+        None => file.to_owned(),
+    }
+}

--- a/crates/server/src/store/sqlite/mod.rs
+++ b/crates/server/src/store/sqlite/mod.rs
@@ -45,10 +45,8 @@ use crate::{
         },
     },
     server::{Request, RequestInfo},
-    store::{
-        file::rooted,
-        in_memory::{InMemoryZoneHandler, zone_from_path},
-    },
+    store::in_memory::{InMemoryZoneHandler, zone_from_path},
+    store::rooted,
     zone_handler::{
         AuthLookup, AxfrPolicy, LookupControlFlow, LookupError, LookupOptions, ZoneHandler,
         ZoneTransfer, ZoneType,


### PR DESCRIPTION
Backport of #3838 to the 0.26 branch.