### PR TITLE
Make arguments to `RecordType::from_str()` uppercase

### DIFF
--- a/conformance/test-server/src/zone_file.rs
+++ b/conformance/test-server/src/zone_file.rs
@@ -88,9 +88,10 @@ pub(crate) fn parse_zone_file(path: &Path) -> Result<Vec<Record>, String> {
                     .decode(sig_base64.as_bytes())
                     .map_err(|e| format!("RRSIG signature decode error: {e:?}"))?;
 
-                let type_covered = RecordType::from_str(tokens[4]).map_err(|_| {
-                    format!("RRSIG covered type error: unexpected type {}", tokens[4])
-                })?;
+                let type_covered =
+                    RecordType::from_str(&tokens[4].to_uppercase()).map_err(|_| {
+                        format!("RRSIG covered type error: unexpected type {}", tokens[4])
+                    })?;
 
                 let rrsig = RRSIG::from_sig(
                     SigInput {
@@ -138,7 +139,7 @@ pub(crate) fn parse_zone_file(path: &Path) -> Result<Vec<Record>, String> {
 
                 for rtype in &tokens[5..] {
                     types.push(
-                        RecordType::from_str(rtype)
+                        RecordType::from_str(&rtype.to_uppercase())
                             .map_err(|_| format!("NSEC unexpected covered type: {rtype}"))?,
                     );
                 }
@@ -160,7 +161,7 @@ pub(crate) fn parse_zone_file(path: &Path) -> Result<Vec<Record>, String> {
 
                 for rtype in &tokens[9..] {
                     types.push(
-                        RecordType::from_str(rtype)
+                        RecordType::from_str(&rtype.to_uppercase())
                             .map_err(|_| format!("NSEC3 unexpected covered type: {rtype}"))?,
                     );
                 }

--- a/crates/proto/src/rr/rdata/csync.rs
+++ b/crates/proto/src/rr/rdata/csync.rs
@@ -155,7 +155,7 @@ impl CSYNC {
         let mut record_types = BTreeSet::new();
 
         for token in tokens {
-            record_types.insert(RecordType::from_str(token)?);
+            record_types.insert(RecordType::from_str(&token.to_uppercase())?);
         }
 
         Ok(Self::new(soa_serial, immediate, soa_minimum, record_types))

--- a/crates/proto/src/serialize/txt/trust_anchor.rs
+++ b/crates/proto/src/serialize/txt/trust_anchor.rs
@@ -47,7 +47,8 @@ impl<'a> Parser<'a> {
                 },
 
                 State::Ttl { name } => {
-                    if let Token::CharData(data) = token {
+                    if let Token::CharData(mut data) = token {
+                        data.make_ascii_uppercase();
                         if let Ok(class) = DNSClass::from_str(&data) {
                             State::Type {
                                 name,
@@ -78,7 +79,8 @@ impl<'a> Parser<'a> {
                 }
 
                 State::Type { name, ttl, class } => {
-                    if let Token::CharData(data) = token {
+                    if let Token::CharData(mut data) = token {
+                        data.make_ascii_uppercase();
                         let rtype = RecordType::from_str(&data)?;
 
                         if !matches!(rtype, RecordType::DNSKEY) {


### PR DESCRIPTION
We have removed the debug assertions in `DNSClass::from_str()` and `RecordType::from_str()` that check that their inputs are uppercase, but they still only recognize uppercase inputs. This PR changes a few callsites to pass uppercase values, where they weren't already.