### PR TITLE
Delete TODO in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,6 @@ env:
 jobs:
   publish:
     name: publish
-    # wait for the cache from all-features
-    #  TODO: we really want this:
-    # needs: ./.github/workflows/test/platform-matrix
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7


### PR DESCRIPTION
This deletes a TODO in `publish.yml`. I don't think the feature described in this comment will be supported any time soon (how would we identify the correct corresponding invocation of a different workflow, with different triggering events?) plus using the GitHub Actions cache in a publishing workflow is an antipattern. Reading from cache in a publishing workflow provides a valuable target for cache poisoning attacks, and GitHub makes defending against cache poisoning very difficult.