### PR TITLE
Use newer APIs

### DIFF
--- a/crates/net/src/client/memoize_client_handle.rs
+++ b/crates/net/src/client/memoize_client_handle.rs
@@ -102,7 +102,7 @@ mod test {
     use crate::{
         proto::{
             op::{DnsRequest, DnsResponse, Message, MessageType, OpCode, Query},
-            rr::RecordType,
+            rr::{Name, RecordType},
         },
         runtime::TokioRuntimeProvider,
         xfer::{DnsHandle, FirstAnswer},
@@ -147,10 +147,10 @@ mod test {
         });
 
         let mut test1 = Message::query();
-        test1.add_query(Query::root().set_query_type(RecordType::A).clone());
+        test1.add_query(Query::new(Name::root(), RecordType::A));
 
         let mut test2 = Message::query();
-        test2.add_query(Query::root().set_query_type(RecordType::AAAA).clone());
+        test2.add_query(Query::new(Name::root(), RecordType::AAAA));
 
         let result = block_on(client.send(DnsRequest::from(test1.clone())).first_answer()).unwrap();
         assert_eq!(result.id, 0);

--- a/crates/net/src/client/mod.rs
+++ b/crates/net/src/client/mod.rs
@@ -258,11 +258,8 @@ pub trait ClientHandle: 'static + Clone + DnsHandle + Send {
         }
 
         // add the query
-        let mut query: Query = Query::root();
-        query
-            .set_name(name)
-            .set_query_class(query_class)
-            .set_query_type(query_type);
+        let mut query = Query::new(name, query_type);
+        query.set_query_class(query_class);
         message.add_query(query);
 
         // add the notify message, see https://tools.ietf.org/html/rfc1996, section 3.7

