### PR TITLE
Resolve TODO in name parser, add early length check

### DIFF
--- a/crates/proto/src/rr/domain/name.rs
+++ b/crates/proto/src/rr/domain/name.rs
@@ -1352,10 +1352,14 @@ fn read_inner(decoder: &mut BinDecoder<'_>, name: &mut Name) -> Result<(), Decod
                 decoder.pop()?;
                 break;
             }
+        };
+
+        // Early, cheap check for names that are definitely too long:
+        if name.label_data.len() >= 255 {
+            return Err(DecodeError::DomainNameTooLong(name.len()));
         }
     }
 
-    // TODO: should we consider checking this while the name is parsed?
     let len = name.len();
     if len >= 255 {
         return Err(DecodeError::DomainNameTooLong(len));


### PR DESCRIPTION
This implements a suggestion in a TODO comment, adding a check to the wire protocol name decoder for too-long names after each label. This new check only looks at the length of `label_data`, and not the number of labels, to keep the impact on benchmarks negligible. This won't catch too-long names on the earliest possible loop iteration, but it won't have any false positives.