### PR TITLE
Wrap long lines and unstick rustfmt

### DIFF
--- a/crates/net/src/error.rs
+++ b/crates/net/src/error.rs
@@ -412,80 +412,90 @@ impl DnsError {
         debug!("response: {}", *response);
 
         match response.response_code {
-                Refused => Err(Self::ResponseCode(Refused)),
-                code @ ServFail
-                | code @ FormErr
-                | code @ NotImp
-                | code @ YXDomain
-                | code @ YXRRSet
-                | code @ NXRRSet
-                | code @ NotAuth
-                | code @ NotZone
-                | code @ BADVERS
-                | code @ BADSIG
-                | code @ BADKEY
-                | code @ BADTIME
-                | code @ BADMODE
-                | code @ BADNAME
-                | code @ BADALG
-                | code @ BADTRUNC
-                | code @ BADCOOKIE => Err(Self::ResponseCode(code)),
-                // Some NXDOMAIN responses contain CNAME referrals, that will not be an error
-                code @ NXDomain |
-                // No answers are available, CNAME referrals are not failures
-                code @ NoError
-                if !response.contains_answer() && !response.truncation => {
-                    // TODO: if authoritative, this is cacheable, store a TTL (currently that requires time, need a "now" here)
-                    // let valid_until = if response.authoritative() { now + response.negative_ttl() };
-                    let soa = response.soa().as_ref().map(RecordRef::to_owned);
+            Refused => Err(Self::ResponseCode(Refused)),
+            code @ ServFail
+            | code @ FormErr
+            | code @ NotImp
+            | code @ YXDomain
+            | code @ YXRRSet
+            | code @ NXRRSet
+            | code @ NotAuth
+            | code @ NotZone
+            | code @ BADVERS
+            | code @ BADSIG
+            | code @ BADKEY
+            | code @ BADTIME
+            | code @ BADMODE
+            | code @ BADNAME
+            | code @ BADALG
+            | code @ BADTRUNC
+            | code @ BADCOOKIE => Err(Self::ResponseCode(code)),
+            // Note that some NXDOMAIN and NOERROR responses contain CNAME records in the answer
+            // section, those will not be treated as an error.
+            code @ NXDomain | code @ NoError
+                if !response.contains_answer() && !response.truncation =>
+            {
+                let soa = response.soa().as_ref().map(RecordRef::to_owned);
 
-                    // Collect any referral nameservers and associated glue records
-                    let mut referral_name_servers = vec![];
-                    for ns in response.authorities.iter().filter(|ns| ns.record_type() == RecordType::NS) {
-                        let glue = response
-                            .additionals
-                            .iter()
-                            .filter_map(|record| {
-                                if let RData::NS(ns_data) = &ns.data {
-                                    if record.name == **ns_data && matches!(&record.data, RData::A(_) | RData::AAAA(_)) {
-                                        return Some(Record::to_owned(record));
-                                    }
+                // Collect any referral nameservers and associated glue records
+                let mut referral_name_servers = vec![];
+                for ns in response
+                    .authorities
+                    .iter()
+                    .filter(|ns| ns.record_type() == RecordType::NS)
+                {
+                    let glue = response
+                        .additionals
+                        .iter()
+                        .filter_map(|record| {
+                            if let RData::NS(ns_data) = &ns.data {
+                                if record.name == **ns_data
+                                    && matches!(&record.data, RData::A(_) | RData::AAAA(_))
+                                {
+                                    return Some(Record::to_owned(record));
                                 }
+                            }
 
-                                None
-                            })
-                            .collect::<Vec<Record>>();
-                        referral_name_servers.push(ForwardNSData { ns: Record::to_owned(ns), glue: glue.into() })
-                    }
-
-                    let option_ns = if !referral_name_servers.is_empty() {
-                        Some(referral_name_servers.into())
-                    } else {
-                        None
-                    };
-
-                    let authorities = if !response.authorities.is_empty() {
-                        Some(response.authorities.to_owned().into())
-                    } else {
-                        None
-                    };
-
-                    let negative_ttl = response.negative_ttl();
-                    let query = response.into_message().queries.drain(..).next().unwrap_or_else(Query::root);
-
-                    Err(Self::NoRecordsFound(NoRecords {
-                        query: Box::new(query),
-                        soa: soa.map(Box::new),
-                        ns: option_ns,
-                        negative_ttl,
-                        response_code: code,
-                        authorities,
-                    }))
+                            None
+                        })
+                        .collect::<Vec<Record>>();
+                    referral_name_servers.push(ForwardNSData {
+                        ns: Record::to_owned(ns),
+                        glue: glue.into(),
+                    })
                 }
-                NXDomain
-                | NoError
-                | Unknown(_) => Ok(response),
+
+                let option_ns = if !referral_name_servers.is_empty() {
+                    Some(referral_name_servers.into())
+                } else {
+                    None
+                };
+
+                let authorities = if !response.authorities.is_empty() {
+                    Some(response.authorities.to_owned().into())
+                } else {
+                    None
+                };
+
+                let negative_ttl = response.negative_ttl();
+                let query = response
+                    .into_message()
+                    .queries
+                    .drain(..)
+                    .next()
+                    .unwrap_or_else(Query::root);
+
+                Err(Self::NoRecordsFound(NoRecords {
+                    query: Box::new(query),
+                    soa: soa.map(Box::new),
+                    ns: option_ns,
+                    negative_ttl,
+                    response_code: code,
+                    authorities,
+                }))
             }
+            NXDomain | NoError | Unknown(_) => Ok(response),
+        }
     }
 
     /// Returns the DNS error as a representative string for use as a metrics label.

--- a/crates/proto/src/rr/record_type_set.rs
+++ b/crates/proto/src/rr/record_type_set.rs
@@ -188,7 +188,8 @@ impl RecordDataDecodable<'_> for RecordTypeSet {
                     for i in 0..8 {
                         // if the current_bytes most significant bit is set
                         if bit_map & 0b1000_0000 == 0b1000_0000 {
-                            // will fail as param in this call if invalid
+                            // Unwrap loop variable from Restrict<u8>. This is only used in checked
+                            // arithmetic below.
                             let left = left.unverified();
 
                             // len - left is the block in the bitmap, times 8 for the bits, + the

--- a/crates/proto/src/rr/record_type_set.rs
+++ b/crates/proto/src/rr/record_type_set.rs
@@ -188,13 +188,18 @@ impl RecordDataDecodable<'_> for RecordTypeSet {
                     for i in 0..8 {
                         // if the current_bytes most significant bit is set
                         if bit_map & 0b1000_0000 == 0b1000_0000 {
-                            // len - left is the block in the bitmap, times 8 for the bits, + the bit in the current_byte
-                            let low_byte: u8 = len
-                            .checked_sub(left.unverified(/*will fail as param in this call if invalid*/))
-                            .checked_mul(8)
-                            .checked_add(i)
-                            .map_err(|_| DecodeError::NsecBitmapOutOfBounds)?
-                            .unverified(/*any u8 is valid at this point*/);
+                            // will fail as param in this call if invalid
+                            let left = left.unverified();
+
+                            // len - left is the block in the bitmap, times 8 for the bits, + the
+                            // bit in the current_byte
+                            let low_byte: Restrict<u8> = len
+                                .checked_sub(left)
+                                .checked_mul(8)
+                                .checked_add(i)
+                                .map_err(|_| DecodeError::NsecBitmapOutOfBounds)?;
+                            // any u8 is valid at this point
+                            let low_byte = low_byte.unverified();
                             let rr_type: u16 = (u16::from(window) << 8) | u16::from(low_byte);
                             types.insert(RecordType::from(rr_type));
                         }

--- a/crates/resolver/src/recursor/handle.rs
+++ b/crates/resolver/src/recursor/handle.rs
@@ -889,22 +889,32 @@ impl<P: ConnectionProvider> RecursorDnsHandle<P> {
             match next {
                 Some(Ok(response)) => {
                     debug!("append_ips_from_lookup: A or AAAA response: {response:?}");
-                    config.extend(response.into_message()
-                        .answers
-                        .into_iter()
-                        .filter_map(|answer| {
-                            let ip = answer.data.ip_addr()?;
+                    config.extend(
+                        response
+                            .into_message()
+                            .answers
+                            .into_iter()
+                            .filter_map(|answer| {
+                                let ip = answer.data.ip_addr()?;
 
-                            if self.name_server_filter.denied(ip) {
-                                debug!(%ip, "append_ips_from_lookup: ignoring address due to do_not_query");
-                                None
-                            } else {
-                                if answer.ttl < ttl {
-                                    ttl = answer.ttl;
+                                if self.name_server_filter.denied(ip) {
+                                    debug!(
+                                        %ip,
+                                        "append_ips_from_lookup: ignoring address due to \
+                                        do_not_query"
+                                    );
+                                    None
+                                } else {
+                                    if answer.ttl < ttl {
+                                        ttl = answer.ttl;
+                                    }
+                                    Some(ip)
                                 }
-                                Some(ip)
-                            }
-                        }).map(|ip| name_server_config(ip, &self.pool_context.opportunistic_encryption)));
+                            })
+                            .map(|ip| {
+                                name_server_config(ip, &self.pool_context.opportunistic_encryption)
+                            }),
+                    );
                 }
                 Some(Err(e)) => {
                     warn!("append_ips_from_lookup: resolution failed failed: {e}");

--- a/crates/server/src/store/in_memory/inner.rs
+++ b/crates/server/src/store/in_memory/inner.rs
@@ -291,7 +291,8 @@ impl InnerInMemory {
                     records = records_tmp;
                     _rrsigs = rrsigs_tmp;
                 } else {
-                    let (records_tmp, rrsigs_tmp) = (rrset.records_without_rrsigs(), Vec::with_capacity(0));
+                    let (records_tmp, rrsigs_tmp) =
+                        (rrset.records_without_rrsigs(), Vec::with_capacity(0));
                     records = records_tmp;
                     _rrsigs = rrsigs_tmp;
                 }


### PR DESCRIPTION
I went looking for long lines that couldn't be properly formatted with `cargo +nightly fmt -- --check --config error_on_line_overflow=true` and fixed a few of the worst offenders. The following patterns can cause rustfmt to get stuck:

* Very long turbofishes
* Block comment inside method calls, i.e. `.unverified(/* ... */)`
* Line comment inside a match pattern
* Macros without special compiler support
* Long string literals

After this, the above command still produces eight errors, and seven of them follow the `.unverified(/* ... */)` pattern. I left them alone as they didn't have an impact on the surrounding code.