### PR TITLE
Wait for server process to exit after killing it

### DIFF
--- a/bin/tests/integration/server_harness.rs
+++ b/bin/tests/integration/server_harness.rs
@@ -197,7 +197,11 @@ impl Drop for TestServer {
     fn drop(&mut self) {
         match self.child.kill() {
             Ok(()) => info!("killed test server"),
-            Err(err) => warn!("could not kill test server: {err}"),
+            Err(error) => warn!(%error, "could not kill test server"),
+        }
+        match self.child.wait() {
+            Ok(exit_status) => info!(%exit_status, "test server exited"),
+            Err(error) => warn!(%error, "error waiting for test server to exit"),
         }
 
         let mut line = String::new();


### PR DESCRIPTION
This should fix CI flakiness we've seen in Windows jobs. The `Drop` implementation of `TestServer` currently kills the server process, reads the server's output, and logs it. We should additionally wait for the child process to finish exiting. On Windows, we can't delete files that the server process has open while it's still running, so we need to wait for this to avoid a race condition with subsequent file cleanup code.