### PR TITLE
Clean up TrustAnchor API

### DIFF
--- a/bin/tests/integration/named_metrics_tests.rs
+++ b/bin/tests/integration/named_metrics_tests.rs
@@ -499,7 +499,7 @@ async fn test_updates() {
             RsaSigningKey::from_pkcs8(&PrivatePkcs8KeyDer::from(rsa_key.to_vec()), verify_algo)
                 .unwrap();
         let mut trust_anchor = TrustAnchors::empty();
-        trust_anchor.insert(&verify_key.to_public_key().unwrap());
+        trust_anchor.insert(&verify_key.to_public_key().unwrap(), Name::root().into());
 
         let origin: Name = Name::parse("example.com.", None).unwrap();
 

--- a/bin/tests/integration/named_test_rsa_dnssec.rs
+++ b/bin/tests/integration/named_test_rsa_dnssec.rs
@@ -18,7 +18,7 @@ use hickory_net::xfer::{DnsExchangeBackground, DnsMultiplexer, Protocol};
 use hickory_proto::{
     dnssec::{Algorithm, TrustAnchors},
     op::{DnsRequestOptions, Query},
-    rr::RecordType,
+    rr::{Name, RecordType},
 };
 use test_support::subscribe;
 
@@ -32,7 +32,7 @@ fn trust_anchor(public_key_path: &Path, algorithm: Algorithm) -> Arc<TrustAnchor
     let public_key = key_pair.to_public_key().unwrap();
     let mut trust_anchor = TrustAnchors::empty();
 
-    trust_anchor.insert(&public_key);
+    trust_anchor.insert(&public_key, Name::root().into());
     Arc::new(trust_anchor)
 }
 

