### PR TITLE
Clean up allow attributes

### DIFF
--- a/bin/tests/integration/server_harness.rs
+++ b/bin/tests/integration/server_harness.rs
@@ -97,7 +97,6 @@ pub struct TestServer {
 
 impl TestServer {
     /// Spins up a Server and handles shutting it down after running the test
-    #[allow(dead_code)]
     pub fn start(toml: &str) -> Self {
         let server_path = env::var("TDNS_WORKSPACE_ROOT").unwrap_or_else(|_| "..".to_owned());
         println!("using server src path: {server_path}");

--- a/bin/tests/integration/txt_tests.rs
+++ b/bin/tests/integration/txt_tests.rs
@@ -12,7 +12,6 @@ use test_support::subscribe;
 
 // TODO: split this test up to test each thing separately
 #[tokio::test]
-#[allow(clippy::cognitive_complexity)]
 async fn test_zone() {
     subscribe();
 

--- a/bin/tests/integration/zone_handler_battery/basic.rs
+++ b/bin/tests/integration/zone_handler_battery/basic.rs
@@ -509,7 +509,6 @@ pub fn test_update_errors(handler: impl ZoneHandler) {
     );
 }
 
-#[allow(clippy::uninlined_format_args)]
 pub fn test_dots_in_name(handler: impl ZoneHandler) {
     let request = Request::from_message(
         MessageRequest::mock(
@@ -558,8 +557,7 @@ pub fn test_dots_in_name(handler: impl ZoneHandler) {
 
     assert!(
         matches!(lookup, LookupError::NameExists),
-        "lookup: {}",
-        lookup
+        "lookup: {lookup}"
     );
 
     // the rest should all be NameExists

--- a/crates/net/src/dnssec/error.rs
+++ b/crates/net/src/dnssec/error.rs
@@ -13,7 +13,6 @@ use crate::{
 };
 
 /// The error kind for dnssec errors that get returned in the crate
-#[allow(unreachable_pub)]
 #[derive(Debug, Error, Clone)]
 #[non_exhaustive]
 pub enum ProofErrorKind {

--- a/crates/net/src/multicast/mdns_stream.rs
+++ b/crates/net/src/multicast/mdns_stream.rs
@@ -439,7 +439,6 @@ pub(crate) mod tests {
 
     // one_shot tests are basically clones from the udp tests
     #[tokio::test]
-    #[allow(unused_qualifications)] // https://github.com/rust-lang/rust/issues/149873
     async fn test_next_random_socket() {
         subscribe();
 

--- a/crates/net/src/runtime.rs
+++ b/crates/net/src/runtime.rs
@@ -119,7 +119,6 @@ pub mod iocompat {
 }
 
 #[cfg(feature = "tokio")]
-#[allow(unreachable_pub)]
 mod tokio_runtime {
     use std::sync::Arc;
     use std::sync::Mutex;

--- a/crates/net/src/tcp/tcp_stream.rs
+++ b/crates/net/src/tcp/tcp_stream.rs
@@ -193,7 +193,6 @@ impl<S: DnsTcpStream> TcpStream<S> {
 impl<S: DnsTcpStream> Stream for TcpStream<S> {
     type Item = io::Result<SerialMessage>;
 
-    #[allow(clippy::cognitive_complexity)]
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let peer = self.peer_addr;
         let (socket, outbound_messages, send_state, read_state) = self.pollable_split();

--- a/crates/proto/src/op/op_code.rs
+++ b/crates/proto/src/op/op_code.rs
@@ -31,7 +31,6 @@ use serde::{Deserialize, Serialize};
 /// ```
 #[derive(Debug, PartialEq, Eq, PartialOrd, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[allow(dead_code)]
 pub enum OpCode {
     /// Query request [RFC 1035](https://tools.ietf.org/html/rfc1035)
     Query,

--- a/crates/proto/src/op/response_code.rs
+++ b/crates/proto/src/op/response_code.rs
@@ -63,7 +63,6 @@ use serde::{Deserialize, Serialize};
 ///  ```
 #[derive(Debug, Default, Eq, PartialEq, PartialOrd, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[allow(dead_code)]
 pub enum ResponseCode {
     /// No Error [RFC 1035](https://tools.ietf.org/html/rfc1035)
     #[default]

--- a/crates/proto/src/rr/dns_class.rs
+++ b/crates/proto/src/rr/dns_class.rs
@@ -24,7 +24,6 @@ use crate::serialize::binary::*;
 /// The DNS Record class
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
-#[allow(dead_code)]
 pub enum DNSClass {
     /// Internet
     IN,

--- a/crates/proto/src/rr/record_type.rs
+++ b/crates/proto/src/rr/record_type.rs
@@ -28,7 +28,6 @@ use crate::serialize::binary::*;
 /// This specifies the type of data in the RData field of the Resource Record
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
-#[allow(dead_code)]
 #[non_exhaustive]
 pub enum RecordType {
     /// [RFC 1035](https://tools.ietf.org/html/rfc1035) IPv4 Address record

--- a/crates/proto/src/serialize/txt/zone.rs
+++ b/crates/proto/src/serialize/txt/zone.rs
@@ -450,7 +450,6 @@ mod tests {
     use super::*;
 
     #[test]
-    #[allow(clippy::uninlined_format_args)]
     fn test_zone_parse() {
         let domain = Name::from_str("parameter.origin.org.").unwrap();
 
@@ -466,8 +465,7 @@ mod tests {
                     .unwrap_err()
                     .to_string()
                     .contains("FAULTY-RECORD-TYPE"),
-            "unexpected success: {:#?}",
-            result
+            "unexpected success: {result:#?}"
         );
     }
 }

--- a/crates/proto/src/serialize/txt/zone_lex.rs
+++ b/crates/proto/src/serialize/txt/zone_lex.rs
@@ -597,7 +597,6 @@ mod lex_test {
     }
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
     fn soa() {
         let mut lexer = Lexer::new(
             "@   IN  SOA     VENERA      Action\\.domains (

--- a/crates/proto/src/serialize/txt/zone_lex.rs
+++ b/crates/proto/src/serialize/txt/zone_lex.rs
@@ -373,10 +373,9 @@ mod lex_test {
 
     use super::*;
 
-    #[allow(clippy::uninlined_format_args)]
     fn next_token(lexer: &mut Lexer<'_>) -> Option<Token> {
         let result = lexer.next_token();
-        assert!(result.is_ok(), "{:?}", result);
+        assert!(result.is_ok(), "{result:?}");
         result.unwrap()
     }
 

--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -456,7 +456,6 @@ impl<'de> Deserialize<'de> for ConnectionConfig {
 }
 
 /// Protocol configuration
-#[allow(missing_docs)]
 #[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(
     feature = "serde",
@@ -464,14 +463,18 @@ impl<'de> Deserialize<'de> for ConnectionConfig {
     serde(deny_unknown_fields, rename_all = "snake_case", tag = "type")
 )]
 pub enum ProtocolConfig {
+    /// DNS over UDP
     #[default]
     Udp,
+    /// DNS over TCP
     Tcp,
+    /// DNS over TLS
     #[cfg(feature = "__tls")]
     Tls {
         /// The server name to use in the TLS handshake.
         server_name: Arc<str>,
     },
+    /// DNS over HTTP, with HTTP/2
     #[cfg(feature = "__https")]
     Https {
         /// The server name to use in the TLS handshake.
@@ -479,11 +482,13 @@ pub enum ProtocolConfig {
         /// The path (or endpoint) to use for the DNS query.
         path: Arc<str>,
     },
+    /// DNS over QUIC
     #[cfg(feature = "__quic")]
     Quic {
         /// The server name to use in the TLS handshake.
         server_name: Arc<str>,
     },
+    /// DNS over HTTP, with HTTP/3
     #[cfg(feature = "__h3")]
     H3 {
         /// The server name to use in the TLS handshake.

--- a/crates/resolver/src/name_server_pool.rs
+++ b/crates/resolver/src/name_server_pool.rs
@@ -1024,7 +1024,6 @@ mod tests {
     #[ignore]
     // because of there is a real connection that needs a reasonable timeout
     #[test]
-    #[allow(clippy::uninlined_format_args)]
     fn test_failed_then_success_pool() {
         subscribe();
 
@@ -1058,8 +1057,7 @@ mod tests {
                         .first_answer()
                     )
                     .is_err(),
-                "iter: {}",
-                i
+                "iter: {i}"
             );
         }
 
@@ -1074,8 +1072,7 @@ mod tests {
                         .first_answer()
                     )
                     .is_ok(),
-                "iter: {}",
-                i
+                "iter: {i}"
             );
         }
     }

--- a/crates/server/src/server/timeout_stream.rs
+++ b/crates/server/src/server/timeout_stream.rs
@@ -113,7 +113,6 @@ mod tests {
     fn test_no_timeout() {
         subscribe();
 
-        #[allow(deprecated)]
         let sequence = iter(vec![Ok(1), Err("error"), Ok(2)]).map_err(io::Error::other);
         let core = Runtime::new().expect("could not get core");
 

--- a/tests/integration-tests/tests/integration/client_tests.rs
+++ b/tests/integration-tests/tests/integration/client_tests.rs
@@ -216,7 +216,6 @@ async fn test_query_edns_response(client: Client<TokioRuntimeProvider>) {
 
 #[tokio::test]
 #[ignore = "flaky test against internet server"]
-#[allow(deprecated)]
 #[cfg(feature = "__dnssec")]
 async fn test_secure_query_example_udp() {
     subscribe();
@@ -225,7 +224,6 @@ async fn test_secure_query_example_udp() {
 }
 
 #[tokio::test]
-#[allow(deprecated)]
 #[cfg(feature = "__dnssec")]
 async fn test_secure_query_example_tcp() {
     subscribe();
@@ -342,7 +340,6 @@ async fn test_timeout_query_tcp() {
 
 #[tokio::test]
 #[ignore = "flaky test against internet server"]
-#[allow(deprecated)]
 #[cfg(feature = "__dnssec")]
 async fn test_nsec_query_example_udp() {
     subscribe();
@@ -352,7 +349,6 @@ async fn test_nsec_query_example_udp() {
 
 #[tokio::test]
 #[ignore = "flaky test against internet server"]
-#[allow(deprecated)]
 #[cfg(feature = "__dnssec")]
 async fn test_nsec_query_example_tcp() {
     subscribe();
@@ -408,7 +404,6 @@ async fn test_nsec3_nxdomain() {
     assert_eq!(response.metadata.response_code, ResponseCode::NXDomain);
 }
 
-#[allow(deprecated)]
 #[cfg(all(feature = "__dnssec", feature = "sqlite"))]
 async fn create_tsig_ready_client(mut catalog: Catalog) -> (Client<TokioRuntimeProvider>, Name) {
     use hickory_proto::rr::TSigner;

--- a/tests/integration-tests/tests/integration/name_server_pool_tests.rs
+++ b/tests/integration-tests/tests/integration/name_server_pool_tests.rs
@@ -550,7 +550,6 @@ fn test_noerror_doesnt_leak() {
 }
 
 #[test]
-#[allow(clippy::uninlined_format_args)]
 fn test_distrust_nx_responses() {
     subscribe();
 
@@ -590,8 +589,7 @@ fn test_distrust_nx_responses() {
         assert_eq!(
             response.answers,
             slice::from_ref(&v4_record),
-            "did not see expected fallback behavior on response code `{}`",
-            response_code
+            "did not see expected fallback behavior on response code `{response_code}`"
         );
     }
 }

--- a/tests/integration-tests/tests/integration/server_future_tests.rs
+++ b/tests/integration-tests/tests/integration/server_future_tests.rs
@@ -38,7 +38,6 @@ use hickory_server::zone_handler::{Catalog, ZoneHandler};
 use test_support::subscribe;
 
 #[tokio::test]
-#[allow(clippy::uninlined_format_args)]
 async fn test_server_www_udp() {
     subscribe();
 
@@ -46,7 +45,7 @@ async fn test_server_www_udp() {
     let udp_socket = UdpSocket::bind(&addr).await.unwrap();
 
     let ipaddr = udp_socket.local_addr().unwrap();
-    println!("udp_socket on port: {}", ipaddr);
+    println!("udp_socket on port: {ipaddr}");
     let server_continue = Arc::new(AtomicBool::new(true));
     let server_continue2 = server_continue.clone();
 
@@ -54,13 +53,12 @@ async fn test_server_www_udp() {
     let client = tokio::spawn(client_thread_www(lazy_udp_client(ipaddr)));
 
     let client_result = client.await;
-    assert!(client_result.is_ok(), "client failed: {:?}", client_result);
+    assert!(client_result.is_ok(), "client failed: {client_result:?}");
     server_continue.store(false, Ordering::Relaxed);
     server.await.unwrap();
 }
 
 #[tokio::test]
-#[allow(clippy::uninlined_format_args)]
 async fn test_server_www_tcp() {
     subscribe();
 
@@ -68,7 +66,7 @@ async fn test_server_www_tcp() {
     let tcp_listener = TcpListener::bind(&addr).await.unwrap();
 
     let ipaddr = tcp_listener.local_addr().unwrap();
-    println!("tcp_listener on port: {}", ipaddr);
+    println!("tcp_listener on port: {ipaddr}");
     let server_continue = Arc::new(AtomicBool::new(true));
     let server_continue2 = server_continue.clone();
 
@@ -76,7 +74,7 @@ async fn test_server_www_tcp() {
     let client = tokio::spawn(client_thread_www(lazy_tcp_client(ipaddr)));
 
     let client_result = client.await;
-    assert!(client_result.is_ok(), "client failed: {:?}", client_result);
+    assert!(client_result.is_ok(), "client failed: {client_result:?}");
     server_continue.store(false, Ordering::Relaxed);
     server.await.unwrap();
 }

--- a/tests/integration-tests/tests/integration/sqlite_zone_handler_tests.rs
+++ b/tests/integration-tests/tests/integration/sqlite_zone_handler_tests.rs
@@ -1118,7 +1118,6 @@ fn test_update_message(name: Name) -> Message {
 
 #[cfg(feature = "__dnssec")]
 #[tokio::test]
-#[allow(clippy::uninlined_format_args)]
 async fn test_zone_signing() {
     use hickory_proto::{dnssec::rdata::RRSIG, rr::RecordData};
 
@@ -1172,8 +1171,7 @@ async fn test_zone_signing() {
                     }
                 })
                 .any(|rrsig| rrsig.input().type_covered == record.record_type()),
-            "record type not covered: {:?}",
-            record
+            "record type not covered: {record:?}"
         );
     }
 }


### PR DESCRIPTION
This gets rid of several `#[allow]` attributes, either deleting them if they are no longer needed, or making easy fixes first.