### PR TITLE
recursor: Add cross-zone cname loop detection and return SERVFAIL on CNAME loops

### DIFF
--- a/crates/resolver/src/recursor/handle.rs
+++ b/crates/resolver/src/recursor/handle.rs
@@ -356,7 +356,8 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
             if let Some(target_name) = target_name_opt {
                 if name_history.contains(&target_name) {
                     // The CNAME records form a loop.
-                    break;
+                    debug!(%query, %target_name, "CNAME loop detected within response");
+                    return Err(RecursorError::from("CNAME loop detected"));
                 }
                 name_history.push(target_name);
                 effective_qname = target_name;
@@ -374,6 +375,18 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
                     record_type: RecordType::CNAME,
                 });
             }
+
+            // Refuse to follow a chain that re-enters a cname already being followed higher up
+            // the stack: the chain has looped back on itself across responses.
+            let _in_flight = limits
+                .try_enter_cnames(effective_qname, &name_history)
+                .inspect_err(|_| {
+                    debug!(
+                        %query,
+                        %effective_qname,
+                        "refusing to re-enter cname already on resolution stack"
+                    );
+                })?;
 
             // Note that we aren't worried about whether the intermediates are local or remote
             // to the original queried name, or included or not included in the original
@@ -923,6 +936,7 @@ pub(crate) struct RequestLimits {
     req_query_count: AtomicU8,
     cname_limit: AtomicU8,
     in_flight_zones: Mutex<HashSet<Name>>,
+    in_flight_cnames: Mutex<HashSet<Name>>,
 }
 
 impl RequestLimits {
@@ -931,6 +945,7 @@ impl RequestLimits {
             req_query_count: AtomicU8::new(0),
             cname_limit: AtomicU8::new(0),
             in_flight_zones: Mutex::new(HashSet::new()),
+            in_flight_cnames: Mutex::new(HashSet::new()),
         }
     }
 
@@ -959,6 +974,36 @@ impl RequestLimits {
             zone: zone.clone(),
         })
     }
+
+    /// Push a CNAME chain onto the resolution stack for the lifetime of the returned guard.
+    /// `chain` is the names walked within a single response, ending with `target`, the name
+    /// about to be resolved via a new query. Any name already on the stack means the chain
+    /// loops back across responses (e.g. `a.zone1 -> b.zone2 -> a.zone1`).
+    ///
+    /// `target` itself is not pushed: it is the next level's query name, and that level pushes it.
+    fn try_enter_cnames<'a>(
+        &'a self,
+        target: &Name,
+        chain: &[&'a Name],
+    ) -> Result<InFlightCnames<'a>, RecursorError> {
+        let mut in_flight = self.in_flight_cnames.lock();
+        if let Some(name) = chain.iter().find(|name| in_flight.contains(*name)) {
+            return Err(RecursorError::from(format!(
+                "CNAME {name} is already on the resolution stack"
+            )));
+        }
+
+        let names = chain
+            .iter()
+            .copied()
+            .filter(|name| *name != target)
+            .collect::<Vec<_>>();
+        in_flight.extend(names.iter().map(|name| (*name).clone()));
+        Ok(InFlightCnames {
+            limits: self,
+            names,
+        })
+    }
 }
 
 struct InFlightZone<'a> {
@@ -969,6 +1014,20 @@ struct InFlightZone<'a> {
 impl Drop for InFlightZone<'_> {
     fn drop(&mut self) {
         self.limits.in_flight_zones.lock().remove(&self.zone);
+    }
+}
+
+struct InFlightCnames<'a> {
+    limits: &'a RequestLimits,
+    names: Vec<&'a Name>,
+}
+
+impl Drop for InFlightCnames<'_> {
+    fn drop(&mut self) {
+        let mut in_flight = self.limits.in_flight_cnames.lock();
+        for name in &self.names {
+            in_flight.remove(*name);
+        }
     }
 }
 

--- a/crates/resolver/src/recursor/tests.rs
+++ b/crates/resolver/src/recursor/tests.rs
@@ -893,6 +893,177 @@ fn validate_response(response: Message, name: &Name, ip: IpAddr) -> bool {
         && response.answers == [Record::from_rdata(name.clone(), 0, ip.into())]
 }
 