--- a/crates/net/src/dnssec/mod.rs
+++ b/crates/net/src/dnssec/mod.rs
@@ -853,7 +853,7 @@ impl<H: DnsHandle> DnssecDnsHandle<H> {
         let pub_key = dns_key.public_key();
 
         // Checks to see if the key is valid against the registered root certificates
-        if self.trust_anchor.contains_with_name(pub_key, name) {
+        if self.trust_anchor.contains(pub_key, name) {
             debug!(
                 "validated dnskey with trust_anchor: {}, {dns_key}",
                 rr.name(),

--- a/crates/proto/src/dnssec/trust_anchor.rs
+++ b/crates/proto/src/dnssec/trust_anchor.rs
@@ -21,7 +21,7 @@ use core::str::FromStr;
 use std::{fs, path::Path};
 
 use crate::dnssec::PublicKey;
-use crate::rr::LowerName;
+use crate::rr::{LowerName, Name};
 use crate::serialize::txt::ParseError;
 use crate::serialize::txt::trust_anchor::{self, Entry};
 
@@ -34,8 +34,7 @@ const ROOT_ANCHOR_2024: &[u8] = include_bytes!("roots/38696.rsa");
 /// The root set of trust anchors for validating DNSSEC, anything in this set will be trusted
 #[derive(Clone)]
 pub struct TrustAnchors {
-    root_public_keys: Vec<PublicKeyBuf>,
-    other_public_keys: Vec<(LowerName, PublicKeyBuf)>,
+    public_keys: Vec<(LowerName, PublicKeyBuf)>,
 }
 
 impl TrustAnchors {
@@ -49,47 +48,13 @@ impl TrustAnchors {
     /// If you want to use the default root anchors, use `TrustAnchor::default()`.
     pub fn empty() -> Self {
         Self {
-            root_public_keys: vec![],
-            other_public_keys: vec![],
+            public_keys: vec![],
         }
     }
 
-    /// Determines if the key is in the trust anchor set.
-    ///
-    /// This only handles keys for the root zone. See [`Self::contains_with_name()`] for keys at
-    /// other names.
-    pub fn contains<P: PublicKey + ?Sized>(&self, other_key: &P) -> bool {
-        self.root_public_keys.iter().any(|k| {
-            other_key.public_bytes() == k.public_bytes() && other_key.algorithm() == k.algorithm()
-        })
-    }
-
-    /// Inserts a public key as a trust anchor.
-    ///
-    /// This only handles keys for the root zone. See [`Self::insert_with_name()`] for keys at
-    /// other names.
-    pub fn insert<P: PublicKey + ?Sized>(&mut self, public_key: &P) -> bool {
-        if self.contains(public_key) {
-            return false;
-        }
-
-        self.root_public_keys.push(PublicKeyBuf::new(
-            public_key.public_bytes().to_vec(),
-            public_key.algorithm(),
-        ));
-        true
-    }
-
-    /// Determines if the key is trusted for a specific name.
-    pub fn contains_with_name<P: PublicKey + ?Sized>(
-        &self,
-        public_key: &P,
-        name: &LowerName,
-    ) -> bool {
-        if name.is_root() {
-            return self.contains(public_key);
-        }
-        self.other_public_keys
+    /// Determines if the key and name is in the trust anchor set.
+    pub fn contains<P: PublicKey + ?Sized>(&self, public_key: &P, name: &LowerName) -> bool {
+        self.public_keys
             .iter()
             .any(|(trust_anchor_name, trust_anchor_public_key)| {
                 trust_anchor_name == name
@@ -98,46 +63,27 @@ impl TrustAnchors {
             })
     }
 
-    /// Inserts a trusted public key for a specific name.
-    pub fn insert_with_name<P: PublicKey + ?Sized>(
-        &mut self,
-        public_key: &P,
-        name: LowerName,
-    ) -> bool {
-        if name.is_root() {
-            return self.insert(public_key);
-        }
-
-        if self.contains_with_name(public_key, &name) {
+    /// Inserts a public key as a trust anchor.
+    pub fn insert<P: PublicKey + ?Sized>(&mut self, public_key: &P, name: LowerName) -> bool {
+        if self.contains(public_key, &name) {
             return false;
         }
 
-        self.other_public_keys.push((
+        self.public_keys.push((
             name,
             PublicKeyBuf::new(public_key.public_bytes().to_vec(), public_key.algorithm()),
         ));
         true
     }
 
-    /// Get the trust anchor at the specified index.
-    ///
-    /// This only retrieves trust anchors for the root zone.
-    pub fn get(&self, idx: usize) -> Option<&PublicKeyBuf> {
-        self.root_public_keys.get(idx)
-    }
-
     /// Number of keys.
-    ///
-    /// This only counts trust anchors for the root zone.
     pub fn len(&self) -> usize {
-        self.root_public_keys.len()
+        self.public_keys.len()
     }
 
     /// Returns true if there are no keys.
-    ///
-    /// This only counts trust anchors for the root zone.
     pub fn is_empty(&self) -> bool {
-        self.root_public_keys.is_empty()
+        self.public_keys.is_empty()
     }
 }
 
@@ -148,53 +94,52 @@ impl FromStr for TrustAnchors {
         let parser = trust_anchor::Parser::new(input);
         let entries = parser.parse()?;
 
-        let mut root_public_keys = Vec::new();
-        let mut other_public_keys = Vec::new();
+        let mut public_keys = Vec::new();
         for entry in entries {
             let Entry::DNSKEY(record) = entry;
             let dnskey = record.data();
             let key = dnskey.key()?;
             let public_key_buf = PublicKeyBuf::new(key.public_bytes().to_vec(), dnskey.algorithm());
-            if record.name().is_root() {
-                root_public_keys.push(public_key_buf);
-            } else {
-                other_public_keys.push((record.name().into(), public_key_buf));
-            }
+            public_keys.push((record.name().into(), public_key_buf));
         }
 
-        Ok(Self {
-            root_public_keys,
-            other_public_keys,
-        })
+        Ok(Self { public_keys })
     }
 }
 
 impl Default for TrustAnchors {
     fn default() -> Self {
         Self {
-            root_public_keys: vec![
-                PublicKeyBuf::new(ROOT_ANCHOR_2018.to_owned(), Algorithm::RSASHA256),
-                PublicKeyBuf::new(ROOT_ANCHOR_2024.to_owned(), Algorithm::RSASHA256),
+            public_keys: vec![
+                (
+                    Name::root().into(),
+                    PublicKeyBuf::new(ROOT_ANCHOR_2018.to_owned(), Algorithm::RSASHA256),
+                ),
+                (
+                    Name::root().into(),
+                    PublicKeyBuf::new(ROOT_ANCHOR_2024.to_owned(), Algorithm::RSASHA256),
+                ),
             ],
-            other_public_keys: vec![],
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::dnssec::{
-        Algorithm, PublicKey, PublicKeyBuf,
-        trust_anchor::{ROOT_ANCHOR_2024, TrustAnchors},
+    use crate::{
+        dnssec::{
+            Algorithm, PublicKeyBuf,
+            trust_anchor::{ROOT_ANCHOR_2024, TrustAnchors},
+        },
+        rr::Name,
     };
     use alloc::borrow::ToOwned;
 
     #[test]
     fn test_contains_dnskey_bytes() {
         let trust = TrustAnchors::default();
-        assert_eq!(trust.get(1).unwrap().public_bytes(), ROOT_ANCHOR_2024);
         let pub_key = PublicKeyBuf::new(ROOT_ANCHOR_2024.to_owned(), Algorithm::RSASHA256);
-        assert!(trust.contains(&pub_key));
+        assert!(trust.contains(&pub_key, &Name::root().into()));
     }
 
     #[test]

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -1604,7 +1604,7 @@ mod tests {
         let private_key =
             Ed25519SigningKey::from_pkcs8(&Ed25519SigningKey::generate_pkcs8().unwrap()).unwrap();
         let public_key = private_key.to_public_key().unwrap();
-        trust_anchors.insert(&public_key);
+        trust_anchors.insert(&public_key, Name::root().into());
 
         let resolver_ip = Ipv4Addr::new(203, 0, 113, 1).into();
         let query_name = Name::parse("www.hickory-dns.testing.", None).unwrap();

--- a/tests/integration-tests/src/lib.rs
+++ b/tests/integration-tests/src/lib.rs
@@ -273,7 +273,7 @@ where
 
     // Client setup
     let mut trust_anchor = TrustAnchors::empty();
-    trust_anchor.insert_with_name(public_key, trust_anchor_name);
+    trust_anchor.insert(public_key, trust_anchor_name);
     let stream = UdpClientStream::builder(local_addr, TokioRuntimeProvider::new()).build();
     let (client, bg) = Client::from_sender(stream);
     let client = DnssecClient::from_client(client, Arc::new(trust_anchor));

--- a/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
+++ b/tests/integration-tests/tests/integration/dnssec_client_handle_tests.rs
@@ -227,7 +227,7 @@ where
             .expect("could not convert keypair to public_key");
 
         let mut trust_anchor = TrustAnchors::empty();
-        trust_anchor.insert_with_name(&public_key, handler.origin().clone());
+        trust_anchor.insert(&public_key, handler.origin().clone());
 
         Arc::new(trust_anchor)
     };

--- a/tests/integration-tests/tests/integration/validating_forwarder_tests.rs
+++ b/tests/integration-tests/tests/integration/validating_forwarder_tests.rs
@@ -233,7 +233,7 @@ async fn setup_client_forwarder(
 
     if let Some(public_key) = public_key {
         let mut anchors = TrustAnchors::empty();
-        anchors.insert(public_key);
+        anchors.insert(public_key, Name::root().into());
         builder = builder.with_trust_anchor(Arc::new(anchors));
     }
     let handler = builder.build().unwrap();

--- a/util/src/bin/dns.rs
+++ b/util/src/bin/dns.rs
@@ -41,7 +41,7 @@ use hickory_net::{
 #[cfg(feature = "__dnssec")]
 use hickory_proto::{
     dnssec::{Algorithm, PublicKey, TrustAnchors, Verifier, rdata::DNSKEY},
-    rr::Record,
+    rr::{LowerName, Record},
 };
 use hickory_proto::{
     op::DnsResponse,
@@ -329,6 +329,7 @@ impl FetchKeysOpt {
         mut client: impl ClientHandle,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let Self { zone, output_dir } = self;
+        let zone_lower = LowerName::from(&zone);
 
         println!("; querying {zone} for key-signing-dnskeys, KSKs");
 
@@ -349,7 +350,7 @@ impl FetchKeysOpt {
         {
             let key_tag = dnskey.data().calculate_key_tag().expect("key_tag failed");
             let algorithm = dnskey.data().algorithm();
-            let in_trust_anchor = trust_anchor.contains(dnskey.data().public_key());
+            let in_trust_anchor = trust_anchor.contains(dnskey.data().public_key(), &zone_lower);
 
             if !dnskey.data().algorithm().is_supported() {
                 println!(


### PR DESCRIPTION
This makes some breaking changes to the `TrustAnchor` API to simplify it. This is a follow up to previous changes that added support for keeping track of names associated with each trust anchor public key, in a backwards-compatible manner.