### PR TITLE
Fix warnings (release/0.26)

### DIFF
--- a/crates/resolver/src/config.rs
+++ b/crates/resolver/src/config.rs
@@ -14,6 +14,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 #[cfg(all(
+    feature = "recursor",
     feature = "toml",
     feature = "serde",
     any(feature = "__tls", feature = "__quic")
@@ -25,6 +26,7 @@ use ipnet::IpNet;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 #[cfg(all(
+    feature = "recursor",
     feature = "toml",
     feature = "serde",
     any(feature = "__tls", feature = "__quic")
@@ -32,6 +34,7 @@ use tracing::warn;
 use tracing::{debug, info};
 
 #[cfg(all(
+    feature = "recursor",
     feature = "toml",
     feature = "serde",
     any(feature = "__tls", feature = "__quic")
@@ -793,6 +796,7 @@ pub enum OpportunisticEncryption {
 
 impl OpportunisticEncryption {
     #[cfg(all(
+        feature = "recursor",
         feature = "toml",
         feature = "serde",
         any(feature = "__tls", feature = "__quic")

--- a/crates/resolver/src/name_server_pool.rs
+++ b/crates/resolver/src/name_server_pool.rs
@@ -133,7 +133,7 @@ impl<P: ConnectionProvider> NameServerPool<P> {
 
 // Type alias for TTL unit tests to use tokio's time pause/advance
 #[cfg(not(feature = "tokio"))]
-type TtlInstant = std::time::Instant;
+type TtlInstant = Instant;
 #[cfg(feature = "tokio")]
 type TtlInstant = tokio::time::Instant;
 


### PR DESCRIPTION
This fixes a couple warnings I noticed on the release branch in the `cargo-all-features` jobs. One fix is backported from the main branch.