### PR TITLE
Use IP address constants

### DIFF
--- a/bin/src/config/tests.rs
+++ b/bin/src/config/tests.rs
@@ -99,7 +99,7 @@ fn test_parse_toml() {
     let config = Config::from_toml("listen_addrs_ipv6 = [\"::0\", \"::1\"]").unwrap();
     assert_eq!(
         config.listen_addrs_ipv6,
-        vec![Ipv6Addr::UNSPECIFIED, Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)]
+        vec![Ipv6Addr::UNSPECIFIED, Ipv6Addr::LOCALHOST]
     );
 
     let config = Config::from_toml("tcp_request_timeout = 25").unwrap();

--- a/conformance/compatibility-tests/src/tsig_tests.rs
+++ b/conformance/compatibility-tests/src/tsig_tests.rs
@@ -127,7 +127,7 @@ async fn test_tsig_zone_transfer() {
         zone_file.add(TestA {
             fqdn: FQDN::from_str(&format!("www{i}.example.net.")).unwrap(),
             ttl: 86400,
-            ipv4_addr: Ipv4Addr::new(127, 0, 0, 1),
+            ipv4_addr: Ipv4Addr::LOCALHOST,
         });
     }
 

--- a/conformance/compatibility-tests/src/zone_transfer.rs
+++ b/conformance/compatibility-tests/src/zone_transfer.rs
@@ -63,7 +63,7 @@ async fn test_zone_transfer() {
         zone_file.add(TestA {
             fqdn: FQDN::from_str(&format!("www{i}.example.net.")).unwrap(),
             ttl: 86400,
-            ipv4_addr: Ipv4Addr::new(127, 0, 0, 1),
+            ipv4_addr: Ipv4Addr::LOCALHOST,
         });
     }
 

--- a/conformance/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
+++ b/conformance/conformance-tests/src/resolver/dnssec/scenarios/bogus.rs
@@ -701,7 +701,7 @@ fn invalid_nsec_wildcard_no_data_test(
     leaf_ns.add(Record::a(wildcard_fqdn.clone(), Ipv4Addr::new(1, 2, 3, 4)));
     // This name ensures the NSEC records matching the wildcard and covering the query are
     // different.
-    leaf_ns.add(Record::a(zero_fqdn.clone(), Ipv4Addr::new(127, 0, 0, 1)));
+    leaf_ns.add(Record::a(zero_fqdn.clone(), Ipv4Addr::LOCALHOST));
 
     let Graph {
         nameservers: _nameservers,

--- a/crates/net/src/tcp/tcp_client_stream.rs
+++ b/crates/net/src/tcp/tcp_client_stream.rs
@@ -155,10 +155,6 @@ mod tests {
     #[tokio::test]
     async fn test_tcp_stream_ipv6() {
         subscribe();
-        tcp_client_stream_test(
-            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
-            TokioRuntimeProvider::new(),
-        )
-        .await;
+        tcp_client_stream_test(IpAddr::V6(Ipv6Addr::LOCALHOST), TokioRuntimeProvider::new()).await;
     }
 }

--- a/crates/net/src/tcp/tcp_stream.rs
+++ b/crates/net/src/tcp/tcp_stream.rs
@@ -412,10 +412,6 @@ mod tests {
     #[tokio::test]
     async fn test_tcp_stream_ipv6() {
         subscribe();
-        tcp_stream_test(
-            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
-            TokioRuntimeProvider::new(),
-        )
-        .await;
+        tcp_stream_test(IpAddr::V6(Ipv6Addr::LOCALHOST), TokioRuntimeProvider::new()).await;
     }
 }

--- a/crates/net/src/udp/udp_client_stream.rs
+++ b/crates/net/src/udp/udp_client_stream.rs
@@ -544,21 +544,14 @@ mod tests {
     #[tokio::test]
     async fn test_udp_client_stream_ipv6() {
         subscribe();
-        udp_client_stream_test(
-            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
-            TokioRuntimeProvider::new(),
-        )
-        .await;
+        udp_client_stream_test(IpAddr::V6(Ipv6Addr::LOCALHOST), TokioRuntimeProvider::new()).await;
     }
 
     #[tokio::test]
     async fn test_udp_client_stream_ipv6_bad_id() {
         subscribe();
-        udp_client_stream_bad_id_test(
-            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
-            TokioRuntimeProvider::new(),
-        )
-        .await;
+        udp_client_stream_bad_id_test(IpAddr::V6(Ipv6Addr::LOCALHOST), TokioRuntimeProvider::new())
+            .await;
     }
 
     #[tokio::test]

--- a/crates/net/src/udp/udp_stream.rs
+++ b/crates/net/src/udp/udp_stream.rs
@@ -393,6 +393,6 @@ mod tests {
     async fn test_udp_stream_ipv6() {
         subscribe();
         let provider = TokioRuntimeProvider::new();
-        udp_stream_test(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), provider).await;
+        udp_stream_test(IpAddr::V6(Ipv6Addr::LOCALHOST), provider).await;
     }
 }

--- a/crates/resolver/src/caching_client.rs
+++ b/crates/resolver/src/caching_client.rs
@@ -937,7 +937,7 @@ mod tests {
     //                 Name::from_str("www.example.com.").unwrap(),
     //             )),
     //             RData::A(Ipv4Addr::LOCALHOST),
-    //             //RData::AAAA(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+    //             //RData::AAAA(Ipv6Addr::LOCALHOST),
     //         ]
     //     );
     // }
@@ -1766,10 +1766,7 @@ mod tests {
         }
 
         {
-            let query = Query::new(
-                Name::from(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
-                RecordType::PTR,
-            );
+            let query = Query::new(Name::from(Ipv6Addr::LOCALHOST), RecordType::PTR);
             let lookup = block_on(client.lookup(query.clone(), DnsRequestOptions::default()))
                 .expect("should have returned localhost");
             assert_eq!(lookup.query(), &query);
@@ -1801,10 +1798,7 @@ mod tests {
 
         assert!(
             block_on(client.lookup(
-                Query::new(
-                    Name::from(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
-                    RecordType::MX
-                ),
+                Query::new(Name::from(Ipv6Addr::LOCALHOST), RecordType::MX),
                 DnsRequestOptions::default()
             ))
             .is_err()

--- a/crates/resolver/src/hosts.rs
+++ b/crates/resolver/src/hosts.rs
@@ -272,7 +272,7 @@ mod tests {
             &[Record::from_rdata(
                 name,
                 MAX_TTL,
-                RData::AAAA(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1).into())
+                RData::AAAA(Ipv6Addr::LOCALHOST.into())
             )]
         );
 

--- a/crates/resolver/src/lookup_ip.rs
+++ b/crates/resolver/src/lookup_ip.rs
@@ -386,7 +386,7 @@ pub(crate) mod tests {
         message.insert_answers(vec![Record::from_rdata(
             Name::root(),
             86400,
-            RData::AAAA(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1).into()),
+            RData::AAAA(Ipv6Addr::LOCALHOST.into()),
         )]);
 
         let resp = DnsResponse::from_message(message.into_response()).unwrap();
@@ -511,7 +511,7 @@ pub(crate) mod tests {
                 .iter()
                 .map(|r| r.data.ip_addr().unwrap())
                 .collect::<Vec<IpAddr>>(),
-            vec![Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)]
+            vec![Ipv6Addr::LOCALHOST]
         );
     }
 
@@ -536,7 +536,7 @@ pub(crate) mod tests {
                 .collect::<Vec<IpAddr>>(),
             vec![
                 IpAddr::V4(Ipv4Addr::LOCALHOST),
-                IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+                IpAddr::V6(Ipv6Addr::LOCALHOST),
             ]
         );
 
@@ -573,7 +573,7 @@ pub(crate) mod tests {
                 .iter()
                 .map(|r| r.data.ip_addr().unwrap())
                 .collect::<Vec<IpAddr>>(),
-            vec![IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))]
+            vec![IpAddr::V6(Ipv6Addr::LOCALHOST)]
         );
 
         // error, then only ipv6 available
@@ -585,7 +585,7 @@ pub(crate) mod tests {
                 .iter()
                 .map(|r| r.data.ip_addr().unwrap())
                 .collect::<Vec<IpAddr>>(),
-            vec![IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))]
+            vec![IpAddr::V6(Ipv6Addr::LOCALHOST)]
         );
     }
 