--- a/crates/net/src/xfer/dns_multiplexer.rs
+++ b/crates/net/src/xfer/dns_multiplexer.rs
@@ -391,7 +391,7 @@ mod test {
     use super::*;
     use crate::proto::op::{DnsRequestOptions, Message, Query};
     use crate::proto::rr::rdata::{NS, SOA};
-    use crate::proto::rr::{DNSClass, Name, RData, Record, RecordType};
+    use crate::proto::rr::{Name, RData, Record, RecordType};
     use crate::proto::serialize::binary::BinEncodable;
     use crate::xfer::{DnsClientStream, StreamReceiver};
 
@@ -474,11 +474,7 @@ mod test {
 
         let mut request = Message::query();
         request.metadata.recursion_desired = true;
-        request.add_query({
-            let mut q = Query::new(name.clone(), RecordType::A);
-            q.set_query_class(DNSClass::IN);
-            q
-        });
+        request.add_query(Query::new(name.clone(), RecordType::A));
 
         let mut response = request.clone().into_response();
         response.add_answer(Record::from_rdata(
@@ -497,11 +493,7 @@ mod test {
 
         let mut msg = Message::query();
         msg.metadata.recursion_desired = true;
-        msg.add_query({
-            let mut query = Query::new(name, RecordType::AXFR);
-            query.set_query_class(DNSClass::IN);
-            query
-        });
+        msg.add_query(Query::new(name, RecordType::AXFR));
         msg
     }
 

--- a/crates/proto/src/op/update_message.rs
+++ b/crates/proto/src/op/update_message.rs
@@ -172,10 +172,8 @@ pub fn create(rrset: RecordSet, zone_origin: Name, use_edns: bool) -> Message {
     assert!(zone_origin.zone_of(rrset.name()));
 
     // for updates, the query section is used for the zone
-    let mut zone: Query = Query::root();
-    zone.set_name(zone_origin)
-        .set_query_class(rrset.dns_class())
-        .set_query_type(RecordType::SOA);
+    let mut zone = Query::new(zone_origin, RecordType::SOA);
+    zone.set_query_class(rrset.dns_class());
 
     // build the message
     let mut message = Message::query();
@@ -240,10 +238,8 @@ pub fn append(rrset: RecordSet, zone_origin: Name, must_exist: bool, use_edns: b
     assert!(zone_origin.zone_of(rrset.name()));
 
     // for updates, the query section is used for the zone
-    let mut zone: Query = Query::root();
-    zone.set_name(zone_origin)
-        .set_query_class(rrset.dns_class())
-        .set_query_type(RecordType::SOA);
+    let mut zone = Query::new(zone_origin, RecordType::SOA);
+    zone.set_query_class(rrset.dns_class());
 
     // build the message
     let mut message = Message::query();
@@ -324,10 +320,8 @@ pub fn compare_and_swap(
     assert!(zone_origin.zone_of(new.name()));
 
     // for updates, the query section is used for the zone
-    let mut zone: Query = Query::root();
-    zone.set_name(zone_origin)
-        .set_query_class(new.dns_class())
-        .set_query_type(RecordType::SOA);
+    let mut zone = Query::new(zone_origin, RecordType::SOA);
+    zone.set_query_class(new.dns_class());
 
     // build the message
     let mut message = Message::query();
@@ -392,10 +386,8 @@ pub fn delete_by_rdata(mut rrset: RecordSet, zone_origin: Name, use_edns: bool) 
     assert!(zone_origin.zone_of(rrset.name()));
 
     // for updates, the query section is used for the zone
-    let mut zone: Query = Query::root();
-    zone.set_name(zone_origin)
-        .set_query_class(rrset.dns_class())
-        .set_query_type(RecordType::SOA);
+    let mut zone = Query::new(zone_origin, RecordType::SOA);
+    zone.set_query_class(rrset.dns_class());
 
     // build the message
     let mut message = Message::query();
@@ -449,10 +441,8 @@ pub fn delete_rrset(mut record: Record, zone_origin: Name, use_edns: bool) -> Me
     assert!(zone_origin.zone_of(&record.name));
 
     // for updates, the query section is used for the zone
-    let mut zone: Query = Query::root();
-    zone.set_name(zone_origin)
-        .set_query_class(record.dns_class)
-        .set_query_type(RecordType::SOA);
+    let mut zone = Query::new(zone_origin, RecordType::SOA);
+    zone.set_query_class(record.dns_class);
 
     // build the message
     let mut message = Message::query();
@@ -515,10 +505,8 @@ pub fn delete_all(
     assert!(zone_origin.zone_of(&name_of_records));
 
     // for updates, the query section is used for the zone
-    let mut zone: Query = Query::root();
-    zone.set_name(zone_origin)
-        .set_query_class(dns_class)
-        .set_query_type(RecordType::SOA);
+    let mut zone = Query::new(zone_origin, RecordType::SOA);
+    zone.set_query_class(dns_class);
 
     // build the message
     let mut message = Message::query();
@@ -562,13 +550,13 @@ pub fn zone_transfer(zone_origin: Name, last_soa: Option<SOA>) -> Message {
         assert_eq!(zone_origin, soa.mname);
     }
 
-    let mut zone: Query = Query::root();
-    zone.set_name(zone_origin).set_query_class(DNSClass::IN);
-    if last_soa.is_some() {
-        zone.set_query_type(RecordType::IXFR);
+    let query_type = if last_soa.is_some() {
+        RecordType::IXFR
     } else {
-        zone.set_query_type(RecordType::AXFR);
-    }
+        RecordType::AXFR
+    };
+    let mut zone = Query::new(zone_origin, query_type);
+    zone.set_query_class(DNSClass::IN);
 
     // build the message
     let mut message = Message::query();

--- a/crates/proto/src/op/update_message.rs
+++ b/crates/proto/src/op/update_message.rs
@@ -555,8 +555,7 @@ pub fn zone_transfer(zone_origin: Name, last_soa: Option<SOA>) -> Message {
     } else {
         RecordType::AXFR
     };
-    let mut zone = Query::new(zone_origin, query_type);
-    zone.set_query_class(DNSClass::IN);
+    let zone = Query::new(zone_origin, query_type);
 
     // build the message
     let mut message = Message::query();

--- a/crates/proto/src/rr/rdata/svcb.rs
+++ b/crates/proto/src/rr/rdata/svcb.rs
@@ -1355,10 +1355,9 @@ impl<'r> BinDecodable<'r> for Unknown {
     fn read(decoder: &mut BinDecoder<'r>) -> Result<Self, DecodeError> {
         // The passed slice is already length delimited, and we cannot
         // assume it's a collection of anything.
-        let len = decoder.len();
 
-        let data = decoder.read_vec(len)?;
-        let unknowns = data.unverified(/*any data is valid here*/).to_vec();
+        let data = decoder.read_vec_to_end();
+        let unknowns = data.unverified(/*any data is valid here*/);
 
         Ok(Self(unknowns))
     }

--- a/crates/proto/src/rr/tsig.rs
+++ b/crates/proto/src/rr/tsig.rs
@@ -463,8 +463,7 @@ mod tests {
         let origin: Name = Name::parse("example.com.", None).unwrap();
         let key_name: Name = Name::from_ascii("key_name.").unwrap();
         let mut question = Message::query();
-        let mut query: Query = Query::root();
-        query.set_name(origin);
+        let query = Query::new(origin, RecordType::A);
         question.add_query(query);
 
         let sig_key = b"some_key".to_vec();
@@ -493,8 +492,7 @@ mod tests {
         let origin: Name = Name::parse("example.com.", None).unwrap();
         let key_name: Name = Name::from_ascii("key_name.").unwrap();
         let mut question = Message::query();
-        let mut query: Query = Query::root();
-        query.set_name(origin);
+        let query = Query::new(origin, RecordType::A);
         question.add_query(query);
 
         let sig_key = b"some_key".to_vec();
@@ -539,9 +537,8 @@ mod tests {
     fn test_sign_and_verify_message_tsig_reject_invalid_mac() {
         let (mut question, signer) = get_message_and_signer();
 
-        let mut query: Query = Query::root();
-        let origin: Name = Name::parse("example.net.", None).unwrap();
-        query.set_name(origin);
+        let origin = Name::parse("example.net.", None).unwrap();
+        let query = Query::new(origin, RecordType::A);
         question.add_query(query);
 
         assert!(

--- a/tests/integration-tests/tests/integration/catalog_tests.rs
+++ b/tests/integration-tests/tests/integration/catalog_tests.rs
@@ -131,8 +131,7 @@ async fn test_catalog_lookup() {
 
     let mut question = Message::query();
 
-    let mut query = Query::root();
-    query.set_name(origin.into());
+    let query = Query::new(origin.into(), RecordType::A);
 
     question.add_query(query);
 
@@ -170,8 +169,7 @@ async fn test_catalog_lookup() {
 
     // other zone
     let mut question = Message::query();
-    let mut query = Query::root();
-    query.set_name(test_origin.into());
+    let query = Query::new(test_origin.into(), RecordType::A);
 
     question.add_query(query);
 
@@ -220,9 +218,7 @@ async fn test_catalog_lookup_soa() {
 
     let mut question = Message::query();
 
-    let mut query = Query::root();
-    query.set_name(origin.into());
-    query.set_query_type(RecordType::SOA);
+    let query = Query::new(origin.into(), RecordType::SOA);
 
     question.add_query(query);
 
@@ -293,8 +289,7 @@ async fn test_catalog_nx_soa() {
 
     let mut question = Message::query();
 
-    let mut query = Query::root();
-    query.set_name(Name::parse("nx.example.com.", None).unwrap());
+    let query = Query::new(Name::parse("nx.example.com.", None).unwrap(), RecordType::A);
 
     question.add_query(query);
 
@@ -349,9 +344,10 @@ async fn test_catalog_soa_query_for_nx_name() {
 
     let mut question = Message::query();
 
-    let mut query = Query::root();
-    query.set_name(Name::parse("nx.example.com.", None).unwrap());
-    query.set_query_type(RecordType::SOA);
+    let query = Query::new(
+        Name::parse("nx.example.com.", None).unwrap(),
+        RecordType::SOA,
+    );
 
     question.add_query(query);
 
@@ -406,9 +402,7 @@ async fn test_non_authoritive_nx_refused() {
 
     let mut question = Message::query();
 
-    let mut query = Query::root();
-    query.set_name(Name::parse("com.", None).unwrap());
-    query.set_query_type(RecordType::SOA);
+    let query = Query::new(Name::parse("com.", None).unwrap(), RecordType::SOA);
 
     question.add_query(query);
 
@@ -463,9 +457,7 @@ async fn test_axfr_allow_all() {
     let mut catalog = Catalog::new();
     catalog.upsert(origin.clone(), vec![Arc::new(test)]);
 
-    let mut query = Query::root();
-    query.set_name(origin.clone().into());
-    query.set_query_type(RecordType::AXFR);
+    let query = Query::new(origin.clone().into(), RecordType::AXFR);
 
     let mut question = Message::query();
     question.add_query(query);
@@ -570,9 +562,7 @@ async fn test_axfr_deny_all() {
     let mut catalog = Catalog::new();
     catalog.upsert(origin.clone(), vec![Arc::new(test)]);
 
-    let mut query = Query::root();
-    query.set_name(origin.into());
-    query.set_query_type(RecordType::AXFR);
+    let query = Query::new(origin.into(), RecordType::AXFR);
 
     let mut question = Message::query();
     question.add_query(query);
@@ -650,9 +640,7 @@ async fn test_axfr_deny_unsigned() {
     let mut catalog = Catalog::new();
     catalog.upsert(origin.clone(), vec![Arc::new(test)]);
 
-    let mut query = Query::root();
-    query.set_name(origin.into());
-    query.set_query_type(RecordType::AXFR);
+    let query = Query::new(origin.into(), RecordType::AXFR);
 
     let mut question = Message::query();
     question.add_query(query);
@@ -773,9 +761,7 @@ async fn test_nsid_enabled_and_requested() {
 }
 
 fn test_nsid_request(origin: LowerName, request_nsid: bool) -> Request {
-    let mut query = Query::root();
-    query.set_name(origin.into());
-    query.set_query_type(RecordType::A);
+    let query = Query::new(origin.into(), RecordType::A);
 
     let mut question_edns = Edns::new();
     if request_nsid {
@@ -853,9 +839,7 @@ async fn test_do_bit_reflected_when_requested() {
 
 /// Build an `A` query for `origin` carrying the given EDNS options.
 fn test_edns_request(origin: LowerName, edns: Edns) -> Request {
-    let mut query = Query::root();
-    query.set_name(origin.into());
-    query.set_query_type(RecordType::A);
+    let query = Query::new(origin.into(), RecordType::A);
 
     let mut question = Message::query();
     question.add_query(query);
@@ -883,9 +867,7 @@ async fn test_cname_alias() {
 
     let mut question = Message::query();
 
-    let mut query = Query::root();
-    query.set_name(Name::from_str("alias.example.com.").unwrap());
-    query.set_query_type(RecordType::A);
+    let query = Query::new(Name::from_str("alias.example.com.").unwrap(), RecordType::A);
 
     question.add_query(query);
 
@@ -933,9 +915,10 @@ async fn test_cname_chain() {
 
     let mut question = Message::query();
 
-    let mut query = Query::root();
-    query.set_name(Name::from_str("alias2.example.com.").unwrap());
-    query.set_query_type(RecordType::A);
+    let query = Query::new(
+        Name::from_str("alias2.example.com.").unwrap(),
+        RecordType::A,
+    );
 
     question.add_query(query);
 
@@ -1174,9 +1157,7 @@ mod dnssec {
     async fn test_dnskey_and_nsec3() {
         let catalog = make_catalog();
 
-        let mut query = Query::root();
-        query.set_name(Name::from_str("test.com.").unwrap());
-        query.set_query_type(RecordType::DNSKEY);
+        let query = Query::new(Name::from_str("test.com.").unwrap(), RecordType::DNSKEY);
 
         // Check DNSKEY + RRSIG
         {
@@ -1209,9 +1190,7 @@ mod dnssec {
 
         // Check NSEC3
         {
-            let mut query = Query::root();
-            query.set_name(Name::from_str("test.com.").unwrap());
-            query.set_query_type(RecordType::NSEC);
+            let query = Query::new(Name::from_str("test.com.").unwrap(), RecordType::NSEC);
 
             let result = run_query(&catalog, query).await;
             assert!(result.answers.is_empty());
@@ -1255,9 +1234,7 @@ mod dnssec {
 
         // Check NSEC3PARAM
         {
-            let mut query = Query::root();
-            query.set_name(Name::from_str("test.com.").unwrap());
-            query.set_query_type(RecordType::NSEC3PARAM);
+            let query = Query::new(Name::from_str("test.com.").unwrap(), RecordType::NSEC3PARAM);
 
             let result = run_query(&catalog, query).await;
 

--- a/tests/integration-tests/tests/integration/chained_zone_handler_tests.rs
+++ b/tests/integration-tests/tests/integration/chained_zone_handler_tests.rs
@@ -332,8 +332,7 @@ fn inner_lookup(
 async fn do_query(catalog: &Catalog, query_name: &str) -> (ResponseInfo, TestResponseHandler) {
     let mut question = Message::query();
 
-    let mut query: Query = Query::root();
-    query.set_name(Name::from_ascii(query_name).unwrap());
+    let query = Query::new(Name::from_ascii(query_name).unwrap(), RecordType::A);
     question.add_query(query);
     question.metadata.recursion_desired = true;
     question.metadata.authentic_data = true;

--- a/tests/integration-tests/tests/integration/client_future_tests.rs
+++ b/tests/integration-tests/tests/integration/client_future_tests.rs
@@ -176,11 +176,7 @@ async fn test_query_edns(client: &mut Client<TokioRuntimeProvider>) {
     // TODO: write builder
     let mut msg = Message::query();
     msg.metadata.recursion_desired = true;
-    msg.add_query({
-        let mut query = Query::new(name.clone(), RecordType::A);
-        query.set_query_class(DNSClass::IN);
-        query
-    });
+    msg.add_query(Query::new(name.clone(), RecordType::A));
 
     edns.set_max_payload(1232).set_version(0);
     msg.edns = Some(edns);

--- a/tests/integration-tests/tests/integration/client_tests.rs
+++ b/tests/integration-tests/tests/integration/client_tests.rs
@@ -164,11 +164,7 @@ async fn test_query_edns_response(client: Client<TokioRuntimeProvider>) {
     // TODO: write builder
     let mut msg = Message::query();
     msg.metadata.recursion_desired = true;
-    msg.add_query({
-        let mut query = Query::new(name.clone(), RecordType::A);
-        query.set_query_class(DNSClass::IN);
-        query
-    });
+    msg.add_query(Query::new(name.clone(), RecordType::A));
 
     edns.set_max_payload(1232).set_version(0);
     edns.options_mut()

--- a/tests/integration-tests/tests/integration/sqlite_zone_handler_tests.rs
+++ b/tests/integration-tests/tests/integration/sqlite_zone_handler_tests.rs
@@ -1102,8 +1102,7 @@ fn test_tsig_signer(key_name: Name) -> TSigner {
 
 #[cfg(feature = "__dnssec")]
 fn test_update_message(name: Name) -> Message {
-    let mut q = Query::new(name.clone(), RecordType::SOA);
-    q.set_query_class(DNSClass::IN);
+    let q = Query::new(name.clone(), RecordType::SOA);
 
     let add_rec = Record::from_rdata(name, 3600, RData::A(A::new(192, 168, 1, 10)));
     let mut message = Message::query();

--- a/tests/integration-tests/tests/integration/sqlite_zone_handler_tests.rs
+++ b/tests/integration-tests/tests/integration/sqlite_zone_handler_tests.rs
@@ -56,8 +56,7 @@ async fn test_search() {
     let example = create_example();
     let origin = example.origin().clone();
 
-    let mut query = Query::root();
-    query.set_name(origin.into());
+    let query = Query::new(origin.into(), RecordType::A);
     let request = Request::from_message(
         MessageRequest::mock(*TEST_METADATA, query),
         SocketAddr::from((Ipv4Addr::LOCALHOST, 53)),
@@ -87,8 +86,7 @@ async fn test_search_www() {
     let example = create_example();
     let www_name = Name::parse("www.example.com.", None).unwrap();
 
-    let mut query = Query::root();
-    query.set_name(www_name);
+    let query = Query::new(www_name, RecordType::A);
     let request = Request::from_message(
         MessageRequest::mock(*TEST_METADATA, query),
         SocketAddr::from((Ipv4Addr::LOCALHOST, 53)),
@@ -1104,10 +1102,8 @@ fn test_tsig_signer(key_name: Name) -> TSigner {
 
 #[cfg(feature = "__dnssec")]
 fn test_update_message(name: Name) -> Message {
-    let mut q = Query::root();
-    q.set_name(name.clone());
+    let mut q = Query::new(name.clone(), RecordType::SOA);
     q.set_query_class(DNSClass::IN);
-    q.set_query_type(RecordType::SOA);
 
     let add_rec = Record::from_rdata(name, 3600, RData::A(A::new(192, 168, 1, 10)));
     let mut message = Message::query();

--- a/tests/integration-tests/tests/integration/truncation_tests.rs
+++ b/tests/integration-tests/tests/integration/truncation_tests.rs
@@ -5,7 +5,7 @@ use hickory_net::udp::UdpClientStream;
 use hickory_net::xfer::FirstAnswer;
 use hickory_proto::op::{DnsRequest, Edns, Message, Query};
 use hickory_proto::rr::rdata::{A, SOA};
-use hickory_proto::rr::{DNSClass, Name, RData, Record, RecordSet, RecordType, RrKey};
+use hickory_proto::rr::{Name, RData, Record, RecordSet, RecordType, RrKey};
 use hickory_server::Server;
 #[cfg(feature = "__dnssec")]
 use hickory_server::dnssec::NxProofKind;
@@ -42,11 +42,7 @@ async fn test_truncation() {
     // Build the query.
     let max_payload = 512;
     let mut msg = Message::query();
-    msg.add_query({
-        let mut query = Query::new(large_name(), RecordType::A);
-        query.set_query_class(DNSClass::IN);
-        query
-    });
+    msg.add_query(Query::new(large_name(), RecordType::A));
     msg.metadata.recursion_desired = true;
     msg.edns = Some({
         let mut edns = Edns::new();


### PR DESCRIPTION
This changes a few callsites to use `BinDecoder::read_vec_to_end()` and `Query::new()`.