+#[tokio::test]
+async fn self_referential_cname_returns_servfail() -> Result<(), NetError> {
+    subscribe();
+
+    let tld_zone = Name::from_ascii("testing.")?;
+    let tld_ns = Name::from_ascii("ns.testing.")?;
+
+    // `loop.testing.` aliases directly to itself.
+    let direct = Name::from_ascii("loop.testing.")?;
+    // `alias.testing.` aliases to `target.testing.`, which then aliases to itself.
+    let alias = Name::from_ascii("alias.testing.")?;
+    let target = Name::from_ascii("target.testing.")?;
+
+    let mut responses = vec![
+        MockRecord::ns(ROOT_IP, &tld_zone, &tld_ns),
+        MockRecord::a(ROOT_IP, &tld_ns, TLD_IP)
+            .with_query_name(&tld_zone)
+            .with_query_type(RecordType::NS)
+            .with_section(MockResponseSection::Additional),
+        MockRecord::cname(TLD_IP, &direct, &direct),
+        MockRecord::cname(TLD_IP, &alias, &target),
+        MockRecord::cname(TLD_IP, &target, &target),
+    ];
+
+    // The QNAME minimization probes for each name are answered with a no-data SOA, so the
+    // zone cut stays at `testing.`.
+    for name in [&direct, &alias, &target] {
+        responses.push(
+            MockRecord::soa(TLD_IP, &tld_zone, &tld_ns, &tld_ns)
+                .with_query_name(name)
+                .with_query_type(RecordType::NS)
+                .with_ttl(3600),
+        );
+    }
+
+    let provider = MockProvider::new(MockNetworkHandler::new(responses));
+    let recursor = Recursor::with_options(
+        &[ROOT_IP],
+        RecursorOptions {
+            deny_server: Vec::new(),
+            ..RecursorOptions::default()
+        },
+        provider.clone(),
+    )?;
+
+    for name in [&direct, &alias, &target] {
+        // The CNAME chain never reaches an A record, so the name is unresolvable and the
+        // recursor must not report success.
+        let result = recursor
+            .resolve(
+                Query::new(name.clone(), RecordType::A),
+                Instant::now(),
+                false,
+            )
+            .await;
+
+        let error = match result {
+            Ok(response) => panic!(
+                "expected an error for {name}, got {} with answers {:?}",
+                response.response_code, response.answers
+            ),
+            Err(error) => error,
+        };
+
+        // The failure must be the loop detection itself, not some other error (the mock
+        // answers unknown queries with SERVFAIL, which would also be a non-negative error).
+        // A loop error is neither NXDOMAIN nor NODATA, so the server renders it as SERVFAIL.
+        assert!(
+            matches!(&error, RecursorError::Message(m) if m.contains("loop")),
+            "expected CNAME loop error for {name}, got {error}"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn cross_zone_cname_loop_returns_servfail() -> Result<(), NetError> {
+    subscribe();
+
+    let tld_zone = Name::from_ascii("testing.")?;
+    let tld_ns = Name::from_ascii("ns.testing.")?;
+
+    // Two zones on separate name servers, each aliasing into the other:
+    //   a.zone1.testing. -> b.zone2.testing. -> a.zone1.testing.
+    // The loop is invisible within any single response and only closes across queries.
+    let zone1 = Name::from_ascii("zone1.testing.")?;
+    let zone1_ns = Name::from_ascii("ns.zone1.testing.")?;
+    let zone2 = Name::from_ascii("zone2.testing.")?;
+    let zone2_ns = Name::from_ascii("ns.zone2.testing.")?;
+    let a = Name::from_ascii("a.zone1.testing.")?;
+    let b = Name::from_ascii("b.zone2.testing.")?;
+
+    let responses = vec![
+        MockRecord::ns(ROOT_IP, &tld_zone, &tld_ns),
+        MockRecord::a(ROOT_IP, &tld_ns, TLD_IP)
+            .with_query_name(&tld_zone)
+            .with_query_type(RecordType::NS)
+            .with_section(MockResponseSection::Additional),
+        MockRecord::ns(TLD_IP, &zone1, &zone1_ns),
+        MockRecord::a(TLD_IP, &zone1_ns, LEAF_IP)
+            .with_query_name(&zone1)
+            .with_query_type(RecordType::NS)
+            .with_section(MockResponseSection::Additional),
+        MockRecord::ns(TLD_IP, &zone2, &zone2_ns),
+        MockRecord::a(TLD_IP, &zone2_ns, DELEGATED_LEAF_IP)
+            .with_query_name(&zone2)
+            .with_query_type(RecordType::NS)
+            .with_section(MockResponseSection::Additional),
+        MockRecord::cname(LEAF_IP, &a, &b),
+        MockRecord::soa(LEAF_IP, &zone1, &zone1_ns, &zone1_ns)
+            .with_query_name(&a)
+            .with_query_type(RecordType::NS)
+            .with_ttl(3600),
+        MockRecord::cname(DELEGATED_LEAF_IP, &b, &a),
+        MockRecord::soa(DELEGATED_LEAF_IP, &zone2, &zone2_ns, &zone2_ns)
+            .with_query_name(&b)
+            .with_query_type(RecordType::NS)
+            .with_ttl(3600),
+    ];
+
+    let provider = MockProvider::new(MockNetworkHandler::new(responses));
+    let recursor = Recursor::with_options(
+        &[ROOT_IP],
+        RecursorOptions {
+            deny_server: Vec::new(),
+            // Disable the response cache so that an undetected loop is visible as repeated
+            // upstream queries rather than being absorbed by cache hits.
+            response_cache_size: 0,
+            ..RecursorOptions::default()
+        },
+        provider.clone(),
+    )?;
+
+    let result = recursor
+        .resolve(Query::new(a.clone(), RecordType::A), Instant::now(), false)
+        .await;
+
+    let error = match result {
+        Ok(response) => panic!(
+            "expected an error for {a}, got {} with answers {:?}",
+            response.response_code, response.answers
+        ),
+        Err(error) => error,
+    };
+    assert!(
+        !error.is_nx_domain(),
+        "expected servfail for {a}, got {error}"
+    );
+    assert!(
+        !error.is_no_records_found(),
+        "expected servfail for {a}, got {error}"
+    );
+
+    // The loop must be detected on its first repeat, so each name server is asked for its
+    // record exactly once rather than until the recursion limit is hit.
+    for (ns, name) in [(LEAF_IP, &a), (DELEGATED_LEAF_IP, &b)] {
+        assert_eq!(
+            provider
+                .queries(&ns)
+                .iter()
+                .filter(|q| q.name == *name && q.query_type == RecordType::A)
+                .count(),
+            1,
+            "expected exactly one A query for {name}",
+        );
+    }
+
+    Ok(())
+}
+
 fn test_fixture() -> Result<(MockProvider, RecursorOptions), NetError> {
     let query_name = Name::from_ascii("host.hickory-dns.testing.")?;
     let dup_query_name = Name::from_ascii("host.hickory-dns-dup.testing.")?;

--- a/tests/test-support/src/lib.rs
+++ b/tests/test-support/src/lib.rs
@@ -21,7 +21,7 @@ use hickory_proto::{
     op::{Message, OpCode, Query, ResponseCode},
     rr::{
         Name, RData, Record, RecordType,
-        rdata::{A, NS, SOA, TXT},
+        rdata::{A, CNAME, NS, SOA, TXT},
     },
     serialize::binary::BinDecodable,
 };
@@ -112,6 +112,19 @@ impl MockRecord {
             query_type: RecordType::A,
             record_name: rr_name.clone(),
             record_data: RData::A(A(v4)),
+            section: MockResponseSection::Answer,
+        }
+    }
+
+    /// A CNAME record answering an A query for `rr_name`, aliasing it to `target`.
+    pub fn cname(server: IpAddr, rr_name: &Name, target: &Name) -> Self {
+        Self {
+            ns: server,
+            ttl: 3600,
+            query_name: rr_name.clone(),
+            query_type: RecordType::A,
+            record_name: rr_name.clone(),
+            record_data: RData::CNAME(CNAME(target.clone())),
             section: MockResponseSection::Answer,
         }
     }


### PR DESCRIPTION
Fixes #3566.

Two fixes to CNAME handling in `resolve_cnames`:

- **Loops within a single response** (`a CNAME a`, or `a CNAME b` + `b CNAME a`) were detected by the `name_history` walk but NOERROR was returned without the requested record.
Single-response CNAME loops now return SERVFAIL. RFC 1034 §3.6.2: "CNAME loops [should be] signalled as an error."
- **Loops spanning multiple responses** (`a.zone1 -> b.zone2 -> a.zone1`) weren't detected at all and ran until `recursion_limit`. I added `in_flight_cnames` that mirrors `in_flight_zones` in `RequestLimits` which tracks visited CNAMEs, so the loop is caught on its first repeat.  The guard takes the whole in-response chain (`name_history`) rather than just the query name, so a loop back into an intermediate name (`a -> b -> c` in one response, then `c -> b`) is caught immediately instead of sending one more upstream query.
- Add tests for both fixes.