@@ -609,7 +609,7 @@ pub(crate) mod tests {
                 .map(|r| r.data.ip_addr().unwrap())
                 .collect::<Vec<IpAddr>>(),
             vec![
-                IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+                IpAddr::V6(Ipv6Addr::LOCALHOST),
                 IpAddr::V4(Ipv4Addr::LOCALHOST),
             ]
         );
@@ -647,7 +647,7 @@ pub(crate) mod tests {
                 .iter()
                 .map(|r| r.data.ip_addr().unwrap())
                 .collect::<Vec<IpAddr>>(),
-            vec![IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))]
+            vec![IpAddr::V6(Ipv6Addr::LOCALHOST)]
         );
 
         // v4 errors, v6 succeeds
@@ -659,7 +659,7 @@ pub(crate) mod tests {
                 .iter()
                 .map(|r| r.data.ip_addr().unwrap())
                 .collect::<Vec<IpAddr>>(),
-            vec![IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))]
+            vec![IpAddr::V6(Ipv6Addr::LOCALHOST)]
         );
     }
 
@@ -681,7 +681,7 @@ pub(crate) mod tests {
                 .iter()
                 .map(|r| r.data.ip_addr().unwrap())
                 .collect::<Vec<IpAddr>>(),
-            vec![Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)]
+            vec![Ipv6Addr::LOCALHOST]
         );
 
         // nothing then ipv4
@@ -739,7 +739,7 @@ pub(crate) mod tests {
                 .iter()
                 .map(|r| r.data.ip_addr().unwrap())
                 .collect::<Vec<IpAddr>>(),
-            vec![Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)]
+            vec![Ipv6Addr::LOCALHOST]
         );
 
         // error then ipv6
@@ -751,7 +751,7 @@ pub(crate) mod tests {
                 .iter()
                 .map(|r| r.data.ip_addr().unwrap())
                 .collect::<Vec<IpAddr>>(),
-            vec![Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)]
+            vec![Ipv6Addr::LOCALHOST]
         );
     }
 }

--- a/crates/resolver/src/resolver.rs
+++ b/crates/resolver/src/resolver.rs
@@ -1133,7 +1133,7 @@ pub(crate) mod testing {
         let mut iter = response.iter();
         assert_eq!(
             iter.next().expect("no AAAA"),
-            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1,))
+            IpAddr::V6(Ipv6Addr::LOCALHOST)
         );
     }
 

--- a/tests/integration-tests/tests/integration/lookup_tests.rs
+++ b/tests/integration-tests/tests/integration/lookup_tests.rs
@@ -93,10 +93,7 @@ async fn test_lookup_hosts() {
     );
     let lookup = lookup.await.unwrap();
 
-    assert_eq!(
-        lookup.iter().next().unwrap(),
-        Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)
-    );
+    assert_eq!(lookup.iter().next().unwrap(), Ipv6Addr::LOCALHOST);
 }
 
 fn create_ip_like_example() -> InMemoryZoneHandler {


### PR DESCRIPTION
This simplifies some test code with more use of `Ipv4Addr`/`Ipv6Addr` constants.