### PR TITLE
QUIC and HTTP/3 server improvements

### DIFF
--- a/crates/net/src/h3/h3_server.rs
+++ b/crates/net/src/h3/h3_server.rs
@@ -16,7 +16,7 @@ use h3::server::{Connection, RequestStream};
 use h3_quinn::{BidiStream, Endpoint};
 use http::Request;
 use quinn::crypto::rustls::QuicServerConfig;
-use quinn::{EndpointConfig, ServerConfig};
+use quinn::{Connecting, EndpointConfig, Incoming, ServerConfig};
 use rustls::server::ResolvesServerCert;
 use rustls::server::ServerConfig as TlsServerConfig;
 use rustls::version::TLS13;
@@ -85,21 +85,8 @@ impl H3Server {
     /// # Returns
     ///
     /// A remote connection that could accept many potential requests and the remote socket address
-    pub async fn accept(&mut self) -> Result<Option<(H3Connection, SocketAddr)>, NetError> {
-        let Some(connecting) = self.endpoint.accept().await else {
-            return Ok(None);
-        };
-
-        let remote_addr = connecting.remote_address();
-        let connection = connecting.await?;
-        Ok(Some((
-            H3Connection {
-                connection: Connection::new(h3_quinn::Connection::new(connection))
-                    .await
-                    .map_err(|e| NetError::from(format!("h3 connection failed: {e}")))?,
-            },
-            remote_addr,
-        )))
+    pub async fn accept(&mut self) -> Option<Incoming> {
+        self.endpoint.accept().await
     }
 
     /// Returns the address this server is listening on
@@ -117,6 +104,18 @@ pub struct H3Connection {
 }
 
 impl H3Connection {
+    /// Complete a QUIC handshake and set up an HTTP/3 connection.
+    pub async fn new(connecting: Connecting) -> Result<Self, NetError> {
+        let quinn_connection = connecting.await?;
+        let h3_quinn_connection = h3_quinn::Connection::new(quinn_connection);
+        let h3_connection = Connection::new(h3_quinn_connection)
+            .await
+            .map_err(|e| NetError::from(format!("h3 connection failed: {e}")))?;
+        Ok(Self {
+            connection: h3_connection,
+        })
+    }
+
     /// Accept the next request from the client
     pub async fn accept(
         &mut self,

--- a/crates/net/src/h3/h3_server.rs
+++ b/crates/net/src/h3/h3_server.rs
@@ -12,9 +12,8 @@ use std::io;
 use std::sync::Arc;
 
 use bytes::Bytes;
-use h3::server::{Connection, RequestStream};
-use h3_quinn::{BidiStream, Endpoint};
-use http::Request;
+use h3::server::{Connection, RequestResolver};
+use h3_quinn::Endpoint;
 use quinn::crypto::rustls::QuicServerConfig;
 use quinn::{Connecting, EndpointConfig, Incoming, ServerConfig};
 use rustls::server::ResolvesServerCert;
@@ -119,17 +118,11 @@ impl H3Connection {
     /// Accept the next request from the client
     pub async fn accept(
         &mut self,
-    ) -> Option<Result<(Request<()>, RequestStream<BidiStream<Bytes>, Bytes>), NetError>> {
-        match self.connection.accept().await {
-            Ok(Some(resolver)) => match resolver.resolve_request().await {
-                Ok((request, stream)) => Some(Ok((request, stream))),
-                Err(e) => Some(Err(NetError::from(format!(
-                    "h3 request resolution failed: {e}"
-                )))),
-            },
-            Ok(None) => None,
-            Err(e) => Some(Err(NetError::from(format!("h3 request failed: {e}")))),
-        }
+    ) -> Result<Option<RequestResolver<h3_quinn::Connection, Bytes>>, NetError> {
+        self.connection
+            .accept()
+            .await
+            .map_err(|e| NetError::from(format!("h3 request failed: {e}")))
     }
 
     /// Shutdown the connection.

--- a/crates/net/src/quic/quic_server.rs
+++ b/crates/net/src/quic/quic_server.rs
@@ -10,7 +10,7 @@ use std::io;
 use std::sync::Arc;
 
 use quinn::crypto::rustls::QuicServerConfig;
-use quinn::{Connection, Endpoint, ServerConfig};
+use quinn::{Connecting, Connection, Endpoint, Incoming, ServerConfig};
 use rustls::server::ResolvesServerCert;
 use rustls::server::ServerConfig as TlsServerConfig;
 use rustls::version::TLS13;
@@ -78,19 +78,9 @@ impl QuicServer {
         Ok(Self { endpoint })
     }
 
-    /// Get the next incoming stream
-    ///
-    /// # Returns
-    ///
-    /// A remote connection that could have many potential bi-directional streams and the remote socket address
-    pub async fn next(&mut self) -> Result<Option<(QuicStreams, SocketAddr)>, NetError> {
-        let Some(connecting) = self.endpoint.accept().await else {
-            return Ok(None);
-        };
-
-        let remote_addr = connecting.remote_address();
-        let connection = connecting.await?;
-        Ok(Some((QuicStreams { connection }, remote_addr)))
+    /// Get the next incoming connection.
+    pub async fn next(&mut self) -> Option<Incoming> {
+        self.endpoint.accept().await
     }
 
     /// Returns the address this server is listening on
@@ -108,6 +98,12 @@ pub struct QuicStreams {
 }
 
 impl QuicStreams {
+    /// Complete a QUIC handshake.
+    pub async fn new(connecting: Connecting) -> Result<Self, NetError> {
+        let connection = connecting.await?;
+        Ok(Self { connection })
+    }
+
     /// Get the next bi directional stream from the client
     pub async fn next(&mut self) -> Option<Result<QuicStream, NetError>> {
         match self.connection.accept_bi().await {

--- a/crates/net/src/quic/tests.rs
+++ b/crates/net/src/quic/tests.rs
@@ -27,7 +27,7 @@ use crate::{
         op::{Message, Query},
         rr::{Name, RecordType},
     },
-    quic::QuicClientStreamBuilder,
+    quic::{QuicClientStreamBuilder, QuicStreams},
     tls::default_provider,
     xfer::DnsRequestSender,
 };
@@ -35,13 +35,15 @@ use crate::{
 use super::quic_server::QuicServer;
 
 async fn server_responder(mut server: QuicServer) {
-    while let Some((mut conn, addr)) = server
-        .next()
-        .await
-        .expect("failed to get next quic session")
-    {
-        println!("received client request {addr}");
+    while let Some(incoming) = server.next().await {
+        println!("received client request {}", incoming.remote_address());
 
+        let connecting = incoming
+            .accept()
+            .expect("failed to accept next quic connection");
+        let mut conn = QuicStreams::new(connecting)
+            .await
+            .expect("failed to establish next quic connection");
         while let Some(stream) = conn.next().await {
             let mut stream = stream.expect("new client stream failed");
 

--- a/crates/server/src/server/h2_handler.rs
+++ b/crates/server/src/server/h2_handler.rs
@@ -73,7 +73,7 @@ pub(super) async fn handle_h2_with_acceptor(
 
     let mut inner_join_set = JoinSet::new();
     loop {
-        let shutdown = cx.shutdown.clone();
+        let shutdown = &cx.shutdown;
         let (tcp_stream, src_addr) = tokio::select! {
             tcp_stream = listener.accept() => match tcp_stream {
                 Ok((t, s)) => (t, s),

--- a/crates/server/src/server/h3_handler.rs
+++ b/crates/server/src/server/h3_handler.rs
@@ -139,39 +139,54 @@ pub(crate) async fn h3_handler(
         let Some(timeout_result) = future.await else {
             break; // A graceful shutdown was initiated.
         };
-        let Ok(accept_option) = timeout_result else {
+        let Ok(accept_result) = timeout_result else {
             break; // Timeout elapsed while waiting for a request.
         };
-        let Some(result) = accept_option else {
-            break; // The connection is closed.
-        };
-        let mut stream = match result {
-            Ok((_request, request_stream)) => request_stream,
+        let request_resolver_opt = match accept_result {
+            Ok(request_resolver_opt) => request_resolver_opt,
             Err(error) => {
-                warn!("error accepting request {}: {}", src_addr, error);
+                warn!(%src_addr, %error, "error accepting request");
                 return Err(error);
             }
         };
-
-        let fetch_future = fetch_body(
-            BodyStream::from(|cx: &mut Context<'_>| stream.poll_recv_data(cx)),
-            None,
-        );
-        let Ok(request_res) = timeout(h3_timeout, fetch_future).await else {
-            break; //Timeout while reading request.
+        let Some(request_resolver) = request_resolver_opt else {
+            break; // The connection is closed.
         };
-        let request = request_res?;
-
-        debug!(
-            "Received bytes {} from {src_addr} {request:?}",
-            request.remaining()
-        );
 
         let cx = cx.clone();
-        let stream = Arc::new(Mutex::new(stream));
-        let responder = H3ResponseHandle(stream.clone());
         tokio::spawn(async move {
-            cx.handle_request(request.freeze(), src_addr, Protocol::H3, responder)
+            let mut stream = match request_resolver.resolve_request().await {
+                Ok((_request, stream)) => stream,
+                Err(error) => {
+                    warn!(%error, "error receiving request headers");
+                    return;
+                }
+            };
+
+            let fetch_future = fetch_body(
+                BodyStream::from(|cx: &mut Context<'_>| stream.poll_recv_data(cx)),
+                None,
+            );
+            let Ok(request_res) = timeout(h3_timeout, fetch_future).await else {
+                return; //Timeout while reading request.
+            };
+            let request = match request_res {
+                Ok(bytes_mut) => bytes_mut.freeze(),
+                Err(error) => {
+                    warn!(%error, "error receiving request body");
+                    return;
+                }
+            };
+
+            debug!(
+                %src_addr,
+                bytes = request.remaining(),
+                ?request,
+                "Received request body"
+            );
+
+            let responder = H3ResponseHandle(Arc::new(Mutex::new(stream)));
+            cx.handle_request(request, src_addr, Protocol::H3, responder)
                 .await
         });
 

--- a/crates/server/src/server/h3_handler.rs
+++ b/crates/server/src/server/h3_handler.rs
@@ -66,21 +66,17 @@ pub(super) async fn handle_h3_with_server(
         let Some(timeout_result) = future.await else {
             break; // A graceful shutdown was initiated. Break out of the loop.
         };
-        let Ok(result) = timeout_result else {
+        let Ok(incoming_opt) = timeout_result else {
             warn!("h3 timeout expired during handshake");
             continue;
         };
-        let (connection, src_addr) = match result {
-            Ok(Some((connection, src_addr))) => (connection, src_addr),
-            Ok(None) => break, // Connection is closed.
-            Err(error) => {
-                debug!(%error, "error receiving h3 connection");
-                continue;
-            }
+        let Some(incoming) = incoming_opt else {
+            break; // Connection is closed.
         };
 
         // verify that the src address is safe for responses
         // TODO: we're relying the quinn library to actually validate responses before we get here, but this check is still worth doing
+        let src_addr = incoming.remote_address();
         if let Err(error) = sanitize_src_address(src_addr) {
             warn!(
                 %error, %src_addr,
@@ -89,9 +85,25 @@ pub(super) async fn handle_h3_with_server(
             continue;
         }
 
+        let connecting = match incoming.accept() {
+            Ok(connecting) => connecting,
+            Err(error) => {
+                debug!(%error, "error accepting incoming h3 connection");
+                continue;
+            }
+        };
+
         let cx = cx.clone();
         let dns_hostname = dns_hostname.clone();
         inner_join_set.spawn(async move {
+            let connection = match H3Connection::new(connecting).await {
+                Ok(connection) => connection,
+                Err(error) => {
+                    debug!(%error, "error establishing incoming h3 connection");
+                    return;
+                }
+            };
+
             debug!("starting h3 stream request from: {src_addr}");
 
             // TODO: need to consider timeout of total connect...

--- a/crates/server/src/server/quic_handler.rs
+++ b/crates/server/src/server/quic_handler.rs
@@ -140,21 +140,30 @@ pub(crate) async fn quic_handler(
             }
         };
 
-        let Ok(request_res) = timeout(quic_timeout, request_stream.receive_bytes()).await else {
-            break; // Timeout while reading body.
-        };
-        let request = request_res?;
+        let cx = cx.clone();
+        tokio::spawn(async move {
+            let Ok(request_res) = timeout(quic_timeout, request_stream.receive_bytes()).await
+            else {
+                return; // Timeout while reading body.
+            };
+            let request = match request_res {
+                Ok(bytes_mut) => bytes_mut.freeze(),
+                Err(error) => {
+                    warn!(%error, %src_addr, "reading quic request failed");
+                    return;
+                }
+            };
 
-        debug!(
-            "Received bytes {} from {src_addr} {request:?}",
-            request.len()
-        );
+            debug!(
+                "Received bytes {} from {src_addr} {request:?}",
+                request.len()
+            );
 
-        let stream = Arc::new(Mutex::new(request_stream));
-        let responder = QuicResponseHandle(stream.clone());
+            let responder = QuicResponseHandle(Arc::new(Mutex::new(request_stream)));
 
-        cx.handle_request(request.freeze(), src_addr, Protocol::Quic, responder)
-            .await;
+            cx.handle_request(request, src_addr, Protocol::Quic, responder)
+                .await;
+        });
 
         max_requests -= 1;
         if max_requests == 0 {

--- a/crates/server/src/server/quic_handler.rs
+++ b/crates/server/src/server/quic_handler.rs
@@ -20,7 +20,7 @@ use super::{
 use crate::{
     net::{
         NetError,
-        quic::{DoqErrorCode, QuicServer, QuicStream, QuicStreams},
+        quic::{QuicServer, QuicStream, QuicStreams},
         xfer::Protocol,
     },
     proto::rr::Record,
@@ -159,8 +159,6 @@ pub(crate) async fn quic_handler(
         max_requests -= 1;
         if max_requests == 0 {
             warn!("exceeded request count, shutting down quic conn: {src_addr}");
-            // DOQ_NO_ERROR (0x0): No error. This is used when the connection or stream needs to be closed, but there is no error to signal.
-            stream.lock().await.stop(DoqErrorCode::NoError)?;
             break;
         }
         // we'll continue handling requests from here.

--- a/crates/server/src/server/quic_handler.rs
+++ b/crates/server/src/server/quic_handler.rs
@@ -55,22 +55,18 @@ pub(super) async fn handle_quic_with_server(
         let Some(timeout_result) = future.await else {
             break; // A graceful shutdown was initiated. Break out of the loop.
         };
-        let Ok(accept_result) = timeout_result else {
+        let Ok(incoming_opt) = timeout_result else {
             warn!("quic timeout expired during handshake");
             continue;
         };
-        let (streams, src_addr) = match accept_result {
-            Ok(Some((streams, src_addr))) => (streams, src_addr),
-            Ok(None) => break, // Connection is closed.
-            Err(error) => {
-                debug!(%error, "error receiving quic connection");
-                continue;
-            }
+        let Some(incoming) = incoming_opt else {
+            break; // Connection is closed.
         };
 
         // Verify that the source address is safe for responses. We're also relying on the quinn
         // library to actually validate responses before we get here, but this check is still worth
         // doing.
+        let src_addr = incoming.remote_address();
         if let Err(error) = sanitize_src_address(src_addr) {
             warn!(
                 %error, %src_addr,
@@ -79,8 +75,24 @@ pub(super) async fn handle_quic_with_server(
             continue;
         }
 
+        let connecting = match incoming.accept() {
+            Ok(connecting) => connecting,
+            Err(error) => {
+                debug!(%error, "error accepting incoming quic connection");
+                continue;
+            }
+        };
+
         let cx = cx.clone();
         inner_join_set.spawn(async move {
+            let streams = match QuicStreams::new(connecting).await {
+                Ok(streams) => streams,
+                Err(error) => {
+                    debug!(%error, "error completing incoming quic connection");
+                    return;
+                }
+            };
+
             debug!("starting quic stream request from: {src_addr}");
 
             // TODO: need to consider timeout of total connect...


### PR DESCRIPTION
This removes some unnecessary serialization in the QUIC and HTTP/3 server implementations. In both protocols, we would wait for one connection to finish its QUIC handshake before processing the next connection. Likewise, within each connection, we would wait to receive one request on a stream before processing the next stream. This is a breaking change, due to changes in the API used across the `hickory-net` and `hickory-server` crates.