### PR TITLE
test-server: Fix parsing NSEC3PARAM salt from text

### DIFF
--- a/conformance/test-server/src/zone_file.rs
+++ b/conformance/test-server/src/zone_file.rs
@@ -182,9 +182,9 @@ pub(crate) fn parse_zone_file(path: &Path) -> Result<Vec<Record>, String> {
                         Nsec3HashAlgorithm::try_from(
                             tokens[4]
                                 .parse::<u8>()
-                                .map_err(|e| format!("NSEC3PARAM algorithm error: {e:?}"))?,
+                                .map_err(|e| format!("NSEC3 algorithm error: {e:?}"))?,
                         )
-                        .map_err(|e| format!("NSEC3PARAM algorithm error: {e:?}"))?,
+                        .map_err(|e| format!("NSEC3 algorithm error: {e:?}"))?,
                         tokens[5] == "1",
                         tokens[6]
                             .parse()
@@ -268,7 +268,9 @@ pub(crate) fn parse_zone_file(path: &Path) -> Result<Vec<Record>, String> {
                         if tokens[7] == "-" {
                             vec![]
                         } else {
-                            tokens[8].as_bytes().to_vec()
+                            HEXUPPER
+                                .decode(tokens[7].as_bytes())
+                                .map_err(|e| format!("NSEC3PARAM unable to decode salt: {e:?}"))?
                         },
                     ))),
                 ));


### PR DESCRIPTION
I noticed that the test server's zone file parsing code handles the salt field of NSEC3PARAM records incorrectly. This doesn't currently affect us, because we only use empty salt values for now. This PR fixes it by copying from the NSEC3 parsing code.